### PR TITLE
Fix issue that produced series options not aligned with the chart data

### DIFF
--- a/assets/js/llms-analytics.js
+++ b/assets/js/llms-analytics.js
@@ -1,7 +1,9 @@
 /**
  * LifterLMS Admin Reporting Widgets & Charts
- * @since    3.0.0
- * @version  3.17.6
+ * @since 3.0.0
+ * @since [version] @since Fix issue that produced series options not aligned with the chart data
+ *
+ * @version [version]
  */
 ;( function( $, undefined ) {
 
@@ -149,7 +151,7 @@
 			if ( data.length ) {
 
 				data = google.visualization.arrayToDataTable( data );
-				data.sort([{column: 0}])
+				data.sort([{column: 0}]);
 				chart.draw( data, options );
 
 			}
@@ -473,10 +475,11 @@
 		};
 
 		/**
-		 * Get a object of series options needed to draw the chart
-		 * @return   void
-		 * @since    3.0.0
-		 * @version  3.0.0
+		 * Get a object of series options needed to draw the chart.
+		 * @return void
+		 *
+		 * @since 3.0.0
+		 * @since Fix issue that produced series options not aligned with the chart data
 		 */
 		this.get_chart_series_options = function() {
 
@@ -498,9 +501,9 @@
 						targetAxisIndex: ( 'count' === type ) ? 1 : 0,
 					};
 
-				}
+					i++;
 
-				i++;
+				}
 
 			}
 


### PR DESCRIPTION
fix #740

## Description
Small change in the llms-anlytics.js code to make sure the series option array (part of the google chart options) is aligned with the data to be drawn. 

## How has this been tested?
I've followed the reproduction steps described here
https://github.com/gocodebox/lifterlms/issues/740#issue-401549285

## Screenshots
![Schermata 2019-06-06 alle 20 31 13](https://user-images.githubusercontent.com/7689242/59057169-1af33b80-889a-11e9-9fcf-07d5775d484b.png)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
