### PR TITLE
Allow [lifterlms_hide_content/] shortcode to accept multiple IDs

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.hide.content.php
+++ b/includes/shortcodes/class.llms.shortcode.hide.content.php
@@ -27,10 +27,10 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 	 */
 	protected function get_default_attributes() {
 		return array(
-			'membership'=> '', // backwards compat, use ID moving forward
-			'message'   => '',
-			'id'        => get_the_ID(),
-			'relation'  => 'all'
+			'membership' => '', // backwards compat, use ID moving forward
+			'message' => '',
+			'id' => get_the_ID(),
+			'relation' => 'all',
 		);
 	}
 
@@ -51,7 +51,7 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 	protected function get_output() {
 
 		// backwards compatibility, get membership if set and fallback to the id
-		$ids = $this->get_attribute( 'membership' ) ?  $this->get_attribute( 'membership' ) : $this->get_attribute( 'id' );
+		$ids = $this->get_attribute( 'membership' ) ? $this->get_attribute( 'membership' ) : $this->get_attribute( 'id' );
 		// Explode, trim whitespace and remove empty values
 		$ids = (array) array_map( 'trim', array_filter( explode( ',', $ids ) ) );
 
@@ -68,14 +68,14 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 		}
 
 		if ( 'all' === $this->get_attribute( 'relation' ) && ! empty( $ids ) ) {
-			$i = 0;
+			$inc = 0;
 			foreach ( $ids as $id ) {
 				if ( llms_is_user_enrolled( get_current_user_id(), $id ) ) {
-					$i++;
+					$inc++;
 				}
 			}
 
-			if ( $i === count( $ids ) ) {
+			if ( count( $ids ) === $inc ) {
 				$hidden = false;
 			}
 		}

--- a/includes/shortcodes/class.llms.shortcode.hide.content.php
+++ b/includes/shortcodes/class.llms.shortcode.hide.content.php
@@ -30,7 +30,7 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 			'membership' => '', // backwards compat, use ID moving forward
 			'message' => '',
 			'id' => get_the_ID(),
-			'relation' => 'all',
+			'relation'   => 'all',
 		);
 	}
 

--- a/includes/shortcodes/class.llms.shortcode.hide.content.php
+++ b/includes/shortcodes/class.llms.shortcode.hide.content.php
@@ -27,9 +27,10 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 	 */
 	protected function get_default_attributes() {
 		return array(
-			'membership' => '', // backwards compat, use ID moving forwad
-			'message' => '',
-			'id' => get_the_ID(),
+			'membership'=> '', // backwards compat, use ID moving forward
+			'message'   => '',
+			'id'        => get_the_ID(),
+			'relation'  => 'all'
 		);
 	}
 
@@ -39,6 +40,10 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 	 * $atts & $content are both filtered before being passed to get_output()
 	 * output is filtered so the return of get_output() doesn't need its own filter
 	 *
+	 * Examples:
+	 * [hide_content id="1,2,3,4" relation="any"] allows member with access to 1,2,3, OR 4 to access content
+	 * [hide_content id="1,2,3,4" relation="all"] allows only members with access 1,2,3 AND 4 to access
+	 *
 	 * @return   string
 	 * @since    3.5.1
 	 * @version  3.5.1
@@ -46,13 +51,36 @@ class LLMS_Shortcode_Hide_Content extends LLMS_Shortcode {
 	protected function get_output() {
 
 		// backwards compatibility, get membership if set and fallback to the id
-		$id = $this->get_attribute( 'membership' ) ?  $this->get_attribute( 'membership' ) : $this->get_attribute( 'id' );
+		$ids = $this->get_attribute( 'membership' ) ?  $this->get_attribute( 'membership' ) : $this->get_attribute( 'id' );
+		// Explode, trim whitespace and remove empty values
+		$ids = (array) array_map( 'trim', array_filter( explode( ',', $ids ) ) );
 
-		if ( llms_is_user_enrolled( get_current_user_id(), $id ) ) {
-			return do_shortcode( $this->get_content() );
+		// Assume content is hidden
+		$hidden = true;
+
+		if ( 'any' === $this->get_attribute( 'relation' ) && ! empty( $ids ) ) {
+			foreach ( $ids as $id ) {
+				if ( llms_is_user_enrolled( get_current_user_id(), $id ) ) {
+					$hidden = false;
+					break;
+				}
+			}
 		}
 
-		return $this->get_attribute( 'message' );
+		if ( 'all' === $this->get_attribute( 'relation' ) && ! empty( $ids ) ) {
+			$i = 0;
+			foreach ( $ids as $id ) {
+				if ( llms_is_user_enrolled( get_current_user_id(), $id ) ) {
+					$i++;
+				}
+			}
+
+			if ( $i === count( $ids ) ) {
+				$hidden = false;
+			}
+		}
+
+		return ! $hidden ? do_shortcode( $this->get_content() ) : $this->get_attribute( 'message' );
 
 	}
 


### PR DESCRIPTION
## Description
See #492 

This pull request brings the ability to pass multiple IDs to the `lifterlms_hide_content ` shortcode. The `relation` option is introduced to the lifterlms_hide_content shortcode, allowing you to calculate access to content with different requirements. The new `relation` parameter defaults to `all` and the other possible value is `any`.

## How has this been tested?

- Imported the Sample course and cloned it so that I would end up with 2 courses with IDs 5 and 27.
- I then proceeded to enroll myself in Course ID 5
- Created page and tested the following shortcode combinations with success. **Extra spaces and commas were added on purpose to make sure the shortcode wouldn't break and still perform as expected.**

`[lifterlms_hide_content id="  5," message="You don't have access to this content." relation="all"]Premium Content[/lifterlms_hide_content]`

`[lifterlms_hide_content id="  5, ,,  27" message="You don't have access to this content." relation="all"]Premium Content[/lifterlms_hide_content]`

`[lifterlms_hide_content id="  5,    27" message="You don't have access to this content." relation="any"]Premium Content[/lifterlms_hide_content]`

`[lifterlms_hide_content membership="  5," message="You don't have access to this content." relation="all"]Premium Content[/lifterlms_hide_content]`

`[lifterlms_hide_content membership="  5,    27" message="You don't have access to this content." relation="all"]Premium Content[/lifterlms_hide_content]`

`[lifterlms_hide_content membership="  5,    27" message="You don't have access to this content." relation="any"]Premium Content[/lifterlms_hide_content]`

The result I saw on the page was:

Premium Content
You don't have access to this content.
Premium Content

Premium Content
You don't have access to this content.
Premium Content

## Types of changes

### What types of changes does your code introduce?
The `relation` option is introduced to the lifterlms_hide_content shortcode, allowing you to calculate access to content with different requirements.