### PR TITLE
fix for is_search called incorrectly

### DIFF
--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -154,10 +154,10 @@ class LLMS_Query {
 	 * @version  3.6.0
 	 */
 	public function pre_get_posts( $query ) {
-
+		global $wp_query;
 		$modify_tax_query = false;
 
-		if ( is_search() ) {
+		if ( isset( $wp_query ) && is_search() ) {
 			$modify_tax_query = true;
 		}
 


### PR DESCRIPTION
I get a lot of:
```Notice: is_search was called incorrectly. Conditional query tags do not work before the query is run. Before then, they always return false. Please see Debugging in WordPress for more information. (This message was added in version 3.1.0.)```
Seems that happen on different url and after a little bit of debugging I found that happen on lifter.
In a day I can have 3mb of logs stuff, with this fix the problem doesn't happen anymore.