### PR TITLE
Make sure backslashes in post content are kept on cloning/importing

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -321,7 +321,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @version  3.14.6
 	 */
 	private function create( $title = '' ) {
-		return wp_insert_post( apply_filters( 'llms_new_' . $this->model_post_type, $this->get_creation_args( $title ) ), true );
+		return wp_insert_post( wp_slash( apply_filters( 'llms_new_' . $this->model_post_type, $this->get_creation_args( $title ) ) ), true );
 	}
 
 	/**

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -884,7 +884,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 			$args[ $post_key ] = apply_filters( 'llms_set_' . $this->model_post_type . '_' . $key, $val, $this );
 
-			if ( wp_update_post( $args ) ) {
+			if ( wp_update_post( wp_slash( $args ) ) ) {
 				$this->post->{$post_key} = $val;
 				return true;
 			} else {


### PR DESCRIPTION
fix #596

## Description
Fix the cases when backslashes in content disappeared on cloning/importing

## How has this been tested?
I tested it by cloning, exporting and importing, a course (and a single lesson) with a backslash in its content.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
