### PR TITLE
Fix use of strcmp when checking access plan status

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -181,7 +181,7 @@ class LLMS_Shortcode_Checkout {
 			$plan_id = llms_filter_input( INPUT_GET, 'plan', FILTER_SANITIZE_NUMBER_INT );
 
 			// Only retrieve if plan is a llms_access_plan and is published
-			if ( 0 === strcmp( get_post_status( $plan_id, 'publish' ) && 0 === strcmp( get_post_type( $plan_id ), 'llms_access_plan' ) ) ) {
+			if ( 0 === strcmp( get_post_status( $plan_id ), 'publish' ) && 0 === strcmp( get_post_type( $plan_id ), 'llms_access_plan' ) ) {
 
 				$coupon = LLMS()->session->get( 'llms_coupon' );
 


### PR DESCRIPTION
## Description
Fix use of strcmp when checking access plan status, a typo prevented accessing the checkout form when buying an access plan.

`PHP Warning:  strcmp() expects exactly 2 parameters, 1 given in /srv/www/wordpress-one/public_html/wp-content/plugins/lifterlms/includes/shortcodes/class.llms.shortcode.checkout.php on line 184`

## How has this been tested?
I can access the checkout form.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.