### PR TITLE
Re-scoped shortcode methods to be more user-extensible (closes #841)

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -50,7 +50,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 * @since    3.14.0
 	 * @version  3.14.0
 	 */
-	private function get_post__in() {
+	protected function get_post__in() {
 
 		$ids = array();
 		$post_id = $this->get_attribute( 'id' );
@@ -82,7 +82,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 * @since    3.14.0
 	 * @version  3.14.0
 	 */
-	private function get_tax_query() {
+	protected function get_tax_query() {
 
 		$has_tax_query = false;
 
@@ -131,7 +131,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 * @since    3.14.0
 	 * @version  3.14.0
 	 */
-	private function get_wp_query() {
+	protected function get_wp_query() {
 
 		$args = array(
 			'paged' => get_query_var( 'paged' ),


### PR DESCRIPTION
## Description

I've moved some `private` methods to `protected` to be more user-extensible.

## How has this been tested?

Works as-expected from a very similar scope.  Now extensible from the user side.

## Types of changes

Method visibility.  Non-breaking change.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->

> ^^ I was having composer issues - please let me know if this causes a problem - I really don't anticipate it.