### PR TITLE
Add support for modules

### DIFF
--- a/includes/modules/class-llms-modules.php
+++ b/includes/modules/class-llms-modules.php
@@ -1,0 +1,108 @@
+<?php
+
+class LLMS_Modules {
+
+	public $loaded = array();
+
+	protected static $_instance = null;
+
+	public static function instance() {
+		if ( is_null( self::$_instance ) ) {
+			self::$_instance = new self(); }
+		return self::$_instance;
+	}
+
+	/**
+	 * Constructor
+	 *
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function __construct() {
+		$this->load();
+	}
+
+	/**
+	 * Loads Modules.
+	 *
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function load() {
+
+		/**
+		 * Filters list of LifterLMS modules to load.
+		 *
+		 * @since	[version]
+		 * @version	[version]
+		 */
+		$final_modules = apply_filters( 'lifterlms_modules', $this->info() );
+
+		foreach ( $final_modules as $module ) {
+
+			// define the constant as true if it hasn't been defined by the user in wp-config.php or similar.
+			if ( ! defined( $module['constant'] ) ) {
+				define( $module['constant'] , true );
+			}
+
+			// if the constant's value is true and the class file exists, include the module class
+			if ( true === constant( $module['constant'] ) && file_exists( $module['file_path'] ) ) {
+				include_once $module['file_path'];
+			}
+
+			$this->loaded[ $module['name'] ] = $module;
+
+		}
+
+		/**
+		 * Fires after all modules are loaded
+		 *
+		 * @since	[version]
+		 * @version	[version]
+		 */
+		do_action( 'lifterlms_modules_loaded', $this->loaded );
+
+	}
+
+	/**
+	 * Loads Module Information.
+	 *
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function info() {
+
+		// get a list of directories inside the modules directory.
+		$directories = glob( LLMS_PLUGIN_DIR . 'includes/modules/*' , GLOB_ONLYDIR );
+
+		$modules = array();
+
+		// loop through every directory
+		foreach ( $directories as $module ) {
+
+			// the name of the module is the same as the name of the directory. eg "certificate-builder"
+			$module_name = basename( $module );
+
+			// the name of the class file is similar. eg "class-llms-certificate-builder.php"
+			$module_class_file_path = "$module/class-llms-$module_name.php";
+
+			// the constant name also uses similar conventions. eg "LLMS_CERTIFICATE_BUILDER"
+			$module_constant_name = 'LLMS_' . strtoupper( str_replace( '-', '_', $module_name ) );
+
+			$modules[ $module_name ] = array(
+				'name' => $module_name,
+				'file_path' => $module_class_file_path,
+				'constant' => $module_constant_name,
+			);
+
+			unset( $module_name );
+			unset( $module_class_file_path );
+			unset( $module_constant_name );
+
+		}
+
+		return $modules;
+
+	}
+
+}

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -86,6 +86,10 @@ final class LifterLMS {
 		//Include required files
 		$this->includes();
 
+		// load modules.
+		$this->load_modules();
+
+
 		// setup session stuff
 		$this->session = new LLMS_Session();
 
@@ -141,6 +145,7 @@ final class LifterLMS {
 			$this->modules_loaded[ $module[ 'name' ] ] = $module;
 
 		}
+
 	}
 
 	/**

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -106,7 +106,9 @@ final class LifterLMS {
 			LLMS_Tracker::init();
 		}
 
-		// Loaded action
+		/**
+		 * Fires after LifterLMS is loaded
+		 */
 		do_action( 'lifterlms_loaded' );
 
 	}
