### PR TITLE
Order status updated automatically using the hook for the enrollment …

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
@@ -3,7 +3,7 @@
  * Metabox for Student Enrollment Information via the Order interface
  *
  * @since 3.0.0
- * @version 3.33.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.0.0
  * @since 3.33.0 Added the logic to handle the Enrollment 'deleted' status on save.
+ * @since [version] In ` save_delete_enrollment()` removed order cancellation instruction, moved elsewhere as reaction to the enrollment deletion.
+ *                @see `LLMS_Controller_Orders->on_deleted_enrollment()` in `includes\controllers\class.llms.controller.orders.php`.
+ *                Also, add order note about the enrollment deletion only if it actually occurred.
  */
 class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 
@@ -131,6 +134,9 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 	 * Delete enrollment data based on posted values.
 	 *
 	 * @since 3.33.0
+	 * @since [version] Removed order cancellation instruction, moved elsewhere as reaction to the enrollment deletion.
+	 *                @see `LLMS_Controller_Orders->on_deleted_enrollment()` in `includes\controllers\class.llms.controller.orders.php`.
+	 *                Also, add order note about the enrollment deletion only if it actually occurred.
 	 *
 	 * @param int $post_id WP_Post ID of the order.
 	 * @return void
@@ -139,14 +145,16 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 
 		$order = llms_get_post( $post_id );
 
-		// Switch the order status to Cancelled: it will also unenroll the student setting the enrollment status to 'cancelled' as well
-		// @see `LLMS_Controller_Orders->error_order()`
-		$order->set_status( 'cancelled' );
+		/**
+		 * Completely remove any enrollment records related to the given product & order.
+		 * Also note that, by design, at this stage the student has already been unenrolled,
+		 * as the delete button is only available when the enrollment status is NOT 'enrolled'.
+		 */
+		if ( llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) ) ) {
 
-		// Completely remove any enrollment records related to the given product & order.
-		llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) );
+			$order->add_note( __( 'Student enrollment records have been deleted.', 'lifterlms' ), true );
 
-		$order->add_note( __( 'Student enrollment records have been deleted.', 'lifterlms' ), true );
+		}
 
 	}
 

--- a/includes/controllers/class.llms.controller.orders.php
+++ b/includes/controllers/class.llms.controller.orders.php
@@ -3,7 +3,7 @@
  * Order processing and related actions controller
  *
  * @since 3.0.0
- * @version 3.36.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.34.4 Added filter `llms_order_can_be_confirmed`.
  * @since 3.34.5 Fixed logic error in `llms_order_can_be_confirmed` conditional.
  * @since 3.36.1 In `recurring_charge()`, made sure to process only proper LLMS_Orders of existing users.
