### PR TITLE
Fix user postmeta functions doc and indentation.

### DIFF
--- a/includes/functions/llms.functions.user.postmeta.php
+++ b/includes/functions/llms.functions.user.postmeta.php
@@ -1,24 +1,33 @@
 <?php
 /**
- * CRUD LifterLMS User Postmeta Data
- * All functions are pluggable
+ * CRUD LifterLMS User Postmeta Data.
+ * All functions are pluggable.
+ *
+ * @package LifterLMS/Functions/UsersPostmeta
+ *
+ * @since 3.21.0
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CRUD LifterLMS User Postmeta Data.
  *
  * @since 3.21.0
  * @since 3.33.0 Added `llms_bulk_delete_user_postmeta`.
- *                  Also now `llms_delete_user_postmeta` returns true only if at least one existing user postmeta has been successfully deleted.
- * @version 3.33.0
+ *               Also now `llms_delete_user_postmeta` returns true only if at least one existing user postmeta has been successfully deleted.
+ * @since [version] Fix doc and indentation.
  */
-defined( 'ABSPATH' ) || exit;
-
 if ( ! function_exists( 'llms_delete_user_postmeta' ) ) :
 	/**
-	 * Delete user postmeta data
+	 * Delete user postmeta data.
 	 *
 	 * @since 3.21.0
 	 * @since 3.33.0 Returns true only if at least one existing user postmeta has been successfully deleted.
 	 *
-	 * @param int    $user_id    WP User ID
-	 * @param int    $post_id    WP Post ID
+	 * @param int    $user_id    WP User ID.
+	 * @param int    $post_id    WP Post ID.
 	 * @param string $meta_key   Optional. Meta key for lookup, if not supplied, all matching items will be removed. Default null.
 	 * @param mixed  $meta_value Optional. Meta value for lookup, if not supplied, all matching items will be removed. Default null.
 	 *
@@ -48,14 +57,14 @@ endif;
 
 if ( ! function_exists( 'llms_bulk_delete_user_postmeta' ) ) :
 	/**
-	 * Bulk remove user postmeta data
+	 * Bulk remove user postmeta data.
 	 *
 	 * @since 3.33.0
 	 *
-	 * @param int   $user_id WP User ID
-	 * @param int   $post_id WP Post ID
-	 * @param array $data    key=>val Optional. Associative array of meta keys => meta values to delete.
-	 *                                If not meta values supplied, all matching items will be removed. Default empty array.
+	 * @param int   $user_id WP User ID.
+	 * @param int   $post_id WP Post ID.
+	 * @param array $data    Optional. Associative array of meta keys => meta values to delete.
+	 *                       If not meta values supplied, all matching items will be removed. Default empty array.
 	 * @return array|boolean On error returns an associative array of the submitted keys, each item will be true for success or false for error.
 	 *                       On success returns true.
 	 */
@@ -84,16 +93,16 @@ endif;
 
 if ( ! function_exists( 'llms_get_user_postmeta' ) ) :
 	/**
-	 * Get user postmeta data or dates by user, post, and key
+	 * Get user postmeta data or dates by user, post, and key.
 	 *
-	 * @param    int    $user_id   WP User ID
-	 * @param    int    $post_id   WP Post ID
-	 * @param    string $meta_key  optional key, if not supplied returns associative array of all metadata found for the given user / post
-	 * @param    bool   $single    if true, returns only the data
-	 * @param    string $return    determine if the meta value or updated date should be returned [meta_value,updated_date]
-	 * @return   mixed
-	 * @since    3.21.0
-	 * @version  3.21.0
+	 * @since 3.21.0
+	 *
+	 * @param int    $user_id  WP User ID.
+	 * @param int    $post_id  WP Post ID.
+	 * @param string $meta_key Optional. Meta key, if not supplied returns associative array of all metadata found for the given user / post. Default null.
+	 * @param bool   $single   Optional. If true, returns only the data. Default true.
+	 * @param string $return   Optional. Determine if the meta value or updated date should be returned [meta_value,updated_date]. Default 'meta_value'.
+	 * @return mixed
 	 */
 	function llms_get_user_postmeta( $user_id, $post_id, $meta_key = null, $single = true, $return = 'meta_value' ) {
 
@@ -118,37 +127,38 @@ if ( ! function_exists( 'llms_get_user_postmeta' ) ) :
 			return count( $res ) ? $res[ $meta_key ] : array();
 		}
 
