### PR TITLE
Updates for WP Privacy integration

### DIFF
--- a/includes/privacy/class-llms-privacy-exporters.php
+++ b/includes/privacy/class-llms-privacy-exporters.php
@@ -22,7 +22,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    string $email_address  email address of the user to retrieve data for
 	 * @param    int    $page           process page number
 	 * @return   array
-	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	public static function achievement_data( $email_address, $page ) {
@@ -63,6 +63,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    int    $page           process page number
 	 * @return   array
 	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	public static function certificate_data( $email_address, $page ) {
@@ -384,6 +385,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    string $post_type      name of the post type
 	 * @return   array
 	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	private static function enrollment_data( $email_address, $page, $post_type ) {
@@ -492,6 +494,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    int    $page           process page number
 	 * @return   array
 	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	public static function order_data( $email_address, $page ) {
@@ -530,6 +533,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    int    $page           process page number
 	 * @return   [type]
 	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	public static function student_data( $email_address, $page ) {
@@ -560,6 +564,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	 * @param    int    $page           process page number
 	 * @return   array
 	 * @since    3.18.0
+	 * @since    3.37.8 Added `$group_description` to the group exporter.
 	 * @version  3.18.0
 	 */
 	public static function quiz_data( $email_address, $page ) {

--- a/includes/privacy/class-llms-privacy-exporters.php
+++ b/includes/privacy/class-llms-privacy-exporters.php
@@ -576,7 +576,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 		if ( $query->has_results() ) {
 
 			$group_label        = __( 'Quiz Attempts', 'lifterlms' );
-			$group_descriptions = __( 'Student quiz attempts data', 'lifterlms' );
+			$group_descriptions = __( 'Student quiz attempt data', 'lifterlms' );
 			foreach ( $query->get_attempts() as $attempt ) {
 
 				$data[] = array(

--- a/includes/privacy/class-llms-privacy-exporters.php
+++ b/includes/privacy/class-llms-privacy-exporters.php
@@ -37,14 +37,16 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 		$achievements = self::get_student_achievements( $student );
 		if ( $achievements ) {
 
-			$group_label = __( 'Achievements', 'lifterlms' );
+			$group_label       = __( 'Achievements', 'lifterlms' );
+			$group_description = __( 'Student achievement data.', 'lifterlms' );
 			foreach ( $achievements as $achievement ) {
 
 				$data[] = array(
-					'group_id'    => 'lifterlms_achievements',
-					'group_label' => $group_label,
-					'item_id'     => sprintf( 'achievement-%d', $achievement->get( 'id' ) ),
-					'data'        => self::get_achievement_data( $achievement ),
+					'group_id'          => 'lifterlms_achievements',
+					'group_label'       => $group_label,
+					'group_description' => $group_description,
+					'item_id'           => sprintf( 'achievement-%d', $achievement->get( 'id' ) ),
+					'data'              => self::get_achievement_data( $achievement ),
 				);
 
 			}
@@ -75,14 +77,16 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 		$certs = self::get_student_certificates( $student );
 		if ( $certs ) {
 
-			$group_label = __( 'Certificates', 'lifterlms' );
+			$group_label       = __( 'Certificates', 'lifterlms' );
+			$group_description = __( 'Student certificate data.', 'lifterlms' );
 			foreach ( $certs as $cert ) {
 
 				$data[] = array(
-					'group_id'    => 'lifterlms_certificates',
-					'group_label' => $group_label,
-					'item_id'     => sprintf( 'certificate-%d', $cert->get( 'id' ) ),
-					'data'        => self::get_certificate_data( $cert ),
+					'group_id'          => 'lifterlms_certificates',
+					'group_label'       => $group_label,
+					'group_description' => $group_description,
+					'item_id'           => sprintf( 'certificate-%d', $cert->get( 'id' ) ),
+					'data'              => self::get_certificate_data( $cert ),
 				);
 
 			}
@@ -400,10 +404,12 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 			foreach ( $enrollments['results'] as $post_id ) {
 
 				$data[] = array(
-					'group_id'    => $group_id,
-					'group_label' => $post_type_obj->labels->name,
-					'item_id'     => sprintf( '%1$s-%2$d', $post_type, $post_id ),
-					'data'        => self::get_enrollment_data( $post_id, $student, $post_type_obj ),
+					'group_id'          => $group_id,
+					'group_label'       => $post_type_obj->labels->name,
+					/* translators: %s: The name of the enrollment post type. */
+					'group_description' => sprintf( __( 'Student %s enrollment data.', 'lifterlms' ), $post_type_obj->labels->name ),
+					'item_id'           => sprintf( '%1$s-%2$d', $post_type, $post_id ),
+					'data'              => self::get_enrollment_data( $post_id, $student, $post_type_obj ),
 				);
 
 			}
@@ -480,7 +486,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	}
 
 	/**
-	 * Export student certificate data by email address
+	 * Export student orders data by email address
 	 *
 	 * @param    string $email_address  email address of the user to retrieve data for
 	 * @param    int    $page           process page number
@@ -499,14 +505,16 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 
 		$orders = self::get_student_orders( $student, $page );
 
-		$group_label = __( 'Orders', 'lifterlms' );
+		$group_label       = __( 'Orders', 'lifterlms' );
+		$group_description = __( 'Student orders data.', 'lifterlms' );
 		foreach ( $orders['orders'] as $order ) {
 
 			$data[] = array(
-				'group_id'    => 'lifterlms_orders',
-				'group_label' => $group_label,
-				'item_id'     => sprintf( 'order-%d', $order->get( 'id' ) ),
-				'data'        => self::get_order_data( $order ),
+				'group_id'          => 'lifterlms_orders',
+				'group_label'       => $group_label,
+				'group_description' => $group_description,
+				'item_id'           => sprintf( 'order-%d', $order->get( 'id' ) ),
+				'data'              => self::get_order_data( $order ),
 			);
 
 		}
@@ -534,10 +542,11 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 		}
 
 		$data[] = array(
-			'group_id'    => 'lifterlms_student',
-			'group_label' => __( 'Personal Information', 'lifterlms' ),
-			'item_id'     => sprintf( 'student-%d', $student->get( 'id' ) ),
-			'data'        => self::get_student_data( $student ),
+			'group_id'          => 'lifterlms_student',
+			'group_label'       => __( 'Personal Information', 'lifterlms' ),
+			'group_description' => __( 'Student personal information data.', 'lifterlms' ),
+			'item_id'           => sprintf( 'student-%d', $student->get( 'id' ) ),
+			'data'              => self::get_student_data( $student ),
 		);
 
 		return self::get_return( $data );
@@ -566,14 +575,16 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 		$done  = true;
 		if ( $query->has_results() ) {
 
-			$group_label = __( 'Quiz Attempts', 'lifterlms' );
+			$group_label        = __( 'Quiz Attempts', 'lifterlms' );
+			$group_descriptions = __( 'Student quiz attempts data', 'lifterlms' );
 			foreach ( $query->get_attempts() as $attempt ) {
 
 				$data[] = array(
-					'group_id'    => 'lifterlms_quizzes',
-					'group_label' => $group_label,
-					'item_id'     => sprintf( 'order-%d', $attempt->get( 'id' ) ),
-					'data'        => self::get_quiz_attempt_data( $attempt ),
+					'group_id'          => 'lifterlms_quizzes',
+					'group_label'       => $group_label,
+					'group_description' => $group_description,
+					'item_id'           => sprintf( 'order-%d', $attempt->get( 'id' ) ),
+					'data'              => self::get_quiz_attempt_data( $attempt ),
 				);
 
 			}

--- a/includes/privacy/class-llms-privacy.php
+++ b/includes/privacy/class-llms-privacy.php
@@ -134,7 +134,7 @@ class LLMS_Privacy extends LLMS_Abstract_Privacy {
 				'<p class="privacy-policy-tutorial">' .
 					__( 'This sample language includes the basics around what personal data your learning platform may be collecting, storing and sharing, as well as who may have access to that data. Depending on what settings are enabled and which additional add-ons are used, the specific information shared by your site will vary. We recommend consulting with a lawyer when deciding what information to disclose on your privacy policy.', 'lifterlms' ) .
 				'</p>' .
-   			    '<p>' . __( 'We collect information about you during the registration, enrollment, and checkout processes on our site.', 'lifterlms' ) . '</p>' .
+				'<p>' . __( 'We collect information about you during the registration, enrollment, and checkout processes on our site.', 'lifterlms' ) . '</p>' .
 				'<h2>' . __( 'What we collect and store', 'lifterlms' ) . '</h2>' .
 				'<p>' . __( 'When you register an account with us, we’ll ask you to provide information including your name, billing address, email address, phone number, credit card/payment details and optional account information like username and password. We’ll use this information for purposes, such as, to:', 'lifterlms' ) . '</p>' .
 				'<ul>' .

--- a/includes/privacy/class-llms-privacy.php
+++ b/includes/privacy/class-llms-privacy.php
@@ -130,46 +130,44 @@ class LLMS_Privacy extends LLMS_Abstract_Privacy {
 	 */
 	public function get_privacy_message() {
 		$content = '
-			<div contenteditable="false">' .
-				'<p class="wp-policy-help">' .
+			<div class="wp-suggested-text">' .
+				'<p class="privacy-policy-tutorial">' .
 					__( 'This sample language includes the basics around what personal data your learning platform may be collecting, storing and sharing, as well as who may have access to that data. Depending on what settings are enabled and which additional add-ons are used, the specific information shared by your site will vary. We recommend consulting with a lawyer when deciding what information to disclose on your privacy policy.', 'lifterlms' ) .
 				'</p>' .
-			'</div>' .
-			'<p>' . __( 'We collect information about you during the registration, enrollment, and checkout processes on our site.', 'lifterlms' ) . '</p>' .
-			'<h2>' . __( 'What we collect and store', 'lifterlms' ) . '</h2>' .
-			'<p>' . __( 'When you register an account with us, we’ll ask you to provide information including your name, billing address, email address, phone number, credit card/payment details and optional account information like username and password. We’ll use this information for purposes, such as, to:', 'lifterlms' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Send you information about your account, orders, courses, and memberships', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Communicate with you about courses and memberships that you’re enrolled in', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Respond to your requests, including refunds and complaints', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Process payments and prevent fraud', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Set up your account for our site', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Comply with any legal obligations we have', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Improve our site’s offerings', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Send you marketing messages, if you choose to receive them', 'lifterlms' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'When you create an account, we will store your name, address, email and phone number, which will be used to populate the enrollment and checkout for future purchases and enrollments.', 'lifterlms' ) . '</p>' .
-			'<p>' . __( 'We generally store information about you for as long as we need the information for the purposes for which we collect and use it, and we are not legally required to continue to keep it. For example, we will store order information for XXX years for tax and accounting purposes. This includes your name, email address and billing address.', 'lifterlms' ) . '</p>' .
-			'<p>' . __( 'We will also store comments or reviews, if you chose to leave them.', 'lifterlms' ) . '</p>' .
-			'<h2>' . __( 'Who on our team has access', 'lifterlms' ) . '</h2>' .
-			'<p>' . __( 'Members of our team have access to the information you provide us. For example, both Administrators and Site Managers can access:', 'lifterlms' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Order information like what was purchased, when it was purchased and where it should be sent, and', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Customer information like your name, email address, and billing information.', 'lifterlms' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'Course and membership instructors can access your course progress and activities including:', 'lifterlms' ) . '</p>' .
-			'<ul>' .
-				'<li>' . __( 'Enrollment dates for their courses and memberships', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Course progress and status information for their courses', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Quiz and assignments answers and grades for their courses', 'lifterlms' ) . '</li>' .
-				'<li>' . __( 'Comments and reviews made on their memberships and courses', 'lifterlms' ) . '</li>' .
-			'</ul>' .
-			'<p>' . __( 'Our team members have access to this information to help fulfill orders, process refunds, and support you.', 'lifterlms' ) . '</p>' .
-			'<h2>' . __( 'What we share with others', 'lifterlms' ) . '</h2>' .
-			'<div contenteditable="false">' .
-				'<p class="wp-policy-help">' . __( 'In this section you should list who you’re sharing data with, and for what purpose. This could include, but may not be limited to, analytics, marketing, payment gateways, and third party embeds.', 'lifterlms' ) . '</p>' .
-			'</div>' .
-			'<p>' . __( 'We share information with third parties who help us provide our orders and store services to you; for example --', 'lifterlms' ) . '</p>';
+   			    '<p>' . __( 'We collect information about you during the registration, enrollment, and checkout processes on our site.', 'lifterlms' ) . '</p>' .
+				'<h2>' . __( 'What we collect and store', 'lifterlms' ) . '</h2>' .
+				'<p>' . __( 'When you register an account with us, we’ll ask you to provide information including your name, billing address, email address, phone number, credit card/payment details and optional account information like username and password. We’ll use this information for purposes, such as, to:', 'lifterlms' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Send you information about your account, orders, courses, and memberships', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Communicate with you about courses and memberships that you’re enrolled in', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Respond to your requests, including refunds and complaints', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Process payments and prevent fraud', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Set up your account for our site', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Comply with any legal obligations we have', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Improve our site’s offerings', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Send you marketing messages, if you choose to receive them', 'lifterlms' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'When you create an account, we will store your name, address, email and phone number, which will be used to populate the enrollment and checkout for future purchases and enrollments.', 'lifterlms' ) . '</p>' .
+				'<p>' . __( 'We generally store information about you for as long as we need the information for the purposes for which we collect and use it, and we are not legally required to continue to keep it. For example, we will store order information for XXX years for tax and accounting purposes. This includes your name, email address and billing address.', 'lifterlms' ) . '</p>' .
+				'<p>' . __( 'We will also store comments or reviews, if you chose to leave them.', 'lifterlms' ) . '</p>' .
+				'<h2>' . __( 'Who on our team has access', 'lifterlms' ) . '</h2>' .
+				'<p>' . __( 'Members of our team have access to the information you provide us. For example, both Administrators and Site Managers can access:', 'lifterlms' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Order information like what was purchased, when it was purchased and where it should be sent, and', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Customer information like your name, email address, and billing information.', 'lifterlms' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'Course and membership instructors can access your course progress and activities including:', 'lifterlms' ) . '</p>' .
+				'<ul>' .
+					'<li>' . __( 'Enrollment dates for their courses and memberships', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Course progress and status information for their courses', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Quiz and assignments answers and grades for their courses', 'lifterlms' ) . '</li>' .
+					'<li>' . __( 'Comments and reviews made on their memberships and courses', 'lifterlms' ) . '</li>' .
+				'</ul>' .
+				'<p>' . __( 'Our team members have access to this information to help fulfill orders, process refunds, and support you.', 'lifterlms' ) . '</p>' .
+				'<h2>' . __( 'What we share with others', 'lifterlms' ) . '</h2>' .
+				'<p class="privacy-policy-tutorial">' . __( 'In this section you should list who you’re sharing data with, and for what purpose. This could include, but may not be limited to, analytics, marketing, payment gateways, and third party embeds.', 'lifterlms' ) . '</p>' .
+				'<p>' . __( 'We share information with third parties who help us provide our orders and store services to you; for example --', 'lifterlms' ) . '</p>' .
+			'</div>';
 
 		return apply_filters( 'llms_privacy_policy_content', $content );
 

--- a/includes/privacy/class-llms-privacy.php
+++ b/includes/privacy/class-llms-privacy.php
@@ -126,6 +126,7 @@ class LLMS_Privacy extends LLMS_Abstract_Privacy {
 	 *
 	 * @return   [type]
 	 * @since    3.18.0
+	 * @since    3.37.8 Replaced deprecated `.wp-policy-help` class with `.privacy-policy-tutorial`.
 	 * @version  3.18.0
 	 */
 	public function get_privacy_message() {


### PR DESCRIPTION
## Description
Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

Update Suggested Privacy Policy text to utilize privacy-policy-tutorial css class instead of wp-policy-help as it was deprecated. Also wrap the contents in the wp-suggested-text div to style the section to match WordPress. This follows from [WPCoreTrac#49282](https://core.trac.wordpress.org/ticket/49282) and although back-compat is being introduced in WP5.4 as of [WPChangeset#47112](https://core.trac.wordpress.org/changeset/47112) this change will better support users of WP5.1-5.4

This also removes the wrapping <div contenteditable="false"> as it's now unnecessary. As long as the content uses the proper privacy-policy-tutorial class then the WP Privacy Policy Guide section copy action will avoid copying that content. The contenteditable divs were there originally when the contents was fully copied due to not using the appropriate class, and when originally the entire guide would be dumped into the WYSIWYG editor with wp-policy-help sections being highlighted.

## How has this been tested?
I tested this by pulling up the privacy policy guide to confirm the styling was fixed and the contents of the clipboard when copied doesn't contain the tutorial test.
For the exporter I setup a customer with some basic data and ran the exporter to ensure the group descriptions were added properly.

## Types of changes
Bug Fix - The privacy policy guide text is now styled appropriately and the tutorial text is no longer present in the copied contents.
Enhancements - The exporters were updated to include a group description.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->