### PR TITLE
Define missing properties

### DIFF
--- a/includes/Users/User.php
+++ b/includes/Users/User.php
@@ -4,7 +4,29 @@ namespace LLMS\Users;
 
 class User
 {
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $first_name;
+
+	/**
+	 * @var int
+	 * @since 1.3.0
+	 */
 	private $id;
+
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $last_name;
+
+	/**
+	 * @var array
+	 * @since 1.3.0
+	 */
+	protected $quiz_data;
 
 	/**
 	 * Constructor

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -10,23 +10,93 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 abstract class LLMS_Analytics_Widget {
 
-	public $charts = false;
-	public $success = false;
-	public $message = '';
-	public $response;
+	/**
+	 * @var array
+	 * @since 3.0.0
+	 */
+	protected $chart_data;
 
-	protected $date_start;
+	/**
+	 * @var bool
+	 * @since 3.0.0
+	 */
+	public $charts = false;
+
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 * @deprecated 3.0.0
+	 */
 	protected $date_end;
 
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 * @deprecated 3.0.0
+	 */
+	protected $date_start;
+
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 */
+	public $message = '';
+
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 * @deprecated 3.0.0
+	 */
 	protected $output;
 
-	protected $query;
-	protected $query_vars;
-	protected $query_function;
+	/**
+	 * One of the wpdb constants: OBJECT, OBJECT_K, ARRAY_A, or ARRAY_N
+	 * @var string
+	 * @since 3.0.0
+	 */
 	protected $output_type;
-	// protected $prepared_query;
 
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 */
+	protected $prepared_query;
+
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 */
+	protected $query;
+
+	/**
+	 * @var string
+	 * @since 3.0.0
+	 */
+	protected $query_function;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $query_vars;
+
+	/**
+	 * @var int
+	 * @since 3.0.0
+	 */
+	public $response;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
 	public $results = array();
+
+	/**
+	 * @var bool
+	 * @since 3.0.0
+	 */
+	public $success = false;
 
 	abstract protected function format_response();
 	abstract protected function set_query();

--- a/includes/abstracts/llms.abstract.exportable.admin.table.php
+++ b/includes/abstracts/llms.abstract.exportable.admin.table.php
@@ -14,6 +14,19 @@ defined( 'ABSPATH' ) || exit;
 abstract class LLMS_Abstract_Exportable_Admin_Table {
 
 	/**
+	 * @var int
+	 * @since 3.28.0
+	 */
+	protected $current_page;
+
+	/**
+	 * Unique ID for the table
+	 * @var  string
+	 * @since 3.28.0
+	 */
+	protected $id;
+
+	/**
 	 * Is the Table Exportable?
 	 * @var  boolean
 	 */

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -39,10 +39,23 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	protected $auto_dupcheck = false;
 
 	/**
+	 * @var LLMS_Course
+	 * @since 3.8.0
+	 */
+	protected $course;
+
+	/**
 	 * WP Post ID associated with the triggering action
 	 * @var  null
 	 */
 	protected $post_id = null;
+
+	/**
+	 * WP Post ID of the post which triggered the achievement to be awarded
+	 * @var int
+	 * @since 3.8.0
+	 */
+	protected $related_post_id;
 
 	/**
 	 * Array of subscriptions for the notification

--- a/includes/abstracts/llms.abstract.notification.view.php
+++ b/includes/abstracts/llms.abstract.notification.view.php
@@ -29,6 +29,12 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 	);
 
 	/**
+	 * @var string
+	 * @since 3.8.0
+	 */
+	protected $id;
+
+	/**
 	 * Instance of the LLMS_Post_Model for the triggering post
 	 * @var  [type]
 	 */

--- a/includes/achievements/class.llms.achievement.user.php
+++ b/includes/achievements/class.llms.achievement.user.php
@@ -9,9 +9,67 @@ defined( 'ABSPATH' ) || exit;
 */
 class LLMS_Achievement_User extends LLMS_Achievement {
 
-	var $user_login;
-	var $user_email;
-	var $user_pass;
+	/**
+	 * @var string|false
+	 * @since 1.0.0
+	 */
+	protected $account_link;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $recipient;
+
+	/**
+	 * partial path and file name of HTML template
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $template_html;
+
+	/**
+	 * user meta fields
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $user = array();
+
+	/**
+	 * @var WP_User|false
+	 * @since 1.0.0
+	 */
+	protected $user_data;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_email;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_firstname;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_lastname;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_login;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_pass;
 
 	/**
 	 * Constructor

--- a/includes/admin/analytics/class.llms.analytics.page.php
+++ b/includes/admin/analytics/class.llms.analytics.page.php
@@ -10,6 +10,18 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Analytics_Page {
 
 	/**
+	 * @var      string
+	 * @since    1.0.0
+	 */
+	protected $id;
+
+	/**
+	 * @var      string
+	 * @since    1.0.0
+	 */
+	protected $label;
+
+	/**
 	 * Add the analytics page
 	 *
 	 * @return array

--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -15,6 +15,12 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_AddOns {
 
 	/**
+	 * @var array
+	 * @since 3.5.0
+	 */
+	protected $data = array();
+
+	/**
 	 * Get the current section from the query string
 	 * defaults to "all"
 	 * @return   string

--- a/includes/admin/class.llms.student.bulk.enroll.php
+++ b/includes/admin/class.llms.student.bulk.enroll.php
@@ -15,7 +15,7 @@ class LLMS_Student_Bulk_Enroll {
 	 * @var string[]
 	 * @since 3.19.4
 	 */
-	public $user_admin_notices = array();
+	public $admin_notices = array();
 
 	/**
 	 * Product (Course/Membership) ID

--- a/includes/admin/class.llms.student.bulk.enroll.php
+++ b/includes/admin/class.llms.student.bulk.enroll.php
@@ -12,7 +12,8 @@ class LLMS_Student_Bulk_Enroll {
 	/**
 	 * Admin notices
 	 *
-	 * @var array
+	 * @var string[]
+	 * @since 3.19.4
 	 */
 	public $user_admin_notices = array();
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
@@ -7,6 +7,14 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Metabox_Editor_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface {
 
 	/**
+	 * Array of editor arguments.
+	 * @see _WP_Editors::parse_settings()
+	 * @var array
+	 * @since 3.11.0
+	 */
+	protected $settings;
+
+	/**
 	 * Class constructor
 	 * @param array $_field Array containing information about field
 	 */

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
@@ -15,6 +15,20 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;
 
+	/**
+	 * temporary order ids
+	 * @var array
+	 * @since 3.0.0
+	 */
+	protected $temp = array();
+
+	/**
+	 * temporary query
+	 * @since 3.0.0
+	 * @var array
+	 */
+	protected $temp_q = array();
+
 	protected function get_chart_data() {
 		return array(
 			'type' => 'amount', // type of field

--- a/includes/admin/settings/class.llms.settings.notifications.php
+++ b/includes/admin/settings/class.llms.settings.notifications.php
@@ -9,6 +9,12 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Settings_Notifications extends LLMS_Settings_Page {
 
 	/**
+	 * @var LLMS_Abstract_Notification_View
+	 * @since 3.8.0
+	 */
+	protected $view;
+
+	/**
 	 * Constructor
 	 * @since    3.8.0
 	 * @version  3.24.0

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -19,6 +19,20 @@ class LLMS_Settings_Page {
 	protected $flush = false;
 
 	/**
+	 * Settings identifier
+	 * @var      string
+	 * @since    1.0.0
+	 */
+	protected $id;
+
+	/**
+	 * Settings page link label
+	 * @var      string
+	 * @since    1.0.0
+	 */
+	protected $label;
+
+	/**
 	 * Add the settings page
 	 * @return array
 	 * @since    1.0.0

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -23,7 +23,7 @@ class LLMS_Settings_Page {
 	 * @var      string
 	 * @since    1.0.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * Settings page link label

--- a/includes/certificates/class.llms.certificate.user.php
+++ b/includes/certificates/class.llms.certificate.user.php
@@ -10,9 +10,72 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Certificate_User extends LLMS_Certificate {
 
-	var $user_login;
-	var $user_email;
-	var $user_pass;
+	/**
+	 * @var string|false
+	 * @since 1.0.0
+	 */
+	protected $account_link;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $email_content;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $recipient;
+
+	/**
+	 * partial path and file name of HTML template
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $template_html;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $user = array();
+
+	/**
+	 * @var WP_User|false
+	 * @since 1.0.0
+	 */
+	protected $user_data;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_email;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_firstname;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_lastname;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_login;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $user_pass;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -43,13 +43,6 @@ class LLMS_Achievement {
 	/**
 	 * @var string
 	 * @since 1.0.0
-	 * @deprecated 1.1.1
-	 */
-	var $heading;
-
-	/**
-	 * @var string
-	 * @since 1.0.0
 	 */
 	protected $id;
 

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -9,10 +9,87 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Achievement {
 
-	// is the achievement enabled
-	var $enabled;
+	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $achievement_template_id;
 
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $achievement_title;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $content;
+
+	/**
+	 * is the achievement enabled
+	 * @var bool
+	 * @since 1.0.0
+	 */
+	protected $enabled;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $find = array();
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 * @deprecated 1.1.1
+	 */
 	var $heading;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $id;
+
+	/**
+	 * image id
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $image;
+
+	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $lesson_id;
+
+	/**
+	 * @var WP_User
+	 * @since 1.0.0
+	 */
+	protected $object;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $replace = array();
+
+	/**
+	 * post title
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $title;
+
+	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $userid;
 
 	function __construct() {
 

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -136,7 +136,9 @@ class LLMS_Achievement {
 	/**
 	 * Get the content of the Achievement
 	 *
-	 * @return array $achievement_content [data needed to generate achievement]
+	 * @return  string data needed to generate achievement
+	 * @since   1.0.0
+	 * @version 1.4.1
 	 */
 	function get_content() {
 

--- a/includes/class.llms.certificate.php
+++ b/includes/class.llms.certificate.php
@@ -9,10 +9,93 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Certificate {
 
 	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $certificate_template_id;
+
+	/**
+	 * post title
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $certificate_title;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $content;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $email_type;
+
+	/**
 	 * Certificate Enabled
 	 * @var bool
+	 * @since 1.0.0
+	 * @deprecated 2.2.0
 	 */
 	var $enabled;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $find = array();
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $id;
+
+	/**
+	 * image id
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $image;
+
+	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $lesson_id;
+
+	/**
+	 * @var WP_User
+	 * @since 1.0.0
+	 */
+	protected $object;
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $replace = array();
+
+	/**
+	 * @var bool
+	 * @since 1.0.0
+	 */
+	protected $sending;
+
+	/**
+	 * post title
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $title;
+
+	/**
+	 * @var int
+	 * @since 1.0.0
+	 */
+	protected $userid;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -15,6 +15,12 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Certificates {
 
 	/**
+	 * @var LLMS_Certificate_User[]
+	 * @since 1.1.1
+	 */
+	protected $certs = array();
+
+	/**
 	 * Instance
 	 * @var  null
 	 */

--- a/includes/class.llms.course.basic.php
+++ b/includes/class.llms.course.basic.php
@@ -13,6 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Course_Basic extends LLMS_Course {
 
 	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $course_type;
+
+	/**
 	 * post id
 	 * @var int
 	 */

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -8,6 +8,22 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 class LLMS_Course_Data {
 
+	/**
+	 * @var LLMS_Course
+	 * @since 3.15.0
+	 */
+	protected $course;
+
+	/**
+	 * @var int
+	 * @since 3.15.0
+	 */
+	protected $course_id;
+
+	/**
+	 * @var array
+	 * @since 3.15.0
+	 */
 	protected $dates = array();
 
 	/**

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -9,6 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 
 	/**
+	 * @var string
+	 * @since 3.0.0
+	 */
+	protected $payment_instructions;
+
+	/**
 	 * Constructor
 	 * @return  void
 	 * @since   3.0.0

--- a/includes/class.llms.lesson.basic.php
+++ b/includes/class.llms.lesson.basic.php
@@ -17,6 +17,12 @@ class LLMS_Lesson_Basic extends LLMS_Lesson {
 	public $id;
 
 	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $lesson_type;
+
+	/**
 	 * post object
 	 * @var object
 	 */

--- a/includes/class.llms.question.manager.php
+++ b/includes/class.llms.question.manager.php
@@ -15,6 +15,12 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Question_Manager {
 
 	/**
+	 * @var LLMS_Question|LLMS_Quiz
+	 * @since 3.16.0
+	 */
+	protected $parent;
+
+	/**
 	 * Constructor
 	 * @param    obj     $parent  instance of the parent LLMS_Quiz or LLMS_Question
 	 * @since    3.16.0

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -9,6 +9,19 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Quiz_Data extends LLMS_Course_Data {
 
 	/**
+	 * @var LLMS_Quiz
+	 * @since 3.16.0
+	 */
+	protected $quiz;
+
+	/**
+	 * WP Post ID of the quiz
+	 * @var int
+	 * @since 3.16.0
+	 */
+	protected $quiz_id;
+
+	/**
 	 * Constructor
 	 * @param    int     $quiz_id  WP Post ID of the quiz
 	 * @since    3.16.0

--- a/includes/class.llms.quiz.legacy.php
+++ b/includes/class.llms.quiz.legacy.php
@@ -17,6 +17,60 @@ class LLMS_Quiz_Legacy {
 	public $id;
 
 	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $llms_allowed_attempts;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $llms_passing_percent;
+
+	/**
+	 * @var LLMS_Question[]
+	 * @since
+	 */
+	protected $llms_questions;
+
+	/**
+	 * @var string
+	 * @since 1.4.0
+	 */
+	protected $llms_random_answers;
+
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $llms_show_correct_answer;
+
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $llms_show_options_description_right_answer;
+
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $llms_show_options_description_wrong_answer;
+
+	/**
+	 * @var string
+	 * @since 1.3.0
+	 */
+	protected $llms_show_results;
+
+	/**
+	 * @var string
+	 * @since 1.2.2
+	 */
+	protected $llms_time_limit;
+
+	/**
 	* Post Object
 	* @access public
 	* @var array

--- a/includes/class.llms.track.php
+++ b/includes/class.llms.track.php
@@ -12,6 +12,12 @@ class LLMS_Track {
 	public $taxonomy = 'course_track';
 
 	/**
+	 * @var WP_Term
+	 * @since 3.0.0
+	 */
+	public $term;
+
+	/**
 	 * Constructor
 	 *
 	 * @param    int|string|obj     $term   term_id, term_slug, or instance of a WP_Term

--- a/includes/emails/class.llms.email.engagement.php
+++ b/includes/emails/class.llms.email.engagement.php
@@ -10,7 +10,17 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 
 class LLMS_Email_Engagement extends LLMS_Email {
 
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
 	protected $id = 'engagement';
+
+	/**
+	 * @var WP_User
+	 * @since 3.8.0
+	 */
+	protected $student;
 
 	/**
 	 * Initialize all variables

--- a/includes/emails/class.llms.email.php
+++ b/includes/emails/class.llms.email.php
@@ -14,20 +14,76 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Email {
 
-	protected $id = 'generic';
+	/**
+	 * @var array
+	 * @since 3.15.0
+	 */
+	private $attachments = array();
 
+	/**
+	 * @var string
+	 * @since 3.8.0
+	 */
+	protected $body = '';
+
+	/**
+	 * @var string
+	 * @since 3.8.0
+	 */
 	protected $content_type = 'text/html';
 
-	protected $body = '';
-	protected $heading = '';
-	protected $subject = '';
+	/**
+	 * @var WP_Post
+	 * @since 3.26.1
+	 */
+	protected $email_post;
 
-	private $attachments = array();
-	private $headers = array();
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
 	private $find = array();
+
+	/**
+	 * @var array
+	 * @since 3.8.0
+	 */
+	private $headers = array();
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $heading = '';
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $id = 'generic';
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
 	private $recipient = array();
+
+	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
 	private $replace = array();
 
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $subject = '';
+
+	/**
+	 * @var string
+	 * @since 3.8.0
+	 */
 	protected $template_html = 'emails/template.php';
 
 	/**

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -87,6 +87,18 @@ implements LLMS_Interface_Post_Audio
 	protected $model_post_type = 'course';
 
 	/**
+	 * @var array
+	 * @since 1.0.0
+	 */
+	protected $sections;
+
+	/**
+	 * @var string
+	 * @since 1.0.0
+	 */
+	protected $sku;
+
+	/**
 	 * Retrieve an instance of the Post Instructors model
 	 * @return   obj
 	 * @since    3.13.0

--- a/includes/models/model.llms.post.instructors.php
+++ b/includes/models/model.llms.post.instructors.php
@@ -21,6 +21,19 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Post_Instructors {
 
 	/**
+	 * WP Post ID
+	 * @var int
+	 * @since 3.13.0
+	 */
+	protected $id;
+
+	/**
+	 * @var LLMS_Post_Model
+	 * @since 3.13.0
+	 */
+	protected $post;
+
+	/**
 	 * Constructor
 	 * @param    mixed     $post  (obj) LLMS_Post_Model
 	 *                            (obj) WP_Post

--- a/includes/notifications/controllers/class.llms.notification.controller.course.track.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.course.track.complete.php
@@ -29,6 +29,12 @@ class LLMS_Notification_Controller_Course_Track_Complete extends LLMS_Abstract_N
 	protected $action_hooks = array( 'lifterlms_course_track_completed' );
 
 	/**
+	 * @var LLMS_Track
+	 * @since 3.8.0
+	 */
+	protected $track;
+
+	/**
 	 * Callback function called when a course track is completed by a student
 	 * @param    int     $student_id  WP User ID of a LifterLMS Student
 	 * @param    int     $course_track_id   WP Post ID of a LifterLMS Course

--- a/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
@@ -29,6 +29,12 @@ class LLMS_Notification_Controller_Lesson_Complete extends LLMS_Abstract_Notific
 	protected $action_hooks = array( 'lifterlms_lesson_completed' );
 
 	/**
+	 * @var LLMS_Lesson
+	 * @since 3.8.0
+	 */
+	protected $lesson;
+
+	/**
 	 * Callback function called when a lesson is completed by a student
 	 * @param    int     $student_id  WP User ID of a LifterLMS Student
 	 * @param    int     $lesson_id   WP Post ID of a LifterLMS Lesson

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -27,6 +27,12 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	protected $action_hooks = array( 'lifterlms_quiz_failed' );
 
 	/**
+	 * @var LLMS_Quiz
+	 * @since 3.8.0
+	 */
+	protected $quiz;
+
+	/**
 	 * Determines if test notifications can be sent
 	 * @var  array
 	 */

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
@@ -27,6 +27,12 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 	protected $action_hooks = array( 'lifterlms_quiz_passed' );
 
 	/**
+	 * @var LLMS_Quiz
+	 * @since 3.8.0
+	 */
+	protected $quiz;
+
+	/**
 	 * Determines if test notifications can be sent
 	 * @var  bool
 	 */

--- a/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
@@ -29,6 +29,12 @@ class LLMS_Notification_Controller_Section_Complete extends LLMS_Abstract_Notifi
 	protected $action_hooks = array( 'lifterlms_section_completed' );
 
 	/**
+	 * @var LLMS_Section
+	 * @since 3.8.0
+	 */
+	protected $section;
+
+	/**
 	 * Callback function called when a section is completed by a student
 	 * @param    int     $student_id  WP User ID of a LifterLMS Student
 	 * @param    int     $section_id   WP Post ID of a LifterLMS Section


### PR DESCRIPTION
## Description
Added missing property definitions.

## How has this been tested?
PHPUnit and PHPCodeSniffer.

## Types of changes
Added DocBlocks with description, `@var`, `@since` and `@deprecated` (where applicable) to new (and some existing) property definitions.
Most property definitions are now sorted alphabetically.

Properties that were not defined or defined with the `var` keyword are now defined with the `protected`
 keyword if the property is only used within that class's hierarchy. This may break other WordPress plugins that expect the properties to be `public`.

## Checklist:
- [X] My code has been tested.
- [X] My code passes all existing automated tests.
- [X] My code follows the LifterLMS Coding Standards.
