### PR TITLE
Add a filter for the section footer's "more" URL and text.

### DIFF
--- a/templates/myaccount/dashboard-section.php
+++ b/templates/myaccount/dashboard-section.php
@@ -5,6 +5,7 @@
  * @version  3.19.5
  */
 defined( 'ABSPATH' ) || exit;
+$more = apply_filters( 'llms_' . $action . '_more', $more );
 ?>
 
 <section class="llms-sd-section <?php echo $slug; ?>">
@@ -21,7 +22,6 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php if ( $more ) : ?>
 		<footer class="llms-sd-section-footer">
-			<?php $more = apply_filters( 'llms_' . $action . '_more', $more ); ?>
 			<a class="llms-button-secondary" href="<?php echo esc_url( $more['url'] ); ?>"><?php echo $more['text']; ?></a>
 		</footer>
 	<?php endif; ?>

--- a/templates/myaccount/dashboard-section.php
+++ b/templates/myaccount/dashboard-section.php
@@ -21,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php if ( $more ) : ?>
 		<footer class="llms-sd-section-footer">
+			<?php $more = apply_filters( 'llms_' . $action . '_more', $more ); ?>
 			<a class="llms-button-secondary" href="<?php echo esc_url( $more['url'] ); ?>"><?php echo $more['text']; ?></a>
 		</footer>
 	<?php endif; ?>


### PR DESCRIPTION
## Description
Added the ability to filter the link URL and text in the dashboard section's footer.

## How has this been tested?
I have not successfully configured my WordPress development environment to run phpunit.
However, with this new hook, I am able to add a filter that changes the the "more" text.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests.
- [X] My code follows the LifterLMS Coding Standards.