### PR TITLE
Fix referring to not set order_clause variable in analytics widget qu…

### DIFF
--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -3,7 +3,7 @@
  * Analytics Widget Abstract
  *
  * @since 3.0.0
- * @version 3.30.3
+ * @version []
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
 *
 * @since 3.0.0
 * @since 3.30.3 Define undefined properties.
+* @since [version] In `set_order_data_query()` always set $order_clause variable to avoid PHP notices
 */
 abstract class LLMS_Analytics_Widget {
 
@@ -287,6 +288,7 @@ abstract class LLMS_Analytics_Widget {
 			$wheres_clause .= $where . "\r\n";
 		}
 
+		$order_clause = '';
 		if ( $order && $orderby ) {
 			$order_clause = 'ORDER BY ' . $orderby . ' ' . $order;
 		}

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -3,7 +3,7 @@
  * Analytics Widget Abstract
  *
  * @since 3.0.0
- * @version []
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
…eries

fix #875

## Description
Make sure to always set the variable $order_clause so to avoid any PHP notices when trying to access to it.

## How has this been tested?
With WP in debug mode
- From the dashboard I navigated through LifterLMS - Reporting - Sales
- No PHP notice logged/displayed.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
