### PR TITLE
Fix LLMS_Course_Data get_unenrollments() method doc: wrong params

### DIFF
--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -248,13 +248,12 @@ class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 	}
 
 	/**
-	 * Retrieve the number of unenrollments on a given date
+	 * Retrieve the number of unenrollments on a given date.
 	 *
-	 * @since    3.15.0
+	 * @since 3.15.0
 	 *
-	 * @param    mixed     $start  date string or timestamp
-	 * @param    mixed     $end    date string or timestamp
-	 * @return   int
+	 * @param  string $period Optional. Date period [current|previous]. Default 'current'.
+	 * @return int
 	 */
 	public function get_unenrollments( $period = 'current' ) {
 


### PR DESCRIPTION
## Description
Minor fix for the get_unenrollments() method docs which was showing wrong input params

## How has this been tested?
-



## Types of changes
Bug fix (documentation)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
