### PR TITLE
Settings refactor

### DIFF
--- a/includes/admin/class-llms-sendwp.php
+++ b/includes/admin/class-llms-sendwp.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.36.1
  * @since 3.37.0 Sanitize URLs, clean up jQuery references, add loading feedback when connector button is clicked.
+ * @since [version] Modify the ID used to determine where to splice in SendWP Options.
  */
 class LLMS_SendWP {
 
@@ -219,13 +220,14 @@ class LLMS_SendWP {
 	 * Find the end of the "email_options" section to splice in new settings.
 	 *
 	 * @since 3.36.1
+	 * @since [version] Modify the ID used to determine where to splice in SendWP Options.
 	 *
 	 * @param array $settings Default engagement settings.
 	 * @return int
 	 */
 	private function get_splice_index( $settings ) {
 		foreach ( $settings as $i => $setting ) {
-			if ( 'email_options' === $setting['id'] && 'sectionend' === $setting['type'] ) {
+			if ( 'email_options_end' === $setting['id'] ) {
 				return $i + 1;
 			}
 		}

--- a/includes/admin/settings/class.llms.settings.accounts.php
+++ b/includes/admin/settings/class.llms.settings.accounts.php
@@ -3,7 +3,7 @@
  * Admin Settings Page, Accounts Tab
  *
  * @since 1.0.0
- * @version 3.24.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,6 +13,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors.
+ * @since [version] Renamed setting field IDs to be unique.
+ *              Removed redundant functions defined in the `LLMS_Settings_Page` class.
+ *              Removed constructor and added `get_label()` method to be compatible with changes in `LLMS_Settings_Page`.
  */
 class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 
@@ -35,6 +38,7 @@ class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 	 *
 	 * @since 1.0.0
 	 * @since 3.30.3 Fixed spelling errors.
+	 * @since [version] Renamed duplicate field id for section close (`user_info_field_options` to `user_info_field_options_end`)
 	 *
 	 * @return array
 	 */
@@ -473,7 +477,7 @@ class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 				),
 
 				array(
-					'id'   => 'user_info_field_options',
+					'id'   => 'user_info_field_options_end',
 					'type' => 'sectionend',
 				),
 			 // end user info field options

--- a/includes/admin/settings/class.llms.settings.accounts.php
+++ b/includes/admin/settings/class.llms.settings.accounts.php
@@ -17,27 +17,18 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 
 	/**
-	 * Allow settings page to determine if a rewrite flush is required
+	 * Settings identifier
 	 *
-	 * @var      boolean
-	 * @since    3.0.4
-	 * @version  3.0.4
+	 * @var string
 	 */
-	protected $flush = true;
+	public $id = 'accounts';
 
 	/**
-	 * Constructor
+	 * Allow settings page to determine if a rewrite flush is required
 	 *
-	 * executes settings tab actions
+	 * @var boolean
 	 */
-	public function __construct() {
-		$this->id    = 'account';
-		$this->label = __( 'Accounts', 'lifterlms' );
-
-		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
-		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
-		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
-	}
+	protected $flush = true;
 
 	/**
 	 * Get settings array
@@ -488,7 +479,18 @@ class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 			 // end user info field options
 
 			)
-		); // End pages settings
+		);
+	}
+
+	/**
+	 * Retrieve the page label.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_label() {
+		return __( 'Accounts', 'lifterlms' );
 	}
 
 }

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -16,25 +16,27 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.8.0 Unknown.
  * @since [version] Renamed setting field IDs to be unique.
+ *              Removed redundant functions defined in the `LLMS_Settings_Page` class.
+ *              Removed constructor and added `get_label()` method to be compatible with changes in `LLMS_Settings_Page`.
  */
 class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 	/**
-	 * Constructor
-	 * executes settings tab actions
+	 * Settings identifier
 	 *
-	 * @since    1.0.0
-	 * @version  3.8.0
+	 * @var string
 	 */
-	public function __construct() {
+	public $id = 'engagements';
 
-		$this->id    = 'engagements';
-		$this->label = __( 'Engagements', 'lifterlms' );
-
-		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
-		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
-		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
-
+	/**
+	 * Retrieve the page label.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return __( 'Engagements', 'lifterlms' );
 	}
 
 	/**

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -35,7 +35,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 *
 	 * @return string
 	 */
-	public function get_label() {
+	protected function set_label() {
 		return __( 'Engagements', 'lifterlms' );
 	}
 

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -44,7 +44,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 *
 	 * @since 1.0.0
 	 * @since 3.8.0 Unknown.
-	 * @since [version] Ensure IDs are unique.
+	 * @since [version] Refactor to pull each settings group from its own method.
 	 *
 	 * @return array
 	 */
@@ -53,33 +53,90 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 		/**
 		 * Modify LifterLMS Admin Settings on the "Engagements" tab,
 		 *
-		 * @since Unknown
+		 * @since 1.0.0
 		 *
 		 * @param array[] $settings Array of settings fields arrays.
 		 */
 		return apply_filters(
 			'lifterlms_engagements_settings',
+			array_merge(
+				$this->get_settings_group_email(),
+				$this->get_settings_group_certs()
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieve fields for the certificates settings group.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	protected function get_settings_group_certs() {
+
+		return $this->generate_settings_group(
+			'certificates_options',
+			__( 'Certificate Settings', 'lifterlms' ),
+			'',
 			array(
-
 				array(
-					'type'  => 'sectionstart',
-					'id'    => 'email_options',
-					'class' => 'top',
+					'title' => __( 'Background Image Settings', 'lifterlms' ),
+					'type' => 'subtitle',
+					'desc' => __( 'Use these sizes to determine the dimensions of certificate background images. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
+					'id'   => 'cert_bg_image_settings',
 				),
-
 				array(
-					'title' => __( 'Email Settings', 'lifterlms' ),
-					'type'  => 'title',
-					'desc'  => __( 'Settings for all emails sent by LifterLMS. Notification and engagement emails will adhere to these settings.', 'lifterlms' ),
-					'id'    => 'email_options_title',
+					'title'    => __( 'Image Width', 'lifterlms' ),
+					'desc'     => __( 'in pixels', 'lifterlms' ),
+					'id'       => 'lifterlms_certificate_bg_img_width',
+					'default'  => '800',
+					'type'     => 'number',
+					'autoload' => false,
 				),
+				array(
+					'title'    => __( 'Image Height', 'lifterlms' ),
+					'id'       => 'lifterlms_certificate_bg_img_height',
+					'desc'     => __( 'in pixels', 'lifterlms' ),
+					'default'  => '616',
+					'type'     => 'number',
+					'autoload' => false,
+				),
+				array(
+					'title'    => __( 'Legacy compatibility', 'lifterlms' ),
+					'desc'     => __( 'Use legacy certificate image sizes.', 'lifterlms' ) .
+									   '<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
+					'id'       => 'lifterlms_certificate_legacy_image_size',
+					'default'  => 'no',
+					'type'     => 'checkbox',
+					'autoload' => false,
+				),
+			)
+		);
+
+	}
+
+	/**
+	 * Retrieve fields for the email settings group.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	protected function get_settings_group_email() {
+
+		return $this->generate_settings_group(
+			'email_options',
+			__( 'Email Settings', 'lifterlms' ),
+			__( 'Settings for all emails sent by LifterLMS. Notification and engagement emails will adhere to these settings.', 'lifterlms' ),
+			array(
 				array(
 					'title'    => __( 'Sender Name', 'lifterlms' ),
 					'desc'     => '<br>' . __( 'Name to be displayed in From field', 'lifterlms' ),
 					'id'       => 'lifterlms_email_from_name',
 					'type'     => 'text',
 					'default'  => esc_attr( get_bloginfo( 'title' ) ),
-					'desc_tip' => true,
 				),
 				array(
 					'title'    => __( 'Sender Email', 'lifterlms' ),
@@ -87,7 +144,6 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'id'       => 'lifterlms_email_from_address',
 					'type'     => 'email',
 					'default'  => get_option( 'admin_email' ),
-					'desc_tip' => true,
 				),
 				array(
 					'title'    => __( 'Header Image', 'lifterlms' ),
@@ -102,69 +158,10 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'id'       => 'lifterlms_email_footer_text',
 					'type'     => 'textarea',
 					'default'  => '',
-					'desc_tip' => true,
 				),
-
-				array(
-					'type' => 'sectionend',
-					'id'   => 'email_options_end',
-				),
-
-				array(
-					'type'  => 'sectionstart',
-					'id'    => 'certificates_options_start',
-					'class' => 'top',
-				),
-
-				array(
-					'title' => __( 'Certificates Settings', 'lifterlms' ),
-					'type'  => 'title',
-					'desc'  => '',
-					'id'    => 'certificates_options_title',
-				),
-
-				array(
-					'type' => 'desc',
-					'desc' => '<strong>' . __( 'Background Image Settings', 'lifterlms' ) . '</strong><br>' .
-							  __( 'Use these sizes to determine the dimensions of certificate background images. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
-					'id'   => 'cert_bg_image_settings',
-				),
-
-				array(
-					'title'    => __( 'Image Width', 'lifterlms' ),
-					'desc'     => __( 'in pixels', 'lifterlms' ),
-					'id'       => 'lifterlms_certificate_bg_img_width',
-					'default'  => '800',
-					'type'     => 'number',
-					'autoload' => false,
-				),
-
-				array(
-					'title'    => __( 'Image Height', 'lifterlms' ),
-					'id'       => 'lifterlms_certificate_bg_img_height',
-					'desc'     => __( 'in pixels', 'lifterlms' ),
-					'default'  => '616',
-					'type'     => 'number',
-					'autoload' => false,
-				),
-
-				array(
-					'title'    => __( 'Legacy compatibility', 'lifterlms' ),
-					'desc'     => __( 'Use legacy certificate image sizes.', 'lifterlms' ) .
-									   '<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
-					'id'       => 'lifterlms_certificate_legacy_image_size',
-					'default'  => 'no',
-					'type'     => 'checkbox',
-					'autoload' => false,
-				),
-
-				array(
-					'type' => 'sectionend',
-					'id'   => 'certificates_options_end',
-				),
-
 			)
 		);
+
 	}
 
 }

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -52,7 +52,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 				array(
 					'type'  => 'sectionstart',
-					'id'    => 'email_options_end',
+					'id'    => 'email_options',
 					'class' => 'top',
 				),
 
@@ -60,7 +60,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'title' => __( 'Email Settings', 'lifterlms' ),
 					'type'  => 'title',
 					'desc'  => __( 'Settings for all emails sent by LifterLMS. Notification and engagement emails will adhere to these settings.', 'lifterlms' ),
-					'id'    => 'email_options_end_title',
+					'id'    => 'email_options_title',
 				),
 				array(
 					'title'    => __( 'Sender Name', 'lifterlms' ),
@@ -154,26 +154,6 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 			)
 		);
-	}
-
-	/**
-	 * save settings to the database
-	 *
-	 * @return void
-	 */
-	public function save() {
-		$settings = $this->get_settings();
-		LLMS_Admin_Settings::save_fields( $settings );
-	}
-
-	/**
-	 * get settings from the database
-	 *
-	 * @return void
-	 */
-	public function output() {
-		$settings = $this->get_settings();
-		LLMS_Admin_Settings::output_fields( $settings );
 	}
 
 }

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -83,9 +83,9 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			array(
 				array(
 					'title' => __( 'Background Image Settings', 'lifterlms' ),
-					'type' => 'subtitle',
-					'desc' => __( 'Use these sizes to determine the dimensions of certificate background images. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
-					'id'   => 'cert_bg_image_settings',
+					'type'  => 'subtitle',
+					'desc'  => __( 'Use these sizes to determine the dimensions of certificate background images. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
+					'id'    => 'cert_bg_image_settings',
 				),
 				array(
 					'title'    => __( 'Image Width', 'lifterlms' ),
@@ -132,18 +132,18 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			__( 'Settings for all emails sent by LifterLMS. Notification and engagement emails will adhere to these settings.', 'lifterlms' ),
 			array(
 				array(
-					'title'    => __( 'Sender Name', 'lifterlms' ),
-					'desc'     => '<br>' . __( 'Name to be displayed in From field', 'lifterlms' ),
-					'id'       => 'lifterlms_email_from_name',
-					'type'     => 'text',
-					'default'  => esc_attr( get_bloginfo( 'title' ) ),
+					'title'   => __( 'Sender Name', 'lifterlms' ),
+					'desc'    => '<br>' . __( 'Name to be displayed in From field', 'lifterlms' ),
+					'id'      => 'lifterlms_email_from_name',
+					'type'    => 'text',
+					'default' => esc_attr( get_bloginfo( 'title' ) ),
 				),
 				array(
-					'title'    => __( 'Sender Email', 'lifterlms' ),
-					'desc'     => '<br>' . __( 'Email Address displayed in the From field', 'lifterlms' ),
-					'id'       => 'lifterlms_email_from_address',
-					'type'     => 'email',
-					'default'  => get_option( 'admin_email' ),
+					'title'   => __( 'Sender Email', 'lifterlms' ),
+					'desc'    => '<br>' . __( 'Email Address displayed in the From field', 'lifterlms' ),
+					'id'      => 'lifterlms_email_from_address',
+					'type'    => 'email',
+					'default' => get_option( 'admin_email' ),
 				),
 				array(
 					'title'    => __( 'Header Image', 'lifterlms' ),
@@ -153,11 +153,11 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'autoload' => false,
 				),
 				array(
-					'title'    => __( 'Email Footer Text', 'lifterlms' ),
-					'desc'     => '<br>' . __( 'Text you would like displayed in the footer of all emails.', 'lifterlms' ),
-					'id'       => 'lifterlms_email_footer_text',
-					'type'     => 'textarea',
-					'default'  => '',
+					'title'   => __( 'Email Footer Text', 'lifterlms' ),
+					'desc'    => '<br>' . __( 'Text you would like displayed in the footer of all emails.', 'lifterlms' ),
+					'id'      => 'lifterlms_email_footer_text',
+					'type'    => 'textarea',
+					'default' => '',
 				),
 			)
 		);

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -6,9 +6,15 @@
  * @version  3.8.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Settings_Engagements class.
+ *
+ * @since 1.0.0
+ * @since 3.8.0 Unknown.
+ * @since [version] Renamed setting field IDs to be unique.
+ */
 class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 	/**
@@ -46,7 +52,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 				array(
 					'type'  => 'sectionstart',
-					'id'    => 'email_options',
+					'id'    => 'email_options_end',
 					'class' => 'top',
 				),
 
@@ -54,7 +60,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'title' => __( 'Email Settings', 'lifterlms' ),
 					'type'  => 'title',
 					'desc'  => __( 'Settings for all emails sent by LifterLMS. Notification and engagement emails will adhere to these settings.', 'lifterlms' ),
-					'id'    => 'email_options',
+					'id'    => 'email_options_end_title',
 				),
 				array(
 					'title'    => __( 'Sender Name', 'lifterlms' ),
@@ -90,7 +96,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 				array(
 					'type' => 'sectionend',
-					'id'   => 'email_options',
+					'id'   => 'email_options_end',
 				),
 
 				array(

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -19,20 +19,24 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 * @version  3.8.0
 	 */
 	public function __construct() {
+
 		$this->id    = 'engagements';
 		$this->label = __( 'Engagements', 'lifterlms' );
 
 		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
 		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
 		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
+
 	}
 
 	/**
 	 * Get settings array
 	 *
+	 * @since 1.0.0
+	 * @since 3.8.0 Unknown.
+	 * @since [version] Ensure IDs are unique.
+	 *
 	 * @return array
-	 * @since    1.0.0
-	 * @version  3.8.0
 	 */
 	public function get_settings() {
 
@@ -91,7 +95,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 				array(
 					'type'  => 'sectionstart',
-					'id'    => 'certificates_options',
+					'id'    => 'certificates_options_start',
 					'class' => 'top',
 				),
 
@@ -99,7 +103,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'title' => __( 'Certificates Settings', 'lifterlms' ),
 					'type'  => 'title',
 					'desc'  => '',
-					'id'    => 'certificates_options',
+					'id'    => 'certificates_options_title',
 				),
 
 				array(
@@ -139,7 +143,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
 				array(
 					'type' => 'sectionend',
-					'id'   => 'certificates_options',
+					'id'   => 'certificates_options_end',
 				),
 
 			)

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -2,8 +2,10 @@
 /**
  * Admin Settings Page: Engagements
  *
- * @since    1.0.0
- * @version  3.8.0
+ * @package LifterLMS/Admin/Classes
+ *
+ * @since 1.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,6 +48,13 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 */
 	public function get_settings() {
 
+		/**
+		 * Modify LifterLMS Admin Settings on the "Engagements" tab,
+		 *
+		 * @since Unknown
+		 *
+		 * @param array[] $settings Array of settings fields arrays.
+		 */
 		return apply_filters(
 			'lifterlms_engagements_settings',
 			array(

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -59,7 +59,7 @@ class LLMS_Settings_Page {
 	 */
 	public function __construct() {
 
-		$this->label = $this->get_label();
+		$this->label = $this->set_label();
 
 		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), $this->tab_priority );
 
@@ -123,7 +123,7 @@ class LLMS_Settings_Page {
 	 *
 	 * @return string
 	 */
-	public function get_label() {
+	protected function set_label() {
 		return $this->id;
 	}
 

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -41,6 +41,15 @@ class LLMS_Settings_Page {
 	public $label = '';
 
 	/**
+	 * Tab priority
+	 *
+	 * Determines the order of the page when registered with the core settings array.
+	 *
+	 * @var int
+	 */
+	public $tab_priority = 20;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since [version]
@@ -51,18 +60,23 @@ class LLMS_Settings_Page {
 
 		$this->label = $this->get_label();
 
-		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
-		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
-		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
+		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), $this->tab_priority );
+
+		if ( $this->id ) {
+
+			add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
+			add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
+
+		}
 
 	}
 
 	/**
 	 * Add the settings page
 	 *
+	 * @since 1.0.0
+	 *
 	 * @return array
-	 * @since    1.0.0
-	 * @version  1.0.0
 	 */
 	public function add_settings_page( $pages ) {
 		$pages[ $this->id ] = $this->label;
@@ -72,15 +86,15 @@ class LLMS_Settings_Page {
 	/**
 	 * Flushes rewrite rules when necessary
 	 *
-	 * @return   void
-	 * @since    3.0.4
-	 * @version  3.0.4
+	 * @since 3.0.4
+	 *
+	 * @return void
 	 */
 	public function flush_rewrite_rules() {
 
-		// add the updated endpoints
-		$q = new LLMS_Query();
-		$q->add_endpoints();
+		// Add the updated endpoints.
+		$query = new LLMS_Query();
+		$query->add_endpoints();
 
 		// flush rewrite rules
 		flush_rewrite_rules();
@@ -93,12 +107,10 @@ class LLMS_Settings_Page {
 	 * @since 3.17.5
 	 * @since 3.35.0 Unslash input data.
 	 *
-	 * @return   string
+	 * @return string
 	 */
 	protected function get_current_section() {
-
 		return isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : 'main';
-
 	}
 
 	/**
@@ -117,9 +129,14 @@ class LLMS_Settings_Page {
 	/**
 	 * Get the page sections (stub)
 	 *
-	 * @return   array
-	 * @since    1.0.0
-	 * @version  3.17.5
+	 * When overriding, this should return an associative array where the key is the
+	 * section id and the value is the (translated) section title. The "default" tab
+	 * should always use the id "main".
+	 *
+	 * @since 1.0.0
+	 * @since 3.17.5 Return an array instead of void.
+	 *
+	 * @return array
 	 */
 	public function get_sections() {
 		return array();
@@ -128,7 +145,7 @@ class LLMS_Settings_Page {
 	/**
 	 * Retrieve the page's settings (stub)
 	 *
-	 * @return   [array
+	 * @return   array
 	 * @since    3.17.5
 	 * @version  3.17.5
 	 */
@@ -150,9 +167,9 @@ class LLMS_Settings_Page {
 	/**
 	 * Output settings sections as tabs and set post href
 	 *
-	 * @return array
-	 * @since    3.17.5
-	 * @version  3.17.5
+	 * @since 3.17.5
+	 *
+	 * @return void
 	 */
 	public function output_sections_nav() {
 
@@ -179,9 +196,10 @@ class LLMS_Settings_Page {
 	/**
 	 * Save the settings field values
 	 *
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  3.17.5
+	 * @since 1.0.0
+	 * @since 3.17.5 Unknown.
+	 *
+	 * @return void
 	 */
 	public function save() {
 

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.35.0 Unslash input data.
  * @since [version] Add a constructor which registers the settings page and automatically saves and outputs settings content.
  *               Add public method stub `get_label()` which is used to automatically set the `$label` property on class initialization.
+ *               Add utility method to generate a group of settings.
  */
 class LLMS_Settings_Page {
 
@@ -124,6 +125,43 @@ class LLMS_Settings_Page {
 	 */
 	public function get_label() {
 		return $this->id;
+	}
+
+	/**
+	 * Generates a group of settings.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $id Group ID. Used to create IDs for the start, end, and title fields.
+	 * @param string $title Title of the group (should be translatable).
+	 * @param string $title_desc (Optional) title field description text.
+	 * @param array[] $settings Array of settings field arrays.
+	 * @return array[]
+	 */
+	protected function generate_settings_group( $id, $title, $title_desc = '', $settings = array() ) {
+
+		$start = array(
+			array(
+				'type' => 'sectionstart',
+				'id'   => $id,
+			),
+			array(
+				'type'  => 'title',
+				'id'    => sprintf( '%s_title', $id ),
+				'title' => $title,
+				'desc'  => $title_desc,
+			),
+		);
+
+		$end = array(
+			array(
+				'type' => 'sectionend',
+				'id'   => sprintf( '%s_end', $id ),
+			),
+		);
+
+		return array_merge( $start, $settings, $end );
+
 	}
 
 	/**

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -3,7 +3,7 @@
  * Admin Settings Page Base Class
  *
  * @since 1.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,33 +14,48 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
  * @since 3.35.0 Unslash input data.
+ * @since [version] Add a constructor which registers the settings page and automatically saves and outputs settings content.
+ *               Add public method stub `get_label()` which is used to automatically set the `$label` property on class initialization.
  */
 class LLMS_Settings_Page {
 
 	/**
 	 * Allow settings page to determine if a rewrite flush is required
 	 *
-	 * @var      boolean
-	 * @since    3.0.4
-	 * @version  3.0.4
+	 * @var boolean
 	 */
 	protected $flush = false;
 
 	/**
 	 * Settings identifier
 	 *
-	 * @var      string
-	 * @since    1.0.0
+	 * @var string
 	 */
-	public $id;
+	public $id = '';
 
 	/**
-	 * Settings page link label
+	 * Settings page label / title.
 	 *
-	 * @var      string
-	 * @since    1.0.0
+	 * @var string
 	 */
-	public $label;
+	public $label = '';
+
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+
+		$this->label = $this->get_label();
+
+		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
+		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
+		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
+
+	}
 
 	/**
 	 * Add the settings page
@@ -87,6 +102,19 @@ class LLMS_Settings_Page {
 	}
 
 	/**
+	 * Retrieve the page label.
+	 *
+	 * Extending classes should override this to return a translated string used as the page's title.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return $this->id;
+	}
+
+	/**
 	 * Get the page sections (stub)
 	 *
 	 * @return   array
@@ -94,9 +122,7 @@ class LLMS_Settings_Page {
 	 * @version  3.17.5
 	 */
 	public function get_sections() {
-
 		return array();
-
 	}
 
 	/**
@@ -107,9 +133,7 @@ class LLMS_Settings_Page {
 	 * @version  3.17.5
 	 */
 	public function get_settings() {
-
 		return array();
-
 	}
 
 	/**
@@ -120,9 +144,7 @@ class LLMS_Settings_Page {
 	 * @version  3.17.5
 	 */
 	public function output() {
-
 		LLMS_Admin_Settings::output_fields( $this->get_settings() );
-
 	}
 
 	/**
@@ -164,11 +186,8 @@ class LLMS_Settings_Page {
 	public function save() {
 
 		LLMS_Admin_Settings::save_fields( $this->get_settings() );
-
 		if ( $this->flush ) {
-
 			add_action( 'shutdown', array( $this, 'flush_rewrite_rules' ) );
-
 		}
 
 	}

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -145,9 +145,9 @@ class LLMS_Settings_Page {
 	/**
 	 * Retrieve the page's settings (stub)
 	 *
-	 * @return   array
-	 * @since    3.17.5
-	 * @version  3.17.5
+	 * @since 3.17.5
+	 *
+	 * @return array
 	 */
 	public function get_settings() {
 		return array();
@@ -156,9 +156,10 @@ class LLMS_Settings_Page {
 	/**
 	 * Output the settings fields
 	 *
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  3.17.5
+	 * @since 1.0.0
+	 * @since 3.17.5 Unknown.
+	 *
+	 * @return void
 	 */
 	public function output() {
 		LLMS_Admin_Settings::output_fields( $this->get_settings() );

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -132,9 +132,9 @@ class LLMS_Settings_Page {
 	 *
 	 * @since [version]
 	 *
-	 * @param string $id Group ID. Used to create IDs for the start, end, and title fields.
-	 * @param string $title Title of the group (should be translatable).
-	 * @param string $title_desc (Optional) title field description text.
+	 * @param string  $id Group ID. Used to create IDs for the start, end, and title fields.
+	 * @param string  $title Title of the group (should be translatable).
+	 * @param string  $title_desc (Optional) title field description text.
 	 * @param array[] $settings Array of settings field arrays.
 	 * @return array[]
 	 */

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -97,7 +97,7 @@ class LLMS_Settings_Page {
 		$query = new LLMS_Query();
 		$query->add_endpoints();
 
-		// flush rewrite rules
+		// Flush rewrite rules.
 		flush_rewrite_rules();
 
 	}

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -2,7 +2,7 @@
 /**
  * Certificates
  *
- * @see LLMS()->certificates()
+ * @package LifterLMS/Classes
  *
  * @since 1.0.0
  * @version 3.30.3
@@ -12,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Certificates class
+ *
+ * @see LLMS()->certificates()
  *
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
@@ -26,17 +28,18 @@ class LLMS_Certificates {
 	protected static $_instance = null;
 
 	/**
-	 * @var LLMS_Certificate_User[]
-	 * @since 1.1.1
+	 * Array of Certificate types.
+	 *
+	 * @var array
 	 */
 	public $certs = array();
 
 	/**
 	 * Instance singleton
 	 *
-	 * @return   LLMS_Certificates
-	 * @since    1.0.0
-	 * @version  1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return LLMS_Certificates
 	 */
 	public static function instance() {
 		if ( is_null( self::$_instance ) ) {
@@ -48,9 +51,9 @@ class LLMS_Certificates {
 	/**
 	 * Constructor
 	 *
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	private function __construct() {
 		$this->init();
@@ -59,9 +62,9 @@ class LLMS_Certificates {
 	/**
 	 * Initialize Class
 	 *
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	public function init() {
 		include_once 'class.llms.certificate.php';
@@ -72,12 +75,12 @@ class LLMS_Certificates {
 	 * Award a certificate to a user
 	 * Calls trigger method passing arguments
 	 *
-	 * @param    int $person_id        [ID of the current user]
-	 * @param    int $achievement      [Achievement template post ID]
-	 * @param    int $related_post_id  Post ID of the related engagement (eg lesson id)
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  1.0.0
+	 * @since 1.0.0
+	 *
+	 * @param int $person_id       WP_User ID.
+	 * @param int $certificate_id  WP_Post ID of the certificate template.
+	 * @param int $related_post_id WP_Post ID of the related post, for example a lesson id.
+	 * @return void
 	 */
 	public function trigger_engagement( $person_id, $certificate_id, $related_post_id ) {
 		$certificate = $this->certs['LLMS_Certificate_User'];
@@ -87,11 +90,11 @@ class LLMS_Certificates {
 	/**
 	 * Generate a downloadable HTML file for a certificate
 	 *
-	 * @param    string $filepath        full path for the created file
-	 * @param    int    $certificate_id  WP Post ID of the earned certificate
-	 * @return   mixed                    WP_Error or full path to the generated export
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 *
+	 * @param string $filepath Full path for the created file.
+	 * @param int    $certificate_id WP_Post ID of the earned certificate.
+	 * @return mixed WP_Error or full path to the generated export.
 	 */
 	private function generate_export( $filepath, $certificate_id ) {
 
@@ -119,11 +122,11 @@ class LLMS_Certificates {
 	/**
 	 * Retrieve an existing or generate a downloadable HTML file for a certificate
 	 *
-	 * @param    int  $certificate_id  WP Post ID of the earned certificate
-	 * @param    bool $use_cache       if true will check for existence of a cached version of the file first
-	 * @return   mixed                    WP_Error or full path to the generated export
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 *
+	 * @param int $certificate_id WP Post ID of the earned certificate.
+	 * @param bool $use_cache If true will check for existence of a cached version of the file first.
+	 * @return   mixed WP_Error or full path to the generated export.
 	 */
 	public function get_export( $certificate_id, $use_cache = false ) {
 
@@ -136,7 +139,7 @@ class LLMS_Certificates {
 
 		$cert = new LLMS_User_Certificate( $certificate_id );
 
-		/* translators: %1$s = url-safe certificate title, %2$s = random alpha-numeric characters for filename obscurity */
+		// Translators: %1$s = url-safe certificate title, %2$s = random alpha-numeric characters for filename obscurity.
 		$filename  = sanitize_title( sprintf( esc_attr_x( 'certificate-%1$s-%2$s', 'certificate download filename', 'lifterlms' ), $cert->get( 'certificate_title' ), wp_generate_password( 12, false, false ) ) );
 		$filename .= '.html';
 		$filepath  = LLMS_TMP_DIR . $filename;
@@ -152,18 +155,19 @@ class LLMS_Certificates {
 	/**
 	 * Retrieves the HTML of a certificate which can be used to create an exportable download
 	 *
-	 * @param    int $certificate_id  WP Post ID of the earned certificate
-	 * @return   string
-	 * @since    3.18.0
-	 * @version  3.24.3
+	 * @since 3.18.0
+	 * @since 3.24.3 Unknown.
+	 *
+	 * @param int $certificate_id WP_Post ID of the earned certificate.
+	 * @return string
 	 */
 	private function get_export_html( $certificate_id ) {
 
-		// create a nonce for getting the export HTML
+		// Create a nonce for getting the export HTML.
 		$token = wp_generate_password( 32, false );
 		update_post_meta( $certificate_id, '_llms_auth_nonce', $token );
 
-		// scrape the html from a one-time use URL
+		// Scrape the html from a one-time use URL.
 		$url = apply_filters( 'llms_get_certificate_export_html_url', add_query_arg( '_llms_cert_auth', $token, get_permalink( $certificate_id ) ), $certificate_id );
 		$req = wp_safe_remote_get(
 			$url,
@@ -172,10 +176,10 @@ class LLMS_Certificates {
 			)
 		);
 
-		// delete the token after the request
+		// Delete the token after the request.
 		delete_post_meta( $certificate_id, '_llms_auth_nonce', $token );
 
-		// error?
+		// Error.
 		if ( is_wp_error( $req ) ) {
 			return $req;
 		}
@@ -186,7 +190,7 @@ class LLMS_Certificates {
 			return apply_filters( 'llms_get_certificate_export_html', $html, $certificate_id );
 		}
 
-		// don't throw or log warnings
+		// Don't throw or log warnings.
 		$libxml_state = libxml_use_internal_errors( true );
 
 		$dom = new DOMDocument();
@@ -195,39 +199,40 @@ class LLMS_Certificates {
 
 			$header = $dom->getElementsByTagName( 'head' )->item( 0 );
 
-			// remove all <scripts>
+			// Remove all <scripts>.
 			$scripts = $dom->getElementsByTagName( 'script' );
 			while ( $scripts && $scripts->length ) {
 				$scripts->item( 0 )->parentNode->removeChild( $scripts->item( 0 ) );
 			}
 
-			// get all <links>
+			// Get all <links>.
 			$links      = $dom->getElementsByTagName( 'link' );
 			$to_replace = array();
 
-			// inline stylesheets
+			// Inline stylesheets.
 			foreach ( $links as $link ) {
 
-				// only proceed for stylesheets
+				// Only proceed for stylesheets.
 				if ( 'stylesheet' !== $link->getAttribute( 'rel' ) ) {
 					continue;
 				}
 
-				// save href for use later
+				// Save href for use later.
 				$href = $link->getAttribute( 'href' );
 
-				// only include local stylesheets
-				// this means that external fonts (google, for example) are excluded from the download
-				// sorry... (kind of)
+				/**
+				 * Only include local stylesheets.
+				 * This means that external fonts (google, for example) are excluded from the download.
+				 */
 				if ( 0 !== strpos( $href, get_site_url() ) ) {
 					continue;
 				}
 
-				// get the actual CSS
+				// Get the actual CSS.
 				$stylepath = strtok( str_replace( get_site_url(), untrailingslashit( ABSPATH ), $href ), '?' );
 				$raw       = file_get_contents( $stylepath );
 
-				// add it to be inlined late
+				// Add it to be inlined late.
 				$tag          = $dom->createElement( 'style', $raw );
 				$to_replace[] = array(
 					'old' => $link,
@@ -236,54 +241,54 @@ class LLMS_Certificates {
 
 			}
 
-			// do replacements, ensures cascade order is retained
+			// Do replacements, ensures cascade order is retained.
 			foreach ( $to_replace as $replacement ) {
-				// var_dump( $replacement['old'] );
 				$replacement['old']->parentNode->replaceChild( $replacement['new'], $replacement['old'] );
-				// $header->replaceChild( $replacement['new'], $replacement['old'] );
 			}
 
-			// remove all remaining non stylesheet <links>
+			// Remove all remaining non stylesheet <links>.
 			$links = $dom->getElementsByTagName( 'link' );
 			while ( $links && $links->length ) {
 				$links->item( 0 )->parentNode->removeChild( $links->item( 0 ) );
 			}
 
-			// convert images to data uris
+			// Convert images to data uris.
 			$images = $dom->getElementsByTagName( 'img' );
 			foreach ( $images as $img ) {
+
 				$src = $img->getAttribute( 'src' );
-				// only include local images
+
+				// Only include local images.
 				if ( 0 !== strpos( $src, get_site_url() ) ) {
 					continue;
 				}
+
 				$imgpath = strtok( str_replace( get_site_url(), untrailingslashit( ABSPATH ), $src ), '?' );
 				$data    = base64_encode( file_get_contents( $imgpath ) );
 				$img->setAttribute( 'src', 'data:' . mime_content_type( $imgpath ) . ';base64,' . $data );
+
 			}
 
-			// hide print stuff
-			// this is faster than traversing the dom to remove the element
+			// Hide print stuff (this is faster than traversing the dom to remove the element).
 			$header->appendChild( $dom->createELement( 'style', '.no-print { display: none !important; }' ) );
 
 			// Remove the admin bar (if found).
 			$admin_bar = $dom->getElementById( 'wpadminbar' );
 			if ( $admin_bar ) {
-				// @codingStandardsIgnoreStart WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
-				$admin_bar->parentNode->removeChild( $admin_bar );
-				// @codingStandardsIgnoreEnd
+				$admin_bar->parentNode->removeChild( $admin_bar ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar.
 			}
 
 			$html = $dom->saveHTML();
 
-		}// End if().
+		}
 
-		// handle errors
+		// Handle errors.
 		libxml_clear_errors();
-		// restore
+
+		// Restore.
 		libxml_use_internal_errors( $libxml_state );
 
-		// return the html
+		// Return the html.
 		return apply_filters( 'llms_get_certificate_export_html', $html, $certificate_id );
 
 	}

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -294,7 +294,7 @@ class LLMS_Certificates {
 			}
 
 			$imgpath = strtok( str_replace( get_site_url(), untrailingslashit( ABSPATH ), $src ), '?' );
-			$data    = base64_encode( file_get_contents( $imgpath ) );
+			$data    = base64_encode( file_get_contents( $imgpath ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
 			$img->setAttribute( 'src', 'data:' . mime_content_type( $imgpath ) . ';base64,' . $data );
 
 		}
@@ -306,7 +306,7 @@ class LLMS_Certificates {
 		// Remove the admin bar (if found).
 		$admin_bar = $dom->getElementById( 'wpadminbar' );
 		if ( $admin_bar ) {
-			$admin_bar->parentNode->removeChild( $admin_bar ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase.
+			$admin_bar->parentNode->removeChild( $admin_bar ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
 
 		$html = $dom->saveHTML();

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -137,7 +137,7 @@ class LLMS_Certificates {
 	 *
 	 * @since 3.18.0
 	 *
-	 * @param int $certificate_id WP Post ID of the earned certificate.
+	 * @param int  $certificate_id WP Post ID of the earned certificate.
 	 * @param bool $use_cache If true will check for existence of a cached version of the file first.
 	 * @return mixed WP_Error or full path to the generated export.
 	 */
@@ -306,7 +306,7 @@ class LLMS_Certificates {
 		// Remove the admin bar (if found).
 		$admin_bar = $dom->getElementById( 'wpadminbar' );
 		if ( $admin_bar ) {
-			$admin_bar->parentNode->removeChild( $admin_bar ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar.
+			$admin_bar->parentNode->removeChild( $admin_bar ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase.
 		}
 
 		$html = $dom->saveHTML();

--- a/includes/models/model.llms.quiz.php
+++ b/includes/models/model.llms.quiz.php
@@ -34,7 +34,7 @@ class LLMS_Quiz extends LLMS_Post_Model {
 	 *
 	 * @var string
 	 */
-	protected $db_post_type    = 'llms_quiz';
+	protected $db_post_type = 'llms_quiz';
 
 	/**
 	 * Post type name (without prefix).

--- a/tests/framework/class-llms-settings-page-test-case.php
+++ b/tests/framework/class-llms-settings-page-test-case.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * LifterLMS Unit Test Case Base class
+ *
+ * @since [version]
+ */
+class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->page = new $this->classname();
+
+	}
+
+	/**
+	 * Stub to be overridden in extending classes.
+	 *
+	 * This function should return an array of arrays.
+	 *
+	 * The array key is the option id and the value is an array of possible values to store.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	protected function get_mock_settings() {
+		return array();
+	}
+
+	/**
+	 * Retrieve an indexed array of ids for the page's registered settings.
+	 *
+	 * @since [version]
+	 *
+	 * @param bool $save_only If `true`, only return fields that can be saved to the database.
+	 * @return string[]
+	 */
+	protected function get_settings_ids( $save_only = true ) {
+
+		$saveable = array( 'checkbox', 'textarea', 'wpeditor', 'password', 'text', 'email', 'number', 'select', 'single_select_page', 'single_select_membership', 'radio', 'hidden', 'image', 'multiselect' );
+
+		$ids = array();
+		foreach ( $this->page->get_settings() as $setting ) {
+			if ( empty( $setting['id'] ) || ( $save_only && ! in_array( $setting['type'], $saveable, true ) ) ) {
+				continue;
+			}
+			$ids[] = $setting['id'];
+		}
+		return $ids;
+
+	}
+
+	/**
+	 * Test the settings page ID matches the expected ID.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_id() {
+		$this->assertEquals( $this->class_id, $this->page->id );
+	}
+
+	/**
+	 * Test the settings page label matches the expected label.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_label() {
+		$this->assertEquals( $this->class_label, $this->page->label );
+	}
+
+	/**
+	 * Ensure all editable settings exist in the settings array.
+	 *
+	 * @since [version]
+	 *
+	 * @return [type]
+	 */
+	public function test_get_settings() {
+
+		$settings = $this->get_mock_settings();
+
+		if ( ! $settings ) {
+			$this->markTestSkipped( 'No mock setting registered to test.' );
+		}
+
+		$mock   = array_keys( $settings );
+		$actual = $this->get_settings_ids();
+		$this->assertEquals( $mock, $actual );
+
+	}
+
+	/**
+	 * Ensure no duplicate values exist in the settings array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_dupcheck() {
+
+		$actual   = $this->get_settings_ids( false );
+		$no_dupes = array_unique( $actual );
+		$this->assertEquals( $no_dupes, $actual );
+
+	}
+
+	/**
+	 * Test the save() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save() {
+
+		$settings = $this->get_mock_settings();
+
+		if ( ! $settings ) {
+			$this->markTestSkipped( 'No mock setting registered to test.' );
+		}
+
+		$post = array();
+		foreach ( $settings as $key => $vals ) {
+			$post[ $key ] = $vals[0];
+
+			foreach ( $vals as $val ) {
+
+				$this->mockPostRequest( array(
+					$key => $val,
+				) );
+				$this->page->save();
+				$this->assertEquals( $val, get_option( $key ), $key );
+
+			}
+
+		}
+
+		// Bulk save all of them at once.
+		$this->mockPostRequest( $post );
+		$this->page->save();
+		foreach ( $post as $key => $val ) {
+			$this->assertEquals( $val, get_option( $key ), $key );
+		}
+
+	}
+
+	/**
+	 * Test the set_label() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_label() {
+		$this->assertEquals( $this->class_label, LLMS_Unit_Test_Util::call_method( $this->page, 'set_label' ) );
+	}
+
+}

--- a/tests/unit-tests/admin/settings/class-llms-test-settings-accounts.php
+++ b/tests/unit-tests/admin/settings/class-llms-test-settings-accounts.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Test LLMS_Settings_Accounts
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group admin
+ * @group settings_page
+ * @group settings_page_accounts
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Settings_Accounts extends LLMS_Settings_Page_Test_Case {
+
+	/**
+	 * Classname.
+	 *
+	 * @var string
+	 */
+	protected $classname = 'LLMS_Settings_Accounts';
+
+	/**
+	 * Expected class $id property.
+	 *
+	 * @var string
+	 */
+	protected $class_id = 'accounts';
+
+	/**
+	 * Expected class $label property.
+	 *
+	 * @var string
+	 */
+	protected $class_label = 'Accounts';
+
+	/**
+	 * Return an array of mock settings and possible values.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function get_mock_settings() {
+
+		$pages = array(
+			$this->factory->post->create( array( 'post_type' => 'page' ) ),
+			$this->factory->post->create( array( 'post_type' => 'page' ) ),
+		);
+
+		return array(
+			'lifterlms_myaccount_page_id' => $pages,
+			'lifterlms_myaccount_courses_in_progress_sorting' => array(
+				'title,ASC',
+				'title,DESC',
+				'date,DESC',
+				'order,ASC',
+				'order,DESC',
+			),
+			'lifterlms_myaccount_grades_endpoint' => array(
+				'my-grades',
+				'custom-endpoint-grades',
+			),
+			'lifterlms_myaccount_courses_endpoint' => array(
+				'my-courses',
+				'custom-endpoint-courses',
+			),
+			'lifterlms_myaccount_memberships_endpoint' => array(
+				'my-memberships',
+				'custom-endpoint-memberships',
+			),
+			'lifterlms_myaccount_achievements_endpoint' => array(
+				'my-achievements',
+				'custom-endpoint-achievements',
+			),
+			'lifterlms_myaccount_certificates_endpoint' => array(
+				'my-certificates',
+				'custom-endpoint-certificates',
+			),
+			'lifterlms_myaccount_notifications_endpoint' => array(
+				'notifications',
+				'custom-endpoint-notifications',
+			),
+			'lifterlms_myaccount_edit_account_endpoint' => array(
+				'edit-account',
+				'custom-endpoint-account',
+			),
+			'lifterlms_myaccount_lost_password_endpoint' => array(
+				'lost-password',
+				'custom-endpoint-reset-pass',
+			),
+			'lifterlms_myaccount_redeem_vouchers_endpoint' => array(
+				'redeem-voucher',
+				'custom-redemption-code'
+			),
+			'lifterlms_myaccount_orders_endpoint' => array(
+				'orders',
+				'custom-order-history',
+			),
+			'lifterlms_registration_generate_username' => array(
+				'yes',
+			),
+			'lifterlms_registration_password_strength' => array(
+				'yes',
+			),
+			'lifterlms_registration_password_min_strength' => array(
+				'weak',
+				'medium',
+				'strong',
+			),
+			'lifterlms_registration_require_agree_to_terms' => array(
+				'yes',
+			),
+			'lifterlms_terms_page_id' => $pages,
+			'llms_terms_notice' => array(
+				llms_get_terms_notice(),
+				'mock terms notice',
+			),
+			'wp_page_for_privacy_policy' => $pages,
+			'llms_privacy_notice' => array(
+				llms_get_privacy_notice(),
+				'mock privacy notice',
+			),
+			'llms_erasure_request_removes_order_data' => array(
+				'yes',
+			),
+			'llms_erasure_request_removes_lms_data' => array(
+				'yes',
+			),
+			'lifterlms_user_info_field_names_checkout_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_address_checkout_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_phone_checkout_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_email_confirmation_checkout_visibility' => array(
+				'yes',
+			),
+			'lifterlms_enable_myaccount_registration' => array(
+				'yes',
+			),
+			'lifterlms_user_info_field_names_registration_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_address_registration_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_phone_registration_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_email_confirmation_registration_visibility' => array(
+				'yes',
+			),
+			'lifterlms_voucher_field_registration_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_names_account_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_address_account_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_phone_account_visibility' => array(
+				'required',
+				'optional',
+				'hidden',
+			),
+			'lifterlms_user_info_field_email_confirmation_account_visibility' => array(
+				'yes',
+			),
+		);
+	}
+
+}

--- a/tests/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Test LLMS_Settings_Engagements
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group admin
+ * @group settings_page
+ * @group settings_page_engagements
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
+
+	/**
+	 * Classname.
+	 *
+	 * @var string
+	 */
+	protected $classname = 'LLMS_Settings_Engagements';
+
+	/**
+	 * Expected class $id property.
+	 *
+	 * @var string
+	 */
+	protected $class_id = 'engagements';
+
+	/**
+	 * Expected class $label property.
+	 *
+	 * @var string
+	 */
+	protected $class_label = 'Engagements';
+
+	/**
+	 * Return an array of mock settings and possible values.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function get_mock_settings() {
+
+		return array(
+			'lifterlms_email_from_name' => array(
+				esc_attr( get_bloginfo( 'title' ) ),
+				'mock from name',
+			),
+			'lifterlms_email_from_address' => array(
+				get_option( 'admin_email' ),
+				'mock@mock.com',
+			),
+			'lifterlms_email_header_image' => array(
+				'fake.png',
+			),
+			'lifterlms_email_footer_text' => array(
+				'footer text content',
+			),
+			'lifterlms_certificate_bg_img_width' => array(
+				800,
+				1024,
+			),
+			'lifterlms_certificate_bg_img_height' => array(
+				616,
+				1200,
+			),
+			'lifterlms_certificate_legacy_image_size' => array(
+				'yes',
+			),
+		);
+
+	}
+
+}

--- a/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
+++ b/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * Test LLMS_Settings_Page
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group admin
+ * @group settings_page
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Settings_Page extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/settings/class.llms.settings.page.php';
+
+		// Setup a mock settings page.
+		$this->page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+			public function get_label() {
+				return 'Mock';
+			}
+		};
+
+	}
+
+	/**
+	 * Test constructor
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+
+		$this->assertEquals( 'Mock', $this->page->label );
+
+		// Tab should be registered.
+		$this->assertEquals( $this->page->tab_priority, has_action( 'lifterlms_settings_tabs_array', array( $this->page, 'add_settings_page' ) ) );
+
+		// Output action.
+		$this->assertEquals( 10, has_action( 'lifterlms_settings_mock', array( $this->page, 'output' ) ) );
+
+		// Save action.
+		$this->assertEquals( 10, has_action( 'lifterlms_settings_save_mock', array( $this->page, 'save' ) ) );
+
+	}
+
+	/**
+	 * Test add_settings_page() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_settings_page() {
+
+		// No other pages exist.
+		$this->assertEquals( array(
+			'mock' => 'Mock',
+		), $this->page->add_settings_page( array() ) );
+
+		// Another page exists, add it to the end.
+		$this->assertEquals( array(
+			'fake' => 'Fake',
+			'mock' => 'Mock',
+		), $this->page->add_settings_page( array(
+			'fake' => 'Fake',
+		) ) );
+
+	}
+
+	/**
+	 * Test generation of a settings group with no settings added.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_settings() {
+
+		// No description.
+		$args = array(
+			'mock_options',
+			'Mock Settings',
+		);
+		$settings = LLMS_Unit_Test_Util::call_method( $this->page, 'generate_settings_group', $args );
+
+		$this->assertEquals( 'mock_options', $settings[0]['id'] );
+		$this->assertEquals( 'sectionstart', $settings[0]['type'] );
+
+		$this->assertEquals( 'mock_options_title', $settings[1]['id'] );
+		$this->assertEquals( 'title', $settings[1]['type'] );
+		$this->assertEquals( 'Mock Settings', $settings[1]['title'] );
+		$this->assertEquals( '', $settings[1]['desc'] );
+
+		$this->assertEquals( 'mock_options_end', $settings[2]['id'] );
+		$this->assertEquals( 'sectionend', $settings[2]['type'] );
+
+		// Has a description.
+		$args = array(
+			'mock_options',
+			'Mock Settings',
+			'Mock Settings Description',
+		);
+		$settings = LLMS_Unit_Test_Util::call_method( $this->page, 'generate_settings_group', $args );
+		$this->assertEquals( 'Mock Settings Description', $settings[1]['desc'] );
+
+		// Has a description.
+		$args = array(
+			'mock_options',
+			'Mock Settings',
+			'Mock Settings Description',
+			array(
+				array(
+					'id'   => 'mock_setting',
+					'type' => 'text',
+				),
+			)
+		);
+		$settings = LLMS_Unit_Test_Util::call_method( $this->page, 'generate_settings_group', $args );
+		$this->assertEquals( 'mock_setting', $settings[2]['id'] );
+		$this->assertEquals( 'text', $settings[2]['type'] );
+
+	}
+
+
+	/**
+	 * Test get_label() stub when no ID exists for the class.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label_stub_no_id() {
+
+		// Empty string because no ID defined.
+		$page = new LLMS_Settings_Page();
+		$this->assertEquals( '', $page->get_label() );
+
+	}
+
+	/**
+	 * Test get_label() stub when an ID is set.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label_stub_with_id() {
+
+		// Return ID because the method isn't overriden.
+		$page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+		};
+		$this->assertEquals( 'mock', $page->get_label() );
+
+	}
+
+	/**
+	 * Test the get_sections() stub.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_sections() {
+		$this->assertEquals( array(), $this->page->get_sections() );
+	}
+
+	/**
+	 * Test the get_settings() stub.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_stub() {
+		$this->assertEquals( array(), $this->page->get_settings() );
+	}
+
+	/**
+	 * Test the output() stub.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output() {
+		$this->assertOutputEmpty( array( $this->page, 'output' ) );
+	}
+
+	/**
+	 * Test the output_sections_nav() stub when no sections exist.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output_sections_nav_empty() {
+		$this->assertOutputEmpty( array( $this->page, 'output_sections_nav' ) );
+	}
+
+	/**
+	 * Test the output_sections_nav() stub when sections do exist.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output_sections_nav() {
+
+		$page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+			public function get_sections() {
+				return array(
+					'section_1' => 'Section 1',
+					'section_2' => 'Section 2',
+				);
+			}
+		};
+
+		$method = array( $page, 'output_sections_nav' );
+
+		$this->assertOutputContains( '<nav class="llms-nav-tab-wrapper llms-nav-text">', $method );
+		$this->assertOutputContains( '<ul class="llms-nav-items">', $method );
+
+		$this->assertOutputContains( 'section=section_1">Section 1</a>', $method );
+		$this->assertOutputContains( 'section=section_2">Section 2</a>', $method );
+
+		$this->assertOutputContains( '</ul>', $method );
+		$this->assertOutputContains( '</nav>', $method );
+
+	}
+
+}

--- a/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
+++ b/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
@@ -243,4 +243,108 @@ class LLMS_Test_Settings_Page extends LLMS_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Test the save() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save() {
+
+		$page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+			public function get_settings() {
+				return array(
+					array(
+						'id'   => 'mock_setting_id',
+						'type' => 'text',
+					),
+					array(
+						'id'   => 'mock_setting_id_2',
+						'type' => 'text',
+					),
+				);
+			}
+		};
+
+		// No data posted.
+		$page->save();
+		$this->assertEmpty( get_option( 'mock_setting_id' ) );
+		$this->assertEmpty( get_option( 'mock_setting_id_2' ) );
+
+		// Some Data posted.
+		$this->mockPostRequest( array( 'mock_setting_id' => 'mock_setting_val' ) );
+		$page->save();
+		$this->assertEquals( 'mock_setting_val', get_option( 'mock_setting_id' ) );
+		$this->assertEmpty( get_option( 'mock_setting_id_2' ) );
+
+		// All Data posted.
+		$this->mockPostRequest( array(
+			'mock_setting_id'   => 'mock_setting_val',
+			'mock_setting_id_2' => 'mock_setting_val',
+		) );
+		$page->save();
+		$this->assertEquals( 'mock_setting_val', get_option( 'mock_setting_id' ) );
+		$this->assertEquals( 'mock_setting_val', get_option( 'mock_setting_id_2' ) );
+
+	}
+
+	/**
+	 * Ensure unregistered (fake) options aren't stored during save events.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fake_option() {
+
+		// Fake option.
+		$this->mockPostRequest( array(
+			'mock_setting_id_3' => 'mock_setting_val',
+		) );
+		$this->page->save();
+		$this->assertEmpty( get_option( 'mock_setting_id_3' ) );
+
+	}
+
+	/**
+	 * Test the save() method when the $flush prop is true.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_flush_disabled() {
+
+		$page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+		};
+
+		$this->assertFalse( has_action( 'shutdown', array( $page, 'flush_rewrite_rules' ) ) );
+		$page->save();
+		$this->assertFalse( has_action( 'shutdown', array( $page, 'flush_rewrite_rules' ) ) );
+
+	}
+
+	/**
+	 * Test the save() method when the $flush prop is true.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_flush_enabled() {
+
+		$page = new class() extends LLMS_Settings_Page {
+			public $id = 'mock';
+			protected $flush = true;
+		};
+
+		$this->assertFalse( has_action( 'shutdown', array( $page, 'flush_rewrite_rules' ) ) );
+		$page->save();
+		$this->assertEquals( 10, has_action( 'shutdown', array( $page, 'flush_rewrite_rules' ) ) );
+
+	}
+
 }

--- a/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
+++ b/tests/unit-tests/admin/settings/class-llms-test-settings-page.php
@@ -27,7 +27,7 @@ class LLMS_Test_Settings_Page extends LLMS_Unit_Test_Case {
 		// Setup a mock settings page.
 		$this->page = new class() extends LLMS_Settings_Page {
 			public $id = 'mock';
-			public function get_label() {
+			protected function set_label() {
 				return 'Mock';
 			}
 		};
@@ -136,34 +136,34 @@ class LLMS_Test_Settings_Page extends LLMS_Unit_Test_Case {
 
 
 	/**
-	 * Test get_label() stub when no ID exists for the class.
+	 * Test set_label() stub when no ID exists for the class.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_get_label_stub_no_id() {
+	public function test_set_label_stub_no_id() {
 
 		// Empty string because no ID defined.
 		$page = new LLMS_Settings_Page();
-		$this->assertEquals( '', $page->get_label() );
+		$this->assertEquals( '', LLMS_Unit_Test_Util::call_method( $page, 'set_label' ) );
 
 	}
 
 	/**
-	 * Test get_label() stub when an ID is set.
+	 * Test set_label() stub when an ID is set.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_get_label_stub_with_id() {
+	public function test_set_label_stub_with_id() {
 
 		// Return ID because the method isn't overriden.
 		$page = new class() extends LLMS_Settings_Page {
 			public $id = 'mock';
 		};
-		$this->assertEquals( 'mock', $page->get_label() );
+		$this->assertEquals( 'mock', LLMS_Unit_Test_Util::call_method( $page, 'set_label' ) );
 
 	}
 

--- a/tests/unit-tests/class-llms-test-certificates.php
+++ b/tests/unit-tests/class-llms-test-certificates.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Test LLMS_Certificates
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group certificates
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Certificates extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Create a certificate template post.
+	 *
+	 * @since [version]
+	 *
+	 * @return int
+	 */
+	private function create_template() {
+
+		$template = $this->factory->post->create( array(
+			'post_type' => 'llms_certificate',
+			'post_content' => '{site_title}, {current_date}',
+		) );
+		update_post_meta( $template, '_llms_certificate_title', 'Mock Certificate Title' );
+		update_post_meta( $template, '_llms_certificate_image', '' );
+
+		return $template;
+
+	}
+
+	private function earn_certificate( $user, $template, $related ) {
+
+		global $llms_user_earned_certs;
+		$llms_user_earned_certs = array();
+
+		// Watch for generation so we can compare against it later.
+		add_action( 'llms_user_earned_certificate', function( $user_id, $cert_id, $related_id ) {
+			global $llms_user_earned_certs;
+			$llms_user_earned_certs[] = array( $user_id, $cert_id, $related_id );
+		}, 10, 3 );
+
+		LLMS()->certificates()->trigger_engagement( $user, $template, $related );
+
+		return array_shift( $llms_user_earned_certs );
+
+	}
+
+	/**
+	 * Test trigger_engagement() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_trigger_engagement() {
+
+		$user = $this->factory->user->create();
+		$template = $this->create_template();
+		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
+
+		$earned = $this->earn_certificate( $user, $template, $related );
+
+		// User ID.
+		$this->assertEquals( $user, $earned[0] );
+
+		// Related ID.
+		$this->assertEquals( $related, $earned[2] );
+
+	}
+
+	/**
+	 * Retrieve a certificate export, bypassing the cache.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_export_no_cache() {
+
+		$user = $this->factory->user->create();
+		$template = $this->create_template();
+		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
+
+		$earned = $this->earn_certificate( $user, $template, $related );
+
+		$cert_id = $earned[1];
+
+		$path = LLMS()->certificates()->get_export( $cert_id );
+		$this->assertTrue( false !== strpos( $path, '/uploads/llms-tmp/certificate-mock-certificate-title' ) );
+		$this->assertTrue( false !== strpos( $path, '.html' ) );
+
+	}
+
+	/**
+	 * Retrieve a certificate export using caching.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_export_with_cache() {
+
+		$user = $this->factory->user->create();
+		$template = $this->create_template();
+		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
+
+		$earned = $this->earn_certificate( $user, $template, $related );
+
+		$cert_id = $earned[1];
+
+		// Generate a new cert when item not found in the cache.
+		$orig_path = LLMS()->certificates()->get_export( $cert_id, true );
+		$this->assertTrue( false !== strpos( $orig_path, '/uploads/llms-tmp/certificate-mock-certificate-title' ) );
+
+		// Store the filepath for future use.
+		$this->assertEquals( $orig_path, get_post_meta( $cert_id, '_llms_export_filepath', true ) );
+
+		// Get it again, should return the original path from the cache.
+		$cached_path = LLMS()->certificates()->get_export( $cert_id, true );
+		$this->assertEquals( $orig_path, $cached_path );
+
+		// Delete the file (simulate LLMS_TMP_DIR file expiration).
+		unlink( $orig_path );
+
+		// Should regen since the file saved in meta data doesn't exist anymore.
+		$new_path = LLMS()->certificates()->get_export( $cert_id, true );
+		$this->assertTrue( $orig_path !== $new_path );
+
+	}
+
+}


### PR DESCRIPTION
## Description

+ Adds tests for some untested area of the codebase (`LLMS_Settings_Page` and `LLMS_Certificates` classes)
+ Adds new utility methods to `LLMS_Settings_Page` to help reduce code redundancy across admin settings page classes
+ Adds logic used in the constructor of every core settings page class to the constructor of `LLMS_Settings_Page`
+ This additionally adds new actions to the `LLMS_Certificates` class as well as refactors some of the existing code. No functional changes have been made though.

## How has this been tested?

+ Manually tested everything to ensure changes don't break existing settings pages.
+ Added some new unit tests.

## Types of changes

This adds new methods in a backwards compatible way. The class `LLMS_Settings_Engagements` implements new methods but all the other settings page classes will continue to work as they previously did without any updates. Since these classes all define their own constructors the new constructor from the base class simply won't be used.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

