### PR TITLE
Add PHP_CodeSniffer "show progress" command line argument.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
       "\"vendor/bin/phpcs\" --config-set default_standard ./phpcs.xml"
     ],
     "phpcs": "composer run-script check-cs",
-    "check-cs": "\"vendor/bin/phpcs\" --colors --extensions=php -n lifterlms.php includes/ templates/",
+    "check-cs": "\"vendor/bin/phpcs\" --colors --extensions=php -n -p lifterlms.php includes/ templates/",
     "fix-cs": "\"vendor/bin/phpcbf\" --extensions=php -n lifterlms.php includes/ templates/",
     "tests-install": [
       "\"vendor/bin/llms-tests\" teardown llms_tests root password 127.0.0.1",


### PR DESCRIPTION
## Description
Added a command line argument to PHP_CodeSniffer to show the run's progress.

## How has this been tested?
`composer run-script phpcs`

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [X] My code has been tested.
- [X] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [X] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
