### PR TITLE
On account edit: email confirmation now only required when changing t…

### DIFF
--- a/assets/js/app/llms-student-dashboard.js
+++ b/assets/js/app/llms-student-dashboard.js
@@ -3,8 +3,10 @@
  *
  * @package LifterLMS/Scripts
  *
- * @since    3.7.0
- * @version  3.10.0
+ * @since 3.7.0
+ * @since 3.10.0 Unknown.
+ * @since [version] Added logic to make the email address confirm field required only if email is different from the original value.
+ * @version [version]
  */
 
 LLMS.StudentDashboard = {
@@ -26,11 +28,13 @@ LLMS.StudentDashboard = {
 	meter_exists: 0,
 
 	/**
-	 * Init
+	 * Init.
 	 *
-	 * @return   void
-	 * @since    3.7.0
-	 * @version  3.10.0
+	 * @since 3.7.0
+	 * @since 3.10.0 Unknown.
+	 * @since [version] Treat the case when we're on edit-account screen and we need to make the email address confirm field required.
+	 *
+	 * @return void
 	 */
 	init: function() {
 
@@ -43,6 +47,13 @@ LLMS.StudentDashboard = {
 
 				this.bind_orders();
 
+			} else if ( 'edit-account' === this.get_screen() ) {
+
+				if ( $( '#email_address_confirm' ).length && 'required' !== $( '#email_address_confirm' ).attr( 'required' ) ) {
+					$( '#email_address' ).data( 'llms-original-email', $( '#email_address' ).val() );
+					this.bind_email_fields();
+				}
+
 			}
 
 		}
@@ -50,11 +61,12 @@ LLMS.StudentDashboard = {
 	},
 
 	/**
-	 * Bind DOM events
+	 * Bind DOM events.
 	 *
-	 * @return   void
-	 * @since    3.7.0
-	 * @version  3.7.4
+	 * @since 3.7.0
+	 * @since 3.7.4 Unknown.
+	 *
+	 * @return void
 	 */
 	bind: function() {
 
@@ -88,7 +100,6 @@ LLMS.StudentDashboard = {
 
 		// this will remove the required by default without having to mess with
 		// conditionals in PHP and still allows the required * to show in the label
-
 		if ( this.meter_exists ) {
 
 			$( '.llms-person-form.edit-account' ).on( 'llms-password-strength-ready', function() {
@@ -108,11 +119,11 @@ LLMS.StudentDashboard = {
 	},
 
 	/**
-	 * Bind events related to the orders screen on the dashboard
+	 * Bind events related to the orders screen on the dashboard.
 	 *
-	 * @return   void
-	 * @since    3.10.0
-	 * @version  3.10.0
+	 * @since 3.10.0
+	 *
+	 * @return void
 	 */
 	bind_orders: function() {
 
@@ -124,12 +135,44 @@ LLMS.StudentDashboard = {
 
 	},
 
+
 	/**
-	 * Get the current dashboard endpoint/tab slug
+	 * Bind events related to the email fields on the dashboard's edit account screen.
 	 *
-	 * @return   void
-	 * @since    3.10.0
-	 * @version  3.10.0
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	bind_email_fields: function() {
+
+		var $email_confirm = $( '#email_address_confirm' ),
+			$email         = $( '#email_address' );
+
+		function maybe_require_email_address_confirm() {
+			if ( $email.data( 'llms-original-email' ) !== $email.val() ) {
+				if ( 'required' !== $email_confirm.attr( 'required' ) ) {
+					$( '<span class="llms-required">*</span>' ).insertBefore( $email_confirm.attr( 'required', 'required' ) );
+				}
+			} else {
+				$email_confirm.removeAttr( 'required' ).prev( '.llms-required' ).remove();
+			}
+		}
+
+		$email.on( 'focusout', maybe_require_email_address_confirm )
+			  .closest( 'form' ).submit( function() {
+				  maybe_require_email_address_confirm();
+				  return true;
+			  });
+
+	},
+
+
+	/**
+	 * Get the current dashboard endpoint/tab slug.
+	 *
+	 * @since 3.10.0
+	 *
+	 * @return void
 	 */
 	get_screen: function() {
 		if ( ! this.screen ) {
@@ -139,12 +182,12 @@ LLMS.StudentDashboard = {
 	},
 
 	/**
-	 * Show a confirmation warning when Cancel Subscription form is submitted
+	 * Show a confirmation warning when Cancel Subscription form is submitted.
 	 *
-	 * @param    obj   e  JS event data
-	 * @return   void
-	 * @since    3.10.0
-	 * @version  3.10.0
+	 * @since 3.10.0
+	 *
+	 * @param obj e JS event data.
+	 * @return void
 	 */
 	order_cancel_warning: function( e ) {
 		e.preventDefault();
@@ -156,12 +199,13 @@ LLMS.StudentDashboard = {
 	},
 
 	/**
-	 * Toggle password related fields on the account edit page
+	 * Toggle password related fields on the account edit page.
 	 *
-	 * @param    string   action  [show|hide]
-	 * @return   void
-	 * @since    3.7.0
-	 * @version  3.7.4
+	 * @since 3.7.0
+	 * @since 3.7.4 Unknown.
+	 *
+	 * @param string action[show|hide]
+	 * @return void
 	 */
 	password_toggle: function( action ) {
 

--- a/tests/unit-tests/controllers/class-llms-test-controller-account.php
+++ b/tests/unit-tests/controllers/class-llms-test-controller-account.php
@@ -27,16 +27,16 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 	 * @var array
 	 */
 	private $user_info = array(
-		'email_address'             => 'help+23568@lifterlms.com',
-		'email_address_confirm'     => 'help+23568@lifterlms.com',
-		'first_name'                => 'Marshall',
-		'last_name'                 => 'Pate',
-		'llms_billing_address_1'    => 'Voluptatem',
-		'llms_billing_address_2'    => '#12345',
-		'llms_billing_city'         => 'Harum est dolorum sed vel perspiciatis consequatur dignissimos possimus delectus quos optio omnis error quas rem dicta et consectetur odio',
-		'llms_billing_state'        => 'Esse ea est dolore sed sunt ipsum a ut nemo dolorem aut aliquam cillum asperiores minim culpa',
-		'llms_billing_zip'          => '72995',
-		'llms_billing_country'      => 'US',
+		'email_address'          => 'help+23568@lifterlms.com',
+		'email_address_confirm'  => 'help+23568@lifterlms.com',
+		'first_name'             => 'Marshall',
+		'last_name'              => 'Pate',
+		'llms_billing_address_1' => 'Voluptatem',
+		'llms_billing_address_2' => '#12345',
+		'llms_billing_city'      => 'Harum est dolorum sed vel perspiciatis consequatur dignissimos possimus delectus quos optio omnis error quas rem dicta et consectetur odio',
+		'llms_billing_state'     => 'Esse ea est dolore sed sunt ipsum a ut nemo dolorem aut aliquam cillum asperiores minim culpa',
+		'llms_billing_zip'       => '72995',
+		'llms_billing_country'   => 'US',
 	);
 
 	/**

--- a/tests/unit-tests/controllers/class-llms-test-controller-account.php
+++ b/tests/unit-tests/controllers/class-llms-test-controller-account.php
@@ -1,31 +1,59 @@
 <?php
 /**
- * Tests for the LLMS_Controller_Account class
+ * Tests for the LLMS_Controller_Account class.
  *
  * @group controllers
  *
  * @since 3.19.0
  * @since 3.34.0 Use `LLMS_Unit_Test_Exception_Exit` from tests lib.
+ * @since [version] Added test methods on email address confirm field requirement.
  */
 class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 
-	// consider dates equal within 60 seconds
+	/**
+	 * Consider dates equal within 60 seconds.
+	 *
+	 * @since ??
+	 *
+	 * @var int
+	 */
 	private $date_delta = 60;
 
 	/**
-	 * Test order completion actions
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 * A default array of user information to feed a request with
+	 *
+	 * @since [version]
+	 *
+	 * @var array
+	 */
+	private $user_info = array(
+		'email_address'             => 'help+23568@lifterlms.com',
+		'email_address_confirm'     => 'help+23568@lifterlms.com',
+		'first_name'                => 'Marshall',
+		'last_name'                 => 'Pate',
+		'llms_billing_address_1'    => 'Voluptatem',
+		'llms_billing_address_2'    => '#12345',
+		'llms_billing_city'         => 'Harum est dolorum sed vel perspiciatis consequatur dignissimos possimus delectus quos optio omnis error quas rem dicta et consectetur odio',
+		'llms_billing_state'        => 'Esse ea est dolore sed sunt ipsum a ut nemo dolorem aut aliquam cillum asperiores minim culpa',
+		'llms_billing_zip'          => '72995',
+		'llms_billing_country'      => 'US',
+	);
+
+	/**
+	 * Test order completion actions.
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_cancel_subscription() {
 
-		// form not submitted
+		// form not submitted.
 		$this->setup_post( array() );
 		do_action( 'init' );
 		$this->assertEquals( 0, did_action( 'llms_subscription_cancelled_by_student' ) );
 
-		// form submitted but missing required fields
+		// form submitted but missing required fields.
 		$this->setup_post( array(
 			'_cancel_sub_nonce' => wp_create_nonce( 'llms_cancel_subscription' ),
 		) );
@@ -35,7 +63,7 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 
 		llms_clear_notices();
 
-		// form submitted but invalid order id or the order id is invalid
+		// form submitted but invalid order id or the order id is invalid.
 		$this->setup_post( array(
 			'_cancel_sub_nonce' => wp_create_nonce( 'llms_cancel_subscription' ),
 			'order_id' => 123,
@@ -46,10 +74,10 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 
 		llms_clear_notices();
 
-		// create a real order
+		// create a real order.
 		$order = $this->get_mock_order();
 
-		// form submitted but invalid order id or the order doesn't belong to the current user
+		// form submitted but invalid order id or the order doesn't belong to the current user.
 		$this->setup_post( array(
 			'_cancel_sub_nonce' => wp_create_nonce( 'llms_cancel_subscription' ),
 			'order_id' => $order->get( 'id' ),
@@ -63,7 +91,7 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 
 		foreach ( array_keys( llms_get_order_statuses( 'recurring' ) ) as $status ) {
 
-			// active order moves to pending cancel
+			// active order moves to pending cancel.
 			$order->set_status( $status );
 
 			$this->setup_post( array(
@@ -80,30 +108,185 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test account update form submission handler
+	 * Test account update form submission handler catching email confirm validation errors.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_email_confirm_error() {
+
+		LLMS_Install::create_pages();
+
+		// create a user.
+		$uid = $this->factory->user->create( array(
+			'user_email' => $this->user_info['email_address'],
+		) );
+
+		// sign the user in.
+		wp_set_current_user( $uid );
+
+		// create nonce.
+		$nonce = array(
+			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
+		);
+		$post  = array_merge( $this->user_info, $nonce );
+
+		// update something: email changes - no email confirm supplied.
+		$post['email_address'] = 'test-' . $this->user_info['email_address'];
+		unset( $post['email_address_confirm'] );
+		$this->setup_post( $post );
+		// expect submission but validation error.
+		do_action( 'init' );
+		$this->assertEquals( 1, did_action( 'llms_before_user_account_update_submit' ) );
+		$this->assertTrue( ( llms_notice_count( 'error' ) >= 1 ) );
+		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
+		llms_clear_notices();
+
+		// update something: email changes - email confirm supplied but empty.
+		$post['email_address_confirm'] = '';
+		$this->setup_post( $post );
+		// expect submission but validation error.
+		do_action( 'init' );
+		$this->assertEquals( 2, did_action( 'llms_before_user_account_update_submit' ) );
+		$this->assertTrue( ( llms_notice_count( 'error' ) >= 1 ) );
+		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
+		llms_clear_notices();
+
+		// update something: email changes - email confirm supplied but not matching.
+		$post['email_address']         = $this->user_info['email_address'];
+		$post['email_address_confirm'] = 'wrong-' . $post['email_address'];
+		$this->setup_post( $post );
+		//expect submission but validation error.
+		do_action( 'init' );
+		$this->assertEquals( 3, did_action( 'llms_before_user_account_update_submit' ) );
+		$this->assertTrue( ( llms_notice_count( 'error' ) >= 1 ) );
+		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
+		llms_clear_notices();
+
+	}
+
+	/**
+	 * Test account update form submission handler when no email and email confirm match.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_email_confirm_matching() {
+
+		LLMS_Install::create_pages();
+
+		// create a user.
+		$uid = $this->factory->user->create( array(
+			'user_email' => $this->user_info['email_address'],
+		) );
+
+		// sign the user in.
+		wp_set_current_user( $uid );
+
+		// create nonce.
+		$nonce = array(
+			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
+		);
+		$post  = array_merge( $this->user_info, $nonce );
+
+		// email changes - email confirm matches.
+		$post['email_address']         = 'test-' . $this->user_info['email_address'];
+		$post['email_address_confirm'] = $post['email_address'];
+
+		$this->setup_post( $post );
+
+		// exceptions thrown in testing env instead of exit().
+		$this->expectException( LLMS_Unit_Test_Exception_Exit::class );
+		$this->expectExceptionMessage( sprintf( '%s [302] YES', llms_get_endpoint_url( 'edit-account', '', llms_get_page_url( 'myaccount' ) ) ) );
+
+		// run these assertions within actions because the exit() at the end of the redirect will halt program execution and then we'll never get to these assertions!
+		add_action( 'llms_before_user_account_update_submit', function() {
+			$this->assertEquals( 1, did_action( 'llms_before_user_account_update_submit' ) );
+			$this->assertEquals( 0, llms_notice_count( 'error' ) );
+		} );
+		add_action( 'lifterlms_user_updated', function() {
+			$this->assertEquals( 1, did_action( 'lifterlms_user_updated' ) );
+		} );
+
+		do_action( 'init' );
+
+	}
+
+	/**
+	 * Test account update form submission handler when no email changed => no email confirm is needed.
+	 *
+	 * @since [version]
+	 * @return void
+	 */
+	public function test_update_email_confirm_unneded() {
+
+		LLMS_Install::create_pages();
+
+		// create a user.
+		$uid = $this->factory->user->create( array(
+			'user_email' => $this->user_info['email_address'],
+		) );
+
+		// sign the user in.
+		wp_set_current_user( $uid );
+
+		// create nonce.
+		$nonce = array(
+			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
+		);
+		$post  = array_merge( $this->user_info, $nonce );
+
+		// no email changing - no need to have an email address confirm.
+		$post['first_name'] = 'test-' . $this->user_info['first_name'];
+		unset( $post['email_address_confirm'] );
+
+		$this->setup_post( $post );
+
+		// exceptions thrown in testing env instead of exit().
+		$this->expectException( LLMS_Unit_Test_Exception_Exit::class );
+		$this->expectExceptionMessage( sprintf( '%s [302] YES', llms_get_endpoint_url( 'edit-account', '', llms_get_page_url( 'myaccount' ) ) ) );
+
+		// run these assertions within actions because the exit() at the end of the redirect will halt program execution and then we'll never get to these assertions!
+		add_action( 'llms_before_user_account_update_submit', function() {
+			$this->assertEquals( 1, did_action( 'llms_before_user_account_update_submit' ) );
+			$this->assertEquals( 0, llms_notice_count( 'error' ) );
+		} );
+		add_action( 'lifterlms_user_updated', function() {
+			$this->assertEquals( 1, did_action( 'lifterlms_user_updated' ) );
+		} );
+
+		do_action( 'init' );
+
+	}
+
+
+	/**
+	 * Test account update form submission handler.
 	 *
 	 * @since 3.19.4
 	 * @since 3.34.0 Use `LLMS_Unit_Test_Exception_Exit` from test lib.
 	 *
-	 * @return   void
+	 * @return void
 	 */
 	public function test_update() {
 
 		LLMS_Install::create_pages();
 
-		// form not submitted
+		// form not submitted.
 		$this->setup_post( array() );
 		do_action( 'init' );
 		$this->assertEquals( 0, did_action( 'llms_before_user_account_update_submit' ) );
 		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
 
-		// also not submitted
+		// also not submitted.
 		$this->setup_get( array() );
 		do_action( 'init' );
 		$this->assertEquals( 0, did_action( 'llms_before_user_account_update_submit' ) );
 		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
 
-		// form submitted but user isn't logged in
+		// form submitted but user isn't logged in.
 		$this->setup_post( array(
 			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
 		) );
@@ -113,12 +296,12 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
 		llms_clear_notices();
 
-		// create a user
+		// create a user.
 		$uid = $this->factory->user->create();
-		// sign the user in
+		// sign the user in.
 		wp_set_current_user( $uid );
 
-		// form submitted but missing fields
+		// form submitted but missing fields.
 		$this->setup_post( array(
 			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
 		) );
@@ -128,27 +311,16 @@ class LLMS_Test_Controller_Account extends LLMS_UnitTestCase {
 		$this->assertEquals( 0, did_action( 'lifterlms_user_updated' ) );
 		llms_clear_notices();
 
-		// update something
-		$this->setup_post( array(
+		// update something.
+		$this->setup_post( array_merge( array(
 			'_llms_update_person_nonce' => wp_create_nonce( 'llms_update_person' ),
-			'email_address' => 'help+23568@lifterlms.com',
-			'email_address_confirm' => 'help+23568@lifterlms.com',
-			'first_name' => 'Marshall',
-			'last_name' => 'Pate',
-			'llms_billing_address_1' => 'Voluptatem',
-			'llms_billing_address_2' => '#12345',
-			'llms_billing_city' => 'Harum est dolorum sed vel perspiciatis consequatur dignissimos possimus delectus quos optio omnis error quas rem dicta et consectetur odio',
-			'llms_billing_state' => 'Esse ea est dolore sed sunt ipsum a ut nemo dolorem aut aliquam cillum asperiores minim culpa',
-			'llms_billing_zip' => '72995',
-			'llms_billing_country' => 'US',
-		) );
+		), $this->user_info ) );
 
-		// exceptions thrown in testing env instead of exit()
+		// exceptions thrown in testing env instead of exit().
 		$this->expectException( LLMS_Unit_Test_Exception_Exit::class );
 		$this->expectExceptionMessage( sprintf( '%s [302] YES', llms_get_endpoint_url( 'edit-account', '', llms_get_page_url( 'myaccount' ) ) ) );
 
-		// run these assertions within actions because the exit() at the end of the redirect will halt program execution
-		// and then we'll never get to these assertions!
+		// run these assertions within actions because the exit() at the end of the redirect will halt program execution and then we'll never get to these assertions!
 		add_action( 'llms_before_user_account_update_submit', function() {
 			$this->assertEquals( 3, did_action( 'llms_before_user_account_update_submit' ) );
 			$this->assertEquals( 0, llms_notice_count( 'error' ) );


### PR DESCRIPTION
…he email

fix #495

## Description
Added the logic to make sure that, on account edit, the email confirmation is required only when changing the email (PHP and JS).

## How has this been tested?
Tested on account edit screen submitting various changes:
1) without touching the email field and leaving the email confirm field empty.
2) then changing the email field and leaving the email confirm empty => validation error (even disabling JS)


## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
