### PR TITLE
Avoid unwanted quotes escaping in Instructor Remarks on Quiz Attempts

### DIFF
--- a/includes/controllers/class.llms.controller.admin.quiz.attempts.php
+++ b/includes/controllers/class.llms.controller.admin.quiz.attempts.php
@@ -70,7 +70,7 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 		foreach ( $questions as &$question ) {
 
 			if ( isset( $remarks[ $question['id'] ] ) ) {
-				$question['remarks'] = wp_kses_post( nl2br( $remarks[ $question['id'] ] ) );
+				$question['remarks'] = wp_kses_post( nl2br( stripslashes( $remarks[ $question['id'] ] ) ) );
 			}
 
 			if ( isset( $points[ $question['id'] ] ) ) {
@@ -98,7 +98,6 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 		do_action( 'llms_quiz_graded', $attempt->get_student()->get_id(), $attempt->get( 'quiz_id' ), $attempt );
 
 	}
-
 
 }
 


### PR DESCRIPTION
fix #746

## Description
Make sure instructor remarks slashes (e.g. for escaped quotes) are stripped before saving a quiz attempt.

Before this PR a remark reading _Mama I'm coming home_ would have been saved as:
`Mama I\'m coming home`
while with this PR it's saved as
`Mama I'm coming home`

hence fixing the issue described in #746 
 
## How has this been tested?
I've simply wrote and saved the following remark:
`Mama I'm coming home`

then checked no backslashes were added before the quote.

## Types of changes
 Bug fix (non-breaking change which fixes an issue) 


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards. 
