### PR TITLE
Remove unused code

### DIFF
--- a/templates/myaccount/my-notifications.php
+++ b/templates/myaccount/my-notifications.php
@@ -13,14 +13,6 @@ $sep = apply_filters( 'lifterlms_my_account_navigation_link_separator', '&bull;'
 
 <div class="llms-sd-notification-center">
 
-<!-- 	<nav class="llms-sd-nav">
-		<ul class="llms-sd-items">
-			<?php foreach ( $sections as $data ) : ?>
-				<li class="llms-sd-item"><a class="llms-sd-link" href="<?php echo esc_url( $data['url'] ); ?>"><?php echo $data['name']; ?></a><span class="llms-sep"><?php echo $sep; ?></span></li>
-			<?php endforeach; ?>
-		</ul>
-	</nav> -->
-
 	<?php if ( isset( $notifications ) ) : ?>
 
 		<?php if ( ! $notifications ) : ?>


### PR DESCRIPTION
Probably undesirable to have old commented out code here, especially as it has resulted in un commented-out PHP being there. Not sure if that'll ever get executed, but I'm betting there's no reason for it to be there.

