### PR TITLE
Improve Instructor Remarks UX on Quiz Attemps

### DIFF
--- a/assets/js/llms-quiz-attempt-review.js
+++ b/assets/js/llms-quiz-attempt-review.js
@@ -37,6 +37,10 @@
 
 			$els = $( '.llms-quiz-attempt-question:not(.type--content)' );
 
+			if ( $els.length < 1 ) {
+				return;
+			}
+
 			var title = LLMS.l10n.translate( 'Remarks to Student' ),
 				points = LLMS.l10n.translate( 'points' );
 
@@ -70,9 +74,13 @@
 
 			} );
 
-
-			$els.first().find( '.toggle-answer' ).trigger( 'click' );
-
+			var $els_first = $els.first();
+			if ( ! $els_first.find( '.llms-quiz-attempt-question-main' ).is( ':visible' ) ) {
+				// expand the first question toggle.
+				$els_first.find( '.toggle-answer' ).trigger( 'click' );
+			}
+			// focus on its remark textarea.
+			$els_first.find( '.llms-remarks-field' ).focus();
 		}
 
 		bind();


### PR DESCRIPTION
fix #801

## Description
Small addition to the assets/js/llms-quiz-attempt-review.js file in order to fix the issue:
on "Start Review" button click:
1) do not collapse the first question if expanded
2) focus the remarks textarea


## How has this been tested?
I followed the steps described in #801 and verified I got the expected behavior.

## Types of changes
Bug fix


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
