### PR TITLE
Fix duplicate array keys

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
@@ -179,7 +179,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 						),
 					),
 					array(
-						'class' 	=> '',
+						'class'     => 'llms-select2-post',
 						'controller' => '#' . $this->prefix . 'restriction_redirect_type',
 						'controller_value' => 'page',
 						'data_attributes' => array(
@@ -188,7 +188,6 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 						'id' 		=> $this->prefix . 'redirect_page_id',
 						'label'		=> __( 'Select a WordPress Page', 'lifterlms' ),
 						'type'		=> 'select',
-						'class'     => 'llms-select2-post',
 						'value'   => $redirect_options,
 					),
 					array(

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -1059,7 +1059,6 @@ class LLMS_Post_Types {
 
 		// course tag
 		self::register_taxonomy( 'course_tag', array( 'course' ), array(
-			'hierarchical' => false,
 			'label' => __( 'Course Tags', 'lifterlms' ),
 			'labels' => array(
 				'name' => __( 'Course Tags', 'lifterlms' ),

--- a/includes/functions/llms.functions.currency.php
+++ b/includes/functions/llms.functions.currency.php
@@ -612,7 +612,6 @@ function get_lifterlms_currency_symbol( $currency = '' ) {
 		'LRD' => '&#36;',
 		'LSL' => 'L',
 		'LYD' => '&#x644;.&#x62f;',
-		'MAD' => '&#x62f;. &#x645;.',
 		'MAD' => '&#x62f;.&#x645;.',
 		'MDL' => 'L',
 		'MGA' => 'Ar',

--- a/tests/unit-tests/user/class-llms-test-person-handler.php
+++ b/tests/unit-tests/user/class-llms-test-person-handler.php
@@ -37,15 +37,15 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 		// test character sanitization
 		$tests = array(
 			'mock_mock' => 'mock_mock',
-			'mockmock' => "mock'mock",
-			'mockmock' => "mock+mock",
+			"mock'mock" => "mockmock",
+			'mock+mock' => "mockmock",
 			'mock.mock' => "mock.mock",
 			'mock-mock' => "mock-mock",
 			'mock mock' => "mock mock",
-			'mockmock' => "mock!mock",
+			'mock!mock' => "mockmock",
 		);
 
-		foreach ( $tests as $expect => $email ) {
+		foreach ( $tests as $email => $expect) {
 			$this->assertEquals( $expect, LLMS_Person_Handler::generate_username( $email . '@whatever.com' ) );
 		}
 


### PR DESCRIPTION
## Description
Removed duplicate/unnecessary array keys.
Fixed the skipping of two username sanitation assertion tests because of duplicate array keys.

## How has this been tested?
PHPUnit and PHP_CodeSniffer.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
