### PR TITLE
Working on 393

### DIFF
--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -980,7 +980,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 		$total = 0;
 		$completed = 0;
 		
-		$saved_complete = get_user_meta( $this->get_id(), '_status_' . $type . '_' . $object_id );
+		$saved_complete = get_user_meta( $this->get_id(), '_status_' . $type . '_' . $object_id, true );
 		if( empty( $saved_complete ) ) {
 			if ( 'course' === $type ) {
 

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -979,38 +979,44 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 
 		$total = 0;
 		$completed = 0;
+		
+		$saved_complete = get_user_meta( $this->get_id(), '_status_' . $type . '_' . $object_id );
+		if( empty( $saved_complete ) ) {
+			if ( 'course' === $type ) {
 
-		if ( 'course' === $type ) {
+				$course = new LLMS_Course( $object_id );
+				$lessons = $course->get_lessons( 'ids' );
+				$total = count( $lessons );
+				foreach ( $lessons as $lesson ) {
+					if ( $this->is_complete( $lesson, 'lesson' ) ) {
+						$completed++;
+					}
+				}
+			} elseif ( 'course_track' === $type ) {
 
-			$course = new LLMS_Course( $object_id );
-			$lessons = $course->get_lessons( 'ids' );
-			$total = count( $lessons );
-			foreach ( $lessons as $lesson ) {
-				if ( $this->is_complete( $lesson, 'lesson' ) ) {
-					$completed++;
+				$track = new LLMS_Track( $object_id );
+				$courses = $track->get_courses();
+				$total = count( $courses );
+				foreach ( $courses as $course ) {
+					if ( $this->is_complete( $course->ID, 'course' ) ) {
+						$completed++;
+					}
+				}
+			} elseif ( 'section' === $type ) {
+
+				$section = new LLMS_Section( $object_id );
+				$lessons = $section->get_lessons( 'ids' );
+				$total = count( $lessons );
+				foreach ( $lessons as $lesson ) {
+					if ( $this->is_complete( $lesson, 'lesson' ) ) {
+						$completed++;
+					}
 				}
 			}
-		} elseif ( 'course_track' === $type ) {
-
-			$track = new LLMS_Track( $object_id );
-			$courses = $track->get_courses();
-			$total = count( $courses );
-			foreach ( $courses as $course ) {
-				if ( $this->is_complete( $course->ID, 'course' ) ) {
-					$completed++;
-				}
-			}
-		} elseif ( 'section' === $type ) {
-
-			$section = new LLMS_Section( $object_id );
-			$lessons = $section->get_lessons( 'ids' );
-			$total = count( $lessons );
-			foreach ( $lessons as $lesson ) {
-				if ( $this->is_complete( $lesson, 'lesson' ) ) {
-					$completed++;
-				}
-			}
+			
+			update_user_meta( $this->get_id(), '_status_' . $type . '_' . $object_id, $completed );
 		}
+		
 
 		return ( ! $completed || ! $total ) ? 0 : round( 100 / ( $total / $completed ), 2 );
 


### PR DESCRIPTION
As explained in #393 the method `get_progress` with the demo data made like 70 query everytime for this value.
70 query!
This commit cache and store this value for the specific user and based on the type in a usermeta.
Now the page do less query!!
The issue actually for me is to cleanup this value when the user do a lesson etc. I am not an expert of the code but I guess that @thomasplevy will have some idea how to implement that part.