### PR TITLE
Fix Composer script paths for Windows compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,14 +53,14 @@
       "\"vendor/bin/phpcs\" --config-set default_standard ./phpcs.xml"
     ],
     "phpcs": "composer run-script check-cs",
-    "check-cs": "./vendor/bin/phpcs --colors --extensions=php -n lifterlms.php includes/ templates/",
-    "fix-cs": "./vendor/bin/phpcbf --extensions=php -n lifterlms.php includes/ templates/",
+    "check-cs": "\"vendor/bin/phpcs\" --colors --extensions=php -n lifterlms.php includes/ templates/",
+    "fix-cs": "\"vendor/bin/phpcbf\" --extensions=php -n lifterlms.php includes/ templates/",
     "tests-install": [
-      "vendor/bin/llms-tests teardown llms_tests root password 127.0.0.1",
-      "vendor/bin/llms-tests install llms_tests root password 127.0.0.1"
+      "\"vendor/bin/llms-tests\" teardown llms_tests root password 127.0.0.1",
+      "\"vendor/bin/llms-tests\" install llms_tests root password 127.0.0.1"
     ],
     "tests-run": [
-      "vendor/bin/phpunit"
+      "\"vendor/bin/phpunit\""
     ]
   }
 }


### PR DESCRIPTION
## Description
Added quotes around the path and command (when the script uses a path) for compatibility with Windows OS.

## How has this been tested?
Tested running Composer scripts from Windows 10 and CentOS 7.

## Checklist:
- [X] My code has been tested.
- [X] My code passes all existing automated tests.
- [X] My code follows the LifterLMS Coding Standards.