+ * @since [version] Added logic to set the order status to 'cancelled' when an enrollment linked to an order is deleted.
+ *               Also `llms_unenroll_on_error_order` fiter hook added.
  */
 class LLMS_Controller_Orders {
 
@@ -24,7 +26,8 @@ class LLMS_Controller_Orders {
 	 *
 	 * @since 3.0.0
 	 * @since 3.19.0 Updated.
-	 * @since 3.33.0 Added `before_delete_post` action to handle order deletion
+	 * @since 3.33.0 Added `before_delete_post` action to handle order deletion.
+	 * @since [version] Added `llms_user_enrollment_deleted` action to handle order status change on enrollment deletion.
 	 */
 	public function __construct() {
 
@@ -38,6 +41,9 @@ class LLMS_Controller_Orders {
 
 		// this action adds lifterlms specific action when an order is deleted, just before the WP post postmetas are removed.
 		add_action( 'before_delete_post', array( $this, 'on_delete_order' ) );
+
+		// this action is meant to do specific actions on orders when an enrollment, with an order as trigger, is deleted.
+		add_action( 'llms_user_enrollment_deleted', array( $this, 'on_user_enrollment_deleted' ), 10, 3 );
 
 		/**
 		 * Status Change Actions for Orders and Transactions
@@ -300,15 +306,33 @@ class LLMS_Controller_Orders {
 	}
 
 	/**
-	 * Called when an order's status changes to refunded, cancelled, expired, or failed
+	 * Called when an order's status changes to refunded, cancelled, expired, or failed.
 	 *
-	 * @param    obj $order  instance of an LLMS_Order
-	 * @return   void
+	 * @since 3.0.0
+	 * @since 3.10.0 Unknown.
+	 * @since [version] Added `llms_unenroll_on_error_order` filter hook.
+	 *
+	 * @param  LLMS_Order $order Instance of an LLMS_Order
+	 * @return void
 	 *
 	 * @since    3.0.0
 	 * @version  3.10.0
 	 */
 	public function error_order( $order ) {
+
+		$order->unschedule_recurring_payment();
+
+		/**
+		 * Determine if student should be unenrolled on order error.
+		 *
+		 * @since [version]
+		 *
+		 * @param bool       $unenroll_on_error_order True if the student should be unenrolled, false otherwise. Default true.
+		 * @param LLMS_Order $order                   Order object.
+		 */
+		if ( ! apply_filters( 'llms_unenroll_on_error_order', true, $order ) ) {
+			return;
+		}
 
 		switch ( current_filter() ) {
 
@@ -326,8 +350,6 @@ class LLMS_Controller_Orders {
 				break;
 
 		}
-
-		$order->unschedule_recurring_payment();
 
 		llms_unenroll_student( $order->get( 'user_id' ), $order->get( 'product_id' ), $status, 'order_' . $order->get( 'id' ) );
 
@@ -347,6 +369,34 @@ class LLMS_Controller_Orders {
 		$order = llms_get_post( $post_id );
 		if ( $order && is_a( $order, 'LLMS_Order' ) ) {
 			llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) );
+		}
+
+	}
+
+	/**
+	 * Called when an user enrollment is deleted.
+	 * Will set the related order status to 'cancelled'.
+	 *
+	 * @since [version]
+	 *
+	 * @param int    $user_id    WP User ID.
+	 * @param int    $product_id WP Post ID of the course or membership.
+	 * @param string $trigger    The deleted enrollment trigger, or 'any' if no specific trigger.
+	 * @return void
+	 */
+	public function on_user_enrollment_deleted( $user_id, $product_id, $trigger ) {
+
+		$order_id = 'order_' === substr( $trigger, 0, 6 ) ? absint( substr( $trigger, 6 ) ) : false;
+		$order    = $order_id ? llms_get_post( $order_id ) : false;
+
+		if ( $order && is_a( $order, 'LLMS_Order' ) ) {
+
+			// No need to run an unenrollment as we're reacting to an enrollment deletion, user enrollments data already removed.
+			add_filter( 'llms_unenroll_on_error_order', '__return_false', 100 );
+			$order->set_status( 'cancelled' );
+			// Reset unenrollment's suspension.
+			remove_filter( 'llms_unenroll_on_error_order', '__return_false', 100 );
+
 		}
 
 	}

--- a/tests/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-order-enrollment.php
+++ b/tests/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-order-enrollment.php
@@ -28,7 +28,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 	}
 
 	/**
-	 * test the LLMS_Meta_Box_Order_Enrollment save method
+	 * test the LLMS_Meta_Box_Order_Enrollment save method.
 	 *
 	 * @since 3.33.0
 	 *
@@ -36,14 +36,14 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 	 */
 	public function test_save() {
 
-		// create a real order
+		// create a real order.
 		$order = $this->get_mock_order();
 
 		$order_id   = $order->get( 'id' );
 		$product_id = $order->get( 'product_id' );
 		$student_id = $order->get( 'user_id' );
 
-		// check enroll
+		// check enroll.
 		$this->setup_post( array(
 			'llms_update_enrollment_status'      => 'Update',
 			'llms_student_old_enrollment_status' => '',
@@ -53,7 +53,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 		$this->metabox->save( $order_id );
 		$this->assertTrue( llms_is_user_enrolled( $student_id, $product_id ) );
 
-		// check unenroll
+		// check unenroll.
 		$this->setup_post( array(
 			'llms_update_enrollment_status'      => 'Update',
 			'llms_student_old_enrollment_status' => 'enrolled',
@@ -63,7 +63,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 		$this->metabox->save( $order_id );
 		$this->assertFalse( llms_is_user_enrolled( $student_id, $product_id ) );
 
-		// check enrollment deleted => no enrollment records + order status set to cancelled
+		// check enrollment deleted => no enrollment records + order status set to cancelled.
 		$this->setup_post( array(
 			'llms_delete_enrollment_status'      => 'Delete',
 			'llms_student_old_enrollment_status' => 'expired',

--- a/tests/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -12,8 +12,9 @@
  * @since 3.36.1 When testing deleting/erroring orders make sure to schedule a recurring payment when setting an order as active so that,
  *               when subsequently we error/delete the order, checking the recurring payment is unscheduled makes sense.
  *               Also add tests on recurrint payments not processed when order or user deleted.
+ * @since [version] Added `test_on_user_enrollment_deleted()`.
  *
- * @version 3.36.1
+ * @version [version]
  */
 class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 
@@ -258,6 +259,59 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * test on user enrollment deleted.
+	 * The controller's `on_user_enrollment_deleted()` method is reponsible of changing the order status to `cancelled`
+	 * in reaction to the deletion of an enrollment with the same order as trigger.
+	 * @group whattino
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_on_user_enrollment_deleted() {
+
+		$order            = $this->get_mock_order();
+		$student_id       = $order->get( 'user_id' );
+		$order_product_id = $order->get( 'product_id' );
+		$order_id         = $order->get( 'id' );
+
+		// enroll the student.
+		$order->set( 'status', 'llms-active' );
+
+		$order_cancelled_actions = did_action( 'lifterlms_order_status_cancelled' );
+
+		$fake_order_id = $order_id + 999;
+
+		// delete user enrollment passing a fake order as trigger.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$fake_order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-active', llms_get_post( $order_id )->get( 'status' ) );
+
+		// delete user enrollment.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions + 1, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+		$order_cancelled_actions = did_action( 'lifterlms_order_status_cancelled' );
+
+		// check that trying to delete it again doesn't trigger the action again.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+		// enroll the student again on the same course with a different trigger.
+		$student = llms_get_student( $student_id );
+		llms_enroll_student( $student_id, $order_product_id );
+
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+	}
 
 	/**
 	 * Test expire access function


### PR DESCRIPTION
…deletion.

## Description
Removed logic to set the order status to 'cancelled' when deleting an enrollment from the order screen.
Added logic to automatically set the order status to 'cancelled' when an enrollment deletion with an order as trigger is deleted, from whatever place.

see https://github.com/gocodebox/lifterlms-rest/issues/95#issuecomment-535595441

## How has this been tested?
Manually, with already existing unit tests and new unit tests

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.