### PR TITLE
Fix metaboxes encoding quotes and double quotes before saving when th…

### DIFF
--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -3,7 +3,7 @@
  * Admin Metabox Class
  *
  * @since 3.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ foreach ( glob( LLMS_PLUGIN_DIR . '/includes/admin/post-types/meta-boxes/fields/
  *
  * @since 3.0.0
  * @since 3.35.0 Sanitize and verify nonce when saving metabox data.
+ * @since [version] Allow quotes to be saved without being encoded for some special fields that store a shortcode.
  */
 abstract class LLMS_Admin_Metabox {
 
@@ -221,8 +222,10 @@ abstract class LLMS_Admin_Metabox {
 	/**
 	 * Generate and output the HTML for the metabox
 	 *
+	 * @since Unknown
+	 * @since [version] Always decode quotes html entities.
+	 *
 	 * @return void
-	 * @version  3.0.0
 	 */
 	public function output() {
 
@@ -355,6 +358,7 @@ abstract class LLMS_Admin_Metabox {
 	 * @since 3.0.0
 	 * @since 3.14.1 Unknown.
 	 * @since 3.35.0 Added nonce verification before processing data; only access `$_POST` data via `llms_filter_input()`.
+	 * @since [version] Allow quotes when sanitizing some special fields that store a shortcode.
 	 *
 	 * @param    int $post_id   WP Post ID of the post being saved
 	 * @return   void
@@ -395,8 +399,11 @@ abstract class LLMS_Admin_Metabox {
 						// get the posted value
 						if ( isset( $_POST[ $field['id'] ] ) ) {
 
-							$val = llms_filter_input( INPUT_POST, $field['id'], FILTER_SANITIZE_STRING );
-
+							if ( isset( $field['sanitize'] ) && 'shortcode' === $field['sanitize'] ) {
+								$val = llms_filter_input( INPUT_POST, $field['id'], FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
+							} else {
+								$val = llms_filter_input( INPUT_POST, $field['id'], FILTER_SANITIZE_STRING );
+							}
 						} elseif ( ! isset( $_POST[ $field['id'] ] ) ) {
 
 							$val = '';

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -3,7 +3,7 @@
  * Course Options
  *
  * @since 1.0.0
- * @version 3.26.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
+ * @since [version] Allow some fields to store values with quotes.
  */
 class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 
@@ -32,11 +33,12 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 	}
 
 	/**
-	 * Setup fields
+	 * Setup fields.
+	 *
+	 * @since 1.0.0
+	 * @since [version] Allow some fields to store values with quotes.
 	 *
 	 * @return array
-	 * @since    1.0.0
-	 * @version  3.26.3
 	 */
 	public function get_fields() {
 
@@ -218,6 +220,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'id'               => $this->prefix . 'enrollment_opens_message',
 						'label'            => __( 'Enrollment Opens Message', 'lifterlms' ),
 						'type'             => 'text',
+						'sanitize'         => 'shortcode',
 					),
 					array(
 						'class'            => 'input-full',
@@ -228,6 +231,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'id'               => $this->prefix . 'enrollment_closed_message',
 						'label'            => __( 'Enrollment Closed Message', 'lifterlms' ),
 						'type'             => 'text',
+						'sanitize'         => 'shortcode',
 					),
 
 					array(
@@ -266,6 +270,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'id'               => $this->prefix . 'course_opens_message',
 						'label'            => __( 'Course Opens Message', 'lifterlms' ),
 						'type'             => 'text',
+						'sanitize'         => 'shortcode',
 					),
 					array(
 						'class'            => 'input-full',
@@ -276,6 +281,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'id'               => $this->prefix . 'course_closed_message',
 						'label'            => __( 'Course Closed Message', 'lifterlms' ),
 						'type'             => 'text',
+						'sanitize'         => 'shortcode',
 					),
 
 					array(

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
@@ -3,7 +3,7 @@
  * Membership Settings Metabox
  *
  * @since 1.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors; removed duplicate array keys.
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
+ * @since [version] Allow some fields to store values with quotes.
  */
 class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 
@@ -82,6 +83,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 	 * @since 3.0.0
 	 * @since 3.30.0 Removed empty field settings. Modified settings to accommodate sortable auto-enrollment table.
 	 * @since 3.30.3 Removed duplicate array keys.
+	 * @since [version] Allow some fields to store values with quotes.
 	 *
 	 * @return array
 	 */
@@ -220,12 +222,13 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 						'value'      => 'yes',
 					),
 					array(
-						'class'   => 'full-width',
-						'desc'    => sprintf( __( 'Shortcodes like %s can be used in this message', 'lifterlms' ), '[lifterlms_membership_link id="' . $this->post->ID . '"]' ),
-						'default' => sprintf( __( 'You must belong to the %s membership to access this content.', 'lifterlms' ), '[lifterlms_membership_link id="' . $this->post->ID . '"]' ),
-						'id'      => $this->prefix . 'restriction_notice',
-						'label'   => __( 'Restricted Content Notice', 'lifterlms' ),
-						'type'    => 'text',
+						'class'    => 'full-width',
+						'desc'     => sprintf( __( 'Shortcodes like %s can be used in this message', 'lifterlms' ), '[lifterlms_membership_link id="' . $this->post->ID . '"]' ),
+						'default'  => sprintf( __( 'You must belong to the %s membership to access this content.', 'lifterlms' ), '[lifterlms_membership_link id="' . $this->post->ID . '"]' ),
+						'id'       => $this->prefix . 'restriction_notice',
+						'label'    => __( 'Restricted Content Notice', 'lifterlms' ),
+						'type'     => 'text',
+						'sanitize' => 'shortcode',
 					),
 				),
 			),

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.text.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.text.php
@@ -3,7 +3,7 @@
  * Metabox Field: Text
  *
  * @since Unknown
- * @version Unknown
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -12,6 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Metabox_Text_Field
  *
  * @since Unknown
+ * @since [version] When outputting the field's value convert quotes (double and single) HTML entities back to characters.
  */
 class LLMS_Metabox_Text_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface {
 
@@ -24,6 +25,7 @@ class LLMS_Metabox_Text_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 	/**
 	 * outputs the Html for the given field
 	 *
+	 * @since [version] Convert quotes (double and single) HTML entities back to characters.
 	 * @return void
 	 */
 	public function output() {
@@ -38,7 +40,7 @@ class LLMS_Metabox_Text_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 				required="required"
 			<?php endif; ?>
 			class="<?php echo esc_attr( $this->field['class'] ); ?>"
-			value="<?php echo htmlentities( $this->meta ); ?>" size="30"
+			value="<?php echo htmlentities( htmlspecialchars_decode( $this->meta, ENT_QUOTES ) ); ?>" size="30"
 			<?php if ( isset( $this->field['required'] ) && $this->field['required'] ) : ?>
 			required="required"
 			<?php endif; ?>


### PR DESCRIPTION
…ey should not

## Description
The idea is the following:
1) Use a field paramater called `sanitize` (borrowing the idea from the admin settings, see the `'sanitize'=>'slug'` case), where we specify a field is going to store a shortcode.
2) When saving a field value whose `sanitize` parameter is set as `'shortcode'` sanitize it with the flag `FILTER_FLAG_NO_ENCODE_QUOTES` so that quotes are not escaped.
3) When building the form text field value make sure we convert quotes (double and single) HTML entities back to characters, so that any previously encoded quote is correctly prepared to be saved(*).

(*) I've decided this because I didn't want to run an `html_entity_decode` whitelisting quotes at each save, even if this also means that the "issue" will not be visible in the backend anymore.
Anyways for whoever would  experience an issue in front with fields containing a shortcode saving a course/membership will fix it.

[edit]
Do you think we should do something like the point 3) when getting the post meta value in front so that that any issue occurred will be automatically be fixed by this?
[/edit]

## How has this been tested?
I've tested that saving a course/membership the fields containing a shortcode where correctly displayed both in front and backend.

## Types of changes
Bug fix 


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
