### PR TITLE
Add Memberships reporting tab

### DIFF
--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -13,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.2.0
  * @since [version] Fix redundant `if` statement in the `output_widget` method.
+ * @since [version] Added Memberships tab.
+ * @since [version] The `output_event()` method now outputs the student's avatar whent in 'membership' context.
  */
 class LLMS_Admin_Reporting {
 
@@ -213,11 +215,13 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Get the full URL to a sub-tab within a reporting screen
-	 * @param    string     $stab  slug of the sub-tab
-	 * @return   string
-	 * @since    3.2.0
-	 * @version  3.16.0
+	 * Get the full URL to a sub-tab within a reporting screen.
+	 *
+	 * @since 3.2.0
+	 * @since [version] Added Memberships tab.
+	 *
+	 * @param string $stab Slug of the sub-tab.
+	 * @return string
 	 */
 	public static function get_stab_url( $stab ) {
 
@@ -228,6 +232,9 @@ class LLMS_Admin_Reporting {
 		);
 
 		switch ( self::get_current_tab() ) {
+			case 'memberships':
+				$args['membership_id'] = $_GET['membership_id'];
+			break;
 
 			case 'courses':
 				$args['course_id'] = $_GET['course_id'];
@@ -248,17 +255,20 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Get an array of tabs to output in the main reporting menu
-	 * @return   array
-	 * @since    3.2.0
-	 * @version  3.19.4
+	 * Get an array of tabs to output in the main reporting menu.
+	 *
+	 * @since 3.2.0
+	 * @since [version] Added Memberships tab.
+	 *
+	 * @return array
 	 */
 	private function get_tabs() {
 		$tabs = array(
-			'students' => __( 'Students', 'lifterlms' ),
-			'courses' => __( 'Courses', 'lifterlms' ),
-			'quizzes' => __( 'Quizzes', 'lifterlms' ),
-			'sales' => __( 'Sales', 'lifterlms' ),
+			'students'    => __( 'Students', 'lifterlms' ),
+			'courses'     => __( 'Courses', 'lifterlms' ),
+			'memberships' => __( 'Memberships', 'lifterlms' ),
+			'quizzes'     => __( 'Quizzes', 'lifterlms' ),
+			'sales'       => __( 'Sales', 'lifterlms' ),
 			'enrollments' => __( 'Enrollments', 'lifterlms' ),
 		);
 		foreach ( $tabs as $slug => $tab ) {
@@ -345,12 +355,14 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Output the HTML for a postmeta event in the recent events sidebar of various reporting screens
-	 * @param    obj     $event    instance of an LLMS_User_Postmeta item
-	 * @param    string     $context  display context [course|student]
+	 * Output the HTML for a postmeta event in the recent events sidebar of various reporting screens.
+	 *
+	 * @since 3.15.0
+	 * @since [version] Outputs the student's avatar whent in 'membership' context
+	 *
+	 * @param obj    $event   Instance of an LLMS_User_Postmeta item.
+	 * @param string $context Optional. Display context [course|student|quiz|membership]. Default 'course'.
 	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.16.0
 	 */
 	public static function output_event( $event, $context = 'course' ) {
 
@@ -368,7 +380,7 @@ class LLMS_Admin_Reporting {
 				<a href="<?php echo esc_url( $url ); ?>">
 			<?php endif; ?>
 
-				<?php if ( 'course' === $context || 'quiz' === $context ) : ?>
+				<?php if ( 'course' === $context || 'membership' === $context || 'quiz' === $context ) : ?>
 					<?php echo $student->get_avatar( 24 ); ?>
 				<?php endif; ?>
 

--- a/includes/admin/reporting/tables/llms.table.membership.students.php
+++ b/includes/admin/reporting/tables/llms.table.membership.students.php
@@ -1,0 +1,416 @@
+<?php
+/**
+ * Display students enrolled in a given membership on the membership students subtab.
+ * @since   [version]
+ * @version [version]
+ */
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Display students enrolled in a given membership on the membership students subtab class.
+ * @since   [version]
+ */
+class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
+
+	/**
+	 * Unique ID for the Table
+	 *
+	 * @since   [version]
+	 *
+	 * @var  string
+	 */
+	protected $id = 'membership-students';
+
+	/**
+	 * Value of the field being filtered by
+	 * Only applicable if $filterby is set.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  string
+	 */
+	protected $filter = 'any';
+
+	/**
+	 * Field results are filtered by.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  string
+	 */
+	protected $filterby = 'status';
+
+	/**
+	 * Is the Table Exportable?
+	 *
+	 * @since   [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_exportable = true;
+
+
+	/**
+	 *
+	 * @since   [version]
+	 *
+	 * Determine if the table is filterable.
+	 * @var  boolean
+	 */
+	protected $is_filterable = true;
+
+	/**
+	 * If true, tfoot will add ajax pagination links.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_paginated = true;
+
+	/**
+	 * Determine of the table is searchable.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_searchable = true;
+
+	/**
+	 * Results sort order 'ASC' or 'DESC'.
+	 * Only applicable of $orderby is not set.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  string
+	 */
+	protected $order = 'ASC';
+
+	/**
+	 * Field results are sorted by.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  string
+	 */
+	protected $orderby = 'name';
+
+	/**
+	 * Post ID for the current table.
+	 *
+	 * @since   [version]
+	 *
+	 * @var  int
+	 */
+	public $membership_id = null;
+
+	/**
+	 * Retrieve data for the columns
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key     The column id / key.
+	 * @param int    $user_id WP User ID.
+	 * @return mixed
+	 */
+	public function get_data( $key, $student ) {
+
+		$value = '';
+
+		switch ( $key ) {
+
+			case 'enrolled':
+				$value = $student->get_enrollment_date( $this->membership_id, 'updated' );
+			break;
+
+			case 'id':
+				$id = $student->get_id();
+				if ( current_user_can( 'edit_users', $id ) ) {
+					$value = '<a href="' . esc_url( get_edit_user_link( $id ) ) . '">' . $id . '</a>';
+				} else {
+					$value = $id;
+				}
+			break;
+
+			case 'name':
+
+				$first = $student->get( 'first_name' );
+				$last  = $student->get( 'last_name' );
+
+				if ( ! $first || ! $last ) {
+					$value = $student->get( 'display_name' );
+				} else {
+					$value = $last . ', ' . $first;
+				}
+
+				$url = add_query_arg( array(
+					'page'          => 'llms-reporting',
+					'tab'           => 'students',
+					'student_id'    => $student->get_id(),
+					'stab'          => 'memberships',
+					'membership_id' => $this->membership_id,
+				), admin_url( 'admin.php' ) );
+				$value = '<a href="' . esc_url( $url ) . '">' . $value . '</a>';
+
+			break;
+
+			case 'status':
+				$value = llms_get_enrollment_status_name( $student->get_enrollment_status( $this->membership_id ) );
+			break;
+
+			default:
+				$value = $key;
+
+		}// End switch().
+
+		return $this->filter_get_data( $value, $key, $student );
+
+	}
+
+	/**
+	 * Retrieve data for a cell in an export file.
+	 * Should be overridden in extending classes.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key     The column id / key.
+	 * @param obj    $student Instance of the LLMS_Student.
+	 * @return mixed
+	 */
+	public function get_export_data( $key, $student ) {
+
+		switch ( $key ) {
+
+			case 'id':
+				$value = $student->get_id();
+			break;
+
+			case 'email':
+				$value = $student->get( 'user_email' );
+			break;
+
+			case 'name_first':
+				$value = $student->get( 'first_name' );
+			break;
+
+			case 'name_last':
+				$value = $student->get( 'last_name' );
+			break;
+
+			default:
+				$value = $this->get_data( $key, $student );
+
+		}// End switch().
+
+		return $this->filter_get_data( $value, $key, $student, 'export' );
+
+	}
+
+
+	/**
+	 * Get a lock key unique to the table & user for locking the table during export generation.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_export_lock_key() {
+		$args = $this->get_args();
+		return sprintf( '%1$s:%2$d:%3$d', $this->id, get_current_user_id(), $args['membership_id'] );
+	}
+
+	/**
+	 * Allow customization of the title for export files.
+	 *
+	 * @since [version]
+	 *
+	 * @param  array $args Optional. Array of arguments passed from table to csv processor. Default empty array.
+	 * @return string
+	 */
+	public function get_export_title( $args = array() ) {
+		$title = $this->get_title();
+		if ( isset( $args['membership_id'] ) ) {
+			$title = get_the_title( $args['membership_id'] ) . ' ' . $title;
+		}
+		return apply_filters( 'llms_table_get_' . $this->id . '_export_title', $title );
+	}
+
+	/**
+	 * Get the Text to be used as the placeholder in a searchable tables search input.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_table_search_form_placeholder() {
+		return apply_filters( 'llms_reporting_get_' . $this->id . '_search_placeholder', __( 'Search students by name or email...', 'lifterlms' ) );
+	}
+
+	/**
+	 * Execute a query to retrieve results from the table.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Optional. Array of query args. Default empty array.
+	 * @return void
+	 */
+	public function get_results( $args = array() ) {
+
+		$this->title = __( 'Students', 'lifterlms' );
+
+		if ( ! $args ) {
+			$args = $this->get_args();
+		}
+
+		$args = $this->clean_args( $args );
+
+		$this->membership_id = $args['membership_id'];
+
+		if ( isset( $args['page'] ) ) {
+			$this->current_page = absint( $args['page'] );
+		}
+
+		$this->filter = isset( $args['filter'] ) ? $args['filter'] : $this->get_filter();
+		$this->filterby = isset( $args['filterby'] ) ? $args['filterby'] : $this->get_filterby();
+
+		$this->order = isset( $args['order'] ) ? $args['order'] : $this->get_order();
+		$this->orderby = isset( $args['orderby'] ) ? $args['orderby'] : $this->get_orderby();
+
+		$sort = array();
+		switch ( $this->get_orderby() ) {
+
+			case 'enrolled':
+				$sort = array(
+					'date' => $this->get_order(),
+					'last_name' => 'ASC',
+					'first_name' => 'ASC',
+					'id' => 'ASC',
+				);
+			break;
+
+			case 'id':
+				$sort = array(
+					'id' => $this->get_order(),
+				);
+			break;
+
+			case 'name':
+				$sort = array(
+					'last_name' => $this->get_order(),
+					'first_name' => 'ASC',
+					'id' => 'ASC',
+				);
+			break;
+
+			case 'status':
+				$sort = array(
+					'status' => $this->get_order(),
+					'last_name' => 'ASC',
+					'first_name' => 'ASC',
+					'id' => 'ASC',
+				);
+			break;
+
+		}
+
+		$query_args = array(
+			'page' => $this->get_current_page(),
+			'post_id' => $args['membership_id'],
+			'per_page' => apply_filters( 'llms_' . $this->id . '_table_students_per_page', 25 ),
+			'sort' => $sort,
+		);
+
+		if ( 'status' === $this->get_filterby() && 'any' !== $this->get_filter() ) {
+
+			$query_args['statuses'] = array( $this->get_filter() );
+
+		}
+
+		if ( isset( $args['search'] ) ) {
+
+			$this->search = $args['search'];
+			$query_args['search'] = $this->get_search();
+
+		}
+
+		$query = new LLMS_Student_Query( $query_args );
+
+		$this->max_pages = $query->max_pages;
+		$this->is_last_page = $query->is_last_page();
+
+		$this->tbody_data = $query->get_students();
+
+	}
+
+
+	/**
+	 * Define the structure of arguments used to pass to the get_results method.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function set_args() {
+
+		if ( ! $this->membership_id ) {
+			$this->membership_id = ! empty( $_GET['membership_id'] ) ? absint( $_GET['membership_id'] ) : null;
+		}
+
+		return array(
+			'membership_id' => $this->membership_id,
+		);
+
+	}
+
+	/**
+	 * Define the structure of the table
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function set_columns() {
+		$cols = array(
+			'id'         => array(
+				'exportable'  => true,
+				'sortable'    => true,
+				'title'       => __( 'ID', 'lifterlms' ),
+			),
+			'name'       => array(
+				'sortable'    => true,
+				'title'       => __( 'Name', 'lifterlms' ),
+			),
+			'name_last'  => array(
+				'exportable'  => true,
+				'export_only' => true,
+				'title'       => __( 'Last Name', 'lifterlms' ),
+			),
+			'name_first' => array(
+				'exportable'  => true,
+				'export_only' => true,
+				'title'       => __( 'First Name', 'lifterlms' ),
+			),
+			'email'      => array(
+				'exportable'  => true,
+				'export_only' => true,
+				'title'       => __( 'Email', 'lifterlms' ),
+			),
+			'status'     => array(
+				'exportable'  => true,
+				'filterable'  => llms_get_enrollment_statuses(),
+				'sortable'    => true,
+				'title'       => __( 'Status', 'lifterlms' ),
+			),
+			'enrolled'   => array(
+				'exportable'  => true,
+				'sortable'    => true,
+				'title'       => __( 'Enrollment Updated', 'lifterlms' ),
+			),
+		);
+
+		return $cols;
+
+	}
+
+}

--- a/includes/admin/reporting/tables/llms.table.memberships.php
+++ b/includes/admin/reporting/tables/llms.table.memberships.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Memberships Reporting Table
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Memberships Reporting Table class.
+ *
+ * @since [version]
+ */
+class LLMS_Table_Memberships extends LLMS_Admin_Table {
+
+	/**
+	 * Unique ID for the Table
+	 *
+	 * @since [version]
+	 *
+	 * @var  string
+	 */
+	protected $id = 'memberships';
+
+	/**
+	 * Value of the field being filtered by.
+	 * Only applicable if $filterby is set.
+	 *
+	 * @since [version]
+	 *
+	 * @var  string
+	 */
+	protected $filter = 'any';
+
+	/**
+	 * Field results are filtered by.
+	 *
+	 * @since [version]
+	 *
+	 * @var  string
+	 */
+	protected $filterby = 'instructor';
+
+	/**
+	 * Is the Table Exportable?
+	 *
+	 * @since [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_exportable = true;
+
+	/**
+	 * Determine if the table is filterable.
+	 *
+	 * @since [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_filterable = true;
+
+	/**
+	 * If true, tfoot will add ajax pagination links.
+	 *
+	 * @since [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_paginated = true;
+
+	/**
+	 * Determine of the table is searchable
+	 *
+	 * @since [version]
+	 *
+	 * @var  boolean
+	 */
+	protected $is_searchable = true;
+
+	/**
+	 * Results sort order 'ASC' or 'DESC'.
+	 * Only applicable of $orderby is not set.
+	 *
+	 * @since [version]
+	 *
+	 * @var  string
+	 */
+	protected $order = 'ASC';
+
+	/**
+	 * Field results are sorted by.
+	 *
+	 * @since [version]
+	 *
+	 * @var  string
+	 */
+	protected $orderby = 'title';
+
+	/**
+	 * Retrieve data for a cell.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key   The column id / key.
+	 * @param mixed  $data  Object / array of data that the function can use to extract the data.
+	 * @return mixed
+	 */
+	protected function get_data( $key, $data ) {
+
+		$membership = llms_get_post( $data );
+
+		switch ( $key ) {
+
+			case 'id':
+				$value = $this->get_post_link( $membership->get( 'id' ) );
+			break;
+
+			case 'instructors':
+				$data = array();
+				foreach ( $membership->get_instructors() as $info ) {
+					$instructor = llms_get_instructor( $info['id'] );
+					if ( $instructor ) {
+						$data[] = sprintf( '%1$s (%2$s)', $instructor->get( 'display_name' ),  $info['label'] );
+					}
+				}
+				$value = implode( ', ', $data );
+			break;
+
+			case 'students':
+				$value = number_format_i18n( $membership->get_student_count(), 0 );
+			break;
+
+			case 'title':
+				$url = LLMS_Admin_Reporting::get_current_tab_url( array(
+					'tab' => 'memberships',
+					'membership_id' => $membership->get( 'id' ),
+				) );
+				$value = '<a href="' . esc_url( $url ) . '">' . $membership->get( 'title' ) . '</a>';
+			break;
+
+			default:
+				$value = $key;
+
+		}// End switch().
+
+		return $value;
+	}
+
+	/**
+	 * Retrieve a list of Instructors to be used for Filtering.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	private function get_instructor_filters() {
+
+		$query = get_users( array(
+			'fields'   => array( 'ID', 'display_name' ),
+			'meta_key' => 'last_name',
+			'orderby'  => 'meta_value',
+			'role__in' => array( 'administrator', 'lms_manager', 'instructor', 'instructors_assistant' ),
+		) );
+
+		$instructors = wp_list_pluck( $query, 'display_name', 'ID' );
+
+		return $instructors;
+
+	}
+
+	/**
+	 * Execute a query to retrieve results from the table.
+	 *
+	 * @since [version]
+	 *
+	 * @param  array $args  Optional. Array of query args. Default empty array.
+	 * @return void
+	 */
+	public function get_results( $args = array() ) {
+
+		$this->title = __( 'Memberships', 'lifterlms' );
+
+		$args = $this->clean_args( $args );
+
+		if ( isset( $args['page'] ) ) {
+			$this->current_page = absint( $args['page'] );
+		}
+
+		$per = apply_filters( 'llms_reporting_' . $this->id . '_per_page', 25 );
+
+		$this->order   = isset( $args['order'] ) ? $args['order'] : $this->order;
+		$this->orderby = isset( $args['orderby'] ) ? $args['orderby'] : $this->orderby;
+
+		$this->filter   = isset( $args['filter'] ) ? $args['filter'] : $this->get_filter();
+		$this->filterby = isset( $args['filterby'] ) ? $args['filterby'] : $this->get_filterby();
+
+		$query_args = array(
+			'order'          => $this->order,
+			'orderby'        => $this->orderby,
+			'paged'          => $this->current_page,
+			'post_status'    => array( 'publish', 'private' ),
+			'post_type'      => 'llms_membership',
+			'posts_per_page' => $per,
+		);
+
+		if ( 'any' !== $this->filter ) {
+
+			$serialized_id = serialize( array(
+				'id' => absint( $this->filter ),
+			) );
+			$serialized_id = str_replace( array( 'a:1:{', '}' ), '', $serialized_id );
+
+			$query_args['meta_query'] = array(
+				array(
+					'compare' => 'LIKE',
+					'key' => '_llms_instructors',
+					'value' => $serialized_id,
+				),
+			);
+
+		}
+
+		if ( isset( $args['search'] ) ) {
+			$query_args['s'] = sanitize_text_field( $args['search'] );
+		}
+
+		// if you can view others reports, make a regular query
+		if ( current_user_can( 'view_others_lifterlms_reports' ) ) {
+
+			$query = new WP_Query( $query_args );
+
+			// user can only see their own reports, get a list of their students
+		} elseif ( current_user_can( 'view_lifterlms_reports' ) ) {
+
+			$instructor = llms_get_instructor();
+			if ( ! $instructor ) {
+				return;
+			}
+			$query = $instructor->get_memberships( $query_args, 'query' );
+
+		} else {
+
+			return;
+
+		}
+
+		$this->max_pages = $query->max_num_pages;
+
+		if ( $this->max_pages > $this->current_page ) {
+			$this->is_last_page = false;
+		}
+
+		$this->tbody_data = $query->posts;
+
+	}
+
+	/**
+	 * Get the Text to be used as the placeholder in a searchable tables search input.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_table_search_form_placeholder() {
+		return apply_filters( 'llms_table_get_' . $this->id . '_search_placeholder', __( 'Search memberships...', 'lifterlms' ) );
+	}
+
+	/**
+	 * Define the structure of arguments used to pass to the get_results method.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function set_args() {
+		return array();
+	}
+
+	/**
+	 * Define the structure of the table.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function set_columns() {
+		return array(
+			'id'          => array(
+				'exportable' => true,
+				'title'      => __( 'ID', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'title'       => array(
+				'exportable' => true,
+				'title'      => __( 'Title', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'instructors' => array(
+				'exportable' => true,
+				'filterable' => current_user_can( 'view_others_lifterlms_reports' ) ? $this->get_instructor_filters() : false,
+				'title'      => __( 'Instructors', 'lifterlms' ),
+			),
+			'students'    => array(
+				'exportable' => true,
+				'title'      => __( 'Students', 'lifterlms' ),
+			),
+		);
+	}
+
+}

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.memberships.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.memberships.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Memberships Tab on Reporting Screen
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Memberships Tab on Reporting Screen class.
+ *
+ * @since [version]
+ */
+class LLMS_Admin_Reporting_Tab_Memberships {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+
+		add_action( 'llms_reporting_content_memberships', array( $this, 'output' ) );
+		add_action( 'llms_reporting_membership_tab_breadcrumbs', array( $this, 'breadcrumbs' ) );
+
+	}
+
+	/**
+	 * Add breadcrumb links to the tab depending on current view.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function breadcrumbs() {
+
+		$links = array();
+
+		// single student
+		if ( isset( $_GET['membership_id'] ) ) {
+			$membership = llms_get_post( absint( $_GET['membership_id'] ) );
+			$links[ LLMS_Admin_Reporting::get_stab_url( 'overview' ) ] = $membership->get( 'title' );
+		}
+
+		foreach ( $links as $url => $title ) {
+
+			echo '<a href="' . esc_url( $url ) . '">' . $title . '</a>';
+
+		}
+
+	}
+
+	/**
+	 * Output tab content.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function output() {
+
+		// single membership
+		if ( isset( $_GET['membership_id'] ) ) {
+
+			if ( ! current_user_can( 'edit_post', $_GET['membership_id'] ) ) {
+				wp_die( __( 'You do not have permission to access this content.', 'lifterlms' ) );
+			}
+
+			$tabs = apply_filters( 'llms_reporting_tab_membership_tabs', array(
+				'overview' => __( 'Overview', 'lifterlms' ),
+				'students' => __( 'Students', 'lifterlms' ),
+			) );
+
+			llms_get_template( 'admin/reporting/tabs/memberships/membership.php', array(
+				'current_tab' => isset( $_GET['stab'] ) ? esc_attr( $_GET['stab'] ) : 'overview',
+				'tabs'        => $tabs,
+				'membership'  => llms_get_post( intval( $_GET['membership_id'] ) ),
+			) );
+
+		} // End if().
+		else {
+
+			$table = new LLMS_Table_Memberships();
+			$table->get_results();
+			echo $table->get_table_html();
+
+		}
+
+	}
+
+}
+
+return new LLMS_Admin_Reporting_Tab_Memberships();

--- a/includes/class.llms.membership.data.php
+++ b/includes/class.llms.membership.data.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Query data about a membership.
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Query data about a membership.
+ *
+ * @since [version]
+ */
+class LLMS_Membership_Data extends LLMS_Abstract_Post_Data {
+
+	/**
+	 * Retrieve # of membership enrollments within the period.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $period Optional.Date period [current|previous]. Default 'current'.
+	 * @return int
+	 */
+	public function get_enrollments( $period = 'current' ) {
+
+		global $wpdb;
+
+		return $wpdb->get_var( $wpdb->prepare( "
+			SELECT DISTINCT COUNT( user_id )
+			FROM {$wpdb->prefix}lifterlms_user_postmeta
+			WHERE meta_value = 'yes'
+			  AND meta_key = '_start_date'
+			  AND post_id = %d
+			  AND updated_date BETWEEN %s AND %s
+			",
+			$this->post_id,
+			$this->get_date( $period, 'start' ),
+			$this->get_date( $period, 'end' )
+		) );
+
+	}
+
+	/**
+	 * Retrieve # of engagements related to the membership awarded within the period.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type   Engagement type [email|certificate|achievement].
+	 * @param string $period Optional. Date period [current|previous]. Default 'current'.
+	 * @return int
+	 */
+	public function get_engagements( $type, $period = 'current' ) {
+
+		global $wpdb;
+
+		return $wpdb->get_var( $wpdb->prepare( "
+			SELECT DISTINCT COUNT( user_id )
+			FROM {$wpdb->prefix}lifterlms_user_postmeta
+			WHERE meta_key = %s
+			  AND post_id = %d
+			  AND updated_date BETWEEN %s AND %s
+			",
+			'_' . $type,
+			$this->post_id,
+			$this->get_date( $period, 'start' ),
+			$this->get_date( $period, 'end' )
+		) );
+
+	}
+
+	/**
+	 * Retrieve # of orders placed for the membership within the period.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $period Optional. Date period [current|previous]. Default 'current'.
+	 * @return int
+	 */
+	public function get_orders( $period = 'current' ) {
+
+		$query = $this->orders_query( array(
+			array(
+				'after'     => $this->get_date( $period, 'start' ),
+				'before'    => $this->get_date( $period, 'end' ),
+				'inclusive' => true,
+			),
+		), 1 );
+		return $query->found_posts;
+
+	}
+
+	/**
+	 * Retrieve total amount of transactions related to orders for the course completed within the period.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $period Optional. Date period [current|previous]. Default 'current'.
+	 * @return float
+	 */
+	public function get_revenue( $period ) {
+
+		$query = $this->orders_query( -1 );
+		$order_ids = wp_list_pluck( $query->posts, 'ID' );
+
+		$revenue = 0;
+
+		if ( $order_ids ) {
+
+			$order_ids = implode( ',', $order_ids );
+
+			global $wpdb;
+			$revenue = $wpdb->get_var( $wpdb->prepare(
+				"SELECT SUM( m2.meta_value )
+				 FROM $wpdb->posts AS p
+				 LEFT JOIN $wpdb->postmeta AS m1 ON m1.post_id = p.ID AND m1.meta_key = '_llms_order_id' -- join for the ID
+				 LEFT JOIN $wpdb->postmeta AS m2 ON m2.post_id = p.ID AND m2.meta_key = '_llms_amount'-- get the actual amounts
+				 WHERE p.post_type = 'llms_transaction'
+				   AND p.post_status = 'llms-txn-succeeded'
+				   AND m1.meta_value IN ({$order_ids})
+				   AND p.post_modified BETWEEN %s AND %s
+				;",
+				$this->get_date( $period, 'start' ),
+				$this->get_date( $period, 'end' )
+			) );
+
+			if ( is_null( $revenue ) ) {
+				$revenue = 0;
+			}
+		}
+
+		return apply_filters( 'llms_membership_data_get_revenue', $revenue, $period, $this );
+
+	}
+
+	/**
+	 * Retrieve the number of unenrollments on a given date.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $period Optional. Date period [current|previous]. Default 'current'.
+	 * @return int
+	 */
+	public function get_unenrollments( $period = 'current' ) {
+
+		global $wpdb;
+
+		return $wpdb->get_var( $wpdb->prepare( "
+			SELECT DISTINCT COUNT( user_id )
+			FROM {$wpdb->prefix}lifterlms_user_postmeta
+			WHERE meta_value != 'enrolled'
+			  AND meta_key = '_status'
+			  AND post_id = %d
+			  AND updated_date BETWEEN %s AND %s
+			",
+			$this->post_id,
+			$this->get_date( $period, 'start' ),
+			$this->get_date( $period, 'end' )
+		) );
+
+	}
+
+	/**
+	 * Execute a WP Query to retrieve orders within the given date range.
+	 *
+	 * @since [version]
+	 *
+	 * @param int   $num_orders Optional. Number of orders to retrieve. Default 1.
+	 * @param array $dates      Optiona. Date range (passed to WP_Query['date_query']). Default empty array.
+	 * @return obj
+	 */
+	private function orders_query( $num_orders = 1, $dates = array() ) {
+
+		$args = array(
+			'post_type'      => 'llms_order',
+			'post_status'    => array( 'llms-active', 'llms-complete' ),
+			'posts_per_page' => $num_orders,
+			'meta_key'       => '_llms_product_id',
+			'meta_value'     => $this->post_id,
+		);
+
+		if ( $dates ) {
+			$args['date_query'] = $dates;
+		}
+
+		$query = new WP_Query( $args );
+
+		return $query;
+
+	}
+
+}

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.0.0
  * @since 3.30.0 Added optional argument to `add_auto_enroll_courses()` method.
- * @version 3.30.0
+ * @since [version] Added `get_student_count()` method.
  *
  * @property $auto_enroll (array) Array of course IDs users will be autoenrolled in upon successful enrollment in this membership
  * @property $instructors (array) Course instructor user information
@@ -153,6 +153,24 @@ implements LLMS_Interface_Post_Instructors
 		}
 
 		return apply_filters( 'llms_membership_get_sales_page_url', $url, $this, $type );
+	}
+
+	/**
+	 * Retrieve the number of enrolled students in the membership.
+	 *
+	 * @since [version]
+	 * @return int
+	 */
+	public function get_student_count() {
+
+		$query = new LLMS_Student_Query( array(
+			'post_id' => $this->get( 'id' ),
+			'statuses' => array( 'enrolled' ),
+			'per_page' => 1,
+		) );
+
+		return $query->found_results;
+
 	}
 
 	/**

--- a/templates/admin/reporting/tabs/memberships/membership.php
+++ b/templates/admin/reporting/tabs/memberships/membership.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Single Membership View.
+ * @since    [version]
+ * @version  [version]
+ */
+defined( 'ABSPATH' ) || exit;
+is_admin() || exit;
+
+$img = $membership->get_image( array( 64, 64 ) );
+?>
+<section class="llms-reporting-tab llms-reporting-membership">
+
+	<header class="llms-reporting-breadcrumbs">
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=llms-reporting&tab=memberships' ) ); ?>"><?php _e( 'Memberships', 'lifterlms' ); ?></a>
+		<?php do_action( 'llms_reporting_membership_tab_breadcrumbs' ); ?>
+	</header>
+
+	<header class="llms-reporting-header">
+
+		<?php if ( $img ) : ?>
+			<div class="llms-reporting-header-img">
+				<img src="<?php echo $img; ?>">
+			</div>
+		<?php endif; ?>
+		<div class="llms-reporting-header-info">
+			<h2><a href="<?php echo get_edit_post_link( $membership->get( 'id' ) ); ?>"><?php echo $membership->get( 'title' ); ?></a></h2>
+		</div>
+
+	</header>
+
+	<nav class="llms-nav-tab-wrapper llms-nav-secondary">
+		<ul class="llms-nav-items">
+		<?php foreach ( $tabs as $name => $label ) : ?>
+			<li class="llms-nav-item<?php echo ( $current_tab === $name ) ? ' llms-active' : ''; ?>">
+				<a class="llms-nav-link" href="<?php echo LLMS_Admin_Reporting::get_stab_url( $name ) ?>">
+					<?php echo $label; ?>
+				</a>
+		<?php endforeach; ?>
+		</ul>
+	</nav>
+
+	<section class="llms-gb-tab">
+		<?php llms_get_template( 'admin/reporting/tabs/memberships/' . $current_tab . '.php', array(
+			'membership' => $membership,
+		) ); ?>
+	</section>
+
+</section>

--- a/templates/admin/reporting/tabs/memberships/overview.php
+++ b/templates/admin/reporting/tabs/memberships/overview.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * Single Membership Tab: Overview Subtab.
+ * @since    [version]
+ * @version  [version]
+ */
+defined( 'ABSPATH' ) || exit;
+is_admin() || exit;
+
+$data   = new LLMS_Membership_Data( $membership->get( 'id' ) );
+$period = isset( $_GET['period'] ) ? $_GET['period'] : 'today';
+$data->set_period( $period );
+
+$periods     = LLMS_Admin_Reporting::get_period_filters();
+$period_text = strtolower( $periods[ $period ] );
+$now         = current_time( 'timestamp' );
+?>
+
+<div class="llms-reporting-tab-content">
+
+	<section class="llms-reporting-tab-main llms-reporting-widgets">
+
+		<header>
+
+			<?php LLMS_Admin_Reporting::output_widget_range_filter( $period, 'memberships', array(
+				'membership_id' => $membership->get( 'id' ),
+			) ); ?>
+			<h3><?php _e( 'Membership Overview', 'lifterlms' ); ?></h3>
+
+		</header><?php
+
+		do_action( 'llms_reporting_single_membership_overview_before_widgets', $membership );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols' => 'd-1of3',
+			'icon' => 'users',
+			'id'   => 'llms-reporting-membership-total-enrollments',
+			'data' => $membership->get_student_count(),
+			'text' => __( 'Currently enrolled students', 'lifterlms' ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols'         => 'd-1of3',
+			'icon'         => 'shopping-cart',
+			'id'           => 'llms-reporting-membership-orders',
+			'data'         => $data->get_orders( 'current' ),
+			'data_compare' => $data->get_orders( 'previous' ),
+			'text'         => sprintf( __( 'New orders %s', 'lifterlms' ), $period_text ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols'         => 'd-1of3',
+			'icon'         => 'money',
+			'id'           => 'llms-reporting-membership-revenue',
+			'data'         => $data->get_revenue( 'current' ),
+			'data_compare' => $data->get_revenue( 'previous' ),
+			'data_type'    => 'monetary',
+			'text'         => sprintf( __( 'Total sales %s', 'lifterlms' ), $period_text ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'icon'         => 'smile-o',
+			'id'           => 'llms-reporting-membership-enrollments',
+			'data'         => $data->get_enrollments( 'current' ),
+			'data_compare' => $data->get_enrollments( 'previous' ),
+			'text'         => sprintf( __( 'New enrollments %s', 'lifterlms' ), $period_text ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'icon'         => 'frown-o',
+			'id'           => 'llms-reporting-membership-unenrollments',
+			'data'         => $data->get_unenrollments( 'current' ),
+			'data_compare' => $data->get_unenrollments( 'previous' ),
+			'text'         => sprintf( __( 'Unenrollments %s', 'lifterlms' ), $period_text ),
+			'impact'       => 'negative',
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols'         => 'd-1of3',
+			'icon'         => 'trophy',
+			'id'           => 'llms-reporting-membership-achievements',
+			'data'         => $data->get_engagements( 'achievement_earned', 'current' ),
+			'data_compare' => $data->get_engagements( 'achievement_earned', 'previous' ),
+			'text'         => sprintf( __( 'Achievements earned %s', 'lifterlms' ), $period_text ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols'         => 'd-1of3',
+			'icon'         => 'certificate',
+			'id'           => 'llms-reporting-membership-certificates',
+			'data'         => $data->get_engagements( 'certificate_earned', 'current' ),
+			'data_compare' => $data->get_engagements( 'certificate_earned', 'previous' ),
+			'text'         => sprintf( __( 'Certificates earned %s', 'lifterlms' ), $period_text ),
+		) );
+
+		LLMS_Admin_Reporting::output_widget( array(
+			'cols'         => 'd-1of3',
+			'icon'         => 'envelope',
+			'id'           => 'llms-reporting-membership-email',
+			'data'         => $data->get_engagements( 'email_sent', 'current' ),
+			'data_compare' => $data->get_engagements( 'email_sent', 'previous' ),
+			'text'         => sprintf( __( 'Emails sent %s', 'lifterlms' ), $period_text ),
+		) );
+
+		do_action( 'llms_reporting_single_membership_overview_after_widgets', $membership ); ?>
+
+	</section>
+
+	<aside class="llms-reporting-tab-side">
+
+		<h3><i class="fa fa-bolt" aria-hidden="true"></i> <?php _e( 'Recent events', 'lifterlms' ); ?></h3>
+
+		<?php foreach ( $data->recent_events() as $event ) : ?>
+			<?php LLMS_Admin_Reporting::output_event( $event, 'membership' ); ?>
+		<?php endforeach; ?>
+
+	</aside>
+
+</div>

--- a/templates/admin/reporting/tabs/memberships/students.php
+++ b/templates/admin/reporting/tabs/memberships/students.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Single Membership Tab: Students Subtab.
+ * @since    [version]
+ * @version  [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+is_admin() || exit;
+
+$table = new LLMS_Table_Membership_Students();
+$table->get_results();
+echo $table->get_table_html();


### PR DESCRIPTION
## Description
Add Memberships reporting tab.

## How has this been tested?
I've played with the new reporting tab and subtabs, checking they behave as expected without throwing any error/notice.

## Types of changes
New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.

## Consideration:
Even after the introduction of the `LLMS_Abstract_Post_Data` class you can still see a bunch of code in "common" between the `LLMS_Membership_Data`  and `LLMS_Course_Data`. Maybe an additional more generic class can be introduced to avoid code repetition.

Also, the new Membership table|tabs classes defined in the reporting/tables|tabs/*membership* files, are mostly copies (or partial copies with very slightly differences) of the Course ones...