### PR TITLE
Use class name as data type in docBlocks.

### DIFF
--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -122,13 +122,13 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 
 	/**
 	 * Holds singletons for extending classes
-	 * @var  array
+	 * @var  LLMS_Abstract_Notification_Controller[]
 	 */
 	private static $_instances = array();
 
 	/**
 	 * Get the singleton instance for the extending class
-	 * @return   obj
+	 * @return   LLMS_Abstract_Notification_Controller
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */
@@ -216,7 +216,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 * @param    int      $subscriber  subscriber id
 	 * @param    int      $user_id     user id
 	 * @param    int      $post_id     post id
-	 * @return   obj
+	 * @return   LLMS_Abstract_Notification_View|false
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */

--- a/includes/abstracts/llms.abstract.notification.view.php
+++ b/includes/abstracts/llms.abstract.notification.view.php
@@ -41,7 +41,7 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 
 	/**
 	 * Instance of the LLMS_Post_Model for the triggering post
-	 * @var  [type]
+	 * @var  LLMS_Post_Model
 	 */
 	protected $post;
 
@@ -59,19 +59,19 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 
 	/**
 	 * Instance of the current LLMS_Notification
-	 * @var  obj
+	 * @var  LLMS_Notification
 	 */
 	protected $notification;
 
 	/**
 	 * Instance of LLMS_Student for the subscriber
-	 * @var  [type]
+	 * @var  LLMS_Student
 	 */
 	protected $subscriber;
 
 	/**
 	 * Instance of an LLMS_Student for the triggering user
-	 * @var  [type]
+	 * @var  LLMS_Student
 	 */
 	protected $user;
 
