### PR TITLE
Fix/export clone capability

### DIFF
--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -68,7 +68,7 @@ class LLMS_Admin_Post_Tables {
 		$action = llms_filter_input( INPUT_GET, 'action' );
 
 		// bail early if request doesn't concern us.
-		if ( empty( $action) ){
+		if ( empty( $action ) ){
 			return;
 		}
 

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -67,43 +67,43 @@ class LLMS_Admin_Post_Tables {
 
 		$action = llms_filter_input( INPUT_GET, 'action' );
 
-		// bail early if request doesn't concern us
+		// bail early if request doesn't concern us.
 		if( empty( $action) ){
 			return;
 		}
 
-		// bail early if it isn't a clone/ export request
+		// bail early if it isn't a clone/ export request.
 		if ( 'llms-clone-post' !== $action && 'llms-export-post' !== $action ) {
 			return;
 		}
 
 		$post_id = llms_filter_input( INPUT_GET, 'post' );
 
-		// bail if there's no post ID
+		// bail if there's no post ID.
 		if ( empty( $post_id ) ) {
 			wp_die( __( 'Missing post ID.', 'lifterlms' ) );
 		}
 
 		$post = get_post( $post_id );
 
-		// bail if post ID is invalid
+		// bail if post ID is invalid.
 		if ( ! $post ) {
 			wp_die( __( 'Invalid post ID.', 'lifterlms' ) );
 		}
 
-		// bail if the action isn't supported on post type
+		// bail if the action isn't supported on post type.
 		if ( ! post_type_supports( $post->post_type, $action ) ) {
 			wp_die( __( 'Action cannot be executed on the current post.', 'lifterlms' ) );
 		}
 
-		// bail if user doesn't have permissions
+		// bail if user doesn't have permissions.
 		if( ! current_user_can( 'edit_course', $post->ID ) ) {
 			wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
 		}
 
 		$post = llms_get_post( $post );
 
-		// run export or clone action as needed
+		// run export or clone action as needed.
 		switch ( $action ) {
 
 			case 'llms-export-post':

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -91,6 +91,10 @@ class LLMS_Admin_Post_Tables {
 			wp_die( __( 'Action cannot be executed on the current post.', 'lifterlms' ) );
 		}
 
+		if( ! current_user_can( 'edit_course', $post->ID ) ) {
+			wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
+		}
+
 		$post = llms_get_post( $post );
 
 		switch ( $action ) {

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -35,7 +35,7 @@ class LLMS_Admin_Post_Tables {
 	 */
 	public function add_links( $actions, $post ) {
 
-		if ( current_user_can( 'edit_post', $post->ID ) && post_type_supports( $post->post_type, 'llms-clone-post' ) ) {
+		if ( current_user_can( 'edit_course', $post->ID ) && post_type_supports( $post->post_type, 'llms-clone-post' ) ) {
 			$url = add_query_arg( array(
 				'post_type' => $post->post_type,
 				'action' => 'llms-clone-post',
@@ -44,7 +44,7 @@ class LLMS_Admin_Post_Tables {
 			$actions['llms-clone'] = '<a href="' . esc_url( $url ) . '">' . __( 'Clone', 'lifterlms' ) . '</a>';
 		}
 
-		if ( current_user_can( 'edit_post', $post->ID ) && post_type_supports( $post->post_type, 'llms-export-post' ) ) {
+		if ( current_user_can( 'edit_course', $post->ID ) && post_type_supports( $post->post_type, 'llms-export-post' ) ) {
 			$url = add_query_arg( array(
 				'post_type' => $post->post_type,
 				'action' => 'llms-export-post',

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -68,7 +68,7 @@ class LLMS_Admin_Post_Tables {
 		$action = llms_filter_input( INPUT_GET, 'action' );
 
 		// bail early if request doesn't concern us.
-		if( empty( $action) ){
+		if ( empty( $action) ){
 			return;
 		}
 
@@ -97,7 +97,7 @@ class LLMS_Admin_Post_Tables {
 		}
 
 		// bail if user doesn't have permissions.
-		if( ! current_user_can( 'edit_course', $post->ID ) ) {
+		if ( ! current_user_can( 'edit_course', $post->ID ) ) {
 			wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
 		}
 

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -68,7 +68,7 @@ class LLMS_Admin_Post_Tables {
 		$action = llms_filter_input( INPUT_GET, 'action' );
 
 		// bail early if request doesn't concern us.
-		if ( empty( $action ) ){
+		if ( empty( $action ) ) {
 			return;
 		}
 

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -67,36 +67,43 @@ class LLMS_Admin_Post_Tables {
 
 		$action = llms_filter_input( INPUT_GET, 'action' );
 
+		// bail early if request doesn't concern us
 		if( empty( $action) ){
 			return;
 		}
 
+		// bail early if it isn't a clone/ export request
 		if ( 'llms-clone-post' !== $action && 'llms-export-post' !== $action ) {
 			return;
 		}
 
 		$post_id = llms_filter_input( INPUT_GET, 'post' );
 
+		// bail if there's no post ID
 		if ( empty( $post_id ) ) {
 			wp_die( __( 'Missing post ID.', 'lifterlms' ) );
 		}
 
 		$post = get_post( $post_id );
 
+		// bail if post ID is invalid
 		if ( ! $post ) {
 			wp_die( __( 'Invalid post ID.', 'lifterlms' ) );
 		}
 
+		// bail if the action isn't supported on post type
 		if ( ! post_type_supports( $post->post_type, $action ) ) {
 			wp_die( __( 'Action cannot be executed on the current post.', 'lifterlms' ) );
 		}
 
+		// bail if user doesn't have permissions
 		if( ! current_user_can( 'edit_course', $post->ID ) ) {
 			wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
 		}
 
 		$post = llms_get_post( $post );
 
+		// run export or clone action as needed
 		switch ( $action ) {
 
 			case 'llms-export-post':

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -65,31 +65,35 @@ class LLMS_Admin_Post_Tables {
 	 */
 	public function handle_link_actions() {
 
-		if ( ! isset( $_GET['action'] ) ) {
+		$action = llms_filter_input( INPUT_GET, 'action' );
+
+		if( empty( $action) ){
 			return;
 		}
 
-		if ( 'llms-clone-post' !== $_GET['action'] && 'llms-export-post' !== $_GET['action'] ) {
+		if ( 'llms-clone-post' !== $action && 'llms-export-post' !== $action ) {
 			return;
 		}
 
-		if ( ! isset( $_GET['post'] ) ) {
+		$post_id = llms_filter_input( INPUT_GET, 'post' );
+
+		if ( empty( $post_id ) ) {
 			wp_die( __( 'Missing post ID.', 'lifterlms' ) );
 		}
 
-		$post = get_post( $_GET['post'] );
+		$post = get_post( $post_id );
 
 		if ( ! $post ) {
 			wp_die( __( 'Invalid post ID.', 'lifterlms' ) );
 		}
 
-		if ( ! post_type_supports( $post->post_type, $_GET['action'] ) ) {
+		if ( ! post_type_supports( $post->post_type, $action ) ) {
 			wp_die( __( 'Action cannot be executed on the current post.', 'lifterlms' ) );
 		}
 
 		$post = llms_get_post( $post );
 
-		switch ( $_GET['action'] ) {
+		switch ( $action ) {
 
 			case 'llms-export-post':
 				$post->export();


### PR DESCRIPTION
## Description

 * Fixed capability as per #870 to hide export & clone links on posts table for unauthorised users.
 * Fixed superglobal access by refactoring to `llms_filter_input()`.
 * Add additional capability check so that unauthorised direct export/clone requests are prevented.

## How has this been tested?

- [x] User with right capability is able to export/clone as usual
- [x] User without such a capability on a course doesn't see the links on post table
- [x] If such a user attempts to directly request the action, they get an error.

## Screenshots

## Types of changes

 * Bug fix for #870 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
