### PR TITLE
Client events tracking - make sure the nonce is always set for server…

### DIFF
--- a/assets/js/app/llms-tracking.js
+++ b/assets/js/app/llms-tracking.js
@@ -5,6 +5,7 @@
  *
  * @since 3.36.0
  * @since 3.36.2 Fix JS error when settings aren't loaded.
+ * @since [version] When adding an event to the storae also make sure the nonce is set for server-side verification.
  */
 LLMS.Tracking = function( settings ) {
 
@@ -39,6 +40,7 @@ LLMS.Tracking = function( settings ) {
 	 *
 	 * @since 3.36.0
 	 * @since 3.36.2 Fix error when settings aren't loaded.
+	 * @since [version] Always make sure the nonce is set for server-side verification.
 	 *
 	 * @param string|obj event Event Id (type.event) or a full event object from `this.makeEventObj()`.
 	 * @param int args Optional additional arguments to pass to `this.makeEventObj()`.
@@ -61,6 +63,8 @@ LLMS.Tracking = function( settings ) {
 		var all = store.get( 'events', [] );
 		all.push( event );
 		store.set( 'events', all );
+		// Make sure the nonce is set for server-side verification.
+		store.set( 'nonce', settings.nonce );
 
 	}
 


### PR DESCRIPTION
… side verification

## Description
Fixes #992

## How has this been tested?
I've first recreated the issue described in #992 using the LaunchPad theme before applying this PR, then applied it, built the js, and verified the issue was gone.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

Do you think we should then remove this (nonce set on init)?
https://github.com/eri-trabiccolo/lifterlms/blob/4c92560a04483f3a282747058af3d0c658773cca/assets/js/app/llms-tracking.js#L27
it should be redundant now, but for some reason I like to have it there, just in case I'm missing anything... which I think I'm not as the first thing we do after adding the nonce is adding an event, that adds a nonce...

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

