### PR TITLE
Use contextual data if available

### DIFF
--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -16,7 +16,7 @@ class LLMS_PlayNice {
 	public function __construct() {
 
 		// Yoast Premium redirect manager slug change filter
-		add_filter( 'wpseo_premium_post_redirect_slug_change', array( $this, 'wp_seo_premium_redirects' ) );
+		add_filter( 'wpseo_premium_post_redirect_slug_change', array( $this, 'wp_seo_premium_redirects' ), 10, 2 );
 
 		// optimize press live editor initialization
 		add_action( 'op_liveeditor_init' , array( $this, 'wp_optimizepress_live_editor' ) );
@@ -68,22 +68,28 @@ class LLMS_PlayNice {
 	 *
 	 * this prevents that
 	 *
-	 * @param    bool     $bool  default is always false, which means a redirect will be created
+	 * @param    bool     $bool    default is always false, which means a redirect will be created
+	 * @param    integer  $post_id the post id of the post being saved
 	 * @return   boolean
 	 * @since    3.1.3
 	 * @version  3.1.3
 	 */
-	public function wp_seo_premium_redirects( $bool ) {
+	public function wp_seo_premium_redirects( $bool, $post_id = null ) {
 
-		$screen = get_current_screen();
-
-		if ( ! empty( $screen->post_type ) && in_array( $screen->post_type, array( 'course', 'llms_membership' ) ) ) {
-
-			$bool = true;
-
+		if ( ! empty( $post_id ) ) {
+			$post_type = get_post_type( $post_id );
 		}
 
-		return $bool;
+		if ( empty( $post_type ) ) {
+			$screen    = get_current_screen();
+			$post_type = $screen->post_type;
+		}
+
+		if ( empty( $post_type ) ) {
+			return $bool;
+		}
+
+		return in_array( $post_type, array( 'course', 'llms_membership' ), true );
 
 	}
 


### PR DESCRIPTION
## Description
Added support for (future implemented) additional context on the filter usage.
This will (most probably) be released in Yoast SEO Premium 9.2

Add a filter call, providing the `$post_id`. This way the `get_current_screen()` should not be used.
The `post_type` of the provided `$post_id` is used to check against.

## How has this been tested?
Loading this together with the patch on Yoast SEO Premium.

In `wordpress-seo-premium/premium/classes/post-watcher.php`:

Change:
```
if ( apply_filters( 'wpseo_premium_post_redirect_slug_change', false ) === true ) {
```

To:
```
if ( apply_filters( 'wpseo_premium_post_redirect_slug_change', false, $post_id, $post, $post_before ) === true ) {
```

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. _I could not get them to run_
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->

Fixes #698 