### PR TITLE
Add ability to filter the table CSS class names.

### DIFF
--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -400,6 +400,28 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 	}
 
 	/**
+	 * Returns an array of CSS class names to use on this table.
+	 * @return array
+	 * @since   [version]
+	 * @version [version]
+	 */
+	protected function get_table_classes() {
+		$classes = [
+			'llms-table',
+			'llms-gb-table',
+			'llms-gb-table-' . $this->id,
+		];
+
+		/**
+		 * Filters the CSS classes to use on the table.
+		 * @param array $classes CSS class names
+		 * @param array $table_id id property of this table object
+		 * @since [version]
+		 */
+		return apply_filters( 'llms_table_get_table_classes', $classes, $this->id );
+	}
+
+	/**
 	 * Get HTML for the filters displayed in the head of the table
 	 * @return   string
 	 * @since    3.4.0
@@ -434,11 +456,7 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 	 */
 	public function get_table_html() {
 
-		$classes = array(
-			'llms-table',
-			'llms-gb-table',
-			'llms-gb-table-' . $this->id,
-		);
+		$classes = $this->get_table_classes();
 
 		if ( $this->is_zebra ) {
 			$classes[] = 'zebra';

--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -417,6 +417,14 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 			'llms-gb-table-' . $this->id,
 		];
 
+		if ( $this->is_zebra ) {
+			$classes[] = 'zebra';
+		}
+
+		if ( $this->is_large ) {
+			$classes[] = 'size-large';
+		}
+
 		/**
 		 * Filters the CSS classes to use on the table.
 		 *
@@ -464,14 +472,6 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 	public function get_table_html() {
 
 		$classes = $this->get_table_classes();
-
-		if ( $this->is_zebra ) {
-			$classes[] = 'zebra';
-		}
-
-		if ( $this->is_large ) {
-			$classes[] = 'size-large';
-		}
 
 		ob_start();
 		?>

--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -422,8 +422,8 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 		 *
 		 * @since [version]
 		 *
-		 * @param array $classes  CSS class names
-		 * @param array $table_id id property of this table object
+		 * @param array $classes  CSS class names.
+		 * @param array $table_id Id property of this table object.
 		 */
 		return apply_filters( 'llms_table_get_table_classes', $classes, $this->id );
 	}

--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -10,6 +10,10 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Admin_Table abstract.
+ *
+ * @since   3.2.0
+ * @since   [version] Added get_table_classes().
+ * @version [version]
  */
 abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 
@@ -401,9 +405,10 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 
 	/**
 	 * Returns an array of CSS class names to use on this table.
+	 *
+	 * @since  [version]
+	 *
 	 * @return array
-	 * @since   [version]
-	 * @version [version]
 	 */
 	protected function get_table_classes() {
 		$classes = [
@@ -414,9 +419,11 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 
 		/**
 		 * Filters the CSS classes to use on the table.
-		 * @param array $classes CSS class names
-		 * @param array $table_id id property of this table object
+		 *
 		 * @since [version]
+		 *
+		 * @param array $classes  CSS class names
+		 * @param array $table_id id property of this table object
 		 */
 		return apply_filters( 'llms_table_get_table_classes', $classes, $this->id );
 	}

--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -3,7 +3,7 @@
  * Admin Tables
  *
  * @since   3.2.0
- * @version 3.28.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,9 +11,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * LLMS_Admin_Table abstract.
  *
- * @since   3.2.0
- * @since   [version] Added get_table_classes().
- * @version [version]
+ * @since 3.2.0
+ * @since [version] Added get_table_classes().
  */
 abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 


### PR DESCRIPTION
## Description
Added the ability to change the array of table CSS class names. I needed a specific table to have left justified text using the `.llms-table.text-left td` selector.
Added `llms_table_get_table_classes` WordPress filter.

## How has this been tested?
* Tested `/wp-admin/admin.php?page=llms-reporting&tab=memberships` with and without this change to make sure the page did not change.
* Tested my plugin with a class that extends `LLMS_Admin_Table` and these methods:
```php
    protected function register_hooks() {
        add_filter( 'llms_table_get_table_classes', [ $this, 'add_table_classes' ], 10, 2 );
    }

    public function add_table_classes( $classes, $table_id ) {
        if ( $table_id !== $this->id ) {
            return $classes;
        }

        $classes[] = 'text-left';

        return $classes;
    }
```
* `composer tests-run`
* `composer phpcs`

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
