### PR TITLE
Allow certificate templates to be exported, fixes #776

### DIFF
--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -44,7 +44,7 @@ class LLMS_Controller_Certificates {
 	 */
 	public function maybe_allow_public_query( $post_type_args ) {
 
-		if ( ! empty( $_REQUEST['_llms_cert_auth'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_REQUEST['_llms_cert_auth'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			$auth = llms_filter_input( INPUT_GET, '_llms_cert_auth', FILTER_SANITIZE_STRING );
 
@@ -72,7 +72,7 @@ class LLMS_Controller_Certificates {
 	 */
 	public function maybe_authenticate_export_generation() {
 
-		if ( empty( $_REQUEST['_llms_cert_auth'] ) ) {
+		if ( empty( $_REQUEST['_llms_cert_auth'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 
@@ -82,7 +82,7 @@ class LLMS_Controller_Certificates {
 			return;
 		}
 
-		if ( get_post_meta( $post_id, '_llms_auth_nonce', true ) !== $_REQUEST['_llms_cert_auth'] ) {
+		if ( get_post_meta( $post_id, '_llms_auth_nonce', true ) !== $_REQUEST['_llms_cert_auth'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -17,9 +17,10 @@ class LLMS_Controller_Certificates {
 	/**
 	 * Constructor
 	 *
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 * @since [version] Add filter hook for `lifterlms_register_post_type_llms_certificate`.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -99,7 +99,7 @@ class LLMS_Controller_Certificates {
 	 * @since 3.18.0
 	 * @since 3.35.0 Sanitize `$_POST` data.
 	 *
-	 * @return   void
+	 * @return void
 	 */
 	public function maybe_handle_reporting_actions() {
 
@@ -117,12 +117,12 @@ class LLMS_Controller_Certificates {
 	}
 
 	/**
-	 * Delete a cert
+	 * Delete a certificate
 	 *
-	 * @param    int $cert_id  WP Post ID of the llms_my_certificate
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 *
+	 * @param int $cert_id WP Post ID of the llms_my_certificate
+	 * @return void
 	 */
 	private function delete( $cert_id ) {
 
@@ -136,12 +136,14 @@ class LLMS_Controller_Certificates {
 	}
 
 	/**
-	 * Generates an HTML export of the certificate from the "Download" button
-	 * on the View Certificate front end & on reporting backend for admins
+	 * Download a Certificate.
 	 *
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * Generates an HTML export of the certificate from the "Download" button
+	 * on the View Certificate front end & on reporting backend for admins.
+	 *
+	 * @since 3.18.0
+	 *
+	 * @return void
 	 */
 	private function download( $cert_id ) {
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.18.0
  * @since 3.35.0 Sanitize `$_POST` data.
  * @since [version] Modify `llms_certificate` post type registration to allow certificate templates to be exported.
+ *                When exporting a certificate template, use the `post_author` for the certificate's WP User ID.
  */
 class LLMS_Controller_Certificates {
 
@@ -60,12 +61,15 @@ class LLMS_Controller_Certificates {
 	}
 
 	/**
-	 * Utilizes a nonce to display a certificate
+	 * Allow cURL requests to view a certificate to be authenticated via a nonce.
+	 *
 	 * cURL request is used to scrape the HTML and this will authenticate the scrape
 	 *
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.24.0
+	 * @since 3.18.0
+	 * @since 3.24.0 Unknown.
+	 * @since [version] Use the `post_author` as the WP_User ID when exporting a certificate template.
+	 *
+	 * @return void
 	 */
 	public function maybe_authenticate_export_generation() {
 
@@ -73,8 +77,9 @@ class LLMS_Controller_Certificates {
 			return;
 		}
 
-		$post_id = get_the_ID();
-		if ( ! in_array( get_post_type( $post_id ), array( 'llms_my_certificate', 'llms_certificate' ) ) ) {
+		$post_id   = get_the_ID();
+		$post_type = get_post_type( $post_id );
+		if ( ! in_array( $post_type, array( 'llms_my_certificate', 'llms_certificate' ), true ) ) {
 			return;
 		}
 
@@ -83,7 +88,8 @@ class LLMS_Controller_Certificates {
 		}
 
 		$cert = new LLMS_User_Certificate( $post_id );
-		wp_set_current_user( $cert->get_user_id() );
+		$uid  = ( 'llms_certificate' === $post_type ) ? get_post_field( 'post_author', $post_id ) : $cert->get_user_id();
+		wp_set_current_user( $uid );
 
 	}
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -44,16 +44,15 @@ class LLMS_Controller_Certificates {
 	 */
 	public function maybe_allow_public_query( $post_type_args ) {
 
-		if ( ! empty( $_REQUEST['_llms_cert_auth'] ) ) {
+		if ( ! empty( $_REQUEST['_llms_cert_auth'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 			$auth = llms_filter_input( INPUT_GET, '_llms_cert_auth', FILTER_SANITIZE_STRING );
 
 			global $wpdb;
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_llms_auth_nonce' AND meta_value = %s", $auth ) );
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_llms_auth_nonce' AND meta_value = %s", $auth ) ); // db call ok; no-cache ok
 			if ( $post_id && 'llms_certificate' === get_post_type( $post_id ) ) {
 				$post_type_args['publicly_queryable'] = true;
 			}
-
 		}
 
 		return $post_type_args;

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -11,7 +11,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.18.0
  * @since 3.35.0 Sanitize `$_POST` data.
  * @since [version] Modify `llms_certificate` post type registration to allow certificate templates to be exported.
- *                When exporting a certificate template, use the `post_author` for the certificate's WP User ID.
+ *               When exporting a certificate template, use the `post_author` for the certificate's WP User ID.
  */
 class LLMS_Controller_Certificates {
 

--- a/tests/framework/class-llms-unit-test-case.php
+++ b/tests/framework/class-llms-unit-test-case.php
@@ -4,6 +4,7 @@
  *
  * @since 3.3.1
  * @since 3.33.0 Marked `setup_get()` and `setup_post()` as deprecated and removed private `setup_request()`. Use methods from lifterlms/lifterlms_tests.
+ * @since [version] Add certificate template mock generation and earning methods.
  */
 class LLMS_UnitTestCase extends LLMS_Unit_Test_Case {
 
@@ -361,4 +362,60 @@ class LLMS_UnitTestCase extends LLMS_Unit_Test_Case {
 		return llms_get_student( $student_id );
 	}
 
+
+	/**
+	 * Create a certificate template post.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $title Certificate title.
+	 * @param string $content Certificate content.
+	 * @param string $image Certificate background image path.
+	 * @return int
+	 */
+	protected function create_certificate_template( $title = 'Mock Certificate Title', $content = '', $image = '' ) {
+
+		$template = $this->factory->post->create( array(
+			'post_type' => 'llms_certificate',
+			'post_content' => $content ? $content : '{site_title}, {current_date}',
+		) );
+		update_post_meta( $template, '_llms_certificate_title', $title );
+		update_post_meta( $template, '_llms_certificate_image', $image );
+
+		return $template;
+
+	}
+
+	/**
+	 * Earn a certificate for a user.
+	 *
+	 * @since 3.37.3
+	 * @since [version] Moved to `LLMS_UnitTestCase`.
+	 *
+	 * @param int $user WP_User ID.
+	 * @param int $template WP_Post ID of the `llms_certificate` template.
+	 * @param int $related WP_Post ID of the related post.
+	 * @return int[] {
+	 *     Indexed array containing information about the earned certificate.
+	 *     int $0 WP_User ID
+	 *     int $1 WP_Post ID of the earned cert (`llms_my_certificate`)
+	 *     int $2 WP_Post ID of the related post.
+	 * }
+	 */
+	protected function earn_certificate( $user, $template, $related ) {
+
+		global $llms_user_earned_certs;
+		$llms_user_earned_certs = array();
+
+		// Watch for generation so we can compare against it later.
+		add_action( 'llms_user_earned_certificate', function( $user_id, $cert_id, $related_id ) {
+			global $llms_user_earned_certs;
+			$llms_user_earned_certs[] = array( $user_id, $cert_id, $related_id );
+		}, 10, 3 );
+
+		LLMS()->certificates()->trigger_engagement( $user, $template, $related );
+
+		return array_shift( $llms_user_earned_certs );
+
+	}
 }

--- a/tests/unit-tests/class-llms-test-certificates.php
+++ b/tests/unit-tests/class-llms-test-certificates.php
@@ -7,58 +7,22 @@
  * @group certificates
  *
  * @since 3.37.3
- * @version 3.37.3
+ * @version [version]
  */
-class LLMS_Test_Certificates extends LLMS_Unit_Test_Case {
-
-	/**
-	 * Create a certificate template post.
-	 *
-	 * @since 3.37.3
-	 *
-	 * @return int
-	 */
-	private function create_template() {
-
-		$template = $this->factory->post->create( array(
-			'post_type' => 'llms_certificate',
-			'post_content' => '{site_title}, {current_date}',
-		) );
-		update_post_meta( $template, '_llms_certificate_title', 'Mock Certificate Title' );
-		update_post_meta( $template, '_llms_certificate_image', '' );
-
-		return $template;
-
-	}
-
-	private function earn_certificate( $user, $template, $related ) {
-
-		global $llms_user_earned_certs;
-		$llms_user_earned_certs = array();
-
-		// Watch for generation so we can compare against it later.
-		add_action( 'llms_user_earned_certificate', function( $user_id, $cert_id, $related_id ) {
-			global $llms_user_earned_certs;
-			$llms_user_earned_certs[] = array( $user_id, $cert_id, $related_id );
-		}, 10, 3 );
-
-		LLMS()->certificates()->trigger_engagement( $user, $template, $related );
-
-		return array_shift( $llms_user_earned_certs );
-
-	}
+class LLMS_Test_Certificates extends LLMS_UnitTestCase {
 
 	/**
 	 * Test trigger_engagement() method.
 	 *
 	 * @since 3.37.3
+	 * @since [version] Use `$this->create_certificate_template()` from test case base.
 	 *
 	 * @return void
 	 */
 	public function test_trigger_engagement() {
 
 		$user = $this->factory->user->create();
-		$template = $this->create_template();
+		$template = $this->create_certificate_template();
 		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
 
 		$earned = $this->earn_certificate( $user, $template, $related );
@@ -75,13 +39,14 @@ class LLMS_Test_Certificates extends LLMS_Unit_Test_Case {
 	 * Retrieve a certificate export, bypassing the cache.
 	 *
 	 * @since 3.37.3
+	 * @since [version] Use `$this->create_certificate_template()` from test case base.
 	 *
 	 * @return void
 	 */
 	public function test_get_export_no_cache() {
 
 		$user = $this->factory->user->create();
-		$template = $this->create_template();
+		$template = $this->create_certificate_template();
 		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
 
 		$earned = $this->earn_certificate( $user, $template, $related );
@@ -98,13 +63,14 @@ class LLMS_Test_Certificates extends LLMS_Unit_Test_Case {
 	 * Retrieve a certificate export using caching.
 	 *
 	 * @since 3.37.3
+	 * @since [version] Use `$this->create_certificate_template()` from test case base.
 	 *
 	 * @return void
 	 */
 	public function test_get_export_with_cache() {
 
 		$user = $this->factory->user->create();
-		$template = $this->create_template();
+		$template = $this->create_certificate_template();
 		$related = $this->factory->post->create( array( 'post_type' => 'course' ) );
 
 		$earned = $this->earn_certificate( $user, $template, $related );

--- a/tests/unit-tests/controllers/class-llms-test-controller-certificates.php
+++ b/tests/unit-tests/controllers/class-llms-test-controller-certificates.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Test LLMS_Controller_Certificates
+ *
+ * @package LifterLMS/Tests/Controllers
+ *
+ * @group controllers
+ * @group certificates
+ * @group controller_certificates
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Controller_Certificates extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->instance = new LLMS_Controller_Certificates();
+
+	}
+
+	/**
+	 * Test maybe_allow_public_query(): no authorization data in query string.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_allow_public_query_no_auth() {
+		$this->assertEquals( array(), $this->instance->maybe_allow_public_query( array() ) );
+	}
+
+	/**
+	 * Test maybe_allow_public_query(): authorization present but invalid.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_allow_public_query_invalid_auth() {
+
+		// Doesn't exist.
+		$args = array(
+			'publicly_queryable' => false,
+		);
+
+		$this->mockGetRequest( array(
+			'_llms_cert_auth' => 'fake',
+		) );
+
+		$this->assertEquals( $args, $this->instance->maybe_allow_public_query( $args ) );
+
+		// Post exists but submitted nocne is incorrect.
+		$post_id = $this->factory->post->create( array( 'post_type' => 'llms_certificate' ) );
+		update_post_meta( $post_id, '_llms_auth_nonce', 'mock-nonce' );
+
+		$this->mockGetRequest( array(
+			'_llms_cert_auth' => 'incorrect-nonce',
+		) );
+		$this->assertEquals( $args, $this->instance->maybe_allow_public_query( $args ) );
+
+	}
+
+	/**
+	 * Test maybe_allow_public_query(): authorization present and exists but on an invalid post type.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_allow_public_query_invalid_post_type() {
+
+		$post_id = $this->factory->post->create();
+		update_post_meta( $post_id, '_llms_auth_nonce', 'mock-nonce' );
+
+		$this->mockGetRequest( array(
+			'_llms_cert_auth' => 'mock-nonce',
+		) );
+
+		$args = array(
+			'publicly_queryable' => false,
+		);
+
+		$this->assertEquals( $args, $this->instance->maybe_allow_public_query( $args ) );
+
+	}
+
+	/**
+	 * Test maybe_allow_public_query(): valid auth and post type.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_allow_public_query_update() {
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'llms_certificate' ) );
+		update_post_meta( $post_id, '_llms_auth_nonce', 'mock-nonce' );
+
+		$this->mockGetRequest( array(
+			'_llms_cert_auth' => 'mock-nonce',
+		) );
+
+		$args = array(
+			'publicly_queryable' => false,
+		);
+		$expect = array(
+			'publicly_queryable' => true,
+		);
+
+		$this->assertEquals( $expect, $this->instance->maybe_allow_public_query( $args ) );
+
+	}
+
+}


### PR DESCRIPTION
## Description

Fixes bug preventing certificate __templates__ from being exported when viewing the template as an admin.

Fixes #776 

## How has this been tested?

+ Manual testing
+ Added new unit tests to test new code

## Types of changes

Fixes bug, no breaking changes.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

