### PR TITLE
Fix lesson drip settings generating warning when course start date no…

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.lesson.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.lesson.php
@@ -3,7 +3,7 @@
  * Lesson Settings Metabox
  *
  * @since 1.0.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors.
+ * @since [version] 'start' drip method made avialble only if the parent course has a start date set.
  */
 class LLMS_Meta_Box_Lesson extends LLMS_Admin_Metabox {
 
@@ -41,6 +42,7 @@ class LLMS_Meta_Box_Lesson extends LLMS_Admin_Metabox {
 	 *
 	 * @since 3.0.0
 	 * @since 3.30.3 Fixed spelling errors.
+	 * @since [version] 'start' drip method made available only if the parent course has a start date set.
 	 *
 	 * @return array
 	 */
@@ -59,6 +61,12 @@ class LLMS_Meta_Box_Lesson extends LLMS_Admin_Metabox {
 		// if the lesson isn't first, add previous completion method
 		if ( 1 !== $lesson->get( 'order' ) || ( $section && 1 !== $section->get( 'order' ) ) ) {
 			$methods['prerequisite'] = __( 'After prerequisite completion', 'lifterlms' );
+		}
+
+		// if the parent course has no start date set, unset the 'start' drip method.
+		$course = $lesson->get_course();
+		if ( ! $course || ! $course->get_date( 'start_date' ) ) {
+			unset( $methods['start'] );
 		}
 
 		return array(

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -1,34 +1,39 @@
 <?php
 /**
- * LifterLMS Lesson Model
+ * LifterLMS Lesson Model.
  *
- * @package  LifterLMS/Models
- * @since    1.0.0
- * @version  3.29.0
+ * @package LifterLMS/Models
  *
- * @property  $audio_embed  (string)  Audio embed URL
- * @property  $date_available  (string/date)  Date when lesson becomes available, applies when $drip_method is "date"
- * @property  $days_before_available  (int)  The number of days before the lesson is available, applies when $drip_method is "enrollment" or "start"
- * @property  $drip_method  (string) What sort of drip method to utilize [''(none)|date|enrollment|start|prerequisite]
- * @property  $free_lesson  (yesno)  Yes if the lesson is free
- * @property  $has_prerequisite  (yesno)  Yes if the lesson has a prereq lesson
- * @property  $order (int)  Lesson's order within its parent section
- * @property  $points  (absint)  Number of points assigned to the lesson, used to calculate the weight of the lesson when grading courses
- * @property  $prerequisite  (int)  WP Post ID of the prerequisite lesson, only if $has_prerequisite is 'yes'
- * @property  $parent_course (int)  WP Post ID of the course the lesson belongs to
- * @property  $parent_section (int)  WP Post ID of the section the lesson belongs to
- * @property  $quiz  (int)  WP Post ID of the llms_quiz
- * @property  $quiz_enabled  (yesno)  Whether or not the attached quiz is enabled for students
- * @property  $require_passing_grade  (yesno)  Whether of not students have to pass the quiz to advance to the next lesson
- * @property  $require_assignment_passing_grade  (yesno)  Whether of not students have to pass the assignment to advance to the next lesson
- * @property  $time_available  (string)  Optional time to make lesson available on $date_available when $drip_method is "date"
- * @property  $video_embed  (string)  Video embed URL
+ * @since 1.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Lesson model.
+ * LLMS_Lesson model class.
+ *
+ * @since 1.0.0
+ * @since 3.29.0 Unknown.
+ * @since [version] When getting the lesson's available date: add available number of days to the course start date only if there's a course start date.
+ *
+ * @property $audio_embed (string) Audio embed URL
+ * @property $date_available (string/date) Date when lesson becomes available, applies when $drip_method is "date"
+ * @property $days_before_available (int) The number of days before the lesson is available, applies when $drip_method is "enrollment" or "start"
+ * @property $drip_method (string) What sort of drip method to utilize [''(none)|date|enrollment|start|prerequisite]
+ * @property $free_lesson (yesno) Yes if the lesson is free
+ * @property $has_prerequisite (yesno) Yes if the lesson has a prereq lesson
+ * @property $order (int) Lesson's order within its parent section
+ * @property $points (absint) Number of points assigned to the lesson, used to calculate the weight of the lesson when grading courses
+ * @property $prerequisite (int) WP Post ID of the prerequisite lesson, only if $has_prerequisite is 'yes'
+ * @property $parent_course (int) WP Post ID of the course the lesson belongs to
+ * @property $parent_section (int) WP Post ID of the section the lesson belongs to
+ * @property $quiz (int) WP Post ID of the llms_quiz
+ * @property $quiz_enabled (yesno) Whether or not the attached quiz is enabled for students
+ * @property $require_passing_grade (yesno) Whether of not students have to pass the quiz to advance to the next lesson
+ * @property $require_assignment_passing_grade (yesno) Whether of not students have to pass the assignment to advance to the next lesson
+ * @property $time_available (string) Optional time to make lesson available on $date_available when $drip_method is "date"
+ * @property $video_embed (string) Video embed URL
  */
 class LLMS_Lesson
 extends LLMS_Post_Model
@@ -92,13 +97,14 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * Get the date a course became or will become available according to element drip settings
-	 * If there are no drip settings, the published date of the element will be returned
+	 * Get the date a course became or will become available according to element drip settings.
+	 * If there are no drip settings, the published date of the element will be returned.
 	 *
-	 * @param    string $format  date format (passed to date_i18n()) (defaults to WP Core date + time formats)
-	 * @return   string
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 * @since [version] Add available number of days to the course start date only if there's a course start date.
+	 *
+	 * @param  string $format Date format (passed to date_i18n()) (defaults to WP Core date + time formats)
+	 * @return string
 	 */
 	public function get_available_date( $format = '' ) {
 
@@ -151,8 +157,13 @@ implements LLMS_Interface_Post_Audio
 
 			// available # of days after course start date
 			case 'start':
-				$course    = $this->get_course();
-				$available = $days + $course->get_date( 'start_date', 'U' );
+				$course            = $this->get_course();
+				$course_start_date = $course ? $course->get_date( 'start_date', 'U' ) : '';
+
+				if ( $course_start_date ) {
+					$available = $days + $course_start_date;
+				}
+
 				break;
 
 		}// End switch().

--- a/tests/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-lesson.php
+++ b/tests/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-lesson.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for LifterLMS Order Metabox
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group metabox_lesson
+ * @group admin
+ * @group metaboxes
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Meta_Box_Lesson extends LLMS_PostTypeMetaboxTestCase {
+
+	/**
+	 * Setup test
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->metabox = new LLMS_Meta_Box_Lesson();
+
+	}
+
+	/**
+	 * Test get fields.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_fields() {
+
+		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
+		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
+		$post   = $lesson->get( 'post' );
+		$this->metabox->post = $post;
+
+		// check the lessons Drip Settings methods list does not cointain 'start',
+		// as the course has no start date set.
+		foreach ( $this->metabox->get_fields() as $index => $f ) {
+			if ( 'Drip Settings' === $f['title'] ) {
+				$this->assertFalse( array_key_exists( 'start', $f['fields'][0]['value'] ) );
+				break;
+			}
+		}
+
+		// set a course start date./*
+		$course->set( 'start_date', current_time( 'm/d/Y' ) );
+		// check the lessons Drip Settings methods list contains 'start',
+		// as the course now has a start date set.
+		foreach ( $this->metabox->get_fields() as $index => $f ) {
+			if ( 'Drip Settings' === $f['title'] ) {
+				$this->assertTrue( array_key_exists( 'start', $f['fields'][0]['value'] ) );
+				break;
+			}
+		}
+
+	}
+
+}

--- a/tests/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -3,8 +3,13 @@
  * Tests for LifterLMS Lesson Model
  * @group     post_models
  * @group     lessons
- * @since     3.14.8
- * @version   3.29.0
+ *
+ * @since  3.14.8
+ * @since 3.29.0 Unknown.
+ * @since [version] Added tests on lesson's availability with drip method set as 3 days after
+ *               the course start date and empty course start date.
+ *               Also added `$date_delta` property to be used to test dates against current time.
+ * @version [version]
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
@@ -20,6 +25,12 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 */
 	protected $post_type = 'lesson';
 
+	/**
+	 * Consider dates equal for +/- 1 min
+	 *
+	 * @var integer
+	 */
+	private $date_delta = 60;
 	/**
 	 * Get properties, used by test_getters_setters
 	 * This should match, exactly, the object's $properties array
@@ -95,6 +106,15 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		   \___/   \_______/|_______/    \___/ |_______/
 	*/
 
+	/**
+	 * Test get available date.
+	 *
+	 * @since Unknown.
+	 * @since [version] Added tests on lesson's availability with drip method set as 3 days after
+	 *               the course start date and empty course start date.
+	 *
+	 * @return void
+	 */
 	public function test_get_available_date() {
 
 		$format = 'Y-m-d';
@@ -107,7 +127,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
-		// no drip settings, lesson is currently available
+		// no drip settings, lesson is currently available.
 		$this->assertEquals( current_time( $format ), $lesson->get_available_date( $format ) );
 
 		$lesson->set( 'drip_method', 'date' );
@@ -137,6 +157,12 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$lesson->set( 'days_before_available', '3' );
 		$this->assertEquals( $student->get_completion_date( $prereq_id, 'U' ) + ( DAY_IN_SECONDS * 3 ), $lesson->get_available_date( 'U' ) );
 
+		// check lesson immediately available if set to be available after 3 days ofter a course start date which is empty.
+		$lesson->set( 'drip_method', 'start' );
+		$lesson->set( 'days_before_available', '3' );
+		$course->set( 'start_date', '' );
+		$this->assertEquals( current_time( 'timestamp' ), $lesson->get_available_date( 'U' ), '', $this->date_delta );
+
 	}
 
 	public function test_get_course() {
@@ -144,10 +170,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
 		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
 
-		// returns a course when everything's okay
+		// returns a course when everything's okay.
 		$this->assertTrue( is_a( $lesson->get_course(), 'LLMS_Course' ) );
 
-		// course trashed / doesn't exist, returns null
+		// course trashed / doesn't exist, returns null.
 		wp_delete_post( $course->get( 'id' ), true );
 		$this->assertNull( $lesson->get_course() );
 


### PR DESCRIPTION
…t set

fix #620

## Description
Added code that prevents generating warning when retrieving lessons availability if the drip method is set to make the lesson available after X days from a course start date, and the parent  course start date is not set.
Additionally, when editing a lesson from the standard editor, prevent setting a lesson's availability as aforementioned by making the related select option not available if the parent course has no start date set.

## How has this been tested?
Manually and with both existing and new unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards. 
