### PR TITLE
Change newly defined properties (and defined with var) to public

### DIFF
--- a/includes/Users/User.php
+++ b/includes/Users/User.php
@@ -8,7 +8,7 @@ class User
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $first_name;
+	public $first_name;
 
 	/**
 	 * @var int
@@ -20,7 +20,7 @@ class User
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $last_name;
+	public $last_name;
 
 	/**
 	 * @var array

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -14,7 +14,7 @@ abstract class LLMS_Analytics_Widget {
 	 * @var array
 	 * @since 3.0.0
 	 */
-	protected $chart_data;
+	public $chart_data;
 
 	/**
 	 * @var bool

--- a/includes/abstracts/llms.abstract.exportable.admin.table.php
+++ b/includes/abstracts/llms.abstract.exportable.admin.table.php
@@ -17,14 +17,14 @@ abstract class LLMS_Abstract_Exportable_Admin_Table {
 	 * @var int
 	 * @since 3.28.0
 	 */
-	protected $current_page;
+	public $current_page;
 
 	/**
 	 * Unique ID for the table
 	 * @var  string
 	 * @since 3.28.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * Is the Table Exportable?

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -42,7 +42,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 * @var LLMS_Course
 	 * @since 3.8.0
 	 */
-	protected $course;
+	public $course;
 
 	/**
 	 * WP Post ID associated with the triggering action
@@ -55,7 +55,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 * @var int
 	 * @since 3.8.0
 	 */
-	protected $related_post_id;
+	public $related_post_id;
 
 	/**
 	 * Array of subscriptions for the notification

--- a/includes/abstracts/llms.abstract.notification.view.php
+++ b/includes/abstracts/llms.abstract.notification.view.php
@@ -32,7 +32,7 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 	 * @var string
 	 * @since 3.8.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * Instance of the LLMS_Post_Model for the triggering post

--- a/includes/achievements/class.llms.achievement.user.php
+++ b/includes/achievements/class.llms.achievement.user.php
@@ -13,63 +13,63 @@ class LLMS_Achievement_User extends LLMS_Achievement {
 	 * @var string|false
 	 * @since 1.0.0
 	 */
-	protected $account_link;
+	public $account_link;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $recipient;
+	public $recipient;
 
 	/**
 	 * partial path and file name of HTML template
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $template_html;
+	public $template_html;
 
 	/**
 	 * user meta fields
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $user = array();
+	public $user = array();
 
 	/**
 	 * @var WP_User|false
 	 * @since 1.0.0
 	 */
-	protected $user_data;
+	public $user_data;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_email;
+	public $user_email;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_firstname;
+	public $user_firstname;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_lastname;
+	public $user_lastname;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_login;
+	public $user_login;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_pass;
+	public $user_pass;
 
 	/**
 	 * Constructor

--- a/includes/admin/analytics/class.llms.analytics.page.php
+++ b/includes/admin/analytics/class.llms.analytics.page.php
@@ -13,13 +13,13 @@ class LLMS_Analytics_Page {
 	 * @var      string
 	 * @since    1.0.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * @var      string
 	 * @since    1.0.0
 	 */
-	protected $label;
+	public $label;
 
 	/**
 	 * Add the analytics page

--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -18,7 +18,7 @@ class LLMS_Admin_AddOns {
 	 * @var array
 	 * @since 3.5.0
 	 */
-	protected $data = array();
+	public $data = array();
 
 	/**
 	 * Get the current section from the query string

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
@@ -12,7 +12,7 @@ class LLMS_Metabox_Editor_Field extends LLMS_Metabox_Field implements Meta_Box_F
 	 * @var array
 	 * @since 3.11.0
 	 */
-	protected $settings;
+	public $settings;
 
 	/**
 	 * Class constructor

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
@@ -20,14 +20,14 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 	 * @var array
 	 * @since 3.0.0
 	 */
-	protected $temp = array();
+	public $temp = array();
 
 	/**
 	 * temporary query
 	 * @since 3.0.0
 	 * @var array
 	 */
