### PR TITLE
Voucher code

### DIFF
--- a/includes/class.llms.voucher.php
+++ b/includes/class.llms.voucher.php
@@ -308,7 +308,7 @@ class LLMS_Voucher {
 
 				}
 
-				do_action( 'llms_voucher_used', $voucher->id, $user_id );
+				do_action( 'llms_voucher_used', $voucher->id, $user_id, $voucher->title );
 
 				// use voucher code
 				$data = array(


### PR DESCRIPTION
## Description
The `llms_voucher_used` action hook now includes the voucher/coupon title as the third parameter

## How has this been tested?
This action hook doesn't seem to be triggered anywhere else within the LifterLMS plugin.

## Types of changes
Introduces a third parameter to `llms_voucher_used` action hook

Closes #619 