### PR TITLE
Bugfix: Prevent error on new user certificate engagement

### DIFF
--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -77,7 +77,7 @@ class LLMS_Certificates {
 		if ( ! $person_id )
 			return;
 
-		$certificate = $this->emails['LLMS_Certificate_User'];
+		$certificate = $this->certs['LLMS_Certificate_User'];
 
 		$certificate->trigger( $person_id, $certificate_id, $engagement_id );
 	}


### PR DESCRIPTION
### Task:

https://trello.com/c/eLe8oKzI/117-engagement-trigger-php-error

It is working for me now but can you please recheck Thomas? Because I can't figure out how was this working since it was written: https://github.com/gocodebox/lifterlms/commit/92d1bcd5a8ef1fd4f2a4d0e2e37c4c743b4e9e70
because there was never '$emails' variable.
