### PR TITLE
LLMS_Post_Model->set_bulk() can accept post properties prefixed by "p…

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -958,10 +958,17 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 		foreach ( $model_array as $key => $val ) {
 
+			$is_post_property = in_array( $key, $post_properties );
+
+			// sanitize the post properties keys by removing the "post_" prefix.
+			if ( $is_post_property && "post_" === substr( $key, 0, 5 ) ) {
+				$key = substr( $key, 5 );
+			}
+
 			$val = $this->scrub( $key, $val );
 
 			// update WordPress Post Properties using the wp_insert_post() function
-			if ( in_array( $key, $post_properties ) ) {
+			if ( $is_post_property ) {
 
 				$type           = 'post';
 				$llms_post_key  = "post_{$key}";

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -960,8 +960,8 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 			$is_post_property = in_array( $key, $post_properties );
 
-			// sanitize the post properties keys by removing the "post_" prefix.
-			if ( $is_post_property && "post_" === substr( $key, 0, 5 ) ) {
+			// sanitize the post properties keys by removing the 'post_' prefix.
+			if ( $is_post_property && 'post_' === substr( $key, 0, 5 ) ) {
 				$key = substr( $key, 5 );
 			}
 


### PR DESCRIPTION
…ost_"

## Description
As of now we could create an LLMS_Post_Model with an array of the type 
```php
array(
    'post_title'   => 'A title',
    'post_content' => 'A content'
)
```
while to update the same model we should provide an array of the type
```php
array(
    'title'   => 'An updated title',
    'content' => 'An updated content'
)
```
This change will unify the way we feed the LLMS_Post_Model either when creating or updating it.

## How has this been tested?
existing unit tests only


## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.