### PR TITLE
LLMS_Post_Model: refresh the whole post property when updated

### DIFF
--- a/tests/framework/class-llms-post-model-unit-test-case.php
+++ b/tests/framework/class-llms-post-model-unit-test-case.php
@@ -2,8 +2,10 @@
 /**
  * Unit Test Case with tests and utilities specific to testing classes
  * which extend the LLMS_Post_Model
- * @since    3.4.0
- * @version  3.28.0
+ *
+ * @since 3.4.0
+ * @since [version] Add tests for new `set_bulk()` method and other recently added properties.
+ * @version [version]
  */
 
 require_once 'class-llms-unit-test-case.php';
@@ -201,6 +203,68 @@ class LLMS_PostModelUnitTestCase extends LLMS_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Test creation date and status relationship on updating.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_date_status_relationship_update() {
+
+		if ( ! $this->get_data() ) {
+			$this->markTestSkipped( 'No properties to test.' );
+		}
+
+		// Check we can update drafts creation date.
+		$this->create( 'test title date status relationship' );
+
+		// Check that when setting the creation date to the future, the post status changes accordingly.
+		$this->obj->set( 'status', 'publish' );
+		$this->obj->set( 'date_gmt', date( 'Y-m-d H:i:s', strtotime( '+1 year', current_time( 'timestamp' ) ) ) );
+		$this->assertEquals( 'future', $this->obj->get( 'status' ) );
+
+	}
+
+	/**
+	 * Test edit_date post proerty.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_edit_date() {
+
+		if ( ! $this->get_data() ) {
+			$this->markTestSkipped( 'No properties to test.' );
+		}
+
+		// Check we can update drafts creation date.
+		$this->create( 'test title draft' );
+
+		// Makes sense only for drafts.
+		if ( 'draft' !== $this->obj->get( 'status' ) ) {
+			$this->markTestSkipped( 'No properties to test.' );
+		}
+
+		$new_date = date( 'Y-m-d H:i:s', strtotime( '-1 year', current_time( 'timestamp' ) ) );
+		$this->obj->set_bulk( array(
+			'date_gmt'  => $new_date,
+			'edit_date' => true,
+		) );
+		$this->assertEquals( $new_date, $this->obj->get( 'date_gmt' ) );
+
+		// Check we cannot update drafts creation dates without passing edit_date.
+		$this->create( 'test title draft two' );
+
+		$this->obj->set_bulk( array(
+			'date_gmt' => $new_date,
+		) );
+		$this->assertNotEquals( $new_date, $this->obj->get( 'date_gmt' ) );
+		$this->assertEquals( '0000-00-00 00:00:00', $this->obj->get( 'date_gmt' ) );
+
+	}
+
 
 	/**
 	 * Test set_bulk()
@@ -229,10 +293,11 @@ class LLMS_PostModelUnitTestCase extends LLMS_UnitTestCase {
 
 		// update should return false, the DB values are the same.
 		$this->assertFalse( $this->obj->set_bulk( $data ) );
+
 	}
 
 	/**
-	 * Test set_bulk() when passing $wp_erro param as true
+	 * Test set_bulk() when passing $wp_error param as true.
 	 *
 	 * @since [version]
 	 * @return void
@@ -270,4 +335,5 @@ class LLMS_PostModelUnitTestCase extends LLMS_UnitTestCase {
 		$this->assertArrayHasKey( 'empty_content', $result->errors );
 
 	}
+
 }


### PR DESCRIPTION
fix #910
also allow drafts creation date to be assigned if explicitly required.

## Description
The main purpose of this PR is to make sure that the `LLMS_Post_Model->post` is synced with the current `WP_Post` state: there might be cases where a change of a post property might impact on another one, e.g. setting a published post date creation to the future makes the post status change to publish.

## How has this been tested?
Tested via unit tests only


## Types of changes
Bug fix/New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
