### PR TITLE
Introduce LLMS_Database_Query arg `no_found_rows`.

### DIFF
--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define undefined properties & fixed typo in output string.
- * @since [version] Instantiate the notification query passing `no_found_row` arg as `true`.
+ * @since [version] Instantiate the notification query passing `no_found_rows` arg as `true`.
  */
 abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Options_Data implements LLMS_Interface_Notification_Controller {
 
@@ -382,8 +382,8 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 * Determine if the notification is a potential duplicate
 	 *
 	 * @since 3.11.0
-	 * @since [version] Instantiate the notification query passing `no_found_row` arg as `true`.
-	 *                  Also use query method `has_reults()` in place of
+	 * @since [version] Instantiate the notification query passing `no_found_rows` arg as `true`.
+	 *                Also use query method `has_results()` in place of a check on query property `found_results`.
 	 *
 	 * @param string $type       Notification type id.
 	 * @param mixed  $subscriber WP User ID for the subscriber, email address, phone number, etc...

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define undefined properties & fixed typo in output string.
+ * @since [version] Instantiate the notification query passing `no_found_row` arg as `true`.
  */
 abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Options_Data implements LLMS_Interface_Notification_Controller {
 
@@ -380,25 +381,28 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	/**
 	 * Determine if the notification is a potential duplicate
 	 *
-	 * @param    string $type        notification type id
-	 * @param    mixed  $subscriber  WP User ID for the subscriber, email address, phone number, etc...
-	 * @return   boolean
-	 * @since    3.11.0
-	 * @version  3.11.0
+	 * @since 3.11.0
+	 * @since [version] Instantiate the notification query passing `no_found_row` arg as `true`.
+	 *                  Also use query method `has_reults()` in place of
+	 *
+	 * @param string $type       Notification type id.
+	 * @param mixed  $subscriber WP User ID for the subscriber, email address, phone number, etc...
+	 * @return boolean
 	 */
 	public function has_subscriber_received( $type, $subscriber ) {
 
 		$query = new LLMS_Notifications_Query(
 			array(
-				'post_id'    => $this->post_id,
-				'subscriber' => $subscriber,
-				'types'      => $type,
-				'trigger_id' => $this->id,
-				'user_id'    => $this->user_id,
+				'post_id'       => $this->post_id,
+				'subscriber'    => $subscriber,
+				'types'         => $type,
+				'trigger_id'    => $this->id,
+				'user_id'       => $this->user_id,
+				'no_found_rows' => true,
 			)
 		);
 
-		return $query->found_results ? true : false;
+		return $query->has_results();
 
 	}
 

--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -14,6 +14,9 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.16.0
  * @since [version] Fixed an issue that allow instructors, who can only see their own reports,
  *               to see all the quizzes when they had no courses or courses with no lessons.
+ *               In `get_data()` use `LLMS_Query_Quiz_Attempt->number_results` in place of `count(`LLMS_Query_Quiz_Attempt->results`)`.
+ *               Also, when calculating the 'average' on 1000 attempts, instantiate the quiz attempt query passing `no_found_rows` arg as `true`,
+ *               to improve .
  */
 class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 
@@ -88,7 +91,9 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 	 *
 	 * @since 3.16.0
 	 * @since 3.24.0 Unknown.
-	 *
+	 * @since [version] Use `LLMS_Query_Quiz_Attempt->number_results` in place of `count(LLMS_Query_Quiz_Attempt->results)`.
+	 *               Also, when calculating the 'average' on 1000 attempts, instantiate the quiz attempt query passing `no_found_rows` arg as `true`,
+	 *               to improve performance.
 	 * @param    string $key   the column id / key
 	 * @param    mixed  $data  object / array of data that the function can use to extract the data
 	 * @return   mixed
@@ -122,12 +127,13 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 				$grade = 0;
 				$query = new LLMS_Query_Quiz_Attempt(
 					array(
-						'quiz_id'  => $quiz->get( 'id' ),
-						'per_page' => 1000,
+						'quiz_id'       => $quiz->get( 'id' ),
+						'per_page'      => 1000,
+						'no_found_rows' => true,
 					)
 				);
 
-				$attempts = count( $query->results );
+				$attempts = $query->number_results;
 
 				if ( ! $attempts ) {
 					$value = 0;

--- a/includes/admin/reporting/tables/llms.table.students.php
+++ b/includes/admin/reporting/tables/llms.table.students.php
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.31.0 Allow filtering the table by Course or Membership
  * @since 3.36.0 Add "Last Seen" column.
  * @since [version] Fixed "Last Seen" column displaying wrong date when the student last login date was saved as timestamp.
+ *               When retrieving the "Last Seen" column's value, instantiate the events query passing `no_found_rows` arg as `true`,
+ *               to improve performance.
  */
 class LLMS_Table_Students extends LLMS_Admin_Table {
 
@@ -102,6 +104,8 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * @since 3.15.0 Unknown.
 	 * @since 3.36.0 Added "Last Seen" column.
 	 * @since [version] Fixed "Last Seen" column displaying wrong date when the student last login date was saved as timestamp.
+	 *               When retrieving the "Last Seen" column's value, instantiate the events query passing `no_found_rows` arg as `true`,
+	 *               to improve .
 	 *
 	 * @param    string $key        the column id / key
 	 * @param    obj    $student    Instance of the LLMS_Student
@@ -163,11 +167,12 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 			case 'last_seen':
 				$query = new LLMS_Events_Query(
 					array(
-						'actor'    => $student->get_id(),
-						'per_page' => 1,
-						'sort'     => array(
+						'actor'         => $student->get_id(),
+						'per_page'      => 1,
+						'sort'          => array(
 							'date' => 'DESC',
 						),
+						'no_found_rows' => true,
 					)
 				);
 

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -1,19 +1,20 @@
 <?php
 /**
- * Perform db queries for events
+ * Perform db queries for events.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Events_Query class
+ * LLMS_Events_Query class.
  *
  * @since 3.36.0
+ * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  */
 class LLMS_Events_Query extends LLMS_Database_Query {
 
@@ -117,6 +118,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 3.36.0
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 *
 	 * @return string
 	 */
@@ -124,7 +126,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
+		return "SELECT {$this->sql_select_columns( 'id' )}
 				FROM {$wpdb->prefix}lifterlms_events
 				{$this->sql_where()}
 				{$this->sql_orderby()}

--- a/includes/class-llms-events.php
+++ b/includes/class-llms-events.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Events class.
  *
  * @since 3.36.0
- * @since [version] Improve performances when checking if an event is valid in `LLMS_Events->is_event_valid()`.
+ * @since [version] Improve performance when checking if an event is valid in `LLMS_Events->is_event_valid()`.
  *               Remove redundant check on `is_singular()` and `is_post_type_archive()` in `LLMS_Events->should_track_client_events()`.
  */
 class LLMS_Events {

--- a/includes/class-llms-sessions.php
+++ b/includes/class-llms-sessions.php
@@ -5,15 +5,17 @@
  * @package  LifterLMS/Classes
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Sessions class..
+ * LLMS_Sessions class.
  *
  * @since 3.36.0
+ * @since [version] In `is_session_idle()`, when retrieving the last event, instantiate the events query passing `no_found_rows` arg as `true`,
+ *               to improve performance.
  */
 class LLMS_Sessions {
 
@@ -175,7 +177,8 @@ class LLMS_Sessions {
 	 * in the last 30 minutes.
 	 *
 	 * @since 3.36.0
-	 *
+	 * @since [version] When retrieving the last event, instantiate the events query passing `no_found_rows` arg as `true`,
+	 *               to improve performance.
 	 * @param LLMS_Event $start Event record for the start of the session.
 	 * @return bool
 	 */
@@ -203,10 +206,11 @@ class LLMS_Sessions {
 		$events = $this->get_session_events(
 			$start,
 			array(
-				'per_page' => 1,
-				'sort'     => array(
+				'per_page'      => 1,
+				'sort'          => array(
 					'date' => 'DESC',
 				),
+				'no_found_rows' => true,
 			)
 		);
 

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -1,20 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Query LifterLMS Students for a given course / membership.
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.16.0
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Query LifterLMS Students for a given course / membership
+ * Query LifterLMS Students for a given course / membership class.
  *
- * @since    3.16.0
- * @version  3.35.0
+ * @since 3.16.0
+ * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  *
- * @arg  $attempt     (int)        Query by attempt number
- * @arg  $quiz_id     (int|array)  Query by Quiz WP post ID (locate multiple quizzes with an array of ids)
- * @arg  $student_id  (int|array)  Query by WP User ID (locate by multiple users with an array of ids)
+ * @arg $attempt    (int)       Query by attempt number.
+ * @arg $quiz_id    (int|array) Query by Quiz WP post ID (locate multiple quizzes with an array of ids).
+ * @arg $student_id (int|array) Query by WP User ID (locate by multiple users with an array of ids).
  *
- * @arg  $page        (int)        Get results by page
- * @arg  $per_page    (int)        Number of results per page (default: 25)
- * @arg  $sort        (array)      Define query sorting options [id,student_id,quiz_id,start_date,update_date,end_date,attempt,grade,current,passed]
+ * @arg $page       (int)       Get results by page.
+ * @arg $per_page   (int)       Number of results per page (default: 25).
+ * @arg $sort       (array)     Define query sorting options [id,student_id,quiz_id,start_date,update_date,end_date,attempt,grade,current,passed].
  *
  * @example
  *       $query = new LLMS_Query_Quiz_Attempt( array(
@@ -122,15 +130,16 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	/**
 	 * Prepare the SQL for the query
 	 *
-	 * @return   string
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 *
+	 * @return string
 	 */
 	protected function preprare_query() {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
+		return "SELECT {$this->sql_select_columns( 'id' )}
 				FROM {$wpdb->prefix}lifterlms_quiz_attempts
 				{$this->sql_where()}
 				{$this->sql_orderby()}

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Query LifterLMS Students for a given course / membership class.
  *
  * @since 3.16.0
+ * @since 3.35.0 Unknown.
  * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  *
  * @arg $attempt    (int)       Query by attempt number.

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * LifterLMS User Postmeta Query.
+ *
+ * @package LifterLMS/Classes/Abstracts
+ *
+ * @since 3.15.0
+ * @version [version]
+ */
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS User Postmeta Query
+ * LifterLMS User Postmeta Query class.
  *
- * @since    3.15.0
- * @version  3.15.0
+ * @since 3.15.0
+ * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  */
 class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 
@@ -188,11 +196,12 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 *
+	 * @return string
 	 */
 	protected function preprare_query() {
 
@@ -204,8 +213,9 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 		$vars[] = $this->get( 'per_page' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items
 		$sql = $wpdb->prepare(
-			"SELECT SQL_CALC_FOUND_ROWS meta_id
+			"SELECT {$this->sql_select_columns( 'meta_id' )}
 			 FROM {$wpdb->prefix}lifterlms_user_postmeta
 			 {$this->sql_where()}
 			 {$this->sql_orderby()}
@@ -213,7 +223,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 		return $sql;
 
 	}

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -224,6 +224,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
 		return $sql;
 
 	}

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Query LifterLMS Students class for a given course / membership.
  *
  * @since 3.4.0
+ * @since 3.13.0 Unknown.
  * @since [version] `$this->sql_select()` uses `$this->sql_select_columns({columns})` to determine additional columns to select.
  *                  `$this->preprare_query()` demands to it to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
  */
@@ -133,6 +134,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.4.0
+	 * @since 3.13.0 Unknown.
 	 * @since [version] Demands to `$this->sql_select()` to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
 	 *
 	 * @return string

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -1,13 +1,22 @@
 <?php
 /**
- * Query LifterLMS Students for a given course / membership
+ * Query LifterLMS Students for a given course / membership.
  *
- * @since    3.4.0
- * @version  3.13.0
+ * @package LifterLMS/Classes
+ *
+ * @since 3.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * Query LifterLMS Students class for a given course / membership.
+ *
+ * @since 3.4.0
+ * @since [version] `$this->sql_select()` uses `$this->sql_select_columns({columns})` to determine additional columns to select.
+ *                  `$this->preprare_query()` demands to it to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
+ */
 class LLMS_Student_Query extends LLMS_Database_Query {
 
 	/**
@@ -121,11 +130,12 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
-	 * @return   void
-	 * @since    3.4.0
-	 * @version  3.13.0
+	 * @since 3.4.0
+	 * @since [version] Demands to `$this->sql_select()` to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
+	 *
+	 * @return string
 	 */
 	protected function preprare_query() {
 
@@ -144,9 +154,9 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		$vars[] = $this->get( 'per_page' );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items
 		$sql = $wpdb->prepare(
-			"SELECT SQL_CALC_FOUND_ROWS
-			{$this->sql_select()}
+			"SELECT {$this->sql_select()}
 			FROM {$wpdb->users} AS u
 			{$this->sql_joins()}
 			{$this->sql_search()}
@@ -156,6 +166,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		return $sql;
 
@@ -278,11 +289,12 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Setup the SQL for the select statement
+	 * Setup the SQL for the select statement.
+	 *
+	 * @since 3.13.0
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine additional columns to select.
 	 *
 	 * @return   string
-	 * @since    3.13.0
-	 * @version  3.13.0
 	 */
 	private function sql_select() {
 
@@ -314,6 +326,8 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		$sql = implode( ', ', $selects );
 
+		$sql = $this->sql_select_columns( $sql );
+
 		if ( $this->get( 'suppress_filters' ) ) {
 			return $sql;
 		}
@@ -323,12 +337,12 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Generate an SQL IN clause based on submitted status arguments
+	 * Generate an SQL IN clause based on submitted status arguments.
 	 *
-	 * @param    string $column  name of the column
-	 * @return   string
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param  string $column  Optional. Name of the column. Default 'status'.
+	 * @return string
 	 */
 	private function sql_status_in( $column = 'status' ) {
 		global $wpdb;
@@ -340,8 +354,9 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			$statuses[] = $status;
 			$comma      = true;
 		}
-
-		$sql = $wpdb->prepare( $sql, $statuses ); // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- $sql contains placeholders.
+		$sql = $wpdb->prepare( $sql, $statuses );
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
 		return "{$column} IN ( {$sql} )";
 
 	}

--- a/includes/models/model.llms.student.quizzes.php
+++ b/includes/models/model.llms.student.quizzes.php
@@ -1,17 +1,24 @@
 <?php
 /**
- * Student Quiz Data
+ * Student Quiz Data.
  * Rather than instantiating this class directly use LLMS_Student->quizzes().
  *
  * @package  LifterLMS/Models
- * @since   3.9.0
- * @version 3.16.11
+ *
+ * @since 3.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Student_Quizzes model.
+ * LLMS_Student_Quizzes model class.
+ *
+ * @since 3.9.0
+ * @since 3.16.11 Unknown.
+ * @since [version] Perfomance improvements: In `get_last_completed_attempt()`, `get_attempts_by_quiz()`,
+ *               and in `get_all()` instantiate the quiz attempt query passing `no_found_rows` arg as `true`
+ *               as we don't need pagination information there.
  */
 class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 
@@ -20,8 +27,8 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	 *
 	 * @since    3.16.0
 	 *
-	 * @param    int $quiz_id  WP Post ID of the quiz
-	 * @return   int
+	 * @param  int $quiz_id WP Post ID of the quiz.
+	 * @return int
 	 */
 	public function count_attempts_by_quiz( $quiz_id ) {
 
@@ -38,12 +45,13 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Remove Student Quiz attempt by ID
+	 * Remove Student Quiz attempt by ID.
 	 *
-	 * @param    int $attempt_id  Attempt ID
-	 * @return   boolean              true on success, false on error
-	 * @since    3.9.0
-	 * @version  3.16.11
+	 * @since 3.9.0
+	 * @since 3.16.11 Unknown.
+	 *
+	 * @param  int $attempt_id Attempt ID.
+	 * @return boolean True on success, false on error.
 	 */
 	public function delete_attempt( $attempt_id ) {
 
@@ -53,19 +61,22 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Retrieve quiz data for a student and optionally filter by quiz_id(s)
+	 * Retrieve quiz data for a student and optionally filter by quiz_id(s).
 	 *
-	 * @param    mixed $quiz    WP Post ID / Array of WP Post IDs
-	 * @return   object           Instance of LLMS_Query_Quiz_Attempt
-	 * @since    3.9.0
-	 * @version  3.16.11
+	 * @since 3.9.0
+	 * @since 3.16.11 Unknown.
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param mixed $quiz WP Post ID / Array of WP Post IDs.
+	 * @return object Instance of LLMS_Query_Quiz_Attempt.
 	 */
 	public function get_all( $quiz = array() ) {
 
 		$query = new LLMS_Query_Quiz_Attempt(
 			array(
-				'quiz_id'  => $quiz,
-				'per_page' => 5000,
+				'quiz_id'       => $quiz,
+				'per_page'      => 5000,
+				'no_found_rows' => true,
 			)
 		);
 
@@ -74,20 +85,22 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Retrieve quiz attempts
+	 * Retrieve quiz attempts.
 	 *
-	 * @param    int   $quiz_id  WP Post ID of the quiz
-	 * @param    array $args     additional args to pass to LLMS_Query_Quiz_Attempt
-	 * @return   array             array of LLMS_Quiz_Attempts
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param int   $quiz_id WP Post ID of the quiz
+	 * @param array $args    Additional args to pass to LLMS_Query_Quiz_Attempt
+	 * @return array Array of LLMS_Quiz_Attempts
 	 */
 	public function get_attempts_by_quiz( $quiz_id, $args = array() ) {
 
 		$args = wp_parse_args(
 			array(
-				'student_id' => $this->get_id(),
-				'quiz_id'    => $quiz_id,
+				'student_id'    => $this->get_id(),
+				'quiz_id'       => $quiz_id,
+				'no_found_rows' => true,
 			),
 			$args
 		);
@@ -103,24 +116,25 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Retrieve an attempt by attempt id
+	 * Retrieve an attempt by attempt id.
 	 *
-	 * @param    int $attempt_id  Attempt ID
-	 * @return   obj
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 *
+	 * @param int $attempt_id Attempt ID.
+	 * @return obj
 	 */
 	public function get_attempt_by_id( $attempt_id ) {
 		return new LLMS_Quiz_Attempt( $attempt_id );
 	}
 
 	/**
-	 * Decodes an attempt string and returns the associated attempt
+	 * Decodes an attempt string and returns the associated attempt.
 	 *
-	 * @param    string $attempt_key  encoded attempt key
-	 * @return   obj|false
-	 * @since    3.9.0
-	 * @version  3.16.0
+	 * @since 3.9.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @param string $attempt_key Encoded attempt key
+	 * @return obj|false
 	 */
 	public function get_attempt_by_key( $attempt_key ) {
 
@@ -133,12 +147,12 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Get the # of attempts remaining by a student for a given quiz
+	 * Get the # of attempts remaining by a student for a given quiz.
 	 *
-	 * @param    int $quiz_id  WP Post ID of the Quiz
-	 * @return   mixed
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 *
+	 * @param int $quiz_id WP Post ID of the Quiz.
+	 * @return mixed
 	 */
 	public function get_attempts_remaining_for_quiz( $quiz_id ) {
 
@@ -168,12 +182,12 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Get all the attempts for a given quiz/lesson from an attempt key
+	 * Get all the attempts for a given quiz/lesson from an attempt key.
 	 *
-	 * @param    string $attempt_key  an encoded attempt key
-	 * @return   false|array
-	 * @since    3.9.0
-	 * @version  3.9.0
+	 * @since 3.9.0
+	 *
+	 * @param string $attempt_key An encoded attempt key.
+	 * @return false|array
 	 */
 	public function get_sibling_attempts_by_key( $attempt_key ) {
 
@@ -185,13 +199,14 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Get the quiz attempt with the highest grade for a given quiz and lesson combination
+	 * Get the quiz attempt with the highest grade for a given quiz and lesson combination.
 	 *
-	 * @param    int  $quiz_id    WP Post ID of a Quiz
-	 * @param    null $deprecated deprecated
-	 * @return   false|array
-	 * @since    3.9.0
-	 * @version  3.16.0
+	 * @since 3.9.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @param int  $quiz_id    WP Post ID of a Quiz.
+	 * @param null $deprecated Deprecated.
+	 * @return false|array
 	 */
 	public function get_best_attempt( $quiz_id = null, $deprecated = null ) {
 
@@ -217,13 +232,14 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Retrieve the last recorded attempt for a student for a given quiz/lesson
-	 * "Last" is defined as the attempt with the highest attempt number
+	 * Retrieve the last recorded attempt for a student for a given quiz/lesson.
+	 * "Last" is defined as the attempt with the highest attempt number.
 	 *
-	 * @param    int $quiz_id    WP Post ID of the quiz
-	 * @return   obj|false
-	 * @since    3.9.0
-	 * @version  3.16.0
+	 * @since 3.9.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @param int $quiz_id WP Post ID of the quiz.
+	 * @return obj|false
 	 */
 	public function get_last_attempt( $quiz_id ) {
 
@@ -248,11 +264,13 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	/**
 	 * Get the last completed attempt for a given quiz or quiz/lesson combination
 	 *
-	 * @param    int $quiz    WP Post ID of a Quiz
-	 * @param    int $lesson  WP Post ID of a Lesson
-	 * @return   false|obj
-	 * @since    3.9.0
-	 * @version  3.16.0
+	 * @since 3.9.0
+	 * @since 3.16.0 Unknown.
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param int $quiz   WP Post ID of a Quiz
+	 * @param int $lesson WP Post ID of a Lesson
+	 * @return false|obj
 	 */
 	public function get_last_completed_attempt( $quiz_id = null, $deprecated = null ) {
 
@@ -261,6 +279,7 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 				'student_id'     => $this->get_id(),
 				'quiz_id'        => $quiz_id,
 				'per_page'       => 1,
+				'no_found_rows'  => true,
 				'status_exclude' => array( 'incomplete' ),
 				'sort'           => array(
 					'end_date' => 'DESC',
@@ -277,12 +296,13 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Parse an attempt key into it's parts
+	 * Parse an attempt key into it's parts.
 	 *
-	 * @param    string $attempt_key  an encoded attempt key
-	 * @return   array|false
-	 * @since    3.9.0
-	 * @version  3.16.7
+	 * @since 3.9.0
+	 * @since 3.16.7 Unknown.
+	 *
+	 * @param string $attempt_key An encoded attempt key
+	 * @return array|false
 	 */
 	private function parse_attempt_key( $attempt_key ) {
 

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -22,6 +22,7 @@ defined( 'ABSPATH' ) || exit;
  *   ) );
  *
  * @since 3.8.0
+ * @since 3.14.0 Unknown.
  * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  */
 class LLMS_Notifications_Query extends LLMS_Database_Query {
@@ -196,6 +197,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 * @since 3.8.0
 	 * @since 3.9.4 Unknown.
 	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -1,6 +1,17 @@
 <?php
 /**
- * Query LifterLMS Students for a given course / membership
+ * Query LifterLMS Notifications for a given course / membership.
+ *
+ * @package LifterLMS/Notifications
+ *
+ * @since 3.8.0
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Query LifterLMS Notifications class for a given course / membership.
  *
  * @example
  *   $query = new LLMS_Notifications_Query( array(
@@ -10,13 +21,9 @@
  *       'types' => 'basic', // array( 'basic', 'email', '...' )
  *   ) );
  *
- * @since    3.8.0
- * @version  3.14.0
+ * @since 3.8.0
+ * @since [version] `$this->preprare_query()` uses `$this->sql_select_columns({columns})` to determine the columns to select.
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 class LLMS_Notifications_Query extends LLMS_Database_Query {
 
 	/**
@@ -188,7 +195,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 *
 	 * @since 3.8.0
 	 * @since 3.9.4 Unknown.
-	 *
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 * @return string
 	 */
 	protected function preprare_query() {
@@ -201,8 +208,9 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- SQL is prepared in other functions.
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items
 		$sql = $wpdb->prepare(
-			"SELECT SQL_CALC_FOUND_ROWS *
+			"SELECT {$this->sql_select_columns()}
 			FROM {$wpdb->prefix}lifterlms_notifications AS n
 			LEFT JOIN {$wpdb->posts} AS p on p.ID = n.post_id
 			{$this->sql_where()}
@@ -212,6 +220,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		return $sql;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -3,7 +3,7 @@
  * Notification Controller: Quiz Failed
  *
  * @since 3.8.0
- * @version 3.24.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since [version] In `get_settings()` instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
  */
 class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notification_Controller {
 
@@ -77,12 +78,13 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	}
 
 	/**
-	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 * Get an array of LifterLMS Admin Page settings to send test notifications.
 	 *
-	 * @param    string $type  notification type [basic|email]
-	 * @return   array
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @return array
 	 */
 	public function get_test_settings( $type ) {
 
@@ -90,17 +92,20 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 			return;
 		}
 
-		$query    = new LLMS_Query_Quiz_Attempt(
+		$query = new LLMS_Query_Quiz_Attempt(
 			array(
-				'per_page' => 25,
-				'status'   => 'fail',
+				'per_page'      => 25,
+				'status'        => 'fail',
+				'no_found_rows' => true,
 			)
 		);
-		$options  = array(
+
+		$options = array(
 			'' => '',
 		);
+
 		$attempts = array();
-		$results  = $query->results;
+
 		if ( $query->has_results() ) {
 			foreach ( $query->get_attempts() as $attempt ) {
 				$quiz    = llms_get_post( $attempt->get( 'quiz_id' ) );

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.graded.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.graded.php
@@ -1,11 +1,18 @@
 <?php
+/**
+ * Notification Controller: Quiz Graded.
+ *
+ * @since 3.24.0
+ * @version [version]
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Notification Controller: Quiz Graded
+ * Notification Controller: Quiz Graded class.
  *
- * @since    3.24.0
- * @version  3.24.0
+ * @since 3.24.0
+ * @since [version] In `get_settings()` instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
  */
 class LLMS_Notification_Controller_Quiz_Graded extends LLMS_Abstract_Notification_Controller {
 
@@ -60,12 +67,13 @@ class LLMS_Notification_Controller_Quiz_Graded extends LLMS_Abstract_Notificatio
 	}
 
 	/**
-	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 * Get an array of LifterLMS Admin Page settings to send test notifications-
 	 *
-	 * @param    string $type  notification type [basic|email]
-	 * @return   array
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @return array
 	 */
 	public function get_test_settings( $type ) {
 
@@ -75,7 +83,8 @@ class LLMS_Notification_Controller_Quiz_Graded extends LLMS_Abstract_Notificatio
 
 		$query = new LLMS_Query_Quiz_Attempt(
 			array(
-				'per_page' => 25,
+				'per_page'      => 25,
+				'no_found_rows' => true,
 			)
 		);
 

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
@@ -1,18 +1,19 @@
 <?php
 /**
- * Notification Controller: Quiz Passed
+ * Notification Controller: Quiz Passed.
  *
  * @since 3.8.0
- * @version 3.24.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Notification Controller: Quiz Passed
+ * Notification Controller: Quiz Passed.
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since [version] In `get_settings()` instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
  */
 class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notification_Controller {
 
@@ -77,12 +78,13 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 	}
 
 	/**
-	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 * Get an array of LifterLMS Admin Page settings to send test notifications-
 	 *
-	 * @param    string $type  notification type [basic|email]
-	 * @return   array
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 * @since [version] Instantiate the quiz attempt query passing `no_found_rows` arg as `true`, to improve performance.
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @return array
 	 */
 	public function get_test_settings( $type ) {
 
@@ -92,8 +94,9 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 
 		$query = new LLMS_Query_Quiz_Attempt(
 			array(
-				'per_page' => 25,
-				'status'   => 'pass',
+				'per_page'      => 25,
+				'status'        => 'pass',
+				'no_found_rows' => true,
 			)
 		);
 


### PR DESCRIPTION
When set to `true` will avoid potentially expensive calculation of total rows.

fix #933

## How has this been tested?
manual tests and existing unit tests

## Types of changes
enhancement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
