### PR TITLE
Make LLMS db query is_last_page method return true when there are no …

### DIFF
--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -206,7 +206,7 @@ abstract class LLMS_Database_Query {
 	 * @version  3.14.0
 	 */
 	public function is_last_page() {
-		return ( absint( $this->get( 'page' ) ) === $this->max_pages );
+		return ! $this->has_results() || ( absint( $this->get( 'page' ) ) === $this->max_pages );
 	}
 
 	/**


### PR DESCRIPTION
…results

fix #803

## Description
Added a small piece of code that will make the method `is_last_page()` of the abstract class `LLMS_Database_Query` return always `true` if the query has no results.

## How has this been tested?
I've tested it for the admin table, specifically for the Attempts table when there are no results.
As said in #803 without this PS a pagination, which depends on whether `is_last_page()` returns `true`, is shown:
![Schermata 2019-04-11 alle 10 49 41](https://user-images.githubusercontent.com/7689242/55971833-89dd5b00-5c82-11e9-9692-97b3152b6823.png)


Here's instead the same page applying this PR:
![Schermata 2019-04-11 alle 17 52 31](https://user-images.githubusercontent.com/7689242/55971874-9c579480-5c82-11e9-9605-d3662f2d0c24.png)

Even if the issue aforementioned could have been fixed in several places more adherent to the specific case, e.g. in the table class, I think it makes sense that the method `is_last_page()` returns `true` when the query has no results.

## Types of changes
Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
