### PR TITLE
Fix typo in Engagement dropdown

### DIFF
--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -347,7 +347,7 @@ function llms_get_engagement_triggers() {
 		'quiz_passed' => __( 'Student passes a quiz', 'lifterlms' ),
 		'quiz_failed' => __( 'Student fails a quiz', 'lifterlms' ),
 		'section_completed' => __( 'Student completes a section', 'lifterlms' ),
-		'course_track_completed' => __( 'Student comepletes a course track', 'lifterlms' ),
+		'course_track_completed' => __( 'Student completes a course track', 'lifterlms' ),
 		'membership_enrollment' => __( 'Student enrolls in a membership', 'lifterlms' ),
 		'membership_purchased' => __( 'Student purchases a membership', 'lifterlms' ),
 	) );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Fixes #687 .
Changed 'comepletes' to 'completes'.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
`composer run-script phpunit`

## Screenshots <!-- if applicable -->
N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix (non-breaking change which fixes an issue

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
