### PR TITLE
Fix data types in DocBlocks.

### DIFF
--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -79,7 +79,7 @@ class LLMS_Query {
 	 *
 	 * @since Unknown
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function get_query_vars() {
 		return apply_filters( 'llms_get_endpoints', $this->query_vars );
@@ -167,7 +167,7 @@ class LLMS_Query {
 	 * @since 1.4.4 Moved from LLMS_Post_Types.
 	 * @since 3.16.8
 	 *
-	 * @param obj $query Main WP_Query Object.
+	 * @param WP_Query $query Main WP_Query Object.
 	 * @return void
 	 */
 	public function pre_get_posts( $query ) {
@@ -235,7 +235,8 @@ class LLMS_Query {
 	 *
 	 * @since Unknown
 	 *
-	 * @return void
+	 * @param  array $vars WP query variables available for query.
+	 * @return array
 	 */
 	public function set_query_vars( $vars ) {
 

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -115,7 +115,7 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 
 	/**
 	 * Prepare the SQL for the query
-	 * @return   void
+	 * @return   string
 	 * @since    3.16.0
 	 * @version  3.16.0
 	 */


### PR DESCRIPTION
## Description
Corrected the data type in the @param and @return DocBlock tags.

## How has this been tested?
Only DocBlocks have been changed.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [ ] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
