### PR TITLE
Fix typo in 'php_time_limit' key name.

### DIFF
--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -408,7 +408,7 @@ class LLMS_Data {
 			$data['php_max_input_vars'] = ini_get( 'max_input_vars' );
 			$data['php_memory_limit'] = ini_get( 'memory_limit' );
 			$data['php_post_max_size'] = ini_get( 'post_max_size' );
-			$data['php_time_limt'] = ini_get( 'max_execution_time' );
+			$data['php_time_limit'] = ini_get( 'max_execution_time' );
 			$data['php_suhosin'] = extension_loaded( 'suhosin' ) ? 'Yes' : 'No';
 		}
 


### PR DESCRIPTION
## Description
Corrected typo in the `php_time_limit` key name.

## How has this been tested?
PHPUnit and PHP_CodeSniffer

## Types of changes
The server data key names are displayed on the [System Report](/wp-admin/admin.php?page=llms-status&tab=report) page. Unless someone is screen scraping that page, we shouldn't be worried about breaking expected behavior.
However, the server data is also used in the `LLMS_Tracker` class and I'm not sure how. The incorrect and corrected versions of the `php_time_limit` key are not found anywhere else in LifterLMS.

## Checklist:
- [X] My code has been tested.
- [X] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [X] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
