### PR TITLE
LLMS_Session: add default value param to the the `get()` method

### DIFF
--- a/includes/class.llms.session.php
+++ b/includes/class.llms.session.php
@@ -21,7 +21,7 @@ class LLMS_Session {
 	/**
 	 * Session data
 	 *
-	 * @var array
+	 * @var array|WP_Session
 	 */
 	private $session;
 
@@ -84,7 +84,7 @@ class LLMS_Session {
 	 *
 	 * @since ??
 	 *
-	 * @return void
+	 * @return array|WP_Session
 	 */
 	public function init() {
 
@@ -117,7 +117,7 @@ class LLMS_Session {
 	 *
 	 * @param string $key     The key of the session variable.
 	 * @param mixed  $default Optional. The default value to return if no session variable is found with the provided key. Default `false`.
-	 * @return string
+	 * @return mixed
 	 */
 	public function get( $key, $default = false ) {
 		$key = sanitize_key( $key );
@@ -131,7 +131,7 @@ class LLMS_Session {
 	 *
 	 * @param string $key   The key of the session variable.
 	 * @param string $value The value of the session variable.
-	 * @return string
+	 * @return mixed
 	 */
 	public function set( $key, $value ) {
 
@@ -215,7 +215,7 @@ class LLMS_Session {
 	 * @since 1.0.0
 	 *
 	 * @param string $key The key of the session variable.
-	 * @return string
+	 * @return mixed
 	 */
 	public function __get( $key ) {
 		return $this->get( $key );
@@ -240,7 +240,7 @@ class LLMS_Session {
 	 * @since 1.0.0
 	 *
 	 * @param string $key The key of the session variable.
-	 * @return void
+	 * @return bool
 	 */
 	public function __isset( $key ) {
 		return isset( $this->session[ sanitize_title( $key ) ] );

--- a/includes/class.llms.session.php
+++ b/includes/class.llms.session.php
@@ -1,21 +1,27 @@
 <?php
 /**
- * LLMS_Session Class
+ * LLMS_Session.
  *
- * @since    1.0.0
- * @version  3.7.7
+ * @since 1.0.0
+ * @version [version]
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Session class.
+ *
+ * @since 1.0.0
+ * @since 3.7.7 Unknown.
+ * @since [version] Added a second parameter to the `get()` method, that represents the default value
+ *               to return if the session variable requested doesn't exist.
+ */
 class LLMS_Session {
 
 	/**
 	 * Session data
 	 *
 	 * @var array
-	 * @access private
 	 */
 	private $session;
 
@@ -23,7 +29,6 @@ class LLMS_Session {
 	 * Use php session
 	 *
 	 * @var bool
-	 * @access private
 	 */
 	private $use_php_sessions = false;
 
@@ -31,15 +36,16 @@ class LLMS_Session {
 	 * Session prefix
 	 *
 	 * @var string
-	 * @access private
 	 */
 	private $prefix = '';
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
-	 * @since    1.0.0
-	 * @version  3.7.5
+	 * @since 1.0.0
+	 * @since 3.7.5 Unkwnown.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -53,7 +59,7 @@ class LLMS_Session {
 
 			}
 
-			// Use PHP SESSION (must be enabled via the LLMS_USE_PHP_SESSIONS constant)
+			// Use PHP SESSION (must be enabled via the LLMS_USE_PHP_SESSIONS constant).
 			add_action( 'init', array( $this, 'maybe_start_session' ), -2 );
 
 		} else {
@@ -74,9 +80,10 @@ class LLMS_Session {
 	}
 
 	/**
-	 * Setup the WP_Session instance
+	 * Setup the WP_Session instance.
 	 *
-	 * @access public
+	 * @since ??
+	 *
 	 * @return void
 	 */
 	public function init() {
@@ -91,32 +98,39 @@ class LLMS_Session {
 	}
 
 	/**
-	 * Retrieve session ID
+	 * Retrieve session ID.
 	 *
-	 * @access public
-	 * @return string Session ID
+	 * @since ??
+	 *
+	 * @return string Session ID.
 	 */
 	public function get_id() {
 		return $this->session->session_id;
 	}
 
 	/**
-	 * Retrieve a session variable
+	 * Retrieve a session variable.
 	 *
-	 * @access public
-	 * @param string $key
+	 * @since 1.0.0
+	 * @since [version] Added the `$default` parameter that represents the default value
+	 *               to return if the session variable requested doesn't exist.
+	 *
+	 * @param string $key     The key of the session variable.
+	 * @param mixed  $default Optional. The default value to return if no session variable is found with the provided key. Default `false`.
 	 * @return string
 	 */
-	public function get( $key ) {
+	public function get( $key, $default = false ) {
 		$key = sanitize_key( $key );
-		return isset( $this->session[ $key ] ) ? maybe_unserialize( $this->session[ $key ] ) : false;
+		return isset( $this->session[ $key ] ) ? maybe_unserialize( $this->session[ $key ] ) : $default;
 	}
 
 	/**
-	 * Set a session variable
+	 * Set a session variable.
 	 *
-	 * @param string $key
-	 * @param string $value
+	 * @since 1.0.0
+	 *
+	 * @param string $key   The key of the session variable.
+	 * @param string $value The value of the session variable.
 	 * @return string
 	 */
 	public function set( $key, $value ) {
@@ -138,10 +152,11 @@ class LLMS_Session {
 	}
 
 	/**
-	 * Force the cookie expiration variant time to 23 hours
+	 * Force the cookie expiration variant time to 23 hours.
 	 *
-	 * @access public
-	 * @param int $exp Default expiration (1 hour)
+	 * @since ??
+	 *
+	 * @param int $exp Default expiration (1 hour).
 	 * @return int
 	 */
 	public function set_expiration_variant_time( $exp ) {
@@ -149,10 +164,11 @@ class LLMS_Session {
 	}
 
 	/**
-	 * Force the cookie expiration time to 24 hours
+	 * Force the cookie expiration time to 24 hours.
 	 *
-	 * @access public
-	 * @param int $exp Default expiration (1 hour)
+	 * @since ??
+	 *
+	 * @param int $exp Default expiration (1 hour).
 	 * @return int
 	 */
 	public function set_expiration_time( $exp ) {
@@ -160,7 +176,9 @@ class LLMS_Session {
 	}
 
 	/**
-	 * Determine should we use php session or wp
+	 * Determine should we use php session or wp.
+	 *
+	 * @since ??
 	 *
 	 * @return bool
 	 */
@@ -179,6 +197,10 @@ class LLMS_Session {
 
 	/**
 	 * Starts a new session if one hasn't started yet.
+	 *
+	 * @since ??
+	 *
+	 * @return void
 	 */
 	public function maybe_start_session() {
 
@@ -188,9 +210,11 @@ class LLMS_Session {
 	}
 
 	/**
-	 * __get function
+	 * __get function.
 	 *
-	 * @param string $key
+	 * @since 1.0.0
+	 *
+	 * @param string $key The key of the session variable.
 	 * @return string
 	 */
 	public function __get( $key ) {
@@ -198,10 +222,12 @@ class LLMS_Session {
 	}
 
 	/**
-	 * __set function
+	 * __set function.
 	 *
-	 * @param string $key
-	 * @param string $value
+	 * @since 1.0.0
+	 *
+	 * @param string $key   The key of the session variable.
+	 * @param string $value The value of the session variable.
 	 * @return void
 	 */
 	public function __set( $key, $value ) {
@@ -209,9 +235,11 @@ class LLMS_Session {
 	}
 
 	/**
-	 * __isset function
+	 * __isset function.
 	 *
-	 * @param string $key
+	 * @since 1.0.0
+	 *
+	 * @param string $key The key of the session variable.
 	 * @return void
 	 */
 	public function __isset( $key ) {
@@ -219,9 +247,11 @@ class LLMS_Session {
 	}
 
 	/**
-	 * __unset function
+	 * __unset function.
 	 *
-	 * @param string $key
+	 * @since 1.0.0
+	 *
+	 * @param string $key The key of the session variable.
 	 * @return void
 	 */
 	public function __unset( $key ) {


### PR DESCRIPTION
also fix docs/cs

## Description
Fixes #1005 

## How has this been tested?
Existing unit tests and manually

## Types of changes
 Bug fix (non-breaking change which fixes an issue

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

