### PR TITLE
Fix "Last Seen" column displaying wrong date when the student last lo…

### DIFF
--- a/includes/admin/reporting/tables/llms.table.students.php
+++ b/includes/admin/reporting/tables/llms.table.students.php
@@ -3,7 +3,7 @@
  * Students Reporting Table
  *
  * @since 3.2.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.28.0 Unknown.
  * @since 3.31.0 Allow filtering the table by Course or Membership
  * @since 3.36.0 Add "Last Seen" column.
+ * @since [version] Fixed "Last Seen" column displaying wrong date when the student last login date was saved as timestamp.
  */
 class LLMS_Table_Students extends LLMS_Admin_Table {
 
@@ -100,6 +101,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * @since 3.2.0
 	 * @since 3.15.0 Unknown.
 	 * @since 3.36.0 Added "Last Seen" column.
+	 * @since [version] Fixed "Last Seen" column displaying wrong date when the student last login date was saved as timestamp.
 	 *
 	 * @param    string $key        the column id / key
 	 * @param    obj    $student    Instance of the LLMS_Student
@@ -177,7 +179,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 					$value = $student->get( 'last_login' );
 				}
 
-				$value = $value ? date_i18n( get_option( 'date_format' ), strtotime( $value ) ) : '&ndash;';
+				$value = $value ? date_i18n( get_option( 'date_format' ), is_numeric( $value ) ? $value : strtotime( $value ) ) : '&ndash;';
 
 				break;
 


### PR DESCRIPTION
…gin date was saved as timestamp.

fix #930

## Description
Small addition to make sure, when displaying the last seen date, we convert to `timestamp` only
not `timestamp` values :) .

## How has this been tested?
Without applying this PR I had several `Last Seen` fields wrongly displaying as the current date. With this applied those fields correctly display the expected last seen date.

## Types of changes
Bug fix.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
