### PR TITLE
Membership model: remove redundant test method `test_get_sections()`

### DIFF
--- a/tests/unit-tests/models/class-llms-test-model-llms-membership.php
+++ b/tests/unit-tests/models/class-llms-test-model-llms-membership.php
@@ -1,31 +1,36 @@
 <?php
 /**
- * Tests for LifterLMS Membership Model
- * @group    LLMS_Membership
- * @group    LLMS_Post_Model
- * @since    3.20.0
- * @version  3.20.0
+ * Tests for LifterLMS Membership Model.
+ *
+ * @group LLMS_Membership
+ * @group LLMS_Post_Model
+ *
+ * @since 3.20.0
+ * @since [version] Remove redundant test method `test_get_sections()`,
+ *                @see tests/unit-tests/models/class-llms-test-model-llms-course.php.
+ * @version [version]
  */
 class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 
 	/**
-	 * class name for the model being tested by the class
-	 * @var  string
+	 * class name for the model being tested by the class.
+	 * @var string
 	 */
 	protected $class_name = 'LLMS_Membership';
 
 	/**
-	 * db post type of the model being tested
-	 * @var  string
+	 * db post type of the model being tested.
+	 * @var string
 	 */
 	protected $post_type = 'llms_membership';
 
 	/**
-	 * Get properties, used by test_getters_setters
-	 * This should match, exactly, the object's $properties array
-	 * @return   array
-	 * @since    3.20.0
-	 * @version  3.20.0
+	 * Get properties, used by test_getters_setters.
+	 * This should match, exactly, the object's $properties array.
+	 *
+	 * @since 3.20.0
+	 *
+	 * @return array
 	 */
 	protected function get_properties() {
 		return array(
@@ -42,11 +47,12 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Get data to fill a create post with
-	 * This is used by test_getters_setters
-	 * @return   array
-	 * @since    3.20.0
-	 * @version  3.20.0
+	 * Get data to fill a create post with.
+	 * This is used by test_getters_setters.
+	 *
+	 * @since 3.20.0
+	 *
+	 * @return array
 	 */
 	protected function get_data() {
 		return array(
@@ -63,10 +69,11 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test get_sales_page_url method
-	 * @return   void
-	 * @since    3.20.0
-	 * @version  3.20.0
+	 * Test get_sales_page_url method.
+	 *
+	 * @since 3.20.0
+	 *
+	 * @return void
 	 */
 	public function test_get_sales_page_url() {
 
@@ -92,43 +99,11 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test the get sections function
-	 * @return   void
-	 * @since    3.12.0
-	 * @version  3.12.0
-	 */
-	public function test_get_sections() {
-
-		$course = llms_get_post( $this->generate_mock_courses( 1, 4, 0, 0, 0 )[0] );
-
-		// get just ids
-		$sections = $course->get_sections( 'ids' );
-		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $id ) {
-			$this->assertTrue( is_numeric( $id ) );
-		}, $sections );
-
-		// wp post objects
-		$sections = $course->get_sections( 'posts' );
-		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $post ) {
-			$this->assertTrue( is_a( $post, 'WP_Post' ) );
-		}, $sections );
-
-		// section objects
-		$sections = $course->get_sections( 'sections' );
-		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $section ) {
-			$this->assertTrue( is_a( $section, 'LLMS_Section' ) );
-		}, $sections );
-
-	}
-
-	/**
-	 * Test the get students function
-	 * @return   void
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * Test the get students function.
+	 *
+	 * @since 3.12.0
+	 *
+	 * @return void
 	 */
 	public function test_get_students() {
 
@@ -145,10 +120,11 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test the has_sales_page_redirect method
-	 * @return   void
-	 * @since    3.20.0
-	 * @version  3.20.0
+	 * Test the has_sales_page_redirect method.
+	 *
+	 * @since 3.20.0
+	 *
+	 * @return void
 	 */
 	public function test_has_sales_page_redirect() {
 


### PR DESCRIPTION
already done in tests/unit-tests/models/class-llms-test-model-llms-course.php
also, memberships have no sections.

## Description
Just removed a redundant test and improved the tests/unit-tests/models/class-llms-test-model-llms-membership.php file dockblocks.

## How has this been tested?
existing unit tests (I didn't break them :P)

## Types of changes
minor tests and documentation improvements.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
