### PR TITLE
When viewing reporting->quizzes, make sure no entry are displayed to …

### DIFF
--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -1,10 +1,19 @@
 <?php
+/**
+ * Quizzes Reporting Table.
+ *
+ * @since 3.16.0
+ * @version [version]
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Quizzes Reporting Table
- * @since    3.16.0
- * @version  3.25.0
+ * Quizzes Reporting Table class.
+ *
+ * @since 3.16.0
+ * @since [version] Fixed an issue that allow instructors, who can only see their own reports,
+ *                  to see all the quizzes when they had no courses or courses with no lessons.
  */
 class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 
@@ -183,11 +192,15 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 	}
 
 	/**
-	 * Execute a query to retrieve results from the table
-	 * @param    array      $args  array of query args
-	 * @return   void
-	 * @since    3.16.0
-	 * @version  3.25.0
+	 * Execute a query to retrieve results from the table.
+	 *
+	 * @since 3.16.0
+	 * @since [version] Fixed an issue that allow instructors, who can only see their own reports,
+	 *                  to see all the quizzes when they had no courses or courses with no lessons.
+	 *
+	 * @param array $args Array of query args.
+	 * @return void
+	 *
 	 */
 	public function get_results( $args = array() ) {
 
@@ -240,6 +253,11 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 			foreach ( $courses as $course ) {
 				$lessons = array_merge( $lessons, $course->get_lessons( 'ids' ) );
 			}
+
+			if ( empty( $lessons ) ) {
+				return;
+			}
+
 			$query_args['meta_query'] = array(
 				array(
 					'compare' => 'IN',
@@ -253,7 +271,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 
 			return;
 
-		}
+		}// End if().
 
 		$this->max_pages = $query->max_num_pages;
 

--- a/tests/unit-tests/tables/class-llms-test-table-quizzes.php
+++ b/tests/unit-tests/tables/class-llms-test-table-quizzes.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Test the quizzes reporting table.
+ *
+ * @package LifterLMS/Tests/Tables
+ * @group reporting_tables
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Table_Quizzes extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup test.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/tables/llms.table.quizzes.php';
+		$this->table = new LLMS_Table_Quizzes();
+
+	}
+
+	/**
+	 * test quizzes table is empty for instructors with no courses or courses with no lessons
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_quizzes_for_instructor_with_no_course_lesson() {
+
+		// Setup a course with lessons and quizzes.
+		$course = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons' => 3,
+			'quizzes' => 2,
+		) );
+
+		// Setup an instructor.
+		$instructor_id = $this->factory->instructor->create();
+
+		wp_set_current_user( $instructor_id );
+
+		// The instructor has no courses, we expect no data.
+		$table = new LLMS_Table_Quizzes();
+		$table->get_results();
+		$this->assertEquals( 0, count( $table->get_tbody_data() ) );
+
+		// Setup a course with no lessons and assign the instructor to the course.
+		$inst_course = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+		) );
+		$inst_course->instructors()->set_instructors(array(
+			array(
+				'id' => $instructor_id,
+			),
+		));
+
+		// The instructor has a course, but the course has no lessons, we expect no data.
+		$table = new LLMS_Table_Quizzes();
+		$table->get_results();
+		$this->assertEquals( 0, count( $table->get_tbody_data() ) );
+
+	}
+
+}


### PR DESCRIPTION
…instructors with no courses/lessons

fix #879

## Description
Small code addition in `LLMS_Table_Quizzes->get_results()` that checks if the current instructor's courses have at least a lesson before performing a quizzes query, so that when there are no lessons no quizzes are displayed.

## How has this been tested?
Followed the reproduction steps in #879 and made sure I couldn't reproduce the bug anymore.
Unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
