### PR TITLE
Do not display the "Delete enrollment" button when there's no enrollment

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Metaboxe for Student Enrollment Information via the Order interface
+ * Metabox for Student Enrollment Information via the Order interface
  *
  * @since 3.0.0
  * @version [version]
@@ -9,7 +9,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metaboxe for Student Enrollment Information via the Order interface
+ * Metabox for Student Enrollment Information via the Order interface
  *
  * @since 3.0.0
  * @since [version] Added the logic to handle the Enrollment 'deleted' status on save.
@@ -95,7 +95,7 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 		echo '<input name="llms_student_old_enrollment_status" type="hidden" value="' . $current_status . '">';
 
 		echo '<input name="llms_update_enrollment_status" type="submit" class="llms-button-secondary small" value="' . __( 'Update Status', 'lifterlms' ) . '"> ';
-		if ( 'enrolled' !== $current_status ) {
+		if ( $current_status && 'enrolled' !== $current_status ) {
 			echo '<input name="llms_delete_enrollment_status" type="submit" class="llms-button-danger small" value="' . __( 'Delete Enrollment', 'lifterlms' ) . '">';
 		}
 


### PR DESCRIPTION
in the enrollment meta box on order edit screen
fix #861

## Description
Added a small condition to not display the "Delete enrollment" button when there's no enrollment to delete.

## How has this been tested?
In the Order edit screen:

1. Turned an enrollment status from 'enrolled' to 'cancelled' via the meta box select and updated.
2. The "Delete enrollment" button appeared and I clicked on it.
3. The enrollment was deleted and the "Deleted enrollment" button was not shown anymore.

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
