### PR TITLE
Bug: some ajax-admin page doesn't have settings.events object, It cau…

### DIFF
--- a/assets/js/app/llms-tracking.js
+++ b/assets/js/app/llms-tracking.js
@@ -49,7 +49,7 @@ LLMS.Tracking = function( settings ) {
 		}
 
 		// If the event isn't registered in the settings don't proceed.
-		if ( -1 === settings.events.indexOf( args.event ) ) {
+		if ( !settings.events || -1 === settings.events.indexOf( args.event ) ) {
 			return;
 		}
 

--- a/assets/js/llms.js
+++ b/assets/js/llms.js
@@ -1852,7 +1852,7 @@ var LLMS = window.LLMS || {};
 			}
 	
 			// If the event isn't registered in the settings don't proceed.
-			if ( -1 === settings.events.indexOf( args.event ) ) {
+			if ( !settings.events || -1 === settings.events.indexOf( args.event ) ) {
 				return;
 			}
 	


### PR DESCRIPTION
## Description
Check setting.events Object existence before access it. (JS)

I've using Anspress and Lifterlms at the same time. Anspress failed after upgrade to Lifterlms 3.36.0.

llms.min.js is included in Anspress ajax-admin request. But the return page doesn't have "setting.events" object. 

## How has this been tested?
Wordpress 5.2.3
Anspress 4.1.15
I've installed clean worpress 5.2.3, Anspress 4.1.15 and my code into wordpress, and test it.

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