@@ -534,7 +534,7 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 
 	/**
 	 * Access the protected notification object
-	 * @return   obj
+	 * @return   LLMS_Notification
 	 * @since    3.18.2
 	 * @version  3.18.2
 	 */

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -20,7 +20,7 @@ class LLMS_Certificates {
 
 	/**
 	 * Instance
-	 * @var  null
+	 * @var  LLMS_Certificates
 	 */
 	protected static $_instance = null;
 
@@ -32,7 +32,7 @@ class LLMS_Certificates {
 
 	/**
 	 * Instance singleton
-	 * @return   void
+	 * @return   LLMS_Certificates
 	 * @since    1.0.0
 	 * @version  1.0.0
 	 */

--- a/includes/class.llms.emails.php
+++ b/includes/class.llms.emails.php
@@ -13,20 +13,20 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
 class LLMS_Emails {
 
 	/**
-	 * Object of all emails
-	 * @var object
+	 * Class names of all emails
+	 * @var string[]
 	 */
 	public $emails;
 
 	/**
 	 * protected private instance of email
-	 * @var string
+	 * @var LLMS_Emails
 	 */
 	protected static $_instance = null;
 
 	/**
 	 * Create instance of class
-	 * @var object self
+	 * @return LLMS_Emails
 	 * @since    1.0.0
 	 * @version  1.0.0
 	 */
@@ -139,7 +139,7 @@ class LLMS_Emails {
 	 * Retrieve a new instance of an email
 	 * @param    string     $id    email id
 	 * @param    array      $args  optional arguments to pass to the email
-	 * @return   obj
+	 * @return   LLMS_Email
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */
@@ -153,6 +153,7 @@ class LLMS_Emails {
 		}
 
 		// otherwise return a generic email and set the ID to be the requested ID
+		/** @var LLMS_Email $generic */
 		$generic = new $emails['generic']( $args );
 		$generic->set_id( $id );
 		return $generic;
@@ -161,7 +162,7 @@ class LLMS_Emails {
 
 	/**
 	 * Get all email objects
-	 * @return array [Array of all email objects]
+	 * @return string[] [Array of all email class names]
 	 * @since    1.0.0
 	 * @version  1.0.0
 	 */

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -26,13 +26,13 @@ class LLMS_Engagements {
 
 	/**
 	 * protected instance of class
-	 * @var null
+	 * @var LLMS_Engagements
 	 */
 	protected static $_instance = null;
 
 	/**
 	 * Create instance of class
-	 * @return object [Instance of engagements class]
+	 * @return LLMS_Engagements [Instance of engagements class]
 	 */
 	public static function instance() {
 		if ( is_null( self::$_instance ) ) {

--- a/includes/class.llms.integrations.php
+++ b/includes/class.llms.integrations.php
@@ -12,13 +12,13 @@ class LLMS_Integrations {
 
 	/**
 	 * Array of integrations, regardless of availability
-	 * @var  array
+	 * @var  LLMS_Abstract_Integration[]
 	 */
 	private $integrations = array();
 
 	/**
 	 * Instance Singleton Generator
-	 * @return   obj
+	 * @return   LLMS_Integrations
 	 * @since    1.0.0
 	 * @version  1.0.0
 	 */
@@ -43,7 +43,7 @@ class LLMS_Integrations {
 	/**
 	 * Get an integration instance by id
 	 * @param    string     $id  id of the integration
-	 * @return   obj|false
+	 * @return   LLMS_Abstract_Integration|false
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */
@@ -86,7 +86,7 @@ class LLMS_Integrations {
 
 	/**
 	 * Get available integrations
-	 * @return   array
+	 * @return   LLMS_Abstract_Integration[]
 	 * @since    1.0.0
 	 * @version  3.17.8
 	 */
@@ -107,7 +107,7 @@ class LLMS_Integrations {
 
 	/**
 	 * Get all integrations regardless of availability
-	 * @return   array
+	 * @return   LLMS_Abstract_Integration[]
 	 * @since    3.18.2
 	 * @version  3.18.2
 	 */
@@ -117,7 +117,7 @@ class LLMS_Integrations {
 
 	/**
 	 * Get all integrations regardless of availability
-	 * @return array
+	 * @return   LLMS_Abstract_Integration[]
 	 * @since    1.0.0
 	 * @version  3.17.8
 	 * @todo     deprecate

--- a/includes/functions/llms.functions.person.php
+++ b/includes/functions/llms.functions.person.php
@@ -113,7 +113,7 @@ function llms_current_user_can( $cap, $obj_id = null ) {
 
 /**
  * Determine whether or not a user can bypass enrollment, drip, and prerequisite restrictions
- * @param    obj|int  $user     LLMS_Student, WP_User, or WP User ID, if none supplied get_current_user() will be used
+ * @param    LLMS_Student|WP_User|int $user LLMS_Student, WP_User, or WP User ID, if none supplied get_current_user() will be used
  * @return   boolean
  * @since    3.7.0
  * @version  3.9.0
@@ -176,7 +176,7 @@ function llms_enroll_student( $user_id, $product_id, $trigger = 'unspecified' ) 
 /**
  * Get an LLMS_Instructor
  * @param    mixed     $user  WP_User ID, instance of WP_User, or instance of any instructor class extending this class
- * @return   obj|false        LLMS_Instructor instance on success, false if user not found
+ * @return   LLMS_Instructor|false LLMS_Instructor instance on success, false if user not found
  * @since    3.13.0
  * @version  3.13.0
  */
@@ -228,7 +228,7 @@ function llms_get_minimum_password_strength_name() {
 /**
  * Get an LLMS_Student
  * @param    mixed     $user  WP_User ID, instance of WP_User, or instance of any student class extending this class
- * @return   obj|false        LLMS_Student instance on success, false if user not found
+ * @return   LLMS_Student|false LLMS_Student instance on success, false if user not found
  * @since    3.8.0
  * @version  3.9.0
  */

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -739,7 +739,7 @@ function llms_get_post( $post, $error = false ) {
 /**
  * Retrieve the parent course for a section, lesson, or quiz
  * @param    mixed     $post  WP Post ID or instance of WP_Post
- * @return   obj|null         Instance of the LLMS_Course or null
+ * @return   LLMS_Course|null Instance of the LLMS_Course or null
  * @since    3.6.0
  * @version  3.17.7
  */

--- a/includes/models/model.llms.notification.php
+++ b/includes/models/model.llms.notification.php
@@ -227,7 +227,7 @@ class LLMS_Notification implements JsonSerializable {
 
 	/**
 	 * Retrieve an instance of the notification view class for the notification
-	 * @return   obj
+	 * @return   LLMS_Abstract_Notification_View|false
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -21,7 +21,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 
 	/**
 	 * Retrieve an instance of the LLMS_Instructor model for the current user
-	 * @return   obj|false
+	 * @return   LLMS_Instructor|false
 	 * @since    3.14.0
 	 * @version  3.14.0
 	 */
@@ -183,7 +183,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	 * Retrieves the most recently updated order for the given product
 	 *
 	 * @param    int        $product_id  WP Post ID of the LifterLMS Product (course, lesson, or membership)
-	 * @return   obj|false               Instance of the LLMS_Order or false if none found
+	 * @return   LLMS_Order|false        Instance of the LLMS_Order or false if none found
 	 * @since    3.0.0
 	 * @version  3.0.0
 	 */

--- a/includes/models/model.llms.user.postmeta.php
+++ b/includes/models/model.llms.user.postmeta.php
@@ -193,7 +193,7 @@ class LLMS_User_Postmeta extends LLMS_Abstract_Database_Store {
 
 	/**
 	 * Retrieve a student obj for the meta item
-	 * @return   obj LLMS_Student
+	 * @return   LLMS_Student|false
 	 * @since    3.15.0
 	 * @version  3.15.0
 	 */

--- a/includes/processors/class.llms.processors.php
+++ b/includes/processors/class.llms.processors.php
@@ -22,7 +22,7 @@ class LLMS_Processors {
 
 	/**
 	 * Array of available processors loaded via $this->load_all()
-	 * @var  array
+	 * @var  LLMS_Abstract_Processor[]
 	 */
 	private $processors = array();
 
@@ -60,7 +60,7 @@ class LLMS_Processors {
 	/**
 	 * Access a single loaded processor instance
 	 * @param    string     $name  name of the processor
-	 * @return   obj|false         instance of the processor if found, otherwise false
+	 * @return   LLMS_Abstract_Processor|false instance of the processor if found, otherwise false
 	 * @since    3.15.0
 	 * @version  3.15.0
 	 */
@@ -113,7 +113,7 @@ class LLMS_Processors {
 	/**
 	 * Load a single processor
 	 * @param    string     $name  name of the processor
-	 * @return   obj|false         instance of the processor if found, otherwise false
+	 * @return   LLMS_Abstract_Processor|false         instance of the processor if found, otherwise false
 	 * @since    3.15.0
 	 * @version  3.15.0
 	 */

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -487,7 +487,7 @@ final class LifterLMS {
 
 	/**
 	 * Grading instance
-	 * @return   obj
+	 * @return   LLMS_Grades
 	 * @since    3.24.0
 	 * @version  3.24.0
 	 */
@@ -497,7 +497,7 @@ final class LifterLMS {
 
 	/**
 	 * get integrations
-	 * @return object instance
+	 * @return LLMS_Integrations instance
 	 */
 	public function integrations() {
 		return LLMS_Integrations::instance();
@@ -505,7 +505,7 @@ final class LifterLMS {
 
 	/**
 	 * Retrieve an instance of the notifications class
-	 * @return   obj
+	 * @return   LLMS_Notifications
 	 * @since    3.8.0
 	 * @version  3.8.0
 	 */
@@ -515,7 +515,7 @@ final class LifterLMS {
 
 	/**
 	 * get payment gateways.
-	 * @return array
+	 * @return LLMS_Payment_Gateways
 	 */
 	public function payment_gateways() {
 		return LLMS_Payment_Gateways::instance();


### PR DESCRIPTION
## Description
Updated some docBlocks to use an object's class name instead of an "obj" data type.
