### PR TITLE
Add LLMS_Membership methods for REST API.

### DIFF
--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -4,7 +4,7 @@
  *
  * @package  LifterLMS/Models
  * @since    3.0.0
- * @version  3.30.0
+ * @version  [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.30.0 Added optional argument to `add_auto_enroll_courses()` method.
  * @since 3.32.0 Added `get_student_count()` method.
+ * @since [version] Added `get_categories()`, `get_tags()` and `toArrayAfter()` methods.
  *
  * @property $auto_enroll (array) Array of course IDs users will be autoenrolled in upon successful enrollment in this membership
  * @property $instructors (array) Course instructor user information
@@ -101,6 +102,18 @@ implements LLMS_Interface_Post_Instructors
 			$courses = $this->get( 'auto_enroll' );
 		}
 		return apply_filters( 'llms_membership_get_auto_enroll_courses', $courses, $this );
+	}
+
+	/**
+	 * Retrieve membership categories.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of args passed to `wp_get_post_terms()`.
+	 * @return array
+	 */
+	public function get_categories( $args = array() ) {
+		return wp_get_post_terms( $this->get( 'id' ), 'membership_cat', $args );
 	}
 
 	/**
@@ -199,6 +212,18 @@ implements LLMS_Interface_Post_Instructors
 	}
 
 	/**
+	 * Retrieve membership tags.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of args passed to `wp_get_post_terms()`.
+	 * @return array
+	 */
+	public function get_tags( $args = array() ) {
+		return wp_get_post_terms( $this->get( 'id' ), 'membership_tag', $args );
+	}
+
+	/**
 	 * Determine if sales page redirection is enabled
 	 *
 	 * @return   string
@@ -235,4 +260,29 @@ implements LLMS_Interface_Post_Instructors
 
 	}
 
+	/**
+	 * Add data to the membership model when converted to array.
+	 *
+	 * Called before data is sorted and returned by `$this->jsonSerialize()`.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $arr Data to be serialized.
+	 * @return array
+	 */
+	public function toArrayAfter( $arr ) {
+		$arr['categories'] = $this->get_categories(
+			array(
+				'fields' => 'names',
+			)
+		);
+
+		$arr['tags'] = $this->get_tags(
+			array(
+				'fields' => 'names',
+			)
+		);
+
+		return $arr;
+	}
 }

--- a/tests/unit-tests/models/class-llms-test-model-llms-membership.php
+++ b/tests/unit-tests/models/class-llms-test-model-llms-membership.php
@@ -63,6 +63,80 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
+	 * Test LLMS_Membership->get_categories() method.
+	 *
+	 * @since [version]
+	 * @return void
+	 */
+	public function test_get_categories() {
+		// create new membership
+		$membership_id = $this->factory->post->create( array( 'post_type' => 'llms_membership' ) );
+		$membership    = new LLMS_Membership( $membership_id );
+
+		// create new categories
+		$taxonomy = 'membership_cat';
+		$created_term_ids = array();
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$new_term_ids = wp_create_term( "mock-membership-category-$i", $taxonomy );
+			$this->assertNotWPError( $new_term_ids );
+			$created_term_ids[ $i ] = $new_term_ids['term_id'];
+		}
+
+		// set categories in membership
+		$term_taxonomy_ids = wp_set_post_terms( $membership_id, $created_term_ids, $taxonomy );
+		$this->assertNotWPError( $term_taxonomy_ids );
+		$this->assertNotFalse( $term_taxonomy_ids );
+
+		// get categories from membership
+		$membership_terms = $membership->get_categories();
+		$membership_term_ids = array();
+		/** @var WP_Term $membership_term */
+		foreach ( $membership_terms as $membership_term ) {
+			$membership_term_ids[] = $membership_term->term_id;
+		}
+
+		// compare array values while ignoring keys and order
+		$this->assertEqualSets( $created_term_ids, $membership_term_ids );
+	}
+
+	/**
+	 * Test LLMS_Membership->get_tags() method.
+	 *
+	 * @since [version]
+	 * @return void
+	 */
+	public function test_get_tags() {
+		// create new membership
+		$membership_id = $this->factory->post->create( array( 'post_type' => 'llms_membership' ) );
+		$membership    = new LLMS_Membership( $membership_id );
+
+		// create new tags
+		$taxonomy = 'membership_tag';
+		$created_term_ids = array();
+		for ( $i = 1; $i <= 3; $i ++ ) {
+			$new_term_ids = wp_create_term( "mock-membership-tag-$i", $taxonomy );
+			$this->assertNotWPError( $new_term_ids );
+			$created_term_ids[ $i ] = $new_term_ids['term_id'];
+		}
+
+		// set tags in membership
+		$term_taxonomy_ids = wp_set_post_terms( $membership_id, $created_term_ids, $taxonomy );
+		$this->assertNotWPError( $term_taxonomy_ids );
+		$this->assertNotFalse( $term_taxonomy_ids );
+
+		// get tags from membership
+		$membership_terms = $membership->get_tags();
+		$membership_term_ids = array();
+		/** @var WP_Term $membership_term */
+		foreach ( $membership_terms as $membership_term ) {
+			$membership_term_ids[] = $membership_term->term_id;
+		}
+
+		// compare array values while ignoring keys and order
+		$this->assertEqualSets( $created_term_ids, $membership_term_ids );
+	}
+
+	/**
 	 * Test get_sales_page_url method
 	 * @return   void
 	 * @since    3.20.0


### PR DESCRIPTION
These methods are needed by the LifterLMS REST API membership operations.

## Description
Added `get_categories()`, `get_tags()` and `toArrayAfter()` methods.

## How has this been tested?
Tested with LifterLMS REST API membership operations, currently in development.
`composer run-script tests-run`
`composer run-script phpcs`

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
