### PR TITLE
Make sure to print js var used by metabox js before its execution

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
@@ -34,7 +34,7 @@ class LLMS_Meta_Box_Product extends LLMS_Admin_Metabox {
 		$this->priority = 'high';
 
 		// output PHP variables for JS access
-		add_action( 'admin_print_footer_scripts', array( $this, 'localize_js' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'localize_js' ), 9 );
 
 	}
 


### PR DESCRIPTION
fix #780

## Description
Prioritized the execution of a callback in order to avoid the consumer accessing not available data.

## How has this been tested?
After reproducing the issue described in #780 (e.g. activating the Yoast SEO plugin, not sure why it triggers this "issue" though), I've just accessed the editor of a Course, with this patch applied, and made sure that issue didn't occur anymore.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
