### PR TITLE
Bugfix: Get correct Courses page in system report

### DIFF
--- a/includes/admin/class.llms.admin.system-report.php
+++ b/includes/admin/class.llms.admin.system-report.php
@@ -259,7 +259,7 @@ class LLMS_Admin_System_Report {
     public static function get_lifterlms_pages_box() {
 
         $pages = array(
-            'llms_shop' => 'Courses',
+            'shop' => 'Courses',
             'memberships' => 'Memberships',
             'myaccount' => 'My Account',
             'checkout' => 'Checkout'
@@ -267,7 +267,7 @@ class LLMS_Admin_System_Report {
 
         echo '<div class="llms-widget-full top">
                 <div class="llms-widget settings-box">
-                    <p class="llms-label">' . __( 'Active Plugins', 'lifterlms' ) . '</p>
+                    <p class="llms-label">' . __( 'LifterLMS Pages', 'lifterlms' ) . '</p>
                     <div class="llms-list">
                         <ul>';
 


### PR DESCRIPTION
### Task:

https://www.bugherd.com/projects/58932/tasks/81

Quick fix for "Page not set" for courses page.
And this box had wrong title.. My bad :/
### Note:

I was using this to figure out "page id": https://github.com/gocodebox/lifterlms/blob/a8d12268274db83b67102f3ecba8308f00546de5/includes/admin/settings/class.llms.settings.courses.php#L33

I guess it is wrong and probably isn't even used on that page..
We should make a not about cleaning it up.
