### PR TITLE
Add abstract LLMS_Abstract_Post_Data

### DIFF
--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -37,19 +37,6 @@ abstract class LLMS_Abstract_Post_Data {
 	protected $dates = array();
 
 	/**
-	 * @var int
-	 * @since [version]
-	 */
-	protected $recent_events_per_page = 10;
-
-	/**
-	 * @var string
-	 * @since [version]
-	 */
-	protected $recent_events_types = '';
-
-
-	/**
 	 * Constructor
 	 * @param    int     $post_id  WP Post ID of the LLMS Post
 	 * @since    [version]
@@ -219,16 +206,13 @@ abstract class LLMS_Abstract_Post_Data {
 	 * @since    [version]
 	 * @version  [version]
 	 */
-	public function recent_events() {
+	public function recent_events( $args = array() ) {
 
-		$query_args = array(
-			'per_page' => $this->recent_events_per_page,
+		$query_args = wp_parse_args( $args, array(
+			'per_page' => 10,
 			'post_id'  => $this->post_id,
-		);
-
-		if ( $this->recent_events_types ) {
-			$query_args['types'] = $this->recent_events_types;
-		}
+			'types'    => 'all',
+		));
 
 		$query = new LLMS_Query_User_Postmeta( $query_args );
 

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Defines base methods and properties for querying data about LifterLMS Custom Post Types
+ *
+ * @package LifterLMS/Abstracts
+ *
+ * @since   [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Post_Data abstract
+ *
+ * @since   [version]
+ * @version [version]
+ */
+abstract class LLMS_Abstract_Post_Data {
+
+	/**
+	 * @var obj LLMS_Post_Model
+	 * @since [version]
+	 */
+	public $post;
+
+	/**
+	 * @var int
+	 * @since [version]
+	 */
+	public $post_id;
+
+	/**
+	 * @var array
+	 * @since [version]
+	 */
+	protected $dates = array();
+
+	/**
+	 * @var int
+	 * @since [version]
+	 */
+	protected $recent_events_per_page = 10;
+
+	/**
+	 * @var string
+	 * @since [version]
+	 */
+	protected $recent_events_types = '';
+
+
+	/**
+	 * Constructor
+	 * @param    int     $post_id  WP Post ID of the LLMS Post
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	public function __construct( $post_id ) {
+
+		$this->post_id = $post_id;
+		$this->post    = llms_get_post( $this->post_id );
+
+	}
+
+	/**
+	 * Allow dates and timestamps to be passed into various data functions
+	 * @param    mixed     $date  date string or timestamp
+	 * @return   int
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	protected function strtotime( $date ) {
+		if ( ! is_numeric( $date ) ) {
+			$date = date( 'U', strtotime( $date ) );
+		}
+		return $date;
+	}
+
+	/**
+	 * Retrieve a start or end date based on the period
+	 * @param    string     $period  period [current|previous]
+	 * @param    string     $date    date type [start|end]
+	 * @return   string
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	protected function get_date( $period, $date ) {
+
+		return date( 'Y-m-d H:i:s', $this->dates[ $period ][ $date ] );
+
+	}
+
+	/**
+	 * Set the dates passed on a date range period
+	 * @param    string     $period  date range period
+	 * @return   void
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	public function set_period( $period = 'today' ) {
+
+		$now = current_time( 'timestamp' );
+
+		switch ( $period ) {
+
+			case 'all_time':
+				$curr_start = 0;
+				$curr_end   = $now;
+
+				$prev_start = 0;
+				$prev_end   = $now;
+			break;
+
+			case 'last_year':
+				$curr_start = strtotime( 'first day of january last year', $now );
+				$curr_end   = strtotime( 'last day of december last year', $now );
+
+				$prev_start = strtotime( 'first day of january last year', $curr_start );
+				$prev_end   = strtotime( 'last day of december last year', $curr_start );
+			break;
+
+			case 'year':
+				$curr_start = strtotime( 'first day of january this year', $now );
+				$curr_end   = strtotime( 'last day of december this year', $now );
+
+				$prev_start = strtotime( 'first day of january last year', $now );
+				$prev_end   = strtotime( 'last day of december last year', $now );
+			break;
+
+			case 'last_month':
+				$curr_start = strtotime( 'first day of previous month', $now );
+				$curr_end   = strtotime( 'last day of previous month', $now );
+
+				$prev_start = strtotime( 'first day of previous month', $curr_start );
+				$prev_end   = strtotime( 'last day of previous month', $curr_start );
+			break;
+
+			case 'month':
+				$curr_start = strtotime( 'first day of this month', $now );
+				$curr_end   = strtotime( 'last day of this month', $now );
+
+				$prev_start = strtotime( 'first day of previous month', $now );
+				$prev_end   = strtotime( 'last day of previous month', $now );
+			break;
+
+			case 'last_week':
+				$curr_start = strtotime( 'monday this week', $now - WEEK_IN_SECONDS );
+				$curr_end   = $now;
+
+				$prev_start = strtotime( 'monday previous week', $curr_start - WEEK_IN_SECONDS );
+				$prev_end   = $curr_start - DAY_IN_SECONDS;
+			break;
+
+			case 'week':
+				$curr_start = strtotime( 'monday this week', $now );
+				$curr_end   = $now;
+
+				$prev_start = strtotime( 'monday previous week', $now );
+				$prev_end   = $curr_start - DAY_IN_SECONDS;
+			break;
+
+			case 'yesterday':
+				$curr_start = $now - DAY_IN_SECONDS;
+				$curr_end   = $curr_start;
+
+				$prev_start = $curr_start - DAY_IN_SECONDS;
+				$prev_end   = $prev_start;
+			break;
+
+			case 'today':
+			default:
+
+				$curr_start = $now;
+				$curr_end   = $now;
+
+				$prev_start = $now - DAY_IN_SECONDS;
+				$prev_end   = $prev_start;
+
+		}// End switch().
+
+		$this->dates = array(
+			'current'  => array(
+				'start' => strtotime( 'midnight', $curr_start ),
+				'end'   => strtotime( 'tomorrow', $curr_end ) - 1,
+			),
+			'previous' => array(
+				'start' => strtotime( 'midnight', $prev_start ),
+				'end'   => strtotime( 'tomorrow', $prev_end ) - 1,
+			),
+		);
+
+	}
+
+	/**
+	 * Retrieve recent LLMS_User_Postmeta for the quiz
+	 * @return   array
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	public function recent_events() {
+
+		$query_args = array(
+			'per_page' => $this->recent_events_per_page,
+			'post_id'  => $this->post_id,
+		);
+
+		if ( $this->recent_events_types ) {
+			$query_args['types'] = $this->recent_events_types;
+		}
+
+		$query = new LLMS_Query_User_Postmeta( $query_args );
+
+		return $query->get_metas();
+
+	}
+
+}

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -22,13 +22,13 @@ abstract class LLMS_Abstract_Post_Data {
 	 * @var obj LLMS_Post_Model
 	 * @since [version]
 	 */
-	public $post;
+	protected $post;
 
 	/**
 	 * @var int
 	 * @since [version]
 	 */
-	public $post_id;
+	protected $post_id;
 
 	/**
 	 * @var array
@@ -60,6 +60,28 @@ abstract class LLMS_Abstract_Post_Data {
 		$this->post_id = $post_id;
 		$this->post    = llms_get_post( $this->post_id );
 
+	}
+
+	/**
+	 * Retrieve the instance of the LLMS_Post_Model.
+	 *
+	 * @since [version]
+	 *
+	 * @return LLMS_Post_Model the instance of the LLMS_Post_Model.
+	 */
+	public function get_post() {
+		return $this->post;
+	}
+
+	/**
+	 * Retrieve the LLMS_Post_Model ID.
+	 *
+	 * @since  [version]
+	 *
+	 * @return int The LLMS_Post_Model ID.
+	 */
+	public function get_post_id() {
+		return $this->post_id;
 	}
 
 	/**

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Defines base methods and properties for querying data about LifterLMS Custom Post Types
+ * Defines base methods and properties for querying data about LifterLMS Custom Post Types.
  *
  * @package LifterLMS/Abstracts
  *
@@ -11,36 +11,40 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Post_Data abstract
+ * LLMS_Post_Data abstract.
  *
- * @since   [version]
- * @version [version]
+ * @since [version]
  */
 abstract class LLMS_Abstract_Post_Data {
 
 	/**
-	 * @var obj LLMS_Post_Model
+	 * LLMS Post instance.
+	 *
 	 * @since [version]
+	 * @var LLMS_Post_Model
 	 */
 	protected $post;
 
 	/**
-	 * @var int
+	 * LLMS Post ID.
+	 *
 	 * @since [version]
+	 * @var int
 	 */
 	protected $post_id;
 
 	/**
-	 * @var array
 	 * @since [version]
+	 * @var array
 	 */
 	protected $dates = array();
 
 	/**
-	 * Constructor
-	 * @param    int     $post_id  WP Post ID of the LLMS Post
-	 * @since    [version]
-	 * @version  [version]
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $post_id WP Post ID of the LLMS Post.
 	 */
 	public function __construct( $post_id ) {
 
@@ -54,7 +58,7 @@ abstract class LLMS_Abstract_Post_Data {
 	 *
 	 * @since [version]
 	 *
-	 * @return LLMS_Post_Model the instance of the LLMS_Post_Model.
+	 * @return LLMS_Post_Model The instance of the LLMS_Post_Model.
 	 */
 	public function get_post() {
 		return $this->post;
@@ -63,7 +67,7 @@ abstract class LLMS_Abstract_Post_Data {
 	/**
 	 * Retrieve the LLMS_Post_Model ID.
 	 *
-	 * @since  [version]
+	 * @since [version]
 	 *
 	 * @return int The LLMS_Post_Model ID.
 	 */
@@ -72,11 +76,12 @@ abstract class LLMS_Abstract_Post_Data {
 	}
 
 	/**
-	 * Allow dates and timestamps to be passed into various data functions
-	 * @param    mixed     $date  date string or timestamp
-	 * @return   int
-	 * @since    [version]
-	 * @version  [version]
+	 * Allow dates and timestamps to be passed into various data functions.
+	 *
+	 * @since [version]
+	 *
+	 * @param  mixed $date A date string or timestamp.
+	 * @return int The Unix timestamp of the given date.
 	 */
 	protected function strtotime( $date ) {
 		if ( ! is_numeric( $date ) ) {
@@ -86,12 +91,13 @@ abstract class LLMS_Abstract_Post_Data {
 	}
 
 	/**
-	 * Retrieve a start or end date based on the period
-	 * @param    string     $period  period [current|previous]
-	 * @param    string     $date    date type [start|end]
-	 * @return   string
-	 * @since    [version]
-	 * @version  [version]
+	 * Retrieve a start or end date based on the period.
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $period Period [current|previous].
+	 * @param  string $date   The date type [start|end].
+	 * @return string The start or end date in the format 'Y-m-d H:i:s'.
 	 */
 	protected function get_date( $period, $date ) {
 
@@ -101,10 +107,11 @@ abstract class LLMS_Abstract_Post_Data {
 
 	/**
 	 * Set the dates passed on a date range period
-	 * @param    string     $period  date range period
-	 * @return   void
-	 * @since    [version]
-	 * @version  [version]
+	 *
+	 * @since [version]
+	 *
+	 * @param  string $period Date range period.
+	 * @return void
 	 */
 	public function set_period( $period = 'today' ) {
 
@@ -202,17 +209,26 @@ abstract class LLMS_Abstract_Post_Data {
 
 	/**
 	 * Retrieve recent LLMS_User_Postmeta for the quiz
-	 * @return   array
-	 * @since    [version]
-	 * @version  [version]
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args {
+	 *     Optional. An array of arguments to feed the LLMS_Query_User_Postmeta with.
+	 *
+	 *     @type int          $per_page The number of posts to query for. Default 10.
+	 *     @type array|string $types    Array of strings for the type of events to fetch, or a string to fetch them all. Default 'all'.
+	 *                                  @see LLMS_Query_User_Postmeta::parse_args()
+	 * }
+	 * @return array Array of LLMS_User_Postmetas.
 	 */
 	public function recent_events( $args = array() ) {
 
 		$query_args = wp_parse_args( $args, array(
 			'per_page' => 10,
-			'post_id'  => $this->post_id,
 			'types'    => 'all',
 		));
+
+		$query_args['post_id'] = $this->post_id;
 
 		$query = new LLMS_Query_User_Postmeta( $query_args );
 

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -18,10 +18,35 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 
 	/**
+	 * @var LLMS_Course
+	 * @since 3.15.0
+	 */
+	public $course;
+	/**
+	 * @var int
+	 * @since 3.15.0
+	 */
+	public $course_id;
+
+	/**
 	 * @var string
 	 * @since [version]
 	 */
 	protected $recent_events_types = 'all';
+
+	/**
+	 * Constructor
+	 * @param    int     $course_id  WP Post ID of the course
+	 * @since    3.15.0
+	 * @version  3.15.0
+	 */
+	public function __construct( $course_id ) {
+
+		$this->course_id = $course_id;
+		$this->course = llms_get_post( $this->course_id );
+		parent::__construct( $course_id );
+
+	}
 
 	/**
 	 * Retrieve an array of all post ids in the course

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -43,7 +43,7 @@ class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 	public function __construct( $course_id ) {
 
 		$this->course_id = $course_id;
-		$this->course = llms_get_post( $this->course_id );
+		$this->course    = llms_get_post( $this->course_id );
 		parent::__construct( $course_id );
 
 	}
@@ -271,11 +271,11 @@ class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 	private function orders_query( $num_orders = 1, $dates = array() ) {
 
 		$args = array(
-			'post_type' => 'llms_order',
-			'post_status' => array( 'llms-active', 'llms-complete' ),
+			'post_type'      => 'llms_order',
+			'post_status'    => array( 'llms-active', 'llms-complete' ),
 			'posts_per_page' => $num_orders,
-			'meta_key' => '_llms_product_id',
-			'meta_value' => $this->post_id,
+			'meta_key'       => '_llms_product_id',
+			'meta_value'     => $this->post_id,
 		);
 
 		if ( $dates ) {

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -13,53 +13,15 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.15.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since [version] Extends LLMS_Abstract_Post_Data.
  */
-class LLMS_Course_Data {
+class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 
 	/**
-	 * @var LLMS_Course
-	 * @since 3.15.0
+	 * @var string
+	 * @since [version]
 	 */
-	public $course;
-
-	/**
-	 * @var int
-	 * @since 3.15.0
-	 */
-	public $course_id;
-
-	/**
-	 * @var array
-	 * @since 3.15.0
-	 */
-	protected $dates = array();
-
-	/**
-	 * Constructor
-	 * @param    int     $course_id  WP Post ID of the course
-	 * @since    3.15.0
-	 * @version  3.15.0
-	 */
-	public function __construct( $course_id ) {
-
-		$this->course_id = $course_id;
-		$this->course = llms_get_post( $this->course_id );
-
-	}
-
-	/**
-	 * Allow dates and timestamps to be passed into various data functions
-	 * @param    mixed     $date  date string or timestamp
-	 * @return   int
-	 * @since    3.15.0
-	 * @version  3.16.0
-	 */
-	protected function strtotime( $date ) {
-		if ( ! is_numeric( $date ) ) {
-			$date = date( 'U', strtotime( $date ) );
-		}
-		return $date;
-	}
+	protected $recent_events_types = 'all';
 
 	/**
 	 * Retrieve an array of all post ids in the course
@@ -70,126 +32,11 @@ class LLMS_Course_Data {
 	 */
 	private function get_all_ids() {
 		return array_merge(
-			array( $this->course_id ),
-			$this->course->get_sections( 'ids' ),
-			$this->course->get_lessons( 'ids' ),
-			$this->course->get_quizzes()
+			array( $this->post_id ),
+			$this->post->get_sections( 'ids' ),
+			$this->post->get_lessons( 'ids' ),
+			$this->post->get_quizzes()
 		);
-	}
-
-	/**
-	 * Retrieve a start or end date based on the period
-	 * @param    string     $period  period [current|previous]
-	 * @param    string     $date    date type [start|end]
-	 * @return   string
-	 * @since    3.15.0
-	 * @version  3.16.0
-	 */
-	protected function get_date( $period, $date ) {
-
-		return date( 'Y-m-d H:i:s', $this->dates[ $period ][ $date ] );
-
-	}
-
-	/**
-	 * Set the dates passed on a date range period
-	 * @param    string     $period  date range period
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.17.2
-	 */
-	public function set_period( $period = 'today' ) {
-
-		$now = current_time( 'timestamp' );
-
-		switch ( $period ) {
-
-			case 'all_time':
-				$curr_start = 0;
-				$curr_end = $now;
-
-				$prev_start = 0;
-				$prev_end = $now;
-			break;
-
-			case 'last_year':
-				$curr_start = strtotime( 'first day of january last year', $now );
-				$curr_end = strtotime( 'last day of december last year', $now );
-
-				$prev_start = strtotime( 'first day of january last year', $curr_start );
-				$prev_end = strtotime( 'last day of december last year', $curr_start );
-			break;
-
-			case 'year':
-				$curr_start = strtotime( 'first day of january this year', $now );
-				$curr_end = strtotime( 'last day of december this year', $now );
-
-				$prev_start = strtotime( 'first day of january last year', $now );
-				$prev_end = strtotime( 'last day of december last year', $now );
-			break;
-
-			case 'last_month':
-				$curr_start = strtotime( 'first day of previous month', $now );
-				$curr_end = strtotime( 'last day of previous month', $now );
-
-				$prev_start = strtotime( 'first day of previous month', $curr_start );
-				$prev_end = strtotime( 'last day of previous month', $curr_start );
-			break;
-
-			case 'month':
-				$curr_start = strtotime( 'first day of this month', $now );
-				$curr_end = strtotime( 'last day of this month', $now );
-
-				$prev_start = strtotime( 'first day of previous month', $now );
-				$prev_end = strtotime( 'last day of previous month', $now );
-			break;
-
-			case 'last_week':
-				$curr_start = strtotime( 'monday this week', $now - WEEK_IN_SECONDS );
-				$curr_end = $now;
-
-				$prev_start = strtotime( 'monday previous week', $curr_start - WEEK_IN_SECONDS );
-				$prev_end = $curr_start - DAY_IN_SECONDS;
-			break;
-
-			case 'week':
-				$curr_start = strtotime( 'monday this week', $now );
-				$curr_end = $now;
-
-				$prev_start = strtotime( 'monday previous week', $now );
-				$prev_end = $curr_start - DAY_IN_SECONDS;
-			break;
-
-			case 'yesterday':
-				$curr_start = $now - DAY_IN_SECONDS;
-				$curr_end = $curr_start;
-
-				$prev_start = $curr_start - DAY_IN_SECONDS;
-				$prev_end = $prev_start;
-			break;
-
-			case 'today':
-			default:
-
-				$curr_start = $now;
-				$curr_end = $now;
-
-				$prev_start = $now - DAY_IN_SECONDS;
-				$prev_end = $prev_start;
-
-		}// End switch().
-
-		$this->dates = array(
-			'current' => array(
-				'start' => strtotime( 'midnight', $curr_start ),
-				'end' => strtotime( 'tomorrow', $curr_end ) - 1,
-			),
-			'previous' => array(
-				'start' => strtotime( 'midnight', $prev_start ),
-				'end' => strtotime( 'tomorrow', $prev_end ) - 1,
-			),
-		);
-
 	}
 
 	/**
@@ -211,7 +58,7 @@ class LLMS_Course_Data {
 			  AND post_id = %d
 			  AND updated_date BETWEEN %s AND %s
 			",
-			$this->course_id,
+			$this->post_id,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
 		) );
@@ -237,7 +84,7 @@ class LLMS_Course_Data {
 			  AND post_id = %d
 			  AND updated_date BETWEEN %s AND %s
 			",
-			$this->course_id,
+			$this->post_id,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
 		) );
@@ -283,7 +130,7 @@ class LLMS_Course_Data {
 
 		global $wpdb;
 
-		$lessons = implode( ',', $this->course->get_lessons( 'ids' ) );
+		$lessons = implode( ',', $this->post->get_lessons( 'ids' ) );
 
 		return $wpdb->get_var( $wpdb->prepare( "
 			SELECT COUNT( * )
@@ -381,7 +228,7 @@ class LLMS_Course_Data {
 			  AND post_id = %d
 			  AND updated_date BETWEEN %s AND %s
 			",
-			$this->course_id,
+			$this->post_id,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
 		) );
@@ -403,7 +250,7 @@ class LLMS_Course_Data {
 			'post_status' => array( 'llms-active', 'llms-complete' ),
 			'posts_per_page' => $num_orders,
 			'meta_key' => '_llms_product_id',
-			'meta_value' => $this->course_id,
+			'meta_value' => $this->post_id,
 		);
 
 		if ( $dates ) {
@@ -413,24 +260,6 @@ class LLMS_Course_Data {
 		$query = new WP_Query( $args );
 
 		return $query;
-
-	}
-
-	/**
-	 * Retrieve recent LLMS_User_Postmeta for the course
-	 * @return   array
-	 * @since    3.15.0
-	 * @version  3.15.0
-	 */
-	public function recent_events() {
-
-		$query = new LLMS_Query_User_Postmeta( array(
-			'per_page' => 10,
-			'post_id' => $this->course_id,
-			'types' => 'all',
-		) );
-
-		return $query->get_metas();
 
 	}
 

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -18,6 +18,33 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Quiz_Data extends LLMS_Abstract_Post_Data {
 
 	/**
+	 * @var LLMS_Quiz
+	 * @since 3.16.0
+	 */
+	public $quiz;
+
+	/**
+	 * WP Post ID of the quiz
+	 * @var int
+	 * @since 3.16.0
+	 */
+	public $quiz_id;
+
+	/**
+	 * Constructor
+	 * @param    int     $quiz_id  WP Post ID of the quiz
+	 * @since    3.16.0
+	 * @version  3.16.0
+	 */
+	public function __construct( $quiz_id ) {
+
+		$this->quiz_id = $quiz_id;
+		$this->quiz = llms_get_post( $this->quiz_id );
+		parent::__construct( $quiz_id );
+
+	}
+
+	/**
 	 * Retrieve # of quiz attempts within the period
 	 * @param    string     $period  date period [current|previous]
 	 * @return   int

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -39,7 +39,7 @@ class LLMS_Quiz_Data extends LLMS_Abstract_Post_Data {
 	public function __construct( $quiz_id ) {
 
 		$this->quiz_id = $quiz_id;
-		$this->quiz = llms_get_post( $this->quiz_id );
+		$this->quiz    = llms_get_post( $this->quiz_id );
 		parent::__construct( $quiz_id );
 
 	}
@@ -154,7 +154,7 @@ class LLMS_Quiz_Data extends LLMS_Abstract_Post_Data {
 	public function recent_events( $args = array() ) {
 
 		$query_args = wp_parse_args( $args, array(
-			'types'    => array(),
+			'types' => array(),
 		) );
 
 		return parent::recent_events( $query_args );

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -143,4 +143,20 @@ class LLMS_Quiz_Data extends LLMS_Abstract_Post_Data {
 		return $this->get_count_by_status( 'pass', $period );
 	}
 
+	/**
+	 * Retrieve recent LLMS_User_Postmeta for the quiz.
+	 * This overrides the LLMS_Abstract_Post_Data method.
+	 *
+	 * @return   array
+	 * @since    3.16.0
+	 * @version  3.16.0
+	 */
+	public function recent_events( $args = array() ) {
+
+		$query_args = wp_parse_args( $args, array(
+			'types'    => array(),
+		) );
+
+		return parent::recent_events( $query_args );
+	}
 }

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -13,34 +13,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.16.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since [version] Extends LLMS_Abstract_Post_Data.
  */
-class LLMS_Quiz_Data extends LLMS_Course_Data {
-
-	/**
-	 * @var LLMS_Quiz
-	 * @since 3.16.0
-	 */
-	public $quiz;
-
-	/**
-	 * WP Post ID of the quiz
-	 * @var int
-	 * @since 3.16.0
-	 */
-	public $quiz_id;
-
-	/**
-	 * Constructor
-	 * @param    int     $quiz_id  WP Post ID of the quiz
-	 * @since    3.16.0
-	 * @version  3.16.0
-	 */
-	public function __construct( $quiz_id ) {
-
-		$this->quiz_id = $quiz_id;
-		$this->quiz = llms_get_post( $this->quiz_id );
-
-	}
+class LLMS_Quiz_Data extends LLMS_Abstract_Post_Data {
 
 	/**
 	 * Retrieve # of quiz attempts within the period
@@ -59,7 +34,7 @@ class LLMS_Quiz_Data extends LLMS_Course_Data {
 			WHERE quiz_id = %d
 			  AND update_date BETWEEN %s AND %s
 			",
-			$this->quiz_id,
+			$this->post_id,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
 		) );
@@ -83,7 +58,7 @@ class LLMS_Quiz_Data extends LLMS_Course_Data {
 			WHERE quiz_id = %d
 			  AND update_date BETWEEN %s AND %s
 			",
-			$this->quiz_id,
+			$this->post_id,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
 		) );
@@ -111,7 +86,7 @@ class LLMS_Quiz_Data extends LLMS_Course_Data {
 			  AND status = %s
 			  AND update_date BETWEEN %s AND %s
 			",
-			$this->quiz_id,
+			$this->post_id,
 			$status,
 			$this->get_date( $period, 'start' ),
 			$this->get_date( $period, 'end' )
@@ -139,23 +114,6 @@ class LLMS_Quiz_Data extends LLMS_Course_Data {
 	 */
 	public function get_pass_count( $period = 'current' ) {
 		return $this->get_count_by_status( 'pass', $period );
-	}
-
-	/**
-	 * Retrieve recent LLMS_User_Postmeta for the quiz
-	 * @return   array
-	 * @since    3.16.0
-	 * @version  3.16.0
-	 */
-	public function recent_events() {
-
-		$query = new LLMS_Query_User_Postmeta( array(
-			'per_page' => 10,
-			'post_id' => $this->quiz_id,
-		) );
-
-		return $query->get_metas();
-
 	}
 
 }


### PR DESCRIPTION
## Description
Added a new abstract class that LLMS_Course_Data and  LLMS_Quiz_Data extends, defining non-specific functions

## How has this been tested?
Tested that Reporting -> Courses -> single course - Overview and Reporting -> Quizzes -> single quiz - Overview screens worked fine without throwing any errors.


## Types of changes
This PR might introduce a breaking change as, e.g. for LLMS_Course_Data, specific post type properties like `$course` and `$course_id`
https://github.com/gocodebox/lifterlms/blob/master/includes/class.llms.course.data.php#L19-L29
won't be available anymore, replaced by the more generic `$post` and `$post_id`.
I've checked that no other pieces of LLMS are referring to those public properties but don't know about other plugins.
Do you think would be better keep some compatibility, re-adding them and mark them as deprecated?

Also, even adding this abstract layer, the LLMS_Course_Data and the brand new LLMS_Membership_Data would still share a bunch of code (e.g. get_orders, get_revenue, orders_query, get_enrollments/get_unenrollments methods are identical). 

What do you think about adding a new class(not necessarily abstract) which defines those methods and that both the LLMS_Course_Data and the LLMS_Membership_Data will extend?
It might be called like LLMS_Saleable_Post_Data (or a better name of course).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
