### PR TITLE
Remove unnecessary if statement.

### DIFF
--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -405,15 +405,12 @@ class LLMS_Admin_Reporting {
 		$change = false;
 		if ( $args['data_compare'] && $args['data'] ) {
 
-			if ( $args['data'] ) {
-
-				$change = round( ( $args['data'] - $args['data_compare'] ) / $args['data'] * 100, 2 );
-				$compare_operator = ( $change <= 0 ) ? '' : '+';
-				if ( 'positive' === $args['impact'] ) {
-					$compare_class = ( $change <= 0 ) ? 'negative' : 'positive';
-				} else {
-					$compare_class = ( $change <= 0 ) ? 'positive' : 'negative';
-				}
+			$change = round( ( $args['data'] - $args['data_compare'] ) / $args['data'] * 100, 2 );
+			$compare_operator = ( $change <= 0 ) ? '' : '+';
+			if ( 'positive' === $args['impact'] ) {
+				$compare_class = ( $change <= 0 ) ? 'negative' : 'positive';
+			} else {
+				$compare_class = ( $change <= 0 ) ? 'positive' : 'negative';
 			}
 		}
 


### PR DESCRIPTION
## Description
Removed an `if` statement on `$args['data']` because it is also evaluated in the previous `if` statement.
Related to issue #750.

## How has this been tested?
PHP_CodeSniffer and PHPUnit.

## Types of changes
minor performance increase

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
