### PR TITLE
add test methods for quiz fail notification, per #653

### DIFF
--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -1,12 +1,10 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Notification Controller: Quiz Failed
  * @since    3.8.0
- * @version  3.16.6
+ * @version  [version]
  */
 class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notification_Controller {
 
@@ -29,6 +27,15 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	protected $action_hooks = array( 'lifterlms_quiz_failed' );
 
 	/**
+	 * Determines if test notifications can be sent
+	 * @var  bool
+	 */
+	protected $testable = array(
+		'basic'	=> false,
+		'email'	=> true,
+	);
+
+	/**
 	 * Callback function called when a quiz is failed by a student
 	 * @param    int     $student_id  WP User ID of a LifterLMS Student
 	 * @param    array   $quiz_id     WP Post ID of a LifterLMS quiz
@@ -49,6 +56,56 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 		$this->send();
 
 	}
+
+	/**
+	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 * @param    string     $type  notification type [basic|email]
+	 * @return   array
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	public function get_test_settings( $type ) {
+		if ( 'email' != $type ) {
+			return;
+		}
+		$query = new LLMS_Query_Quiz_Attempt( array(
+			'per_page'	=> 25,
+			'status'	=> 'fail',
+		));
+		$options = array(
+		   '' => '',
+		);
+		$attempts = array();
+		$results = $query->results;
+		if ( $results ) {
+			foreach ( $results as $result ) {
+				$attempts[] = new LLMS_Quiz_Attempt( $result->id );
+			}
+		}
+		foreach ( $attempts as $attempt ) {
+			$quiz = llms_get_post( $attempt->get( 'quiz_id' ) );
+			$student = llms_get_student( $attempt->get( 'user_id' ) );
+			if ( $attempt && $student ) {
+				$options[ $attempt->get( 'id' ) ] = esc_attr( sprintf( __( 'Attempt #%1$d for Quiz "%2$s" by %3$s', 'lifterlms' ), $attempt->get( 'id' ), $quiz->get( 'title' ), $student->get_name() ) );
+			}
+		}
+		return array(
+		   array(
+			   'class' => 'llms-select2',
+			   'custom_attributes' => array(
+				   'data-allow-clear' => true,
+				   'data-placeholder' => __( 'Select a failed quiz', 'lifterlms' ),
+			   ),
+			   'default'	=> '',
+			   'id' => 'attempt_id',
+			   'desc' => '<br/>' . __( 'Send yourself a test notification using information from the selected quiz.', 'lifterlms' ),
+			   'options' => $options,
+			   'title' => __( 'Send a Test', 'lifterlms' ),
+			   'type' => 'select',
+		   ),
+		);
+	}
+
 
 	/**
 	 * Takes a subscriber type (student, author, etc) and retrieves a User ID
@@ -91,6 +148,27 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	 */
 	public function get_title() {
 		return __( 'Quiz Failed', 'lifterlms' );
+	}
+
+	/**
+	 * Send a test notification to the currently logged in users
+	 * Extending classes should redefine this in order to properly setup the controller with post_id and user_id data
+	 * @param    string   $type  notification type [basic|email]
+	 * @param    array    $data  array of test notification data as specified by $this->get_test_data()
+	 * @return   int|false
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	public function send_test( $type, $data = array() ) {
+		if ( ! isset( $data['attempt_id'] ) ) {
+			return;
+		}
+		$attempt = new LLMS_Quiz_Attempt( $data['attempt_id'] );
+		$this->user_id = $attempt->get( 'student_id' );
+		$this->post_id = $attempt->get( 'quiz_id' );
+		$this->quiz = llms_get_post( $attempt->get( 'quiz_id' ) );
+		$this->course = $this->quiz->get_course();
+		return parent::send_test( $type );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add methods to https://github.com/gocodebox/lifterlms/blob/master/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
to send test emails

per #653 

## How has this been tested?
Tested by sending emails.  
PHP 7.1.7
WP 4.9.8

## Screenshots <!-- if applicable -->

## Types of changes
New Feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
