### PR TITLE
Fix for issue #690

### DIFF
--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
@@ -64,7 +64,7 @@ class LLMS_Metabox_Select_Field extends LLMS_Metabox_Field implements Meta_Box_F
 				<?php foreach ( $this->field['value'] as $key => $option ) :
 					$selected_text = '';
 					if ( is_array( $selected ) ) {
-						if ( in_array( $option['key'], $selected ) ) {
+						if ( in_array( $option['key'], $selected, true ) ) {
 							$selected_text = ' selected="selected" ';
 						}
 					} elseif ( isset( $option['key'] ) && $option['key'] == $selected ) {


### PR DESCRIPTION
Fixes #690 

## Description
Enforced strict checking on `in_array()` call in llms.class.meta.box.select.php line 67

## How has this been tested?
```
function test_course_lesson_metabox( $fields ) {

	$values = array(
		array(
			'key'	=> '1',
			'title' => '1',
		),
		array(
			'key'	=> '2',
			'title' => '2',
		),
		array(
			'key'	=> 'Three',
			'title' => 'Three',
		),
		array(
			'key'	=> '0',
			'title' => '0',
		)
	);

	$selected = array( '1', 'Three' );

	$fields['test'] = array( 'title' => 'Test', 'fields' => array() );

	$fields['test']['fields'][] = array(
			'id'              => 'test',
			'label'           => 'Test',
			'multi'           => '1',
			'type'            => 'select',
			'value'           => $values,
			'selected'        => $selected
		);

	return $fields;

}

add_filter( 'llms_metabox_fields_lifterlms_course_options', 'test_course_lesson_metabox' );
```
## Checklist:
- [X] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script phpunit` -->
- [X] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
