### PR TITLE
Ensure the mark complete button is displayed on lessons

### DIFF
--- a/templates/course/complete-lesson-link.php
+++ b/templates/course/complete-lesson-link.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 global $post;
 
 $lesson = llms_get_post( $post );
-if ( ! $lesson || ! is_a( $post, 'LLMS_Lesson' ) ) {
+if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 	return;
 }
 


### PR DESCRIPTION
fix #863

## Description
in the complete-lesson-link template I've replaced this check:
 `is_a( $post, 'LLMS_Lesson' )`
with this one: 
`is_a( $lesson, 'LLMS_Lesson' )`

As the global `$post` can never an instance of `'LLMS_Lesson'` while `$lesson`, previously retrieved via `llms_get_post( $post )`, can.

## How has this been tested?
I've tested that the button appears in lessons as expected and that still doesn't appear, and throws not errors, when, for example, added to a Course via shortcode.

## Screenshots
n/a

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
