### PR TITLE
Fix backslash escaping in builder

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -359,7 +359,8 @@ if ( ! empty( $active_post_lock ) ) {
 		}
 
 		// only mess with our data
-		$data = json_decode( $data['llms_builder'], true );
+		$data = json_decode( str_replace( '\\', '\\\\', $data['llms_builder'] ), true );
+		
 
 		// setup our return
 		$ret = array(

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -360,7 +360,6 @@ if ( ! empty( $active_post_lock ) ) {
 
 		// only mess with our data
 		$data = json_decode( str_replace( '\\', '\\\\', $data['llms_builder'] ), true );
-		
 
 		// setup our return
 		$ret = array(


### PR DESCRIPTION
## Description

Fixed json_decode in builder to escape and save backslashes correctly. Fixes #677 but not #596.

## How has this been tested?

Added the following string to Quiz Description, question and options:

`C:\\Program Files\Test\`

Before the fix, it would turn into `C:\Program FilesTest` once the builder is exited and returned to or the quiz is previewed. After the fix the string stays as it is.

I also tested cloning and export/import and with both of them, this fix doesn't work because the code doesn't come into play at all. However, unlike a previous attempt, it doesn't break cloning or export/import. (The string continues to turn into `C:\Program FilesTest` on cloning and export/import. )Fixing that is more complicated that what's done here but at least users will be able to start using LaTex and backslashes in course and course unit content and part of the problem will get resolved.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix for #677 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
