### PR TITLE
Add class because the panel groups are collapsed by default

### DIFF
--- a/templates/quiz/summary.php
+++ b/templates/quiz/summary.php
@@ -20,7 +20,7 @@ use LLMS\Users\User;
 
 	<div class = "accordion hidden">
 
-		<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel-group collapsed" id="accordion" role="tablist" aria-multiselectable="true">
 
 		<?php
 


### PR DESCRIPTION
On academy we are adding styles based on the .collapsed class but they
only show up after you've opened any of the panels
