### PR TITLE
Pass $check_availability as parameter for the acces plan checkout url…

### DIFF
--- a/includes/models/model.llms.access.plan.php
+++ b/includes/models/model.llms.access.plan.php
@@ -6,7 +6,7 @@
  * @package  LifterLMS/Models
  *
  * @since    3.0.0
- * @version  3.30.1
+ * @version  [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -48,7 +48,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.30.0 Added checkout redirect properties and methods
  * @since 3.30.1 Added method to get the initial price due on checkout.
- * @since [version] Added 'llms_access_plan_get_checkout_url' filter and deprecated 'llms_plan_get_checkout_url' filter.
+ * @since [version] The `$check_availability` parameter was added to the `llms_plan_get_checkout_url` filter.
  */
 class LLMS_Access_Plan extends LLMS_Post_Model {
 
@@ -266,7 +266,6 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 	 *
 	 * @since    3.0.0
 	 * @since    3.30.0 Added access plan redirection settings.
-	 * @since    [version] Added 'llms_access_plan_get_checkout_url' filter and deprecated 'llms_plan_get_checkout_url' filter.
 	 *
 	 * @param    bool   $check_availability  determine if availability checks should be made (allows retrieving plans on admin panel).
 	 * @return   string
@@ -311,24 +310,14 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 		 * Filter the checkout URL for an access plan.
 		 *
 		 * @since Unknown
-		 * @deprecated [version], use 'llms_access_plan_get_checkout_url' instead.
+		 * @since [version] The `$check_availability` parameter was added.
 		 *
-		 * @param string $ret The checkout URL.
+		 * @param string $ret      The checkout URL.
 		 * @param LLMS_Access_Plan $this Access plan object.
-		 */
-		$ret = apply_filters( 'llms_plan_get_checkout_url', $ret, $this );
-
-		/**
-		 * Filter the checkout URL for an access plan.
-		 *
-		 * @since [version]
-		 *
-		 * @param string           $ret                The checkout URL.
 		 * @param bool             $check_availability Determine if availability checks should be made.
 		 *                                             (allows retrieving plans on admin panel)
-		 * @param LLMS_Access_Plan $this               Access plan object.
 		 */
-		return apply_filters( 'llms_access_plan_get_checkout_url', $ret, $check_availability, $this );
+		return apply_filters( 'llms_plan_get_checkout_url', $ret, $this, $check_availability );
 
 	}
 

--- a/includes/models/model.llms.access.plan.php
+++ b/includes/models/model.llms.access.plan.php
@@ -48,6 +48,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.30.0 Added checkout redirect properties and methods
  * @since 3.30.1 Added method to get the initial price due on checkout.
+ * @since [version] Added 'llms_access_plan_get_checkout_url' filter and deprecated 'llms_plan_get_checkout_url' filter.
  */
 class LLMS_Access_Plan extends LLMS_Post_Model {
 
@@ -265,7 +266,7 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 	 *
 	 * @since    3.0.0
 	 * @since    3.30.0 Added access plan redirection settings.
-	 * @version  3.30.0
+	 * @since    [version] Added 'llms_access_plan_get_checkout_url' filter and deprecated 'llms_plan_get_checkout_url' filter.
 	 *
 	 * @param    bool   $check_availability  determine if availability checks should be made (allows retrieving plans on admin panel).
 	 * @return   string
@@ -310,12 +311,24 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 		 * Filter the checkout URL for an access plan.
 		 *
 		 * @since Unknown
-		 * @version 3.30.0
+		 * @deprecated [version], use 'llms_access_plan_get_checkout_url' instead.
 		 *
 		 * @param string $ret The checkout URL.
 		 * @param LLMS_Access_Plan $this Access plan object.
 		 */
-		return apply_filters( 'llms_plan_get_checkout_url', $ret, $this );
+		$ret = apply_filters( 'llms_plan_get_checkout_url', $ret, $this );
+
+		/**
+		 * Filter the checkout URL for an access plan.
+		 *
+		 * @since [version]
+		 *
+		 * @param string           $ret                The checkout URL.
+		 * @param bool             $check_availability Determine if availability checks should be made.
+		 *                                             (allows retrieving plans on admin panel)
+		 * @param LLMS_Access_Plan $this               Access plan object.
+		 */
+		return apply_filters( 'llms_access_plan_get_checkout_url', $ret, $check_availability, $this );
 
 	}
 


### PR DESCRIPTION
… filter

fix #844

## Description
Add a new filter for the access plan checkout url, so that the `$check_availability` parameter can be passed but keeping backward compatibility.

## How has this been tested?
I've hooked into the new and old filter checking everything was fine.


## Types of changes
New feature (non-breaking change which adds functionality) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
