### PR TITLE
Allow getting LLMS_Post_Model raw properties

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -352,7 +352,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 		// force numeric id and prevent filtering on the id.
 		if ( 'id' === $key ) {
 
-			return $raw ? $this->$key : absint( $this->$key );
+			return absint( $this->$key );
 
 		} elseif ( in_array( $key, array_keys( $this->get_post_properties() ) ) ) {
 			$post_key = 'post_' . $key;


### PR DESCRIPTION
fixes #893

## Description
Adds a parameter to the `LLMS_Post_Model->get` method in order to retrieve "raw" properties (aka unfiltered).

## How has this been tested?
I've tested this didn't introduce any regression navigating the front courses.

## Types of changes
Possibly a breaking change?!

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards. 
