### PR TITLE
decode html entities for email titles

### DIFF
--- a/includes/notifications/views/class.llms.notification.view.purchase.receipt.php
+++ b/includes/notifications/views/class.llms.notification.view.purchase.receipt.php
@@ -156,7 +156,7 @@ class LLMS_Notification_View_Purchase_Receipt extends LLMS_Abstract_Notification
 			break;
 
 			case '{{PRODUCT_TITLE}}':
-				$code = $order->get( 'product_title' );
+				$code = wp_specialchars_decode( $order->get( 'product_title' ) );
 			break;
 
 			case '{{PRODUCT_TITLE_LINK}}':


### PR DESCRIPTION
fix for #644 using `wp_specialchars_decode`