### PR TITLE
Fix typo in default question icon.

### DIFF
--- a/includes/class.llms.question.types.php
+++ b/includes/class.llms.question.types.php
@@ -52,7 +52,7 @@ class LLMS_Question_Types {
 				'order' => 20,
 				'name' => __( 'Other', 'lifterlms' ),
 			),
-			'icon' => 'question-cirlce',
+			'icon' => 'question-circle',
 			'id' => 'generic',
 			'image' => true,
 			'name' => esc_html__( 'Question', 'lifterlms' ),


### PR DESCRIPTION
## Description
Corrected icon name of default question.

## How has this been tested?
PHPUnit and PHP_CodeSniffer.

## Types of changes
Bug fix (non-breaking change which fixes an issue).
It appears the default icon name is not used internally by LifterLMS because `LLMS_Question_Types::get_types()` defines icons for all questions. However, this will fix any plug-ins that use the `llms_question_type_model_defaults` filter and do not have a default icon.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
