### PR TITLE
Escape description to be able to use &lt;

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.question.general.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.question.general.php
@@ -54,7 +54,7 @@ class LLMS_Meta_Box_Question_General {
 									<textarea name ="option_text[]" class="option-text"><?php echo esc_textarea( $value['option_text'] ); ?></textarea>
 									<br>
 									<label><?php _e( 'Explanation Field', 'lifterlms' ); ?></label>
-									<textarea name ="option_description[]" class="option-text"><?php echo array_key_exists( 'option_description', $value ) ? $value['option_description'] : ''; ?></textarea>
+									<textarea name ="option_description[]" class="option-text"><?php echo array_key_exists( 'option_description', $value ) ? esc_textarea( $value['option_description'] ) : ''; ?></textarea>
 									</td>
 									</tr>
 								<?php


### PR DESCRIPTION
We want to have HTML on the frontend but don't render it. For example for `<title>` and `<head>` which we want to be able to display but not render. For this purpose we use `&lt;` and `&gt;`, but these are rendered in the admin so the next time you save the post the `&lt;` is transformed into `<`.
