### PR TITLE
Allow Admin/Instructor to view checkout form when enrolled in a product

### DIFF
--- a/assets/js/llms-view-manager.js
+++ b/assets/js/llms-view-manager.js
@@ -3,8 +3,10 @@
  *
  * @package LifterLMS/Scripts
  *
- * @since    3.8.0
- * @version  3.8.0
+ * @since 3.8.0
+ * @since [version] Added access plans action button selector to the list of links to update.
+ *
+ * @version [version]
  */
 
 ( function( $, undefined ) {
@@ -41,11 +43,12 @@
 		}
 
 		/**
-		 * Update various links on the page for easy navigation when using views
+		 * Update various links on the page for easy navigation when using views.
 		 *
-		 * @return   void
-		 * @since    3.8.0
-		 * @version  3.8.0
+		 * @since 3.8.0
+		 * @since [version] Added access plans action button selector to the list of links to update.
+		 *
+		 * @return void
 		 */
 		this.update_links = function() {
 
@@ -53,7 +56,7 @@
 				return;
 			}
 
-			var $links = $( '.llms-widget-syllabus .llms-lesson a, .llms-course-progress a, .llms-lesson-preview a.llms-lesson-link, .llms-parent-course-link a.llms-lesson-link' );
+			var $links = $( '.llms-widget-syllabus .llms-lesson a, .llms-course-progress a, .llms-lesson-preview a.llms-lesson-link, .llms-parent-course-link a.llms-lesson-link, .llms-access-plans a.llms-button-action' );
 
 			$links.each( function() {
 

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -7,16 +7,17 @@
  * @package LifterLMS/Classes
  *
  * @since 3.7.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_View_Manager
+ * LLMS_View_Manager class.
  *
  * @since 3.7.0
  * @since 3.35.0 Sanitize `$_GET` data.
+ * @since [version] Disable the view management when creating a pending order.
  */
 class LLMS_View_Manager {
 
@@ -24,36 +25,37 @@ class LLMS_View_Manager {
 	 * Constructor
 	 *
 	 * @since 3.7.0
-	 * @version 3.7.0
+	 * @since [version] Added early return when creating a pending order.
 	 */
 	public function __construct() {
 
+		// Do nothing if we're creating a pending order.
+		if ( ! empty( $_POST['action'] ) && 'create_pending_order' === $_POST['action'] ) {// phpcs:disable WordPress.Security.NonceVerification.Missing
+			return;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		add_action( 'init', array( $this, 'add_actions' ) );
 
 	}
 
 	/**
-	 * Add actions & filters
+	 * Add actions & filters.
 	 *
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @return void
 	 */
 	public function add_actions() {
 
-		// if user can't bypass restrictions don't do anything
-		if ( ! llms_can_user_bypass_restrictions( get_current_user_id() ) ) {
-			return;
-		}
-
-		// output view links on the admin menu
+		// output view links on the admin menu.
 		add_action( 'admin_bar_menu', array( $this, 'add_menu_items' ), 777 );
 
-		// filter page restrictions
+		// filter page restrictions.
 		add_filter( 'llms_page_restricted', array( $this, 'modify_restrictions' ), 10, 1 );
 		add_filter( 'llms_is_course_open', array( $this, 'modify_course_open' ), 10, 1 );
 		add_filter( 'llms_is_course_enrollment_open', array( $this, 'modify_course_open' ), 10, 1 );
 
-		// filters we'll only run when view as links are called
+		// filters we'll only run when view as links are called.
 		if ( isset( $_GET['llms-view-as'] ) ) {
 
 			add_filter( 'llms_is_course_complete', array( $this, 'modify_completion' ), 10, 1 );
@@ -69,11 +71,12 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Add view links to the admin menu bar for qualifying users
+	 * Add view links to the admin menu bar for qualifying users.
 	 *
-	 * @return   void
-	 * @since    3.7.0
-	 * @version  3.16.0
+	 * @since 3.7.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function add_menu_items() {
 
@@ -129,13 +132,12 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Inline JS
-	 * Updates links so admins can navigate around quickly when "viewing as"
+	 * Inline JS.
+	 * Updates links so admins can navigate around quickly when "viewing as".
 	 *
 	 * @since 3.7.0
 	 * @since 3.35.0 Sanitize `$_GET` data.
-	 *
-	 * @return   string
+	 * @return string
 	 */
 	private function get_inline_script() {
 		ob_start();
@@ -146,13 +148,13 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Get a view url for the requested view
+	 * Get a view url for the requested view.
 	 *
-	 * @param    string $role  view option [self|visitor|student]
-	 * @param    array  $args  additional query args to add to the url
-	 * @return   string
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @param string $role View option [self|visitor|student].
+	 * @param array  $args Optional. Additional query args to add to the url. Default empty array.
+	 * @return string
 	 */
 	private function get_url( $role, $args = array() ) {
 
@@ -173,12 +175,12 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Get the current view role/type
+	 * Get the current view role/type.
 	 *
 	 * @since 3.7.0
 	 * @since 3.35.0 Sanitize `$_GET` data.
 	 *
-	 * @return   string
+	 * @return string
 	 */
 	private function get_view() {
 
@@ -197,11 +199,11 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Get a list of available views
+	 * Get a list of available views.
 	 *
-	 * @return   array
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @return array
 	 */
 	private function get_views() {
 		return array(
@@ -212,13 +214,13 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Modify the completion status of course, lessons, tracks based on current view
-	 * Visitors and students will always show content as not completed
+	 * Modify the completion status of course, lessons, tracks based on current view.
+	 * Visitors and students will always show content as not completed.
 	 *
-	 * @param    boolean $completed   actual status for the current user
-	 * @return   boolean
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @param boolean $completed The actual status for the current user.
+	 * @return boolean
 	 */
 	public function modify_completion( $completed ) {
 		switch ( $this->get_view() ) {
@@ -233,14 +235,14 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Modify the status of a course access period based on the current view
-	 * Students and Visitors will see the actual access period
-	 * If viewing as self and self can bypass restrictions will appear as if course is open
+	 * Modify the status of a course access period based on the current view.
+	 * Students and Visitors will see the actual access period.
+	 * If viewing as self and self can bypass restrictions will appear as if course is open.
 	 *
-	 * @param    boolean $status  default status
-	 * @return   boolean
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @param boolean $status The default status.
+	 * @return boolean
 	 */
 	public function modify_course_open( $status ) {
 
@@ -255,14 +257,14 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Modify the enrollment status of current user based on the view
-	 * students will always show as enrolled
-	 * visitors will always show as not-enrolled
+	 * Modify the enrollment status of current user based on the view.
+	 * Students will always show as enrolled.
+	 * Visitors will always show as not-enrolled.
 	 *
-	 * @param    string $status   actual status for the current user
-	 * @return   string
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @param string $status The actual status for the current user.
+	 * @return string
 	 */
 	public function modify_enrollment_status( $status ) {
 
@@ -283,12 +285,12 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Modify llms_page_restricted for qualifying users to allow them to bypass restrictions
+	 * Modify llms_page_restricted for qualifying users to allow them to bypass restrictions.
 	 *
-	 * @param    array $restrictions  restriction data
-	 * @return   array
-	 * @since    3.7.0
-	 * @version  3.7.0
+	 * @since 3.7.0
+	 *
+	 * @param array $restrictions Restriction data.
+	 * @return array
 	 */
 	public function modify_restrictions( $restrictions ) {
 
@@ -303,7 +305,7 @@ class LLMS_View_Manager {
 	}
 
 	/**
-	 * Enqueue Scripts
+	 * Enqueue Scripts.
 	 *
 	 * @since 3.7.0
 	 * @since 3.17.8 Unknown.

--- a/includes/functions/llms.functions.order.php
+++ b/includes/functions/llms.functions.order.php
@@ -297,6 +297,7 @@ function llms_setup_pending_order( $data = array() ) {
 		$err->add(
 			'already-enrolled',
 			sprintf(
+				// Translators: %2$s = The product type (course/membership); %1$s = product permalink.
 				__( 'You already have access to this %2$s! Visit your dashboard <a href="%1$s">here.</a>', 'lifterlms' ),
 				llms_get_page_url( 'myaccount' ),
 				$product->get_post_type_label()

--- a/includes/functions/llms.functions.order.php
+++ b/includes/functions/llms.functions.order.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.29.0
- * @version 3.30.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -170,16 +170,16 @@ function llms_locate_order_for_user_and_plan( $user_id, $plan_id ) {
  * Setup a pending order which can be passed to an LLMS_Payment_Gateway for processing.
  *
  * @since 3.29.0
- * @version 3.29.0
+ * @since [version] Prevent double displaying a notice to already enrolled students in the product being purchased.
  *
  * @param array $data {
  *     Data used to create a pending order.
  *
- *     @type int plan_id (Required) LLMS_Access_Plan ID.
- *     @type array customer (Required). Array of customer information formatted to be passed to `LLMS_Person_Handler::update()` or `llms_register_user()`
- *     @type string agree_to_terms (Required if `llms_are_terms_and_conditions_required()` are required) If terms & conditions are required this should be "yes" for agreement.
+ *     @type int    plan_id         (Required) LLMS_Access_Plan ID.
+ *     @type array  customer        (Required). Array of customer information formatted to be passed to `LLMS_Person_Handler::update()` or `llms_register_user()`
+ *     @type string agree_to_terms  (Required if `llms_are_terms_and_conditions_required()` are required) If terms & conditions are required this should be "yes" for agreement.
  *     @type string payment_gateway (Optional) ID of a registered LLMS_Payment_Gateway which will be used to process the order.
- *     @type string coupon_code (Optional) Coupon code to be applied to the order.
+ *     @type string coupon_code     (Optional) Coupon code to be applied to the order.
  * }
  * @return array
  */
@@ -187,6 +187,8 @@ function llms_setup_pending_order( $data = array() ) {
 
 	/**
 	 * @filter llms_before_setup_pending_order
+	 *
+	 * @param array $data Array of input data from a checkout form.
 	 */
 	$data = apply_filters( 'llms_before_setup_pending_order', $data );
 
@@ -204,7 +206,7 @@ function llms_setup_pending_order( $data = array() ) {
 
 	$err = new WP_Error();
 
-	// check t & c if configured
+	// check t & c if configured.
 	if ( llms_are_terms_and_conditions_required() ) {
 		if ( ! isset( $data['agree_to_terms'] ) || ! llms_parse_bool( $data['agree_to_terms'] ) ) {
 			$err->add( 'terms-violation', sprintf( __( 'You must agree to the %s to continue.', 'lifterlms' ), get_the_title( get_option( 'lifterlms_terms_page_id' ) ) ) );
@@ -212,24 +214,24 @@ function llms_setup_pending_order( $data = array() ) {
 		}
 	}
 
-	// we must have a plan_id to proceed
+	// we must have a plan_id to proceed.
 	if ( empty( $data['plan_id'] ) ) {
 		$err->add( 'missing-plan-id', __( 'Missing an Access Plan ID.', 'lifterlms' ) );
 		return $err;
 	}
 
-	// validate the plan is a real plan
+	// validate the plan is a real plan.
 	$plan = llms_get_post( absint( $data['plan_id'] ) );
 	if ( ! $plan || 'llms_access_plan' !== $plan->get( 'type' ) ) {
 		$err->add( 'invalid-plan-id', __( 'Invalid Access Plan ID.', 'lifterlms' ) );
 		return $err;
 	}
 
-	// used later
+	// used later.
 	$coupon_id = null;
 	$coupon    = false;
 
-	// if a coupon is being used, validate it
+	// if a coupon is being used, validate it.
 	if ( ! empty( $data['coupon_code'] ) ) {
 
 		$coupon_id = llms_find_coupon( $data['coupon_code'] );
@@ -240,18 +242,18 @@ function llms_setup_pending_order( $data = array() ) {
 			return $err;
 		}
 
-		// coupon is real, make sure it's valid for the current plan
+		// coupon is real, make sure it's valid for the current plan.
 		$coupon = llms_get_post( $coupon_id );
 		$valid  = $coupon->is_valid( $data['plan_id'] );
 
-		// if the coupon has a validation error, return an error message
+		// if the coupon has a validation error, return an error message.
 		if ( is_wp_error( $valid ) ) {
 			$err->add( 'invalid-coupon', $valid->get_error_message() );
 			return $err;
 		}
 	}
 
-	// if payment is required, verify we have a gateway
+	// if payment is required, verify we have a gateway.
 	if ( $plan->requires_payment( $coupon_id ) && empty( $data['payment_gateway'] ) ) {
 		$err->add( 'missing-gateway-id', __( 'No payment method selected.', 'lifterlms' ) );
 		return $err;
@@ -268,19 +270,19 @@ function llms_setup_pending_order( $data = array() ) {
 		return $err;
 	}
 
-	// update the customer
+	// update the customer.
 	if ( ! empty( $data['customer']['user_id'] ) ) {
 		$person_id = LLMS_Person_Handler::update( $data['customer'], 'checkout' );
 	} else {
 		$person_id = llms_register_user( $data['customer'], 'checkout', true );
 	}
 
-	// validation or registration issues
+	// validation or registration issues.
 	if ( is_wp_error( $person_id ) ) {
 		return $person_id;
 	}
 
-	// this will likely never actually happen unless there's something very strange afoot
+	// this will likely never actually happen unless there's something very strange afoot.
 	if ( ! is_numeric( $person_id ) ) {
 
 		$err->add( 'account-creation', __( 'An unknown error occurred when attempting to create an account, please try again.', 'lifterlms' ) );
@@ -288,7 +290,7 @@ function llms_setup_pending_order( $data = array() ) {
 
 	}
 
-	// ensure the new user isn't enrolled in the product being purchased
+	// ensure the new user isn't enrolled in the product being purchased.
 	if ( llms_is_user_enrolled( $person_id, $plan->get( 'product_id' ) ) ) {
 
 		$product = $plan->get_product();
@@ -300,6 +302,9 @@ function llms_setup_pending_order( $data = array() ) {
 				$product->get_post_type_label()
 			)
 		);
+		// Prevent double displaying a notice to already enrolled students in the product being purchased.
+		add_filter( 'llms_display_checkout_form_enrolled_students_notice', '__return_false' );
+
 		return $err;
 	}
 

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * LifterLMS Checkout Page Shortcode
+ * LifterLMS Checkout Page Shortcode.
  *
  * Controls functionality associated with shortcode [llms_checkout].
  *
- * @package LifterLMS/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 1.0.0
- * @version 3.36.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.33.0 Checkout form not displayed to users already enrolled in the product being purchased, a notice informing them of that is displayed instead.
  * @since 3.35.0 Sanitize input data.
  * @since 3.36.3 Added l10n function to membership restriction error message.
+ * @since [version] Added filter to control the displaying of the notice informing the students they're already enrolled in the product being purchased.
  */
 class LLMS_Shortcode_Checkout {
 
@@ -31,24 +32,25 @@ class LLMS_Shortcode_Checkout {
 	public static $uid;
 
 	/**
-	 * Renders the checkout template
+	 * Renders the checkout template.
 	 *
 	 * @since 1.0.0
 	 * @since 3.33.0 Do not display the checkout form but a notice to a logged in user enrolled in the product being purchased.
 	 * @since 3.36.3 Added l10n function to membership restriction error message.
+	 * @since [version] Added filter to control the displaying of the notice informing the students they're already enrolled in the product being purchased.
 	 *
 	 * @param array $atts Shortcode attributes array.
 	 * @return void
 	 */
 	private static function checkout( $atts ) {
 
-		// if there are membership restrictions, check the user is in at least one membership
-		// this is to combat CHEATERS
+		// if there are membership restrictions, check the user is in at least one membership.
+		// this is to combat CHEATERS.
 		if ( $atts['plan']->has_availability_restrictions() ) {
 			$access = false;
 			foreach ( $atts['plan']->get_array( 'availability_restrictions' ) as $mid ) {
 
-				// once we find a membership, exit
+				// once we find a membership, exit.
 				if ( llms_is_user_enrolled( self::$uid, $mid ) ) {
 					$access = true;
 					break;
@@ -64,15 +66,25 @@ class LLMS_Shortcode_Checkout {
 			// ensure the user isn't enrolled in the product being purchased.
 			if ( isset( $atts['product'] ) && llms_is_user_enrolled( self::$uid, $atts['product']->get( 'id' ) ) ) {
 
-				llms_print_notice(
-					sprintf(
-						// Translators: 2$s = The product type (course/membership); %1$s = product permalink.
-						__( 'You already have access to this %2$s! Visit your dashboard <a href="%1$s">here.</a>', 'lifterlms' ),
-						llms_get_page_url( 'myaccount' ),
-						$atts['product']->get_post_type_label()
-					),
-					'notice'
-				);
+				/**
+				 * Filter the displaying of the checkout form notice for already enrolled in the product being purchased.
+				 *
+				 * @since [version]
+				 *
+				 * @param $display_notice bool Whether or not displaying the checkout form notice for already enrolled students in the product being purchased.
+				 */
+				if ( apply_filters( 'llms_display_checkout_form_enrolled_students_notice', true ) ) {
+					llms_print_notice(
+						sprintf(
+							// Translators: %2$s = The product type (course/membership); %1$s = product permalink.
+							__( 'You already have access to this %2$s! Visit your dashboard <a href="%1$s">here.</a>', 'lifterlms' ),
+							llms_get_page_url( 'myaccount' ),
+							$atts['product']->get_post_type_label()
+						),
+						'notice'
+					);
+				}
+
 				return;
 			}
 
@@ -87,7 +99,7 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Renders the confirm payment checkout template
+	 * Renders the confirm payment checkout template.
 	 *
 	 * @since 1.0.0
 	 * @version 3.0.0
@@ -102,12 +114,12 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Output error messages when they're encountered
+	 * Output error messages when they're encountered.
 	 *
 	 * @since 3.0.0
-	 * @version 3.0.0
 	 *
-	 * @return   void
+	 * @param string $message The error message.
+	 * @return void
 	 */
 	private static function error( $message ) {
 
@@ -116,12 +128,11 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Retrieve the shortcode content
+	 * Retrieve the shortcode content.
 	 *
 	 * @since 1.0.0
-	 * @version 1.0.0
 	 *
-	 * @param array $atts shortcode attributes.
+	 * @param array $atts Shortcode attributes.
 	 * @return string
 	 */
 	public static function get( $atts ) {
@@ -131,13 +142,13 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Gather a bunch of information and output the actual content for the shortcode
+	 * Gather a bunch of information and output the actual content for the shortcode.
 	 *
 	 * @since 1.0.0
 	 * @since 3.30.1 Added check via llms_locate_order_for_user_and_plan() to automatically resume an existing pending order for logged in users if one exists.
 	 * @since 3.35.0 Sanitize input data.
 	 *
-	 * @param array $atts shortcode atts from originating shortcode
+	 * @param array $atts Shortcode atts from originating shortcode.
 	 * @return void
 	 */
 	public static function output( $atts ) {
@@ -164,8 +175,8 @@ class LLMS_Shortcode_Checkout {
 
 		echo '<div class="llms-checkout-wrapper">';
 
-		// allow gateways to throw errors before outputting anything else
-		// useful if you need to check for extra session or query string data
+		// allow gateways to throw errors before outputting anything else.
+		// useful if you need to check for extra session or query string data.
 		$err = apply_filters( 'lifterlms_pre_checkout_error', false );
 		if ( $err ) {
 			return self::error( $err );
@@ -173,12 +184,12 @@ class LLMS_Shortcode_Checkout {
 
 		llms_print_notices();
 
-		// purchase step 1
+		// purchase step 1.
 		if ( isset( $_GET['plan'] ) && is_numeric( $_GET['plan'] ) ) {
 
 			$plan_id = llms_filter_input( INPUT_GET, 'plan', FILTER_SANITIZE_NUMBER_INT );
 
-			// Only retrieve if plan is a llms_access_plan and is published
+			// Only retrieve if plan is a llms_access_plan and is published.
 			if ( 0 === strcmp( get_post_status( $plan_id ), 'publish' ) && 0 === strcmp( get_post_type( $plan_id ), 'llms_access_plan' ) ) {
 
 				$coupon = LLMS()->session->get( 'llms_coupon' );

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -71,7 +71,7 @@ class LLMS_Shortcode_Checkout {
 				 *
 				 * @since [version]
 				 *
-				 * @param $display_notice bool Whether or not displaying the checkout form notice for already enrolled students in the product being purchased.
+				 * @param bool $display_notice Whether or not displaying the checkout form notice for already enrolled students in the product being purchased.
 				 */
 				if ( apply_filters( 'llms_display_checkout_form_enrolled_students_notice', true ) ) {
 					llms_print_notice(

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -1,16 +1,28 @@
 <?php
 /**
- * Single Access Plan Button
+ * Single Access Plan Button.
  *
- * @property  obj  $plan  Instance of the LLMS_Access_Plan
- * @author    LifterLMS
- * @package   LifterLMS/Templates
- * @since     3.23.0
- * @version   3.23.0
+ * @property LLMS_Access_Plan $plan Instance of the LLMS_Access_Plan.
+ * @author LifterLMS
+ * @package LifterLMS/Templates
+ *
+ * @since 3.23.0
+ * @since [version] Added `llms_display_free_enroll_form` filter hook.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
-<?php if ( get_current_user_id() && $plan->has_free_checkout() && $plan->is_available_to_user() ) : ?>
+<?php
+/**
+ * Filter the displaying of the free enroll form.
+ *
+ * @since [version]
+ *
+ * @param boolean          $display Whether or not displaying the free enroll form.
+ * @param LLMS_Access_Plan $plan    Instance of the LLMS_Access_Plan.
+ */
+if ( apply_filters( 'llms_display_free_enroll_form', get_current_user_id() && $plan->has_free_checkout() && $plan->is_available_to_user(), $plan ) ) :
+	?>
 	<?php llms_get_template( 'product/free-enroll-form.php', compact( 'plan' ) ); ?>
 <?php else : ?>
 	<a class="llms-button-action button" href="<?php echo $plan->get_checkout_url(); ?>"><?php echo $plan->get_enroll_text(); ?></a>


### PR DESCRIPTION
fix #869

## Description
Added the logic to view the checkout as "visitor" when logged in as admin/instructor.

## How has this been tested?
- Logged-in to WP as an admin (or instructor)
- Enrolled myself in a course
- Attempted to review an access plan for the course on the frontend
- using the View Manager, I switched the view as "visitor" so to see the Access Plan enrollment button
- Clicked on an access plan enrollment button
- **I could see the checkout form as visitor**!
- Clicking on the Buy Now button, I was shown the following notice:

> You already have access to this Course! Visit your dashboard here.

I've also tested that an enrolled admin couldn't view the checkout form if he didn't switch the view to "visitor".

## Types of changes
 Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
