### PR TITLE
Fix Issue #853 catalog order

### DIFF
--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -194,6 +194,9 @@ class LLMS_Query {
 				$sorting = explode( ',', get_option( 'lifterlms_shop_ordering', 'menu_order,ASC' ) );
 
 				$order = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
+				if ( 'menu_order' === $order ) {
+					$order .= ' post_title';
+				}
 				$orderby = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
 
 				$query->set( 'orderby', apply_filters( 'llms_courses_orderby', $order ) );
@@ -208,6 +211,9 @@ class LLMS_Query {
 				$sorting = explode( ',', get_option( 'lifterlms_memberships_ordering', 'menu_order,ASC' ) );
 
 				$order = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
+				if ( 'menu_order' === $order ) {
+					$order .= ' post_title';
+				}
 				$orderby = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
 
 				$query->set( 'orderby', apply_filters( 'llms_memberships_orderby', $order ) );

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -4,7 +4,7 @@
 * Handles queries and endpoints.
 *
 * @since 1.0.0
-* @version 3.28.2
+* @version [version]
 */
 
 defined( 'ABSPATH' ) || exit;
@@ -166,6 +166,7 @@ class LLMS_Query {
 	 *
 	 * @since 1.4.4 Moved from LLMS_Post_Types.
 	 * @since 3.16.8
+	 * @since [version] Added `post_title` as a secondary sort when the primary sort is `menu_order`
 	 *
 	 * @param WP_Query $query Main WP_Query Object.
 	 * @return void

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -193,14 +193,14 @@ class LLMS_Query {
 
 				$sorting = explode( ',', get_option( 'lifterlms_shop_ordering', 'menu_order,ASC' ) );
 
-				$order = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
-				if ( 'menu_order' === $order ) {
-					$order .= ' post_title';
+				$orderby = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
+				if ( 'menu_order' === $orderby ) {
+					$orderby .= ' post_title';
 				}
-				$orderby = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
+				$order = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
 
-				$query->set( 'orderby', apply_filters( 'llms_courses_orderby', $order ) );
-				$query->set( 'order', apply_filters( 'llms_courses_order', $orderby ) );
+				$query->set( 'orderby', apply_filters( 'llms_courses_orderby', $orderby ) );
+				$query->set( 'order', apply_filters( 'llms_courses_order', $order ) );
 
 				$modify_tax_query = true;
 
@@ -210,14 +210,14 @@ class LLMS_Query {
 
 				$sorting = explode( ',', get_option( 'lifterlms_memberships_ordering', 'menu_order,ASC' ) );
 
-				$order = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
-				if ( 'menu_order' === $order ) {
-					$order .= ' post_title';
+				$orderby = empty( $sorting[0] ) ? 'menu_order' : $sorting[0];
+				if ( 'menu_order' === $orderby ) {
+					$orderby .= ' post_title';
 				}
-				$orderby = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
+				$order = empty( $sorting[1] ) ? 'ASC' : $sorting[1];
 
-				$query->set( 'orderby', apply_filters( 'llms_memberships_orderby', $order ) );
-				$query->set( 'order', apply_filters( 'llms_memberships_order', $orderby ) );
+				$query->set( 'orderby', apply_filters( 'llms_memberships_orderby', $orderby ) );
+				$query->set( 'order', apply_filters( 'llms_memberships_order', $order ) );
 
 				$modify_tax_query = true;
 


### PR DESCRIPTION
## Description
Added a secondary sort on `post_title` when the primary sort column is `menu_order`.
Renamed `$order` to `$orderby` and `$orderby` to `$order` to be consistent with WordPress's usage.

## How has this been tested?
```
composer run-script tests-run
composer run-script phpcs
```
PHP 7.2.11
Made sure that the query's `ORDER` clause is:
```sql
ORDER BY wp_posts.menu_order ASC, wp_posts.post_title ASC
```

## Types of changes
Fixed issue #853

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
