### PR TITLE
Rename instances of `preprare_query()` to `prepare_query()`

### DIFF
--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -223,7 +223,7 @@ abstract class LLMS_Database_Query {
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */
-	abstract protected function preprare_query();
+	abstract protected function prepare_query();
 
 	/**
 	 * Execute a query
@@ -235,7 +235,7 @@ abstract class LLMS_Database_Query {
 
 		global $wpdb;
 
-		$this->sql = $this->preprare_query();
+		$this->sql = $this->prepare_query();
 		if ( ! $this->get( 'suppress_filters' ) ) {
 			$this->sql = apply_filters( $this->get_filter( 'prepare_query' ), $this->sql, $this );
 		}

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -119,7 +119,7 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	 * @since    3.16.0
 	 * @version  3.16.0
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -185,7 +185,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	 * @since    3.15.0
 	 * @version  3.15.0
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -121,7 +121,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 * @since    3.4.0
 	 * @version  3.13.0
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -178,7 +178,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 * @since    3.8.0
 	 * @version  3.9.4
 	 */
-	protected function preprare_query() {
+	protected function prepare_query() {
 
 		global $wpdb;
 


### PR DESCRIPTION
## Description
I noticed there were several instances of methods called `preprared_query()` (note the misspelling of the word "prepared". This misspelling seems to have been consistent so the code executed properly, but it's probably asking for future trouble to leave those misspellings in place.
