### PR TITLE
Improve performances when checking if an event is valid in `LLMS_Even…

### DIFF
--- a/includes/class-llms-events.php
+++ b/includes/class-llms-events.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS/Classes
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Events class.
  *
  * @since 3.36.0
+ * @since [version] Improve performances when checking if an event is valid in `LLMS_Events->is_event_valid()`.
  */
 class LLMS_Events {
 
@@ -107,13 +108,14 @@ class LLMS_Events {
 	 * Determine if the event string is registered and valid.
 	 *
 	 * @since 3.36.0
+	 * @since [version] Use more performant `array_key_exists( $key, $array_assoc )` in place of `in_array( $key, array_keys( $array_assoc ), true )`.
 	 *
 	 * @param string $event Event string (${event_type}.${event_action}). EG: "account.signon".
 	 * @return bool
 	 */
 	protected function is_event_valid( $event ) {
 
-		return in_array( $event, array_keys( $this->get_registered_events() ), true );
+		return array_key_exists( $event, $this->get_registered_events() );
 
 	}
 


### PR DESCRIPTION
…ts->is_event_valid()`.

see:
https://github.com/gocodebox/lifterlms/pull/928#discussion_r324844493

## Description
Use more performant `array_key_exists( $key, $array_assoc )` in place of `in_array( $key, array_keys( $array_assoc ), true )`.

## How has this been tested?
unit tests and logging in (generating an event to be recorded).


## Types of changes
minor enhancement.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. 
- [x] My code follows the LifterLMS Coding Standards.
