### PR TITLE
Fix accessing to a not set $_GET field when filtering the Attempts table

### DIFF
--- a/includes/admin/reporting/tables/llms.table.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.attempts.php
@@ -227,7 +227,7 @@ class LLMS_Table_Quiz_Attempts extends LLMS_Admin_Table {
 	 */
 	public function set_args() {
 		return array(
-			'quiz_id' => ! empty( $this->quiz_id ) ? $this->quiz_id : absint( $_GET['quiz_id'] ),
+			'quiz_id' => ! empty( $this->quiz_id ) ? $this->quiz_id : ( isset( $_GET['quiz_id'] ) ? absint( $_GET['quiz_id'] ) : null ),
 			'student_id' => 0,
 		);
 	}

--- a/includes/admin/reporting/tables/llms.table.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.attempts.php
@@ -227,7 +227,7 @@ class LLMS_Table_Quiz_Attempts extends LLMS_Admin_Table {
 	 */
 	public function set_args() {
 		return array(
-			'quiz_id' => ! empty( $this->quiz_id ) ? $this->quiz_id : ( isset( $_GET['quiz_id'] ) ? absint( $_GET['quiz_id'] ) : null ),
+			'quiz_id'    => ! empty( $this->quiz_id ) ? $this->quiz_id : ( isset( $_GET['quiz_id'] ) ? absint( $_GET['quiz_id'] ) : null ),
 			'student_id' => 0,
 		);
 	}


### PR DESCRIPTION
fix #805

## Description
(In the `LLMS_Table_Quiz_Attempts` class, when defining the structure of arguments used to pass to the `get_results` method) Added a check on the existence of the $_GET['quiz_id'] before referring to it, and fall back on null if it is not set.
  
## How has this been tested?
Tested following the Reproduction Steps described in https://github.com/gocodebox/lifterlms/issues/805 and verified no PHP notices were logged.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
