### PR TITLE
Fix typo in header sent in download_csv().

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
@@ -193,7 +193,7 @@ class LLMS_Meta_Box_Voucher_Export {
 	public static function download_csv( $csv, $name ) {
 
 		header( 'Content-Type: application/csv' );
-		header( 'Content-Disposition: attachement; filename="' . $name . '";' );
+		header( 'Content-Disposition: attachment; filename="' . $name . '";' );
 
 		echo $csv;
 		exit;


### PR DESCRIPTION
## Description
Corrected the word "attachment" in the `Content-Disposition` header, which may have caused download issues in some browsers.

## How has this been tested?
Created a voucher and exported it. Examined HTTP headers in Chrome's DevTools.
PHPUnit and PHPCodeSniffer.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
