### PR TITLE
Fix typo in LLMS_Instructor->toArray() 'description' key name.

### DIFF
--- a/includes/models/model.llms.instructor.php
+++ b/includes/models/model.llms.instructor.php
@@ -254,7 +254,7 @@ class LLMS_Instructor extends LLMS_Abstract_User_Data {
 	 */
 	public function toArray() {
 		return array(
-			'descrpition' => $this->get( 'description' ),
+			'description' => $this->get( 'description' ),
 			'email' => $this->get( 'user_email' ),
 			'first_name' => $this->get( 'first_name' ),
 			'id' => $this->get_id(),


### PR DESCRIPTION
## Description
Fixed typo in the `description` key name of `LLMS_Instructor->toArray()`,

## How has this been tested?
In addition to running PHPUnit tests, I searched for any use of this array element, but could not find one inside LifterLMS code.

## Types of changes
Potentially a breaking change.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
