### PR TITLE
Fix typo in $generator variable.

### DIFF
--- a/includes/admin/class.llms.admin.import.php
+++ b/includes/admin/class.llms.admin.import.php
@@ -135,7 +135,7 @@ class LLMS_Admin_Import {
 		$generator = new LLMS_Generator( $raw );
 		if ( is_wp_error( $generator->set_generator() ) ) {
 			LLMS_Admin_Notices::flash_notice( $generator->error->get_error_message(), 'error' );
-			return $generater->error;
+			return $generator->error;
 		}
 
 		$generator->generate();


### PR DESCRIPTION
## Description
Fixed a typo where `$generator` was spelled `$generater`.

## How has this been tested?
With automated tests.

This typo was not caught because `LLMS_Admin_Import->upload_import()`  expects `LLMS_Generator->set_generator()` to return WP_Error when something goes wrong, but it actually adds an error code and message to a WP_Error object and returns void. Then `LLMS_Admin_Import->upload_import()` calls `LLMS_Generator->is_error()` which finally causes WP_Error to be returned. (documented in issue #959.) 

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md -->
