### PR TITLE
Fix "Your settings have been saved." notification always shown.

### DIFF
--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -152,7 +152,11 @@ class LLMS_Admin_Settings {
 
 		$current_tab = empty( $_GET['tab'] ) ? 'general' : llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING );
 
-		self::save();
+		// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce is checked in self::save().
+		if ( ! empty( $_POST ) ) {
+			self::save();
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Missing.
 
 		$err = llms_filter_input( INPUT_GET, 'llms_error', FILTER_SANITIZE_STRING );
 		if ( $err ) {
@@ -876,7 +880,6 @@ class LLMS_Admin_Settings {
 	public static function save_fields( $settings ) {
 
 		// phpcs:disable WordPress.Security.NonceVerification.Missing -- nonce is checked in self::save().
-
 		if ( empty( $_POST ) ) {
 			return false;
 		}


### PR DESCRIPTION
fix #920

## Description
fix #920

## How has this been tested?
Just navigated to LifterLMS->Settings and the notice doesn't appear anymore, but it correctly does if I save something.


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
