### PR TITLE
Remove current user check in llms_is_user_enrolled

### DIFF
--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -703,31 +703,27 @@ function llms_is_user_enrolled( $user_id, $product_id ) {
 	$enrolled = false;
 
 	$post = get_post( $product_id );
-	if (!$post->post_type == 'lesson' || !$post->post_type == 'course') 
+	if (!$post->post_type == 'lesson' || !$post->post_type == 'course')
 		return true;
-
-
-	if ( is_user_logged_in() ) {
 	
-		if ( !empty($user_id) && !empty( $product_id ) ) {
+	if ( !empty($user_id) && !empty( $product_id ) ) {
 
-			$user = new LLMS_Person;
+		$user = new LLMS_Person;
 
-			if ( $post->post_type == 'lesson' ) {
-				$lesson = new LLMS_Lesson($post->ID);
-				$product_id = $lesson->get_parent_course();
+		if ( $post->post_type == 'lesson' ) {
+			$lesson = new LLMS_Lesson($post->ID);
+			$product_id = $lesson->get_parent_course();
+		}
+
+		$user_postmetas = $user->get_user_postmeta_data( $user_id, $product_id );
+
+		if (isset($user_postmetas['_status'])) {
+			$course_status = $user_postmetas['_status']->meta_value;
+
+			if ( $course_status == 'Enrolled' ) {
+				$enrolled = true;
 			}
 
-			$user_postmetas = $user->get_user_postmeta_data( $user_id, $product_id );
-
-			if (isset($user_postmetas['_status'])) {
-				$course_status = $user_postmetas['_status']->meta_value;
-
-				if ( $course_status == 'Enrolled' ) {
-					$enrolled = true;
-				}
-
-			}
 		}
 	}
 


### PR DESCRIPTION
With the check the function is not very useful as a general check if a
specific user (user_id) is inrolled in a specific course (course_id).

We need to check if a user is in a course but the check for a current user prevent us from doing that. This PR fixes that.