@@ -145,6 +147,9 @@ final class LifterLMS {
 
 		/**
 		 * Fires after all modules are loaded
+		 *
+		 * @since	[version]
+		 * @version	[version]
 		 */
 		do_action( 'lifterlms_modules_loaded', $this->modules_loaded );
 

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -89,7 +89,6 @@ final class LifterLMS {
 		// load modules.
 		$this->load_modules();
 
-
 		// setup session stuff
 		$this->session = new LLMS_Session();
 
@@ -118,7 +117,7 @@ final class LifterLMS {
 	 * @since    [version]
 	 * @version  [version]
 	 */
-	private function load_modules(){
+	private function load_modules() {
 
 		/**
 		 * Filters list of LifterLMS modules to load.
@@ -130,19 +129,19 @@ final class LifterLMS {
 
 		$modules_loaded = array();
 
-		foreach( $final_modules as $module ){
+		foreach ( $final_modules as $module ) {
 
 			// define the constant as true if it hasn't been defined by the user in wp-config.php or similar.
-			if( ! defined( $module[ 'constant' ] ) ){
-				define( $module[ 'constant' ] , true );
+			if ( ! defined( $module['constant'] ) ) {
+				define( $module['constant'] , true );
 			}
 
 			// if the constant's value is true and the class file exists, include the module class
-			if( constant( $module[ 'constant' ] ) === true && file_exists( $module[ 'file_path' ] ) ){
-				include_once $module[ 'file_path' ];
+			if ( constant( $module['constant'] ) === true && file_exists( $module['file_path'] ) ) {
+				include_once $module['file_path'];
 			}
 
-			$this->modules_loaded[ $module[ 'name' ] ] = $module;
+			$this->modules_loaded[$module['name']] = $module;
 
 		}
 
@@ -154,7 +153,7 @@ final class LifterLMS {
 	 * @since    [version]
 	 * @version  [version]
 	 */
-	private function load_module_info(){
+	private function load_module_info() {
 
 		// get a list of directories inside the modules directory.
 		$directories = glob( LLMS_PLUGIN_DIR . 'includes/modules/*' , GLOB_ONLYDIR );
@@ -162,7 +161,7 @@ final class LifterLMS {
 		$modules = array();
 
 		// loop through every directory
-		foreach( $directories as $module ){
+		foreach ( $directories as $module ) {
 
 			// the name of the module is the same as the name of the directory. eg "certificate-builder"
 			$module_name = basename( $module );
@@ -176,7 +175,7 @@ final class LifterLMS {
 			$modules[ $module_name ] = array(
 				'name' => $module_name,
 				'file_path' => $module_class_file_path,
-				'constant' => $module_constant_name
+				'constant' => $module_constant_name,
 			);
 
 			unset( $module_name );

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -141,7 +141,7 @@ final class LifterLMS {
 				include_once $module['file_path'];
 			}
 
-			$this->modules_loaded[$module['name']] = $module;
+			$this->modules_loaded[ $module['name'] ] = $module;
 
 		}
 

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -43,6 +43,8 @@ final class LifterLMS {
 	public $query = null;
 	public $session = null;
 
+	public $modules_loaded = array();
+
 	/**
 	 * Main Instance of LifterLMS
 	 * Ensures only one instance of LifterLMS is loaded or can be loaded.
@@ -103,6 +105,82 @@ final class LifterLMS {
 
 		// Loaded action
 		do_action( 'lifterlms_loaded' );
+
+	}
+
+	/**
+	 * Loads Modules.
+	 *
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function load_modules(){
+
+		/**
+		 * Filters list of LifterLMS modules to load.
+		 *
+		 * @since	[version]
+		 * @version	[version]
+		 */
+		$final_modules = apply_filters( 'lifterlms_modules', $this->load_module_info() );
+
+		$modules_loaded = array();
+
+		foreach( $final_modules as $module ){
+
+			// define the constant as true if it hasn't been defined by the user in wp-config.php or similar.
+			if( ! defined( $module[ 'constant' ] ) ){
+				define( $module[ 'constant' ] , true );
+			}
+
+			// if the constant's value is true and the class file exists, include the module class
+			if( constant( $module[ 'constant' ] ) === true && file_exists( $module[ 'file_path' ] ) ){
+				include_once $module[ 'file_path' ];
+			}
+
+			$this->modules_loaded[ $module[ 'name' ] ] = $module;
+
+		}
+	}
+
+	/**
+	 * Loads Module Information.
+	 *
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function load_module_info(){
+
+		// get a list of directories inside the modules directory.
+		$directories = glob( LLMS_PLUGIN_DIR . 'includes/modules/*' , GLOB_ONLYDIR );
+
+		$modules = array();
+
+		// loop through every directory
+		foreach( $directories as $module ){
+
+			// the name of the module is the same as the name of the directory. eg "certificate-builder"
+			$module_name = basename( $module );
+
+			// the name of the class file is similar. eg "class-llms-certificate-builder.php"
+			$module_class_file_path = "$module/class-llms-$module_name.php";
+
+			// the constant name also uses similar conventions. eg "LLMS_CERTIFICATE_BUILDER"
+			$module_constant_name = 'LLMS_' . strtoupper( str_replace( '-', '_', $module_name ) );
+
+			$modules[ $module_name ] = array(
+				'name' => $module_name,
+				'file_path' => $module_class_file_path,
+				'constant' => $module_constant_name
+			);
+
+			unset( $module_name );
+			unset( $module_class_file_path );
+			unset( $module_constant_name );
+
+		}
+
+		return $modules;
 
 	}
 

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -127,8 +127,6 @@ final class LifterLMS {
 		 */
 		$final_modules = apply_filters( 'lifterlms_modules', $this->load_module_info() );
 
-		$modules_loaded = array();
-
 		foreach ( $final_modules as $module ) {
 
 			// define the constant as true if it hasn't been defined by the user in wp-config.php or similar.
@@ -144,6 +142,11 @@ final class LifterLMS {
 			$this->modules_loaded[ $module['name'] ] = $module;
 
 		}
+
+		/**
+		 * Fires after all modules are loaded
+		 */
+		do_action( 'lifterlms_modules_loaded', $this->modules_loaded );
 
 	}
 


### PR DESCRIPTION
## Description

This adds autoloading support for modules inside `includes/modules/`.

Modules have an expected naming convention without which they won't work:

- The name of the directory is the name of the module. That is, for a folder `includes/modules/certificate-builder`, the name of the module is `'certificate-builder'`.
- The main class for  a module is expected inside the module name folder as `class-llms-{modulename}.php`. That is, in the same example as above, the main class that will be included is `class-llms-certificate-builder.php`.
- Each module will have an associated constant that acts as a toggle for the module and the name will be `LLMS_{ALLCAPSMODULENAME}`. Setting this constant explicitly to false inside `wp-config.php` will disable the module. For instance, to disable the Certificate Builder module, add the following:

```php
define( 'LLMS_CERTIFICATE_BUILDER', false );
```
- Modules (both internal and external, for example from plugins and addons) can use their own naming conventions and load by hooking into a `lifterlms_modules` filter. This will filter an associative array of available modules where each module is in turn an array:

```php
$modules['module_name'] = array(
    'name' => 'module_name',
    'file_path' => 'path/to/the/main-file-to-be-included.php',
    'constant' => 'TOGGLE_CONSTANT_MODULE_NAME'
);
```

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
