### PR TITLE
no checkout form but a notice to users buying a product they've already enrolled

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Shortcodes
  *
  * @since 1.0.0
- * @version 3.30.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.30.1 Added check via llms_locate_order_for_user_and_plan() to automatically resume an existing pending order for logged in users if one exists.
- * @version 3.30.1
+ * @since [version] Checkout form not displayed to users already enrolled in the product being purchased, a notice informing them of that is displayed insted.
  */
 class LLMS_Shortcode_Checkout {
 
@@ -36,7 +36,7 @@ class LLMS_Shortcode_Checkout {
 	 * Renders the checkout template
 	 *
 	 * @since 1.0.0
-	 * @version 3.0.0
+	 * @since [version] Do not display the checkout form but a notice to a logged in user enrolled in the product being purchased.
 	 *
 	 * @param array $atts Shortcode attributes array.
 	 * @return void
@@ -62,6 +62,17 @@ class LLMS_Shortcode_Checkout {
 		}
 
 		if ( self::$uid ) {
+			// ensure the user isn't enrolled in the product being purchased
+			if ( isset( $atts['product'] ) && llms_is_user_enrolled( self::$uid, $atts['product']->get( 'id' ) ) ) {
+
+				llms_print_notice( sprintf(
+					__( 'You already have access to this %2$s! Visit your dashboard <a href="%s">here.</a>', 'lifterlms' ),
+					llms_get_page_url( 'myaccount' ),
+					$atts['product']->get_post_type_label()
+				), 'error' );
+				return;
+			}
+
 			$user = get_userdata( self::$uid );
 			llms_print_notice( sprintf( __( 'You are currently logged in as <em>%1$s</em>. <a href="%2$s">Click here to logout</a>', 'lifterlms' ), $user->user_email, wp_logout_url( $atts['plan']->get_checkout_url() ) ), 'notice' );
 		} else {


### PR DESCRIPTION
fix #607

## Description
A simple enrollment check performed within the checkout form shortcode logic: if logged in users are already enrolled in the product being purchased:
1) display a notice informing them of that
2) do not display the checkout form

## How has this been tested?
Tested it accessing the checkout page as:
1) NOT logged in user => checkout form displayed and NO "error" notice
2) logged in user not enrolled in the access plan's product id => checkout form displayed and NO "error" notice
3) logged in user enrolled in the access plan's product id  => checkout form NOT displayed and "error" notice


## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.