### PR TITLE
Limit prices to numbers

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.main.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.main.php
@@ -259,7 +259,7 @@ class LLMS_Meta_Box_Main extends LLMS_Admin_Metabox{
                         'group' 	=> 'bottom llms-custom-single-price-bottom',
                     ),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Single Payment Price ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter a price to offer your course for a one time purchase.',
 						'id' 		=> self::$prefix . 'regular_price',
@@ -279,7 +279,7 @@ class LLMS_Meta_Box_Main extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Sale Price ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter a sale price for the course.',
 						'id' 		=> self::$prefix . 'sale_price',
@@ -324,7 +324,7 @@ class LLMS_Meta_Box_Main extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Recurring Payment ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter the amount you will bill at set intervals.',
 						'id' 		=> self::$prefix . 'llms_subscription_price',
@@ -334,7 +334,7 @@ class LLMS_Meta_Box_Main extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'First Payment ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter the payment amount you will charge on product purchase. This can be 0 to give users a free trial period.',
 						'id' 		=> self::$prefix . 'llms_subscription_first_payment',

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
@@ -131,7 +131,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Single Payment Price ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter a price to offer your membership for a one time purchase.',
 						'id' 		=> self::$prefix . 'regular_price',
@@ -151,7 +151,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Sale Price ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter a sale price for the membership.',
 						'id' 		=> self::$prefix . 'sale_price',
@@ -196,7 +196,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'Recurring Payment ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter the amount you will bill at set intervals.',
 						'id' 		=> self::$prefix . 'llms_subscription_price',
@@ -206,7 +206,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox{
 						'group' 	=> '',
 					),
 					array(
-						'type'		=> 'text',
+						'type'		=> 'number',
 						'label'		=> 'First Payment ( ' . get_lifterlms_currency_symbol() . ' )',
 						'desc' 		=> 'Enter the payment amount you will charge on product purchase. This can be 0 to give users a free trial period.',
 						'id' 		=> self::$prefix . 'llms_subscription_first_payment',

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
@@ -2,11 +2,11 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 /**
-* 
+*
 */
 class LLMS_Metabox_Number_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface
 {
-	
+
 	function __construct($_field)
 	{
 		$this->field = $_field;
@@ -14,28 +14,29 @@ class LLMS_Metabox_Number_Field extends LLMS_Metabox_Field implements Meta_Box_F
 
 	/**
 	 * Outputs the Html for the given field
-	 * @return HTML 
+	 * @return HTML
 	 */
 	public function Output()
 	{
 		global $post;
-		
+
 		parent::Output(); ?>
-					
+
 		<input type="number"
 		<?php
 			if (isset($this->field['min'])) {
 				echo 'min="' . $this->field['min'] . '"';
 			}
 		?>
-			name="<?php echo $this->field['id']; ?>" 
-			id="<?php echo $this->field['id']; ?>" 
+			name="<?php echo $this->field['id']; ?>"
+			id="<?php echo $this->field['id']; ?>"
 			class="<?php echo esc_attr( $this->field['class'] ); ?>"
-			value="<?php echo $this->meta; ?>" size="30" 
+			value="<?php echo $this->meta; ?>" size="30"
+			step="<?php echo isset($this->field['meta']) ? $this->field['meta'] : 'any'; ?>"
 		/>
-			
+
 		<?php
-		parent::CloseOutput();				
+		parent::CloseOutput();
 	}
 }
 


### PR DESCRIPTION
### Task:

https://www.bugherd.com/projects/58932/tasks/93

I guess solution is to limit prices to numbers but I can't recreate bug. I can't get ~~old price~~ new price format to output and I tracked it down to this file having functions like this:
https://github.com/gocodebox/lifterlms/blob/master/includes/class.llms.product.php#L554

File has few unset variables used around in functions and stuff like that so I am having trouble following out logic that determines price output. @thomasplevy do you have any suggestions on how to proceed here? That file could use refactor but I am afraid that I might break something if I do partial job on it.
