### PR TITLE
Make sure the Mark Complete button never displays outside of lesson

### DIFF
--- a/templates/course/complete-lesson-link.php
+++ b/templates/course/complete-lesson-link.php
@@ -12,6 +12,10 @@ defined( 'ABSPATH' ) || exit;
 
 global $post;
 
+if ( ! is_lesson() ) {
+	return;
+}
+
 $lesson = llms_get_post( $post );
 if ( ! $lesson ) {
 	return;


### PR DESCRIPTION
fix #775

## Description
Add a check on `is_lesson()` very early in the lesson comple button template that will avoid the button rendering when outside a lesson, hence also avoiding the triggering of the PHP fatal error reported in #775.

## How has this been tested?
Added a mark complete button to a course through the shortcode `[lifterlms_lesson_mark_complete]` and verified it was not displayed.
I've also added the button to a lesson through the shortcode aforementioned and verified it was correctly displayed.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
