### PR TITLE
Delete orphaned quizzes and automatically delete quiz attempts during quiz deletion

### DIFF
--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -119,7 +119,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 				<i class="fa fa-trash" aria-hidden="true"></i>
 			</button>
 
-			<input type="hidden" name="_llms_quiz_actions_nonce" value="<?php wp_create_nonce( 'llms-quiz-actions' ); ?>">
+			<input type="hidden" name="_llms_quiz_actions_nonce" value="<?php echo wp_create_nonce( 'llms-quiz-actions' ); ?>">
 
 		</form>
 

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -158,7 +158,6 @@ class LLMS_Post_Relationships {
 	 *
 	 * @return array
 	 */
-	 */
 	private function get_relationships() {
 		return apply_filters( 'llms_get_post_relationships', $this->relationships );
 	}

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -27,13 +27,13 @@ class LLMS_Post_Relationships {
 		'lesson'     => array(
 			array(
 				'action'               => 'unset',
-				'meta_key'             => '_llms_prerequisite',
+				'meta_key'             => '_llms_prerequisite', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_keys_additional' => array( '_llms_has_prerequisite' ),
 				'post_type'            => 'lesson',
 			),
 			array(
 				'action'    => 'unset',
-				'meta_key'  => '_llms_lesson_id',
+				'meta_key'  => '_llms_lesson_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'post_type' => 'llms_quiz',
 			),
 		),
@@ -41,7 +41,7 @@ class LLMS_Post_Relationships {
 		'llms_order' => array(
 			array(
 				'action'    => 'delete',
-				'meta_key'  => '_llms_order_id',
+				'meta_key'  => '_llms_order_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'post_type' => 'llms_transaction',
 			),
 		),
@@ -49,12 +49,12 @@ class LLMS_Post_Relationships {
 		'llms_quiz'  => array(
 			array(
 				'action'    => 'delete', // delete = force delete; trash = move to trash
-				'meta_key'  => '_llms_parent_id',
+				'meta_key'  => '_llms_parent_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'post_type' => 'llms_question',
 			),
 			array(
 				'action'               => 'unset',
-				'meta_key'             => '_llms_quiz',
+				'meta_key'             => '_llms_quiz', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_keys_additional' => array( '_llms_quiz_enabled' ),
 				'post_type'            => 'lesson',
 			),
@@ -79,9 +79,9 @@ class LLMS_Post_Relationships {
 	 * @since 3.16.12
 	 * @since [version] Allow for deletion of related items outside the WP core posts table.
 	 *
-	 * @param    obj   $post  WP Post that's been deleted
-	 * @param    array $data  relationship data array
-	 * @return   void
+	 * @param obj   $post WP Post that's been deleted.
+	 * @param array $data Relationship data array.
+	 * @return void
 	 */
 	private function delete_relationships( $post, $data ) {
 
@@ -102,14 +102,14 @@ class LLMS_Post_Relationships {
 	 *
 	 * @since  [version]
 	 *
-	 * @param    obj   $post  WP Post that's been deleted.
-	 * @param    array $data  relationship data array.
-	 * @return   void
+	 * @param obj   $post WP Post that's been deleted.
+	 * @param array $data Relationship data array.
+	 * @return void
 	 */
 	private function delete_table_records( $post, $data ) {
 
 		global $wpdb;
-		$wpdb->delete(
+		$wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prefix . $data['table_name'],
 			array(
 				$data['table_key'] => $post->ID,
@@ -124,9 +124,9 @@ class LLMS_Post_Relationships {
 	 *
 	 * @since [version]
 	 *
-	 * @param    obj   $post  WP Post that's been deleted.
-	 * @param    array $data  relationship data array.
-	 * @return   void
+	 * @param obj   $post WP Post that's been deleted.
+	 * @param array $data Relationship data array.
+	 * @return void
 	 */
 	private function delete_wp_posts( $post, $data ) {
 
@@ -143,9 +143,9 @@ class LLMS_Post_Relationships {
 	/**
 	 * Get a list of post types with relationships that should be checked
 	 *
-	 * @return   array
-	 * @since    3.16.12
-	 * @version  3.16.12
+	 * @since 3.16.12
+	 *
+	 * @return array
 	 */
 	private function get_post_types() {
 		return array_keys( $this->get_relationships() );
@@ -154,9 +154,10 @@ class LLMS_Post_Relationships {
 	/**
 	 * Retrieve filtered LifterLMS post relationships array
 	 *
-	 * @return   array
-	 * @since    3.16.12
-	 * @version  3.16.12
+	 * @since 3.16.12
+	 *
+	 * @return array
+	 */
 	 */
 	private function get_relationships() {
 		return apply_filters( 'llms_get_post_relationships', $this->relationships );
@@ -165,17 +166,17 @@ class LLMS_Post_Relationships {
 	/**
 	 * Retrieve an array of post ids related to the deleted post by post type and meta key
 	 *
-	 * @param    int    $post_id    WP Post ID of the deleted post
-	 * @param    string $post_type  WP Post type of the related post(s)
-	 * @param    string $meta_key   meta_key to check for relations by
-	 * @return   array
-	 * @since    3.16.12
-	 * @version  3.16.12
+	 * @since 3.16.12
+	 *
+	 * @param int    $post_id   WP Post ID of the deleted post.
+	 * @param string $post_type WP Post type of the related post(s).
+	 * @param string $meta_key  meta_key to check for relations by.
+	 * @return array
 	 */
 	private function get_related_posts( $post_id, $post_type, $meta_key ) {
 
 		global $wpdb;
-		return $wpdb->get_col(
+		return $wpdb->get_col(  // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT p.ID
 			 FROM {$wpdb->posts} AS p
@@ -197,15 +198,15 @@ class LLMS_Post_Relationships {
 	 * Called on `delete_post` hook (before a post is deleted)
 	 *
 	 * @since 3.16.12
-	 * @since 3.24.0
+	 * @since 3.24.0 Unknown.
 	 *
-	 * @param    int $post_id  WP Post ID of the deleted post
-	 * @return   void
+	 * @param int $post_id  WP Post ID of the deleted post.
+	 * @return void
 	 */
 	public function maybe_update_relationships( $post_id ) {
 
 		$post = get_post( $post_id );
-		if ( ! in_array( $post->post_type, $this->get_post_types() ) ) {
+		if ( ! in_array( $post->post_type, $this->get_post_types(), true ) ) {
 			return;
 		}
 
@@ -217,7 +218,7 @@ class LLMS_Post_Relationships {
 
 			foreach ( $relationships as $data ) {
 
-				if ( in_array( $data['action'], array( 'delete', 'trash' ) ) ) {
+				if ( in_array( $data['action'], array( 'delete', 'trash' ), true ) ) {
 
 					$this->delete_relationships( $post, $data );
 
@@ -234,11 +235,12 @@ class LLMS_Post_Relationships {
 	/**
 	 * Unsets relationship data from post_meta when a post is deleted
 	 *
-	 * @param    obj   $post  WP Post that's been deleted
-	 * @param    array $data  relationship data array
-	 * @return   void
-	 * @since    3.16.12
-	 * @version  3.24.0
+	 * @since 3.16.12
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param obj   $post WP Post that's been deleted.
+	 * @param array $data Relationship data array.
+	 * @return void
 	 */
 	private function unset_relationships( $post, $data ) {
 

--- a/includes/controllers/class.llms.controller.quizzes.php
+++ b/includes/controllers/class.llms.controller.quizzes.php
@@ -2,27 +2,71 @@
 /**
  * Quiz related con
  *
- * @since   3.9.0
- * @version 3.9.0
+ * @since 3.9.0
+ * @version [version]
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Controller_Quizzes class
+ *
+ * @since 3.9.0
+ * @since [version] Add admin reporting actions handler.
+ */
 class LLMS_Controller_Quizzes {
 
+	/**
+	 * Constructor
+	 *
+	 * @since 3.9.0
+	 * @since [version] Add reporting actions handler action.
+	 *
+	 * @return void
+	 */
 	public function __construct() {
 
 		add_action( 'init', array( $this, 'take_quiz' ) );
+		add_action( 'admin_init', array( $this, 'maybe_handle_reporting_actions' ) );
+
+	}
+
+	/**
+	 * Handle quiz reporting screen actions buttons
+	 *
+	 * On the quiz reporting screen this allows orphaned quizzes to be deleted.
+	 *
+	 * @since [version]
+	 *
+	 * @return null|false|WP_Post `null` if the form wasn't submitted or the nonce couldn't be verified.
+	 *                            `false` if an error was encountered.
+	 *                            `WP_Post` of the deleted quiz on success.
+	 */
+	public function maybe_handle_reporting_actions() {
+
+		if ( ! llms_verify_nonce( '_llms_quiz_actions_nonce', 'llms-quiz-actions' ) ) {
+			return null;
+		}
+
+		$id = llms_filter_input( INPUT_POST, 'llms_del_quiz', FILTER_SANITIZE_NUMBER_INT );
+		if ( $id && 'llms_quiz' === get_post_type( $id ) ) {
+			$quiz = llms_get_post( $id );
+			if ( $quiz && ( $quiz->is_orphan() || ! $quiz->get_course() ) ) {
+				return wp_delete_post( $id, true );
+			}
+		}
+
+		return false;
 
 	}
 
 	/**
 	 * Handle form submission of the "take quiz" button attached to lessons with quizzes
 	 *
-	 * @return  void
-	 * @since   1.0.0
-	 * @version 3.9.0
+	 * @since 1.0.0
+	 * @since 3.9.0 Unkown.
+	 *
+	 * @return void
 	 */
 	public function take_quiz() {
 

--- a/tests/phpunit/framework/class-llms-unit-test-case.php
+++ b/tests/phpunit/framework/class-llms-unit-test-case.php
@@ -5,6 +5,7 @@
  * @since 3.3.1
  * @since 3.33.0 Marked `setup_get()` and `setup_post()` as deprecated and removed private `setup_request()`. Use methods from lifterlms/lifterlms_tests.
  * @since 3.37.4 Add certificate template mock generation and earning methods.
+ * @since [version] Changed return of `take_quiz` method from `void` to an `LLMS_Quiz_Attempt` object
  */
 class LLMS_UnitTestCase extends LLMS_Unit_Test_Case {
 
@@ -108,15 +109,16 @@ class LLMS_UnitTestCase extends LLMS_Unit_Test_Case {
 
 	/**
 	 * Take a quiz for a student and get a desired grade
-	 * @param    int        $quiz_id     WP Post ID of the Quiz
-	 * @param    int        $student_id  WP Used ID of the student
-	 * @param    int        $grade       desired grade
-	 *                                   do the math in the test, this can't make the grade happen if it's not possible
-	 *                                   EG: a quiz with 5 questions CANNOT get a 75%!
 	 *
-	 * @return   void
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 * @since [version] Change return from `void` to an `LLMS_Quiz_Attempt` object
+	 *
+	 * @param int $quiz_id    WP Post ID of the Quiz.
+	 * @param int $student_id WP Used ID of the student.
+	 * @param int $grade      Desired grade. Do the math in the test, this can't make the grade happen if it's not possible
+	 *                        for example a quiz with 5 questions CANNOT get a 75%!
+	 *
+	 * @return LLMS_Quiz_Attempt
 	 */
 	public function take_quiz( $quiz_id, $student_id, $grade = 100 ) {
 
@@ -164,6 +166,8 @@ class LLMS_UnitTestCase extends LLMS_Unit_Test_Case {
 		}
 
 		$attempt->end();
+
+		return $attempt;
 
 	}
 

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-conroller-quizzes.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-conroller-quizzes.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Test LLMS_Controller_Quizzes
+ *
+ * @package LifterLMS/Tests/Controllers
+ *
+ * @group controllers
+ * @group quizzes
+ * @group controller_quizzes
+ *
+ * @since [version]
+ */
+class LLMS_Test_Controller_Quizzes extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->controller = new LLMS_Controller_Quizzes();
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions(): form not submitted
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_not_submitted() {
+
+		$this->assertNull( $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions(): invalid nonce
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_invalid_nonce() {
+
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => 'fake',
+		) );
+
+		$this->assertNull( $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions(): there's no quiz id passed via to the button form element.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_no_button() {
+
+		// Button not set.
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+		) );
+
+		$this->assertFalse( $this->controller->maybe_handle_reporting_actions() );
+
+		// Button empty
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+			'llms_del_quiz' => '',
+		) );
+
+		$this->assertFalse( $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions(): submitted WP Post ID isn't a quiz id.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_not_a_quiz() {
+
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+			'llms_del_quiz' => $this->factory->post->create(),
+		) );
+
+		$this->assertFalse( $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions(): the quiz isn't an orphan.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_not_an_orphan() {
+
+		$courses = $this->generate_mock_courses( 1, 1, 1, 1, 1 );
+		$lesson  = llms_get_post( llms_get_post( $courses[0] )->get_lessons( 'ids' )[0] );
+		$quiz    = $lesson->get_quiz();
+
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+			'llms_del_quiz' => $quiz->get( 'id' ),
+		) );
+
+		$this->assertFalse( $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions() success: the quiz is an orphan and can be deleted.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_is_orphan() {
+
+		$quiz = $this->factory->post->create_and_get( array( 'post_type' => 'llms_quiz' ) );
+
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+			'llms_del_quiz' => $quiz->ID,
+		) );
+
+		$this->assertEquals( $quiz, $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+	/**
+	 * Test maybe_handle_reporting_actions() success: the quiz's parent course doesn't exist anymore and the quiz can be deleted.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_handle_reporting_actions_no_course() {
+
+		$courses = $this->generate_mock_courses( 1, 1, 1, 1, 1 );
+		$lesson  = llms_get_post( llms_get_post( $courses[0] )->get_lessons( 'ids' )[0] );
+		$quiz    = $lesson->get_quiz();
+
+		$this->mockPostRequest( array(
+			'_llms_quiz_actions_nonce' => wp_create_nonce( 'llms-quiz-actions' ),
+			'llms_del_quiz' => $quiz->get( 'id' ),
+		) );
+
+		// Now it's attached to an orphaned lesson, we should still be able to delete it.
+		$lesson->set( 'parent_course', '' );
+
+		$this->assertEquals( $quiz->post, $this->controller->maybe_handle_reporting_actions() );
+
+	}
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
## Description

Since quizzes can only be deleted on the admin panel from within the course builder an "Orphaned" quiz (a quiz with no parent lesson or no parent course) cannot be deleted without attaching it to a lesson first.

This PR adds functionality to allow admins to delete an orphaned quiz (and only orphaned quizzes) from the quizzes reporting screen.

While this *semantically* doesn't belong on the reporting screen there's no better place to add this functionality in the current UI provided by LifterLMS. We could alternatively enable the WP Posts table for the quiz post type but that would add a whole new area ripe with potential confusion.

We've already received support requests from users who expect to be able to delete from the reporting screen and we have existing conventions to delete items like engagements (certs and achievements) from their respective reporting screens.

Fixes #488 

This additionally adds automatic deletion of all student quiz attempts when a quiz is deleted.

## How has this been tested?

Manually tested the UI and ensured the intended actions occur as a result.

New PHP tests have been added


## Screenshots <!-- if applicable -->

![Screenshot_2020-01-20_15-16-26](https://user-images.githubusercontent.com/1290739/72763260-e23d7380-3b97-11ea-81ab-ddd68b46159a.png)

## Types of changes

Bug fix, new features, no breaking changes.


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

