### PR TITLE
Remove gap above responsive self hosted lesson/course's videos

### DIFF
--- a/assets/scss/frontend/_main.scss
+++ b/assets/scss/frontend/_main.scss
@@ -33,6 +33,7 @@
 		padding-top: 56.25%;
 		text-align: center;
 
+		& > .wp-video,
 		.fluid-width-video-wrapper,
 		iframe, object, embed {
 			height: 100%;
@@ -42,6 +43,9 @@
 			width: 100%;
 		}
 
+		& > .wp-video {
+			width: 100% !important;
+		}
 		.fluid-width-video-wrapper {
 			padding-top: 0 !important;
 		}


### PR DESCRIPTION
fix #964

## How has this been tested?
Tested on a lesson with a self-hosted video.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
