### PR TITLE
Add overflow visibility to page containers for themes that set it to …

### DIFF
--- a/_private/scss/frontend/certificates.scss
+++ b/_private/scss/frontend/certificates.scss
@@ -81,7 +81,12 @@ body {
 	/* Make everything on the page invisible */
     body * {
         visibility: hidden;
+		background: #fff none;
     }
+
+	.site, .site-content{
+		overflow: visible;
+	}
 
 	/* remove all headers, menus and footers */
     header, nav, footer {

--- a/_private/scss/frontend/certificates.scss
+++ b/_private/scss/frontend/certificates.scss
@@ -105,5 +105,6 @@ body {
 		left: 0;
 		right: 0;
 		margin: 0 auto;
+		background: #fff none;
 	}
 }


### PR DESCRIPTION
Themes like Astra set the overflow property of container divs to hidden (not sure why), because of which the absolutely positioned certificate gets cut off:

![capture d ecran 2018-04-27 a 12 33 20](https://user-images.githubusercontent.com/1739834/39473474-b5ac0b12-4d6c-11e8-9d84-472528d0541b.png)

To prevent that, the print css now sets `.site` and `.site-content`'s `overflow` to `visible`. 

In addition, it explicitly sets a white background on the page as well as on the certificate container.