### PR TITLE
Fix for Failed opening '' for inclusion

### DIFF
--- a/includes/functions/llms.functions.template.php
+++ b/includes/functions/llms.functions.template.php
@@ -79,8 +79,8 @@ function llms_get_template( $template_name, $args = array(), $template_path = ''
 
 	  do_action( 'lifterlms_before_template_part', $template_name, $template_path, $located, $args );
 
-	  if( file_exists( $located ) ) {
-	     include( $located );
+	  if ( file_exists( $located ) ) {
+		include($located);
 	  }
 
 	  do_action( 'lifterlms_after_template_part', $template_name, $template_path, $located, $args );

--- a/includes/functions/llms.functions.template.php
+++ b/includes/functions/llms.functions.template.php
@@ -79,7 +79,9 @@ function llms_get_template( $template_name, $args = array(), $template_path = ''
 
 	  do_action( 'lifterlms_before_template_part', $template_name, $template_path, $located, $args );
 
-	  include( $located );
+	  if( file_exists( $located ) ) {
+	     include( $located );
+	  }
 
 	  do_action( 'lifterlms_after_template_part', $template_name, $template_path, $located, $args );
 }


### PR DESCRIPTION
```Warning (2): include(): Failed opening '' for inclusion (include_path='.:/opt/alt/php71/usr/share/pear') in [/home/domain/wp-content/plugins/lifterlms/includes/functions/llms.functions.template.php, line 82]```