### PR TITLE
function doc has failed instead of passed fixes #674

### DIFF
--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
@@ -29,7 +29,7 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 	protected $action_hooks = array( 'lifterlms_quiz_passed' );
 
 	/**
-	 * Callback function called when a quiz is failed by a student
+	 * Callback function called when a quiz is passed by a student
 	 * @param    int     $student_id  WP User ID of a LifterLMS Student
 	 * @param    array   $quiz_id     WP Post ID of a LifterLMS quiz
 	 * @return   void


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
changed 'failed' to 'passed' in documentation.
fix for #674 
## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [ ] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