-			return $res;
+		return $res;
 
 	}
 endif;
 
 if ( ! function_exists( 'llms_update_user_postmeta' ) ) :
 	/**
-	 * Update user postmeta data
+	 * Update user postmeta data.
 	 *
-	 * @param    int    $user_id     WP User ID
-	 * @param    int    $post_id     WP Post ID
-	 * @param    string $meta_key    meta key
-	 * @param    mixed  $meta_value  meta value (don't serialize serializable values)
-	 * @param    bool   $unique      if true, updates existing value (if it exists)
-	 *                               if false, will add a new record (allowing multiple records with the same key to exist)
-	 * @return   bool
-	 * @since    3.21.0
-	 * @version  3.21.0
+	 * @since 3.21.0
+	 *
+	 * @param int    $user_id    WP User ID.
+	 * @param int    $post_id    WP Post ID.
+	 * @param string $meta_key   Meta key.
+	 * @param mixed  $meta_value Meta value (don't serialize serializable values).
+	 * @param bool   $unique     Optional. If true, updates existing value (if it exists).
+	 *                           If false, will add a new record (allowing multiple records with the same key to exist).
+	 *                           Deafult true.
+	 * @return bool
 	 */
 	function llms_update_user_postmeta( $user_id, $post_id, $meta_key, $meta_value, $unique = true ) {
 
 		$item = false;
 
-		// if unique is true, make an update to the existing item (if it exists)
+		// if unique is true, make an update to the existing item (if it exists).
 		if ( $unique ) {
 
-			// locate the item
+			// locate the item.
 			$existing = _llms_query_user_postmeta( $user_id, $post_id, $meta_key );
 			if ( $existing ) {
 
-				// load it and make sure it exists
+				// load it and make sure it exists.
 				$item = new LLMS_User_Postmeta( $existing[0]->meta_id, false );
 				if ( ! $item->exists() ) {
 					$item = false;
@@ -160,7 +170,7 @@ if ( ! function_exists( 'llms_update_user_postmeta' ) ) :
 			$item = new LLMS_User_Postmeta();
 		}
 
-		// setup the data we want to store
+		// setup the data we want to store.
 		$updated_date = llms_current_time( 'mysql' );
 		$meta_value   = maybe_serialize( $meta_value );
 		$item->setup( compact( 'user_id', 'post_id', 'meta_key', 'meta_value', 'updated_date' ) );
@@ -171,17 +181,19 @@ endif;
 
 if ( ! function_exists( 'llms_bulk_update_user_postmeta' ) ) :
 	/**
-	 * Update bulk update user postmeta data
+	 * Update bulk update user postmeta data.
 	 *
-	 * @param    int   $user_id     WP User ID
-	 * @param    int   $post_id     WP Post ID
-	 * @param    array $data        key=>val associative array of meta keys => meta values to update/add
-	 * @param    bool  $unique      if true, updates existing value (if it exists)
-	 *                              if false, will add a new record (allowing multiple records with the same key to exist)
-	 * @return   array|true              on error returns an associative array of the submitted keys, each item will be true for success or false for error
-	 *                                   on success returns true
-	 * @since    3.21.0
-	 * @version  3.21.0
+	 * @since 3.21.0
+	 *
+	 * @param int   $user_id WP User ID.
+	 * @param int   $post_id WP Post ID.
+	 * @param array $data    Optional. Associative array of meta keys => meta values to update.
+	 *                       Default empty array.
+	 * @param bool  $unique  Optional. If true, updates existing value (if it exists).
+	 *                       If false, will add a new record (allowing multiple records with the same key to exist).
+	 *                       Deafult true.
+	 * @return array|true On error returns an associative array of the submitted keys, each item will be true for success or false for error.
+	 *                    On success returns true.
 	 */
 	function llms_bulk_update_user_postmeta( $user_id, $post_id, $data = array(), $unique = true ) {
 
@@ -202,17 +214,18 @@ endif;
 
 if ( ! function_exists( '_llms_query_user_postmeta' ) ) :
 	/**
-	 * Query user postmeta data
+	 * Query user postmeta data.
 	 * This function is marked for internal use only.
 	 *
-	 * @access   private
-	 * @param    int    $user_id     WP User ID
-	 * @param    int    $post_id     WP Post ID
-	 * @param    string $meta_key    optional meta key
-	 * @param    string $meta_value  optional meta value
-	 * @return   array
-	 * @since    3.21.0
-	 * @version  3.21.0
+	 * @since 3.21.0
+	 *
+	 * @access private
+	 *
+	 * @param int    $user_id WP User ID.
+	 * @param int    $post_id WP Post ID.
+	 * @param string $meta_key   Optional. Meta key. Default null.
+	 * @param string $meta_value Optional. Meta value. Default null.
+	 * @return array
 	 */
 	function _llms_query_user_postmeta( $user_id, $post_id, $meta_key = null, $meta_value = null ) {
 
@@ -236,5 +249,3 @@ if ( ! function_exists( '_llms_query_user_postmeta' ) ) :
 
 	}
 endif;
-
-


### PR DESCRIPTION
## Description
Only docs and indentation fixes.

I was browsing the code working on other stuff and found this line I couldn't stand:
https://github.com/gocodebox/lifterlms/blob/3.36.2/includes/functions/llms.functions.user.postmeta.php#L121

Had to fix it, I've then decided to spend 5 minutes more fixing the doc throughout the file.


## How has this been tested?
already existing tests.


## Types of changes
doc fixes.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
