### PR TITLE
Fix sales reporting page not holding filter specification.

### DIFF
--- a/assets/js/llms-analytics.js
+++ b/assets/js/llms-analytics.js
@@ -4,6 +4,8 @@
  * @since 3.0.0
  * @since 3.17.2 Unknown.
  * @since 3.33.1 Fix issue that produced series options not aligned with the chart data.
+ * @since [version] Added the `allow_clear` paramater when initializiing the `llmsStudentSelect2`.
+ *
  */( function( $, undefined ) {
 
 	window.llms = window.llms || {};
@@ -47,9 +49,10 @@
 		/**
 		 * Bind DOM events
 		 *
-		 * @return   void
-		 * @since    3.0.0
-		 * @version  3.0.0
+		 * @since 3.0.0
+		 * @since [version] Added the `allow_clear` paramater when initializiing the `llmsStudentSelect2`.
+		 *
+		 * @return void
 		 */
 		this.bind = function() {
 
@@ -61,6 +64,7 @@
 			$( '#llms-students-ids-filter' ).llmsStudentsSelect2( {
 				multiple: true,
 				placeholder: LLMS.l10n.translate( 'Filter by Student(s)' ),
+				allow_clear: true,
 			} );
 
 			$( 'a[href="#llms-toggle-filters"]' ).on( 'click', function( e ) {

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -1,20 +1,21 @@
 <?php
 /**
- * Analytics Widget Abstract
+ * Analytics Widget Abstract.
  *
  * @since 3.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Analytics Widget Abstract
+ * Analytics Widget Abstract.
  *
  * @since 3.0.0
  * @since 3.30.3 Define undefined properties.
- * @since 3.33.1 In `set_order_data_query()` always set $order_clause variable to avoid PHP notices
+ * @since 3.33.1 In `set_order_data_query()` always set $order_clause variable to avoid PHP notices.
  * @since 3.35.0 Sanitize input data from reporting filters.
+ * @since [version] Avoid warnings on using wpdb::prepare without placeholders.
  */
 abstract class LLMS_Analytics_Widget {
 
@@ -201,13 +202,13 @@ abstract class LLMS_Analytics_Widget {
 				$args,
 				array(
 					'select'         => array( '*' ),
-					'date_range'     => true, // whether or not to add a "where" for the posted date range
+					'date_range'     => true, // whether or not to add a "where" for the posted date range.
 					'date_field'     => 'post_date',
-					'query_function' => 'get_results', // query function to pass to $wpdb->query()
+					'query_function' => 'get_results', // query function to pass to $wpdb->query().
 					'output_type'    => OBJECT,
-					'joins'          => array(), // array of JOIN statements
-					'statuses'       => array(), // array of order statuses to query
-					'wheres'         => array(), // array of "WHERE" statements
+					'joins'          => array(), // array of JOIN statements.
+					'statuses'       => array(), // array of order statuses to query.
+					'wheres'         => array(), // array of "WHERE" statements.
 					'order'          => 'ASC',
 					'orderby'        => '',
 
@@ -221,7 +222,7 @@ abstract class LLMS_Analytics_Widget {
 
 		global $wpdb;
 
-		// setup student join & where clauses
+		// setup student join & where clauses.
 		$students       = $this->get_posted_students();
 		$students_join  = '';
 		$students_where = '';
@@ -231,7 +232,7 @@ abstract class LLMS_Analytics_Widget {
 			$students_where .= ' AND m1.meta_value IN ( ' . implode( ', ', $students ) . ' )';
 		}
 
-		// setup post (product) joins & where clauses
+		// setup post (product) joins & where clauses.
 		$posts          = $this->get_posted_posts();
 		$products_join  = '';
 		$products_where = '';
@@ -249,7 +250,7 @@ abstract class LLMS_Analytics_Widget {
 			$this->query_vars[] = $this->format_date( $dates['end'], 'end' );
 		}
 
-		// setup post status conditions in the where clause
+		// setup post status conditions in the where clause.
 		$post_statuses = '';
 		if ( $statuses ) {
 			$post_statuses .= ' AND ( ';
@@ -263,7 +264,7 @@ abstract class LLMS_Analytics_Widget {
 			$post_statuses .= ' )';
 		}
 
-		// setup the select clause
+		// setup the select clause.
 		$select_clause = '';
 		foreach ( $select as $i => $s ) {
 			if ( $i > 0 ) {
@@ -303,14 +304,31 @@ abstract class LLMS_Analytics_Widget {
 
 	}
 
+	/**
+	 * Perform the query.
+	 *
+	 * @since unknown.
+	 * @since [version] Avoid warnings on using wpdb::prepare without placeholders.
+	 */
 	protected function query() {
 
 		global $wpdb;
-		// no output options
-		if ( in_array( $this->query_function, array( 'get_var', 'get_col' ) ) ) {
-			$this->results = $wpdb->{$this->query_function}( $wpdb->prepare( $this->query, $this->query_vars ) ); // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- It is prepared.
+
+		// Roughly avoid warnings on using wpdb::prepare without placeholders.
+		// The following strpos simple check is the same wpdb::prepare() does to check the correct usage.
+		if ( strpos( $this->query, '%' ) === false || empty( $this->query_vars ) ) {
+			$query = $this->query;
 		} else {
-			$this->results = $wpdb->{$this->query_function}( $wpdb->prepare( $this->query, $this->query_vars ), $this->output_type ); // phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- It is prepared.
+			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared -- It is prepared.
+			$query = $wpdb->prepare( $this->query, $this->query_vars );
+			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		// no output options.
+		if ( in_array( $this->query_function, array( 'get_var', 'get_col' ), true ) ) {
+			$this->results = $wpdb->{$this->query_function}( $query );
+		} else {
+			$this->results = $wpdb->{$this->query_function}( $query, $this->output_type );
 		}
 
 		$this->prepared_query = trim( str_replace( array( "\r", "\n", "\t", '  ' ), ' ', $wpdb->last_query ) );
@@ -332,6 +350,7 @@ abstract class LLMS_Analytics_Widget {
 
 		$this->set_query();
 		$this->query();
+
 		$this->response = $this->format_response();
 
 		if ( $this->charts ) {

--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -3,7 +3,7 @@
  * Admin Reporting Base Class
  *
  * @since 3.2.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.32.0 Added Memberships tab.
  * @since 3.32.0 The `output_event()` method now outputs the student's avatar whent in 'membership' context.
  * @since 3.35.0 Sanitize input data.
+ * @since [version] Fixed sanitization for input data array.
  */
 class LLMS_Admin_Reporting {
 
@@ -32,16 +33,18 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Get array of course IDs selected according to applied filters
+	 * Get array of course IDs selected according to applied filters.
 	 *
 	 * @since 3.2.0
 	 * @since 3.35.0 Sanitize input data.
+	 * @since [version] Fixed sanitization for input data array.
 	 *
 	 * @return   array
 	 */
 	public static function get_current_courses() {
 
-		$r = isset( $_GET['course_ids'] ) ? llms_filter_input( INPUT_GET, 'course_ids', FILTER_SANITIZE_STRING ) : array();
+		$r = isset( $_GET['course_ids'] ) ? llms_filter_input( INPUT_GET, 'course_ids', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY ) : array();
+
 		if ( '' === $r ) {
 			$r = array();
 		}
@@ -53,16 +56,18 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Get array of membership IDs selected according to applied filters
+	 * Get array of membership IDs selected according to applied filters.
 	 *
 	 * @since 3.2.0
 	 * @since 3.35.0 Sanitize input data.
+	 * @since [version] Fixed sanitization for input data array.
 	 *
 	 * @return   array
 	 */
 	public static function get_current_memberships() {
 
-		$r = isset( $_GET['membership_ids'] ) ? llms_filter_input( INPUT_GET, 'membership_ids', FILTER_SANITIZE_STRING ) : array();
+		$r = isset( $_GET['membership_ids'] ) ? llms_filter_input( INPUT_GET, 'membership_ids', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY ) : array();
+
 		if ( '' === $r ) {
 			$r = array();
 		}
@@ -87,16 +92,17 @@ class LLMS_Admin_Reporting {
 	}
 
 	/**
-	 * Get array of student IDs according to current filters
+	 * Get array of student IDs according to current filters.
 	 *
 	 * @since 3.2.0
 	 * @since 3.35.0 Sanitize input data.
+	 * @since [version] Fixed sanitization for input data array.
 	 *
 	 * @return   array
 	 */
 	public static function get_current_students() {
 
-		$r = isset( $_GET['student_ids'] ) ? llms_filter_input( INPUT_GET, 'student_ids', FILTER_SANITIZE_STRING ) : array();
+		$r = isset( $_GET['student_ids'] ) ? llms_filter_input( INPUT_GET, 'student_ids', FILTER_SANITIZE_STRING, FILTER_REQUIRE_ARRAY ) : array();
 		if ( '' === $r ) {
 			$r = array();
 		}

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.refunded.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.refunded.php
@@ -6,12 +6,17 @@
  * according to active filters
  *
  * @since  3.0.0
- * @version 3.0.0
+ * @version [version]
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Refunded Amount Widget.
+ *
+ * @since 3.0.0
+ * @since [version] In `format_response()` method avoid running `wp_list_pluck()` on non arrays.
+ */
 class LLMS_Analytics_Refunded_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;
@@ -34,10 +39,10 @@ class LLMS_Analytics_Refunded_Widget extends LLMS_Analytics_Widget {
 
 		$txn_meta_join  = '';
 		$txn_meta_where = '';
-		// create an "IN" clause that can be used for later in WHERE clauses
+		// create an "IN" clause that can be used for later in WHERE clauses.
 		if ( $this->get_posted_students() || $this->get_posted_posts() ) {
 
-			// get an array of order based on posted students & products
+			// get an array of order based on posted students & products.
 			$this->set_order_data_query(
 				array(
 					'date_range'     => false,
@@ -69,7 +74,7 @@ class LLMS_Analytics_Refunded_Widget extends LLMS_Analytics_Widget {
 			}
 		}
 
-		// date range will be used to get transactions between given dates
+		// date range will be used to get transactions between given dates.
 		$dates            = $this->get_posted_dates();
 		$this->query_vars = array(
 			$this->format_date( $dates['start'], 'start' ),
@@ -96,11 +101,18 @@ class LLMS_Analytics_Refunded_Widget extends LLMS_Analytics_Widget {
 
 	}
 
+	/**
+	 * Format response.
+	 *
+	 * @since unknown
+	 * @since [version] Avoid running `wp_list_pluck()` on non arrays.
+	 */
 	protected function format_response() {
 
 		if ( ! $this->is_error() ) {
 
-			return llms_price_raw( floatval( array_sum( wp_list_pluck( $this->get_results(), 'amount' ) ) ) );
+			$results = $this->get_results();
+			return llms_price_raw( floatval( is_array( $results ) ? array_sum( wp_list_pluck( $results, 'amount' ) ) : $results ) );
 
 		}
 

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
@@ -1,21 +1,22 @@
 <?php
 /**
- * Sold Amount Widget
+ * Sold Amount Widget.
  *
  * Retrieves the total amount of all successful transactions
- * according to active filters
+ * according to active filters.
  *
  * @since 3.0.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Sold Amount Widget
+ * Sold Amount Widget.
  *
  * @since 3.0.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since [version] In `format_response()` method avoid running `wp_list_pluck()` on non arrays.
  */
 class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 
@@ -39,8 +40,8 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 
 	protected function get_chart_data() {
 		return array(
-			'type'   => 'amount', // type of field
-			'key'    => 'amount', // key of result field to add when counting
+			'type'   => 'amount', // type of field.
+			'key'    => 'amount', // key of result field to add when counting.
 			'header' => array(
 				'id'    => 'sold',
 				'label' => __( 'Net Sales', 'lifterlms' ),
@@ -55,10 +56,10 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 
 		$txn_meta_join  = '';
 		$txn_meta_where = '';
-		// create an "IN" clause that can be used for later in WHERE clauses
+		// create an "IN" clause that can be used for later in WHERE clauses.
 		if ( $this->get_posted_students() || $this->get_posted_posts() ) {
 
-			// get an array of order based on posted students & products
+			// get an array of order based on posted students & products.
 			$this->set_order_data_query(
 				array(
 					'date_range'     => false,
@@ -92,7 +93,7 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 			}
 		}
 
-		// date range will be used to get transactions between given dates
+		// date range will be used to get transactions between given dates.
 		$dates            = $this->get_posted_dates();
 		$this->query_vars = array(
 			$this->format_date( $dates['start'], 'start' ),
@@ -119,11 +120,18 @@ class LLMS_Analytics_Sold_Widget extends LLMS_Analytics_Widget {
 
 	}
 
+	/**
+	 * Format response.
+	 *
+	 * @since unknown
+	 * @since [version] Avoid running `wp_list_pluck()` on non arrays.
+	 */
 	protected function format_response() {
 
 		if ( ! $this->is_error() ) {
 
-			return llms_price_raw( floatval( array_sum( wp_list_pluck( $this->get_results(), 'amount' ) ) ) );
+			$results = $this->get_results();
+			return llms_price_raw( floatval( is_array( $results ) ? array_sum( wp_list_pluck( $results, 'amount' ) ) : $results ) );
 
 		}
 


### PR DESCRIPTION
fix #956

## Description
This PR fixes the issue aforementioned by adding the `FILTER_REQUIRE_ARRAY` option to `llms_filter_input()` where needed, it also adds some small additions in order to avoid warnings on using some wp core functions not correctly: 

- using `wpdb::prepare()` with a query without placeholders
- calling `wp_list_pluck()` on non arrays

It also makes the students filter select2 clearable.

## How has this been tested?
existing unit tests and manually


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.
