### PR TITLE
Twenty Twenty support: Fixed course information block misalignment.

### DIFF
--- a/includes/theme-support/class-llms-twenty-twenty.php
+++ b/includes/theme-support/class-llms-twenty-twenty.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS/Classes/ThemeSupport
  *
  * @since 3.37.0
- * @version 3.37.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Twenty_Twenty class..
  *
  * @since 3.37.0
+ * @since [version] Fixed course information block misalignment.
  */
 class LLMS_Twenty_Twenty {
 
@@ -56,6 +57,7 @@ class LLMS_Twenty_Twenty {
 	 * Generate inline CSS using colors from the TwenyTwenty Theme settings.
 	 *
 	 * @since 3.37.0
+	 * @since [version] Fixed course information block misalignment.
 	 *
 	 * @return void
 	 */
@@ -96,6 +98,10 @@ class LLMS_Twenty_Twenty {
 		.llms-pagination ul {
 			margin-left: 0;
 			margin-right: 0;
+		}
+		.course .llms-meta-info {
+			margin-left: auto;
+			margin-right: auto;
 		}
 		</style>
 		<?php


### PR DESCRIPTION
## Description
Fixed course information block misalignment in the Twenty Twenty theme.

Fixes #986

## How has this been tested?
manually

## Screenshots
![Schermata 2019-11-13 alle 17 15 21](https://user-images.githubusercontent.com/7689242/68782157-3593c280-0639-11ea-84d4-8cf9cf5703ef.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

