### PR TITLE
Fix typo in notification settings id.

### DIFF
--- a/includes/admin/settings/class.llms.settings.notifications.php
+++ b/includes/admin/settings/class.llms.settings.notifications.php
@@ -147,7 +147,7 @@ class LLMS_Settings_Notifications extends LLMS_Settings_Page {
 		$settings[] = array(
 			'title' => __( 'Notification Settings', 'lifterlms' ),
 			'type' => 'title',
-			'id' => 'notificati_options_title',
+			'id' => 'notification_options_title',
 		);
 
 		if ( isset( $_GET['notification'] ) ) {


### PR DESCRIPTION
## Description
Fixed typo in the HTML `id` attribute of the "Notification Settings" title element.

## How has this been tested?
PHPUnit and PHP_CodeSniffer.

## Types of changes
Bug fix (non-breaking change which fixes an issue).
Hopefully there aren't any WordPress plug-ins or themes that use the misspelled version of this id.
LifterLMS does not have any code that looks for this specific id.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
