### PR TITLE
avoid adding quotes before quotes in access plan description/title wh…

### DIFF
--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.32.0 Update `select2_query_posts` to use llms_filter_input() and allows for querying posts by post status(es).
  * @since 3.33.0 Update `update_student_enrollment` to handle enrollment deletion requests, make sure the input array param 'post_id' field is not empty.
  *                  Also always return either a WP_Error on failure or a "success" array on requested action performed.
+ * @since [version] Update `llms_update_access_plans` to use `wp_unslash()` before inserting access plan data.
  */
 class LLMS_AJAX_Handler {
 
@@ -1140,10 +1141,11 @@ class LLMS_AJAX_Handler {
 	/**
 	 * AJAX handler for creating and updating access plans via the metabox on courses & memberships
 	 *
-	 * @param   array $request $_POST data.
-	 * @return  array
-	 * @since   3.29.0
-	 * @version 3.29.2
+	 * @since 3.29.0
+	 * @since [version] Use `wp_unslash()` before inserting access plan data.
+	 *
+	 * @param array $request $_POST data.
+	 * @return array
 	 */
 	public static function llms_update_access_plans( $request ) {
 
@@ -1162,6 +1164,8 @@ class LLMS_AJAX_Handler {
 			if ( empty( $raw_plan_data ) ) {
 				continue;
 			}
+
+			$raw_plan_data = wp_unslash( $raw_plan_data );
 
 			// Ensure we can switch plans that used to be paid to free.
 			if ( isset( $raw_plan_data['is_free'] ) && llms_parse_bool( $raw_plan_data['is_free'] ) && ! isset( $raw_plan_data['price'] ) ) {


### PR DESCRIPTION
…en saving/updating

fix #871

## Description
Make sure `wp_unslash` is applied to the access plans data being inserted/updated.

## How has this been tested?
I created (and updated) access plans with quotes into their description and made sure they were saved without any additional backslash added before quotes.


## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