-	protected $temp_q = array();
+	public $temp_q = array();
 
 	protected function get_chart_data() {
 		return array(

--- a/includes/admin/settings/class.llms.settings.notifications.php
+++ b/includes/admin/settings/class.llms.settings.notifications.php
@@ -12,7 +12,7 @@ class LLMS_Settings_Notifications extends LLMS_Settings_Page {
 	 * @var LLMS_Abstract_Notification_View
 	 * @since 3.8.0
 	 */
-	protected $view;
+	public $view;
 
 	/**
 	 * Constructor

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -30,7 +30,7 @@ class LLMS_Settings_Page {
 	 * @var      string
 	 * @since    1.0.0
 	 */
-	protected $label;
+	public $label;
 
 	/**
 	 * Add the settings page

--- a/includes/certificates/class.llms.certificate.user.php
+++ b/includes/certificates/class.llms.certificate.user.php
@@ -14,68 +14,68 @@ class LLMS_Certificate_User extends LLMS_Certificate {
 	 * @var string|false
 	 * @since 1.0.0
 	 */
-	protected $account_link;
+	public $account_link;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $email_content;
+	public $email_content;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $recipient;
+	public $recipient;
 
 	/**
 	 * partial path and file name of HTML template
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $template_html;
+	public $template_html;
 
 	/**
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $user = array();
+	public $user = array();
 
 	/**
 	 * @var WP_User|false
 	 * @since 1.0.0
 	 */
-	protected $user_data;
+	public $user_data;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_email;
+	public $user_email;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_firstname;
+	public $user_firstname;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_lastname;
+	public $user_lastname;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_login;
+	public $user_login;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $user_pass;
+	public $user_pass;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -13,76 +13,76 @@ class LLMS_Achievement {
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $achievement_template_id;
+	public $achievement_template_id;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $achievement_title;
+	public $achievement_title;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $content;
+	public $content;
 
 	/**
 	 * is the achievement enabled
 	 * @var bool
 	 * @since 1.0.0
 	 */
-	protected $enabled;
+	public $enabled;
 
 	/**
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $find = array();
+	public $find = array();
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * image id
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $image;
+	public $image;
 
 	/**
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $lesson_id;
+	public $lesson_id;
 
 	/**
 	 * @var WP_User
 	 * @since 1.0.0
 	 */
-	protected $object;
+	public $object;
 
 	/**
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $replace = array();
+	public $replace = array();
 
 	/**
 	 * post title
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $title;
+	public $title;
 
 	/**
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $userid;
+	public $userid;
 
 	function __construct() {
 

--- a/includes/class.llms.certificate.php
+++ b/includes/class.llms.certificate.php
@@ -12,26 +12,26 @@ class LLMS_Certificate {
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $certificate_template_id;
+	public $certificate_template_id;
 
 	/**
 	 * post title
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $certificate_title;
+	public $certificate_title;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $content;
+	public $content;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $email_type;
+	public $email_type;
 
 	/**
 	 * Certificate Enabled
@@ -39,63 +39,63 @@ class LLMS_Certificate {
 	 * @since 1.0.0
 	 * @deprecated 2.2.0
 	 */
-	var $enabled;
+	public $enabled;
 
 	/**
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $find = array();
+	public $find = array();
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * image id
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $image;
+	public $image;
 
 	/**
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $lesson_id;
+	public $lesson_id;
 
 	/**
 	 * @var WP_User
 	 * @since 1.0.0
 	 */
-	protected $object;
+	public $object;
 
 	/**
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $replace = array();
+	public $replace = array();
 
 	/**
 	 * @var bool
 	 * @since 1.0.0
 	 */
-	protected $sending;
+	public $sending;
 
 	/**
 	 * post title
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $title;
+	public $title;
 
 	/**
 	 * @var int
 	 * @since 1.0.0
 	 */
-	protected $userid;
+	public $userid;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -18,7 +18,7 @@ class LLMS_Certificates {
 	 * @var LLMS_Certificate_User[]
 	 * @since 1.1.1
 	 */
-	protected $certs = array();
+	public $certs = array();
 
 	/**
 	 * Instance

--- a/includes/class.llms.course.basic.php
+++ b/includes/class.llms.course.basic.php
@@ -16,7 +16,7 @@ class LLMS_Course_Basic extends LLMS_Course {
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $course_type;
+	public $course_type;
 
 	/**
 	 * post id

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -12,13 +12,13 @@ class LLMS_Course_Data {
 	 * @var LLMS_Course
 	 * @since 3.15.0
 	 */
-	protected $course;
+	public $course;
 
 	/**
 	 * @var int
 	 * @since 3.15.0
 	 */
-	protected $course_id;
+	public $course_id;
 
 	/**
 	 * @var array

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -12,7 +12,7 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 	 * @var string
 	 * @since 3.0.0
 	 */
-	protected $payment_instructions;
+	public $payment_instructions;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.lesson.basic.php
+++ b/includes/class.llms.lesson.basic.php
@@ -20,7 +20,7 @@ class LLMS_Lesson_Basic extends LLMS_Lesson {
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $lesson_type;
+	public $lesson_type;
 
 	/**
 	 * post object

--- a/includes/class.llms.question.manager.php
+++ b/includes/class.llms.question.manager.php
@@ -18,7 +18,7 @@ class LLMS_Question_Manager {
 	 * @var LLMS_Question|LLMS_Quiz
 	 * @since 3.16.0
 	 */
-	protected $parent;
+	public $parent;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -12,14 +12,14 @@ class LLMS_Quiz_Data extends LLMS_Course_Data {
 	 * @var LLMS_Quiz
 	 * @since 3.16.0
 	 */
-	protected $quiz;
+	public $quiz;
 
 	/**
 	 * WP Post ID of the quiz
 	 * @var int
 	 * @since 3.16.0
 	 */
-	protected $quiz_id;
+	public $quiz_id;
 
 	/**
 	 * Constructor

--- a/includes/class.llms.quiz.legacy.php
+++ b/includes/class.llms.quiz.legacy.php
@@ -20,55 +20,55 @@ class LLMS_Quiz_Legacy {
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $llms_allowed_attempts;
+	public $llms_allowed_attempts;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $llms_passing_percent;
+	public $llms_passing_percent;
 
 	/**
 	 * @var LLMS_Question[]
 	 * @since
 	 */
-	protected $llms_questions;
+	public $llms_questions;
 
 	/**
 	 * @var string
 	 * @since 1.4.0
 	 */
-	protected $llms_random_answers;
+	public $llms_random_answers;
 
 	/**
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $llms_show_correct_answer;
+	public $llms_show_correct_answer;
 
 	/**
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $llms_show_options_description_right_answer;
+	public $llms_show_options_description_right_answer;
 
 	/**
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $llms_show_options_description_wrong_answer;
+	public $llms_show_options_description_wrong_answer;
 
 	/**
 	 * @var string
 	 * @since 1.3.0
 	 */
-	protected $llms_show_results;
+	public $llms_show_results;
 
 	/**
 	 * @var string
 	 * @since 1.2.2
 	 */
-	protected $llms_time_limit;
+	public $llms_time_limit;
 
 	/**
 	* Post Object

--- a/includes/emails/class.llms.email.engagement.php
+++ b/includes/emails/class.llms.email.engagement.php
@@ -20,7 +20,7 @@ class LLMS_Email_Engagement extends LLMS_Email {
 	 * @var WP_User
 	 * @since 3.8.0
 	 */
-	protected $student;
+	public $student;
 
 	/**
 	 * Initialize all variables

--- a/includes/emails/class.llms.email.php
+++ b/includes/emails/class.llms.email.php
@@ -36,7 +36,7 @@ class LLMS_Email {
 	 * @var WP_Post
 	 * @since 3.26.1
 	 */
-	protected $email_post;
+	public $email_post;
 
 	/**
 	 * @var array

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -90,13 +90,13 @@ implements LLMS_Interface_Post_Audio
 	 * @var array
 	 * @since 1.0.0
 	 */
-	protected $sections;
+	public $sections;
 
 	/**
 	 * @var string
 	 * @since 1.0.0
 	 */
-	protected $sku;
+	public $sku;
 
 	/**
 	 * Retrieve an instance of the Post Instructors model

--- a/includes/models/model.llms.post.instructors.php
+++ b/includes/models/model.llms.post.instructors.php
@@ -25,13 +25,13 @@ class LLMS_Post_Instructors {
 	 * @var int
 	 * @since 3.13.0
 	 */
-	protected $id;
+	public $id;
 
 	/**
 	 * @var LLMS_Post_Model
 	 * @since 3.13.0
 	 */
-	protected $post;
+	public $post;
 
 	/**
 	 * Constructor

--- a/includes/notifications/controllers/class.llms.notification.controller.course.track.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.course.track.complete.php
@@ -32,7 +32,7 @@ class LLMS_Notification_Controller_Course_Track_Complete extends LLMS_Abstract_N
 	 * @var LLMS_Track
 	 * @since 3.8.0
 	 */
-	protected $track;
+	public $track;
 
 	/**
 	 * Callback function called when a course track is completed by a student

--- a/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
@@ -32,7 +32,7 @@ class LLMS_Notification_Controller_Lesson_Complete extends LLMS_Abstract_Notific
 	 * @var LLMS_Lesson
 	 * @since 3.8.0
 	 */
-	protected $lesson;
+	public $lesson;
 
 	/**
 	 * Callback function called when a lesson is completed by a student

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -30,7 +30,7 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	 * @var LLMS_Quiz
 	 * @since 3.8.0
 	 */
-	protected $quiz;
+	public $quiz;
 
 	/**
 	 * Determines if test notifications can be sent

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
@@ -30,7 +30,7 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 	 * @var LLMS_Quiz
 	 * @since 3.8.0
 	 */
-	protected $quiz;
+	public $quiz;
 
 	/**
 	 * Determines if test notifications can be sent

--- a/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
@@ -32,7 +32,7 @@ class LLMS_Notification_Controller_Section_Complete extends LLMS_Abstract_Notifi
 	 * @var LLMS_Section
 	 * @since 3.8.0
 	 */
-	protected $section;
+	public $section;
 
 	/**
 	 * Callback function called when a section is completed by a student


### PR DESCRIPTION
## Description
Change visibility of recently defined properties (and redefined from var keyword) to `public`. This prevents breaking other plugins that use the previously undefined properties.

## How has this been tested?
PHPUnit and PHPCodeSniffer.

## Checklist:
- [X] My code has been tested.
- [X] My code passes all existing automated tests.
- [X] My code follows the LifterLMS Coding Standards.
