### PR TITLE
Sequential completion of lessons in a course.

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -38,7 +38,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @since 3.36.0 Allow some fields to store values with quotes.
-	 * @since 3.37.1 Added option to enable sequential completion
+	 * @since [version] Added option to enable sequential completion.
 	 *
 	 * @return array
 	 */

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
  * @since 3.36.0 Allow some fields to store values with quotes.
+ * @since 3.37.1 Added option to enable sequential completion
  */
 class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 
@@ -37,6 +38,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @since 3.36.0 Allow some fields to store values with quotes.
+	 * @since 3.37.1 Added option to enable sequential completion
 	 *
 	 * @return array
 	 */
@@ -350,7 +352,6 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'label'            => __( 'Capacity Reached Message', 'lifterlms' ),
 						'type'             => 'text',
 					),
-					// Require sequential completetion
 					array(
 						'is_controller' => true,
 						'type'          => 'checkbox',

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
  * @since 3.36.0 Allow some fields to store values with quotes.
- * @since 3.37.1 Added option to enable sequential completion
+ * @since [version] Added option to enable sequential completion.
  */
 class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -350,6 +350,17 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'label'            => __( 'Capacity Reached Message', 'lifterlms' ),
 						'type'             => 'text',
 					),
+					// Require sequential completetion
+					array(
+						'is_controller' => true,
+						'type'          => 'checkbox',
+						'label'         => __( 'Enable Sequential Lesson Completion', 'lifterlms' ),
+						'desc'          => __( 'This will require that the lessons in the course be completed in order.', 'lifterlms' ),
+						'id'            => $this->prefix . 'complete_sequentially',
+						'class'         => '',
+						'value'         => 'yes',
+						'desc_class'    => 'd-3of4 t-3of4 m-1of2',
+					),
 				),
 			),
 		);

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -353,8 +353,15 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 		}
 	}
 
-	// otherwise return false
-	// no prereq
+	/**
+	 * Allow external plugins to specify pre_requisite restrictions
+	 *
+	 * @since 3.37.1
+	 *
+	 * @param bool whether the post is already restricted
+	 * @param int the ID of the post
+	 * @param int the ID of the current user
+	 */
 	return apply_filters( 'llms_is_post_restricted_by_prerequisite', false, $post_id, $user_id );
 
 }

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -356,7 +356,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 	/**
 	 * Allow external plugins to specify pre_requisite restrictions
 	 *
-	 * @since 3.37.1
+	 * @since [version]
 	 *
 	 * @param bool whether the post is already restricted
 	 * @param int the ID of the post

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -355,7 +355,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 
 	// otherwise return false
 	// no prereq
-	return false;
+	return apply_filters( 'llms_is_post_restricted_by_prerequisite', false, $post_id, $user_id );
 
 }
 

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -773,7 +773,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return WP_Post[]
 	 * @deprecated 3.0.0
-	 *
 	 */
 	public function get_children_sections() {
 		llms_deprecated_function( 'LLMS_Course::get_children_sections()', '3.0.0', "LLMS_Course::get_sections( 'posts' )" );
@@ -787,7 +786,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return WP_Post[]
 	 * @deprecated 3.0.0
-	 *
 	 */
 	public function get_children_lessons() {
 		llms_deprecated_function( 'LLMS_Course::get_children_lessons()', '3.0.0', "LLMS_Course::get_lessons( 'posts' )" );
@@ -801,7 +799,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return WP_User instance of WP_User
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_author() {
 		llms_deprecated_function( 'LLMS_Course::get_author()', '[version]' );
@@ -815,7 +812,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return int
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_author_id() {
 		llms_deprecated_function( 'LLMS_Course::get_author_id()', '[version]', 'LLMS_Course::get( "author" )' );
@@ -829,7 +825,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_author_name() {
 		llms_deprecated_function( 'LLMS_Course::get_author_name()', '[version]' );
@@ -844,7 +839,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_sku() {
 		llms_deprecated_function( 'LLMS_Course::get_sku()', '[version]', 'LLMS_Course::get( "sku" )' );
@@ -858,7 +852,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return int
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_id() {
 		llms_deprecated_function( 'LLMS_Course::get_id()', '[version]', 'LLMS_Course::get( "id" )' );
@@ -872,7 +865,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_title() {
 		llms_deprecated_function( 'LLMS_Course::get_title()', '[version]', 'get_the_title()' );
@@ -886,7 +878,6 @@ class LLMS_Course
 	 * @since      3.0.0
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_permalink() {
 		llms_deprecated_function( 'LLMS_Course::get_permalink()', '[version]', 'get_permalink()' );
@@ -900,7 +891,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return array
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_user_postmeta_data( $post_id ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_postmeta_data()', '[version]' );
@@ -922,7 +912,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return  array
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_user_postmetas_by_key( $post_id, $meta_key ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_postmetas_by_key()', '[version]' );
@@ -943,7 +932,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_checkout_url() {
 		llms_deprecated_function( 'LLMS_Course::get_checkout_url()', '[version]' );
@@ -963,7 +951,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_start_date() {
 		llms_deprecated_function( 'LLMS_Course::get_start_date()', '[version]', 'LLMS_Course::get_date( "start_date" )' );
@@ -980,7 +967,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_end_date() {
 		llms_deprecated_function( 'LLMS_Course::get_end_date()', '[version]', 'LLMS_Course::get_date( "end_date" )' );
@@ -994,7 +980,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return int|false
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_next_uncompleted_lesson() {
 		llms_deprecated_function( 'LLMS_Course::get_next_uncompleted_lesson()', '[version]' );
@@ -1020,7 +1005,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return int[]
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_lesson_ids() {
 		llms_deprecated_function( 'LLMS_Course::get_lesson_ids()', '[version]', 'LLMS_Course::get_lessons( "ids" )' );
@@ -1057,7 +1041,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return array
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_syllabus_sections() {
 		llms_deprecated_function( 'LLMS_Course::get_syllabus_sections()', '[version]', 'LLMS_Course::get_sections()' );
@@ -1078,7 +1061,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_short_description() {
 		llms_deprecated_function( 'LLMS_Course::get_short_description()', '[version]', 'LLMS_Course::get( "excerpt" )' );
@@ -1093,7 +1075,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return array
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_syllabus() {
 		llms_deprecated_function( 'LLMS_Course::get_syllabus()', '[version]', 'LLMS_Course::get_sections()' );
@@ -1111,7 +1092,6 @@ class LLMS_Course
 	 *
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_user_enroll_date( $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_enroll_date()', '[version]' );
@@ -1142,7 +1122,6 @@ class LLMS_Course
 	 *
 	 * @return mixed
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public static function get_user_post_data( $post_id, $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_post_data()', '[version]' );
@@ -1178,7 +1157,6 @@ class LLMS_Course
 	 *
 	 * @return mixed
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public static function check_enrollment( $course_id, $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::check_enrollment()', '[version]' );
@@ -1222,7 +1200,6 @@ class LLMS_Course
 	 *
 	 * @return bool
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function is_user_enrolled( $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::is_user_enrolled()', '[version]', 'llms_is_user_enrolled()' );
@@ -1248,7 +1225,6 @@ class LLMS_Course
 	 *
 	 * @return obj
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_student_progress( $user_id = '' ) {
 
@@ -1375,7 +1351,6 @@ class LLMS_Course
 	 * @since      Unknown
 	 * @return string
 	 * @deprecated 3.34.0
-	 *
 	 */
 	public function get_membership_link() {
 		llms_deprecated_function( 'LLMS_Course::get_membership_link()', '[version]' );

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -2,10 +2,10 @@
 /**
  * LifterLMS Course Model
  *
- * @package LifterLMS/Models
- *
- * @since 1.0.0
+ * @since   1.0.0
  * @version 3.30.3
+ *
+ * @package LifterLMS/Models
  *
  * @property $audio_embed  (string)  URL to an oEmbed enable audio URL
  * @property $average_grade  (float)  Calculated value of the overall average grade of all *enrolled* students in the course.
@@ -43,14 +43,14 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
- * @since 3.37.1 Added must_complete_sequentially() method.
+ * @since [version] Added must_complete_sequentially() method.
  */
 class LLMS_Course
-extends LLMS_Post_Model
-implements LLMS_Interface_Post_Audio
-		 , LLMS_Interface_Post_Instructors
-		 , LLMS_Interface_Post_Sales_Page
-		 , LLMS_Interface_Post_Video {
+	extends LLMS_Post_Model
+	implements LLMS_Interface_Post_Audio
+	, LLMS_Interface_Post_Instructors
+	, LLMS_Interface_Post_Sales_Page
+	, LLMS_Interface_Post_Video {
 
 	protected $properties = array(
 
@@ -87,27 +87,27 @@ implements LLMS_Interface_Post_Audio
 		'temp_calc_data'             => 'array',
 	);
 
-	protected $db_post_type    = 'course';
+	protected $db_post_type = 'course';
 	protected $model_post_type = 'course';
 
 	/**
-	 * @var array
 	 * @since 1.0.0
+	 * @var array
 	 */
 	public $sections;
 
 	/**
-	 * @var string
 	 * @since 1.0.0
+	 * @var string
 	 */
 	public $sku;
 
 	/**
 	 * Retrieve an instance of the Post Instructors model
 	 *
-	 * @return   LLMS_Post_Instructors
 	 * @since    3.13.0
 	 * @version  3.13.0
+	 * @return   LLMS_Post_Instructors
 	 */
 	public function instructors() {
 		return new LLMS_Post_Instructors( $this );
@@ -116,25 +116,28 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve the total points available for the course
 	 *
-	 * @return   int
 	 * @since    3.24.0
 	 * @version  3.24.0
+	 * @return   int
 	 */
 	public function get_available_points() {
 		$points = 0;
 		foreach ( $this->get_lessons() as $lesson ) {
 			$points += $lesson->get( 'points' );
 		}
+
 		return apply_filters( 'llms_course_get_available_points', $points, $this );
 	}
 
 	/**
 	 * Get course's prerequisite id based on the type of prerequisite
 	 *
-	 * @param    string $type  Type of prereq to retrieve id for [course|track]
-	 * @return   int|false         Post ID of a course, taxonomy ID of a track, or false if none found
 	 * @since    3.0.0
 	 * @version  3.7.3
+	 *
+	 * @param string $type Type of prereq to retrieve id for [course|track]
+	 *
+	 * @return   int|false         Post ID of a course, taxonomy ID of a track, or false if none found
 	 */
 	public function get_prerequisite_id( $type = 'course' ) {
 
@@ -165,9 +168,9 @@ implements LLMS_Interface_Post_Audio
 	 * Attempt to get oEmbed for an audio provider
 	 * Falls back to the [audio] shortcode if the oEmbed fails
 	 *
-	 * @return string
 	 * @since   1.0.0
 	 * @version 3.17.0
+	 * @return string
 	 */
 	public function get_audio() {
 		return $this->get_embed( 'audio' );
@@ -176,10 +179,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course categories
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
 	 * @since    3.3.0
 	 * @version  3.3.0
+	 *
+	 * @param array $args array of args passed to wp_get_post_terms
+	 *
+	 * @return   array
 	 */
 	public function get_categories( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_cat', $args );
@@ -188,12 +193,14 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get Difficulty
 	 *
-	 * @param    string $field  which field to return from the available term fields
-	 *                          any public variables from a WP_Term object are acceptable
-	 *                          term_id, name, slug, and more
-	 * @return   string
 	 * @since    1.0.0
 	 * @version  3.24.0
+	 *
+	 * @param string $field     which field to return from the available term fields
+	 *                          any public variables from a WP_Term object are acceptable
+	 *                          term_id, name, slug, and more
+	 *
+	 * @return   string
 	 */
 	public function get_difficulty( $field = 'name' ) {
 
@@ -217,10 +224,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course instructor information
 	 *
-	 * @param    boolean $exclude_hidden  if true, excludes hidden instructors from the return array
-	 * @return   array
 	 * @since    3.13.0
 	 * @version  3.13.0
+	 *
+	 * @param boolean $exclude_hidden if true, excludes hidden instructors from the return array
+	 *
+	 * @return   array
 	 */
 	public function get_instructors( $exclude_hidden = false ) {
 
@@ -236,10 +245,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get course lessons
 	 *
-	 * @param    string $return  type of return [ids|posts|lessons]
-	 * @return   int[]|WP_Post[]|LLMS_Lesson[] type depends on value of $return
 	 * @since    3.0.0
 	 * @version  3.24.0
+	 *
+	 * @param string $return type of return [ids|posts|lessons]
+	 *
+	 * @return   int[]|WP_Post[]|LLMS_Lesson[] type depends on value of $return
 	 */
 	public function get_lessons( $return = 'lessons' ) {
 
@@ -255,6 +266,7 @@ implements LLMS_Interface_Post_Audio
 		} else {
 			$ret = array_map( 'llms_get_post', $lessons );
 		}
+
 		return $ret;
 
 	}
@@ -262,9 +274,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an array of quizzes within a course
 	 *
-	 * @return   array            array of WP_Post IDs of the quizzes
 	 * @since    3.12.0
 	 * @version  3.16.0
+	 * @return   array            array of WP_Post IDs of the quizzes
 	 */
 	public function get_quizzes() {
 
@@ -274,6 +286,7 @@ implements LLMS_Interface_Post_Audio
 				$quizzes[] = $lesson->get( 'quiz' );
 			}
 		}
+
 		return $quizzes;
 
 	}
@@ -281,9 +294,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the URL to a WP Page or Custom URL when sales page redirection is enabled
 	 *
-	 * @return   string
 	 * @since    3.20.0
 	 * @version  3.23.0
+	 * @return   string
 	 */
 	public function get_sales_page_url() {
 
@@ -309,10 +322,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get course sections
 	 *
-	 * @param    string $return  type of return [ids|posts|sections]
-	 * @return   int[]|WP_Post[]|LLMS_Section[] type depends on value of $return
 	 * @since    3.0.0
 	 * @version  3.24.0
+	 *
+	 * @param string $return type of return [ids|posts|sections]
+	 *
+	 * @return   int[]|WP_Post[]|LLMS_Section[] type depends on value of $return
 	 */
 	public function get_sections( $return = 'sections' ) {
 
@@ -350,9 +365,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve the number of enrolled students in the course
 	 *
-	 * @return   int
 	 * @since    3.15.0
 	 * @version  3.15.0
+	 * @return   int
 	 */
 	public function get_student_count() {
 
@@ -371,13 +386,15 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get an array of student IDs based on enrollment status in the course
 	 *
-	 * @param    string|array $statuses  list of enrollment statuses to query by
-	 *                                   status query is an OR relationship
-	 * @param    integer      $limit        number of results
-	 * @param    integer      $skip         number of results to skip (for pagination)
-	 * @return   array
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 *
+	 * @param integer      $skip         number of results to skip (for pagination)
+	 * @param string|array $statuses     list of enrollment statuses to query by
+	 *                                   status query is an OR relationship
+	 * @param integer      $limit        number of results
+	 *
+	 * @return   array
 	 */
 	public function get_students( $statuses = 'enrolled', $limit = 50, $skip = 0 ) {
 
@@ -388,10 +405,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course tags
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
 	 * @since    3.3.0
 	 * @version  3.3.0
+	 *
+	 * @param array $args array of args passed to wp_get_post_terms
+	 *
+	 * @return   array
 	 */
 	public function get_tags( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_tag', $args );
@@ -400,10 +419,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course tracks
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
 	 * @since    3.3.0
 	 * @version  3.3.0
+	 *
+	 * @param array $args array of args passed to wp_get_post_terms
+	 *
+	 * @return   array
 	 */
 	public function get_tracks( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_track', $args );
@@ -412,11 +433,13 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an array of students currently enrolled in the course
 	 *
-	 * @param    integer $limit   number of results
-	 * @param    integer $skip    number of results to skip (for pagination)
-	 * @return   array
 	 * @since    1.0.0
 	 * @version  3.0.0 - updated the function to be less complicated
+	 *
+	 * @param integer $limit number of results
+	 * @param integer $skip  number of results to skip (for pagination)
+	 *
+	 * @return   array
 	 */
 	public function get_enrolled_students( $limit, $skip ) {
 
@@ -427,9 +450,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get a user's percentage completion through the course
 	 *
-	 * @return  float
 	 * @since   1.0.0
 	 * @version 3.17.2
+	 * @return  float
 	 */
 	public function get_percent_complete( $user_id = '' ) {
 
@@ -437,6 +460,7 @@ implements LLMS_Interface_Post_Audio
 		if ( ! $student ) {
 			return 0;
 		}
+
 		return $student->get_progress( $this->get( 'id' ), 'course' );
 
 	}
@@ -444,9 +468,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of the LLMS_Product for this course
 	 *
-	 * @return   LLMS_Product instance of an LLMS_Product
 	 * @since    3.3.0
 	 * @version  3.3.0
+	 * @return   LLMS_Product instance of an LLMS_Product
 	 */
 	public function get_product() {
 		return new LLMS_Product( $this->get( 'id' ) );
@@ -456,9 +480,9 @@ implements LLMS_Interface_Post_Audio
 	 * Attempt to get oEmbed for a video provider
 	 * Falls back to the [video] shortcode if the oEmbed fails
 	 *
-	 * @return   string
 	 * @since    1.0.0
 	 * @version  3.17.0
+	 * @return   string
 	 */
 	public function get_video() {
 		return $this->get_embed( 'video' );
@@ -467,11 +491,13 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Compare a course meta info date to the current date and get a bool
 	 *
-	 * @param    string $date_key  property key, eg "start_date" or "enrollment_end_date"
-	 * @return   boolean               true when the date is in the past
-	 *                                 false when the date is in the future
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 *
+	 * @param string $date_key property key, eg "start_date" or "enrollment_end_date"
+	 *
+	 * @return   boolean               true when the date is in the past
+	 *                                 false when the date is in the future
 	 */
 	public function has_date_passed( $date_key ) {
 
@@ -496,9 +522,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if the course is at capacity based on course capacity settings
 	 *
-	 * @return   boolean    true if not at capacity, false if at or over capacity
 	 * @since    3.0.0
 	 * @version  3.15.0
+	 * @return   boolean    true if not at capacity, false if at or over capacity
 	 */
 	public function has_capacity() {
 
@@ -521,10 +547,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if prerequisites are enabled and there are prereqs configured
 	 *
-	 * @param    string $type  determine if a specific type of prereq exists [any|course|track]
-	 * @return   boolean         Returns true if prereq is enabled and there is a prerequisite course or track
 	 * @since    3.0.0
 	 * @version  3.7.5
+	 *
+	 * @param string $type determine if a specific type of prereq exists [any|course|track]
+	 *
+	 * @return   boolean         Returns true if prereq is enabled and there is a prerequisite course or track
 	 */
 	public function has_prerequisite( $type = 'any' ) {
 
@@ -552,32 +580,36 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Whether the course lessons must be completed sequentially
 	 *
+	 * @since   [version]
+	 *
 	 * @return bool
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function must_complete_sequentially(){
+	public function must_complete_sequentially() {
 		return ( 'yes' === $this->get( 'complete_sequentially' ) );
 	}
 
 	/**
 	 * Determine if sales page redirection is enabled
 	 *
-	 * @return   string
 	 * @since    3.20.0
 	 * @version  3.23.0
+	 * @return   string
 	 */
 	public function has_sales_page_redirect() {
 		$type = $this->get( 'sales_page_content_type' );
-		return apply_filters( 'llms_course_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ) ), $this, $type );
+
+		return apply_filters( 'llms_course_has_sales_page_redirect', in_array( $type, array(
+			'page',
+			'url'
+		) ), $this, $type );
 	}
 
 	/**
 	 * Determine if students can access course content based on the current date
 	 *
-	 * @return   boolean
 	 * @since    3.0.0
 	 * @version  3.7.0
+	 * @return   boolean
 	 */
 	public function is_enrollment_open() {
 
@@ -602,9 +634,9 @@ implements LLMS_Interface_Post_Audio
 	 * Note that enrollment does not affect the outcome of this check as regardless
 	 * of enrollment, once a course closes content is locked
 	 *
-	 * @return   boolean
 	 * @since    3.0.0
 	 * @version  3.7.0
+	 * @return   boolean
 	 */
 	public function is_open() {
 
@@ -626,10 +658,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a prerequisite is completed for a student
 	 *
-	 * @param    string $type  type of prereq [course|track]
-	 * @return   boolean
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 *
+	 * @param string $type type of prereq [course|track]
+	 *
+	 * @return   boolean
 	 */
 	public function is_prerequisite_complete( $type = 'course', $student_id = null ) {
 
@@ -659,9 +693,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Save instructor information
 	 *
-	 * @param    array $instructors  array of course instructor information
 	 * @since    3.13.0
 	 * @version  3.13.0
+	 *
+	 * @param array $instructors array of course instructor information
+	 *
+	 * @return mixed
 	 */
 	public function set_instructors( $instructors = array() ) {
 
@@ -673,10 +710,12 @@ implements LLMS_Interface_Post_Audio
 	 * Add data to the course model when converted to array
 	 * Called before data is sorted and returned by $this->jsonSerialize()
 	 *
-	 * @param    array $arr   data to be serialized
-	 * @return   array
 	 * @since    3.3.0
 	 * @version  3.8.0
+	 *
+	 * @param array $arr data to be serialized
+	 *
+	 * @return   array
 	 */
 	public function toArrayAfter( $arr ) {
 
@@ -731,128 +770,137 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return WP_Post[]
 	 * @deprecated 3.0.0
 	 *
-	 * @return WP_Post[]
 	 */
 	public function get_children_sections() {
 		llms_deprecated_function( 'LLMS_Course::get_children_sections()', '3.0.0', "LLMS_Course::get_sections( 'posts' )" );
+
 		return $this->get_sections( 'posts' );
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return WP_Post[]
 	 * @deprecated 3.0.0
 	 *
-	 * @return WP_Post[]
 	 */
 	public function get_children_lessons() {
 		llms_deprecated_function( 'LLMS_Course::get_children_lessons()', '3.0.0', "LLMS_Course::get_lessons( 'posts' )" );
+
 		return $this->get_sections( 'posts' );
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since 3.0.0
+	 * @since      3.0.0
+	 * @return WP_User instance of WP_User
 	 * @deprecated 3.34.0
 	 *
-	 * @return WP_User instance of WP_User
 	 */
 	public function get_author() {
 		llms_deprecated_function( 'LLMS_Course::get_author()', '[version]' );
+
 		return new WP_User( $this->get_author_id() );
 	}
 
 	/**
 	 * Get the course author's WP User ID
 	 *
-	 * @since  3.0.0
+	 * @since      3.0.0
+	 * @return int
 	 * @deprecated 3.34.0
 	 *
-	 * @return int
 	 */
 	public function get_author_id() {
 		llms_deprecated_function( 'LLMS_Course::get_author_id()', '[version]', 'LLMS_Course::get( "author" )' );
+
 		return $this->post->post_author;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since  3.0.0
+	 * @since      3.0.0
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_author_name() {
 		llms_deprecated_function( 'LLMS_Course::get_author_name()', '[version]' );
 		$author = $this->get_author();
+
 		return $author->display_name;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_sku() {
 		llms_deprecated_function( 'LLMS_Course::get_sku()', '[version]', 'LLMS_Course::get( "sku" )' );
+
 		return $this->sku;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since 3.0.0
+	 * @since      3.0.0
+	 * @return int
 	 * @deprecated 3.34.0
 	 *
-	 * @return int
 	 */
 	public function get_id() {
 		llms_deprecated_function( 'LLMS_Course::get_id()', '[version]', 'LLMS_Course::get( "id" )' );
+
 		return $this->id;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since  3.0.0
+	 * @since      3.0.0
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_title() {
 		llms_deprecated_function( 'LLMS_Course::get_title()', '[version]', 'get_the_title()' );
+
 		return get_the_title( $this->get_id() );
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since 3.0.0
+	 * @since      3.0.0
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_permalink() {
 		llms_deprecated_function( 'LLMS_Course::get_permalink()', '[version]', 'get_permalink()' );
+
 		return get_permalink( $this->get_id() );
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return array
 	 * @deprecated 3.34.0
 	 *
-	 * @return array
 	 */
 	public function get_user_postmeta_data( $post_id ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_postmeta_data()', '[version]' );
@@ -860,40 +908,42 @@ implements LLMS_Interface_Post_Audio
 		$user_id     = get_current_user_id();
 		$results     = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}lifterlms_user_postmeta WHERE post_id = %d", $user_id, $post_id ) );
 		$num_results = count( $results );
-		for ( $i = 0; $i < $num_results; $i++ ) {
+		for ( $i = 0; $i < $num_results; $i ++ ) {
 			$results[ $results[ $i ]->meta_key ] = $results[ $i ];
 			unset( $results[ $i ] );
 		}
+
 		return $results;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return  array
 	 * @deprecated 3.34.0
 	 *
-	 * @return  array
 	 */
 	public function get_user_postmetas_by_key( $post_id, $meta_key ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_postmetas_by_key()', '[version]' );
 		global $wpdb;
 		$results     = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}lifterlms_user_postmeta WHERE post_id = %s and meta_key = %s ORDER BY updated_date DESC", $post_id, $meta_key ) );
 		$num_results = count( $results );
-		for ( $i = 0; $i < $num_results; $i++ ) {
+		for ( $i = 0; $i < $num_results; $i ++ ) {
 			$results[ $results[ $i ]->post_id ] = $results[ $i ];
 			unset( $results[ $i ] );
 		}
+
 		return $results;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_checkout_url() {
 		llms_deprecated_function( 'LLMS_Course::get_checkout_url()', '[version]' );
@@ -903,16 +953,17 @@ implements LLMS_Interface_Post_Audio
 			$checkout_page_id = llms_get_page_id( 'myaccount' );
 		}
 		$checkout_url = apply_filters( 'lifterlms_get_checkout_url', $checkout_page_id ? get_permalink( $checkout_page_id ) : '' );
+
 		return apply_filters( 'lifterlms_product_purchase_checkout_redirect', add_query_arg( 'product-id', $this->id, $checkout_url ) );
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_start_date() {
 		llms_deprecated_function( 'LLMS_Course::get_start_date()', '[version]', 'LLMS_Course::get_date( "start_date" )' );
@@ -926,23 +977,24 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_end_date() {
 		llms_deprecated_function( 'LLMS_Course::get_end_date()', '[version]', 'LLMS_Course::get_date( "end_date" )' );
+
 		return $this->end_date;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return int|false
 	 * @deprecated 3.34.0
 	 *
-	 * @return int|false
 	 */
 	public function get_next_uncompleted_lesson() {
 		llms_deprecated_function( 'LLMS_Course::get_next_uncompleted_lesson()', '[version]' );
@@ -965,10 +1017,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return int[]
 	 * @deprecated 3.34.0
 	 *
-	 * @return int[]
 	 */
 	public function get_lesson_ids() {
 		llms_deprecated_function( 'LLMS_Course::get_lesson_ids()', '[version]', 'LLMS_Course::get_lessons( "ids" )' );
@@ -995,16 +1047,17 @@ implements LLMS_Interface_Post_Audio
 				$lessons[] = $lessonojb->ID;
 			}
 		}
+
 		return $lessons;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return array
 	 * @deprecated 3.34.0
 	 *
-	 * @return array
 	 */
 	public function get_syllabus_sections() {
 		llms_deprecated_function( 'LLMS_Course::get_syllabus_sections()', '[version]', 'LLMS_Course::get_sections()' );
@@ -1015,45 +1068,50 @@ implements LLMS_Interface_Post_Audio
 				array_push( $sections, $value['section_id'] );
 			}
 		}
+
 		return $sections;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_short_description() {
 		llms_deprecated_function( 'LLMS_Course::get_short_description()', '[version]', 'LLMS_Course::get( "excerpt" )' );
 		$short_description = wpautop( $this->post->post_excerpt );
+
 		return $short_description;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return array
 	 * @deprecated 3.34.0
 	 *
-	 * @return array
 	 */
 	public function get_syllabus() {
 		llms_deprecated_function( 'LLMS_Course::get_syllabus()', '[version]', 'LLMS_Course::get_sections()' );
 		$syllabus = $this->sections;
+
 		return $syllabus;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
-	 * @deprecated 3.34.0
+	 * @since      Unknown
 	 *
 	 * @param string $user_id WP_User ID.
+	 *
 	 * @return string
+	 * @deprecated 3.34.0
+	 *
 	 */
 	public function get_user_enroll_date( $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_enroll_date()', '[version]' );
@@ -1070,18 +1128,21 @@ implements LLMS_Interface_Post_Audio
 				}
 			}
 		}
+
 		return $enrolled_date;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
-	 * @deprecated 3.34.0
+	 * @since      Unknown
 	 *
 	 * @param int    $post_id WP_Post ID.
 	 * @param string $user_id WP_User ID.
+	 *
 	 * @return mixed
+	 * @deprecated 3.34.0
+	 *
 	 */
 	public static function get_user_post_data( $post_id, $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::get_user_post_data()', '[version]' );
@@ -1103,18 +1164,21 @@ implements LLMS_Interface_Post_Audio
 				)
 			);
 		}
+
 		return $results;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
-	 * @deprecated 3.34.0
+	 * @since      Unknown
 	 *
 	 * @param int    $course_id WP_Post ID.
-	 * @param string $user_id WP_User ID.
+	 * @param string $user_id   WP_User ID.
+	 *
 	 * @return mixed
+	 * @deprecated 3.34.0
+	 *
 	 */
 	public static function check_enrollment( $course_id, $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::check_enrollment()', '[version]' );
@@ -1145,17 +1209,20 @@ implements LLMS_Interface_Post_Audio
 				}
 			}
 		}
+
 		return $enrolled;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
-	 * @deprecated 3.34.0
+	 * @since      Unknown
 	 *
 	 * @param string $user_id WP_User ID.
+	 *
 	 * @return bool
+	 * @deprecated 3.34.0
+	 *
 	 */
 	public function is_user_enrolled( $user_id = '' ) {
 		llms_deprecated_function( 'LLMS_Course::is_user_enrolled()', '[version]', 'llms_is_user_enrolled()' );
@@ -1168,17 +1235,20 @@ implements LLMS_Interface_Post_Audio
 				}
 			}
 		}
+
 		return $enrolled;
 	}
 
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
-	 * @deprecated 3.34.0
+	 * @since      Unknown
 	 *
 	 * @param string $user_id WP_User ID.
+	 *
 	 * @return obj
+	 * @deprecated 3.34.0
+	 *
 	 */
 	public function get_student_progress( $user_id = '' ) {
 
@@ -1302,10 +1372,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Deprecated.
 	 *
-	 * @since Unknown
+	 * @since      Unknown
+	 * @return string
 	 * @deprecated 3.34.0
 	 *
-	 * @return string
 	 */
 	public function get_membership_link() {
 		llms_deprecated_function( 'LLMS_Course::get_membership_link()', '[version]' );
@@ -1315,6 +1385,7 @@ implements LLMS_Interface_Post_Audio
 		} else {
 			$membership_url = get_permalink( $memberships_required[0] );
 		}
+
 		return apply_filters( 'lifterlms_product_purchase_redirect_membership_required', $membership_url );
 	}
 }

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -43,6 +43,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
+ * @since 3.37.1 Added must_complete_sequentially() method.
  */
 class LLMS_Course
 extends LLMS_Post_Model
@@ -552,6 +553,8 @@ implements LLMS_Interface_Post_Audio
 	 * Whether the course lessons must be completed sequentially
 	 *
 	 * @return bool
+	 * @since 3.37.1
+	 * @version 3.37.1
 	 */
 	public function must_complete_sequentially(){
 		return ( 'yes' === $this->get( 'complete_sequentially' ) );

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -549,6 +549,15 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
+	 * Whether the course lessons must be completed sequentially
+	 *
+	 * @return bool
+	 */
+	public function must_complete_sequentially(){
+		return ( 'yes' === $this->get( 'complete_sequentially' ) );
+	}
+
+	/**
 	 * Determine if sales page redirection is enabled
 	 *
 	 * @return   string

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -2,10 +2,10 @@
 /**
  * LifterLMS Lesson Model.
  *
+ * @since   1.0.0
+ * @version 3.36.2
  * @package LifterLMS/Models
  *
- * @since 1.0.0
- * @version 3.36.2
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,42 +17,42 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.29.0 Unknown.
  * @since 3.36.2 When getting the lesson's available date: add available number of days to the course start date only if there's a course start date.
  *
- * @property $audio_embed (string) Audio embed URL
- * @property $date_available (string/date) Date when lesson becomes available, applies when $drip_method is "date"
- * @property $days_before_available (int) The number of days before the lesson is available, applies when $drip_method is "enrollment" or "start"
- * @property $drip_method (string) What sort of drip method to utilize [''(none)|date|enrollment|start|prerequisite]
- * @property $free_lesson (yesno) Yes if the lesson is free
- * @property $has_prerequisite (yesno) Yes if the lesson has a prereq lesson
- * @property $order (int) Lesson's order within its parent section
- * @property $points (absint) Number of points assigned to the lesson, used to calculate the weight of the lesson when grading courses
- * @property $prerequisite (int) WP Post ID of the prerequisite lesson, only if $has_prerequisite is 'yes'
- * @property $parent_course (int) WP Post ID of the course the lesson belongs to
- * @property $parent_section (int) WP Post ID of the section the lesson belongs to
- * @property $quiz (int) WP Post ID of the llms_quiz
- * @property $quiz_enabled (yesno) Whether or not the attached quiz is enabled for students
- * @property $require_passing_grade (yesno) Whether of not students have to pass the quiz to advance to the next lesson
+ * @property $audio_embed                      (string) Audio embed URL
+ * @property $date_available                   (string/date) Date when lesson becomes available, applies when $drip_method is "date"
+ * @property $days_before_available            (int) The number of days before the lesson is available, applies when $drip_method is "enrollment" or "start"
+ * @property $drip_method                      (string) What sort of drip method to utilize [''(none)|date|enrollment|start|prerequisite]
+ * @property $free_lesson                      (yesno) Yes if the lesson is free
+ * @property $has_prerequisite                 (yesno) Yes if the lesson has a prereq lesson
+ * @property $order                            (int) Lesson's order within its parent section
+ * @property $points                           (absint) Number of points assigned to the lesson, used to calculate the weight of the lesson when grading courses
+ * @property $prerequisite                     (int) WP Post ID of the prerequisite lesson, only if $has_prerequisite is 'yes'
+ * @property $parent_course                    (int) WP Post ID of the course the lesson belongs to
+ * @property $parent_section                   (int) WP Post ID of the section the lesson belongs to
+ * @property $quiz                             (int) WP Post ID of the llms_quiz
+ * @property $quiz_enabled                     (yesno) Whether or not the attached quiz is enabled for students
+ * @property $require_passing_grade            (yesno) Whether of not students have to pass the quiz to advance to the next lesson
  * @property $require_assignment_passing_grade (yesno) Whether of not students have to pass the assignment to advance to the next lesson
- * @property $time_available (string) Optional time to make lesson available on $date_available when $drip_method is "date"
- * @property $video_embed (string) Video embed URL
+ * @property $time_available                   (string) Optional time to make lesson available on $date_available when $drip_method is "date"
+ * @property $video_embed                      (string) Video embed URL
  */
 class LLMS_Lesson
-extends LLMS_Post_Model
-implements LLMS_Interface_Post_Audio
-		 , LLMS_Interface_Post_Video {
+	extends LLMS_Post_Model
+	implements LLMS_Interface_Post_Audio
+	, LLMS_Interface_Post_Video {
 
 	protected $properties = array(
 
-		'order'                            => 'absint',
+		'order'                 => 'absint',
 
 		// drippable
-		'days_before_available'            => 'absint',
-		'date_available'                   => 'text',
-		'drip_method'                      => 'text',
-		'time_available'                   => 'text',
+		'days_before_available' => 'absint',
+		'date_available'        => 'text',
+		'drip_method'           => 'text',
+		'time_available'        => 'text',
 
 		// parent element
-		'parent_course'                    => 'absint',
-		'parent_section'                   => 'absint',
+		'parent_course'         => 'absint',
+		'parent_section'        => 'absint',
 
 		'audio_embed'                      => 'text',
 		'free_lesson'                      => 'yesno',
@@ -73,24 +73,24 @@ implements LLMS_Interface_Post_Audio
 	 * Array of default property values
 	 * key => default value
 	 *
-	 * @var  array
 	 * @since   3.24.0
 	 * @version 3.24.0
+	 * @var  array
 	 */
 	protected $property_defaults = array(
 		'points' => 1,
 	);
 
-	protected $db_post_type    = 'lesson';
+	protected $db_post_type = 'lesson';
 	protected $model_post_type = 'lesson';
 
 	/**
 	 * Attempt to get oEmbed for an audio provider
 	 * Falls back to the [audio] shortcode if the oEmbed fails
 	 *
-	 * @return   string
 	 * @since    1.0.0
 	 * @version  3.17.0
+	 * @return   string
 	 */
 	public function get_audio() {
 		return $this->get_embed( 'audio' );
@@ -103,7 +103,8 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.16.0
 	 * @since 3.36.2 Add available number of days to the course start date only if there's a course start date.
 	 *
-	 * @param  string $format Date format (passed to date_i18n()) (defaults to WP Core date + time formats)
+	 * @param string $format Date format (passed to date_i18n()) (defaults to WP Core date + time formats)
+	 *
 	 * @return string
 	 */
 	public function get_available_date( $format = '' ) {
@@ -175,9 +176,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of LLMS_Course for the element's parent course
 	 *
-	 * @return   obj|null|LLMS_Course
 	 * @since    3.16.0
 	 * @version  3.16.0
+	 * @return   obj|null|LLMS_Course
 	 */
 	public function get_course() {
 
@@ -194,10 +195,12 @@ implements LLMS_Interface_Post_Audio
 	 * An array of default arguments to pass to $this->create()
 	 * when creating a new post
 	 *
-	 * @param    array $args   args of data to be passed to wp_insert_post
-	 * @return   array
 	 * @since    3.13.0
 	 * @version  3.13.0
+	 *
+	 * @param array $args args of data to be passed to wp_insert_post
+	 *
+	 * @return   array
 	 */
 	protected function get_creation_args( $args = null ) {
 
@@ -234,10 +237,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieves the lesson's order within its parent section
 	 *
-	 * @todo  this should be deprecated
-	 * @return int
-	 * @since  1.0.0
+	 * @since    1.0.0
 	 * @version  3.0.0
+	 * @return int
+	 * @todo     this should be deprecated
 	 */
 	public function get_order() {
 		return $this->get( 'order' );
@@ -246,9 +249,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get parent course id
 	 *
-	 * @return  int
 	 * @since   1.0.0
 	 * @version 3.0.0
+	 * @return  int
 	 */
 	public function get_parent_course() {
 		return absint( get_post_meta( $this->get( 'id' ), '_llms_parent_course', true ) );
@@ -257,9 +260,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get parent section id
 	 *
-	 * @return  int
 	 * @since   1.0.0
 	 * @version 3.0.0
+	 * @return  int
 	 */
 	public function get_parent_section() {
 		return absint( get_post_meta( $this->get( 'id' ), '_llms_parent_section', true ) );
@@ -268,9 +271,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get CSS classes to display on the course syllabus .llms-lesson-preview element
 	 *
-	 * @return   string
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 * @return   string
 	 */
 	public function get_preview_classes() {
 
@@ -292,9 +295,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get HTML of the icon to display in the .llms-lesson-preview element on the syllabus
 	 *
-	 * @return   string
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 * @return   string
 	 */
 	public function get_preview_icon_html() {
 
@@ -320,9 +323,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of LLMS_Course for the elements's parent section
 	 *
-	 * @return   obj|null
 	 * @since    3.16.0
 	 * @version  3.16.0
+	 * @return   obj|null
 	 */
 	public function get_section() {
 
@@ -338,9 +341,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an object for the assigned quiz (if a quiz is assigned )
 	 *
-	 * @return   obj|false
 	 * @since    3.3.0
 	 * @version  3.16.0
+	 * @return   obj|false
 	 */
 	public function get_quiz() {
 		if ( $this->has_quiz() ) {
@@ -349,6 +352,7 @@ implements LLMS_Interface_Post_Audio
 				return $quiz;
 			}
 		}
+
 		return false;
 	}
 
@@ -356,9 +360,9 @@ implements LLMS_Interface_Post_Audio
 	 * Attempt to get oEmbed for a video provider
 	 * Falls back to the [video] shortcode if the oEmbed fails
 	 *
-	 * @return   string
 	 * @since    1.0.0
 	 * @version  3.17.0
+	 * @return   string
 	 */
 	public function get_video() {
 		return $this->get_embed( 'video' );
@@ -367,9 +371,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the lesson prerequisite
 	 *
-	 * @return int [ID of the prerequisite post]
-	 *
 	 * @since 3.37.1 added filter and compatibility for course level prerequisite setting
+	 * @return int ID of the prerequisite post
+	 *
 	 */
 	public function get_prerequisite() {
 
@@ -378,12 +382,12 @@ implements LLMS_Interface_Post_Audio
 		$course = $this->get_course();
 
 		// Check course level setting.
-		if ( $course && $course->must_complete_sequentially() ){
-			// might be false so we are okay
+		if ( $course && $course->must_complete_sequentially() ) {
+			// Might be false so we are okay.
 			$pre_req = $this->get_previous_lesson();
 
-		} else if( $this->has_prerequisite ){
-			// Good ol' fashioned way
+		} else if ( $this->has_prerequisite ) {
+			// Good ol' fashioned way.
 			$pre_req = $this->prerequisite;
 
 		}
@@ -394,7 +398,7 @@ implements LLMS_Interface_Post_Audio
 		 * @since 3.37.1
 		 *
 		 * @param $pre_req int|false the ID of the prerequisite or false if none is available
-		 * @param $this LLMS_Lesson the lesson object
+		 * @param $this    LLMS_Lesson the lesson object
 		 */
 		return apply_filters( 'llms_lesson_get_prerequisite', $pre_req, $this );
 	}
@@ -402,22 +406,22 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if lesson prereq is enabled and a prereq lesson is selected
 	 *
-	 * @return   boolean
 	 * @since    3.0.0
-	 * @cince    3.37.1 Add filter and compatibility for course level prerequisite setting.
+	 * @since    3.37.1 Add filter and compatibility for course level prerequisite setting.
 	 * @version  3.0.0
+	 * @return   boolean
 	 */
 	public function has_prerequisite() {
 
 		$course = $this->get_course();
 
-		// check course level setting
-		if ( $course && $course->must_complete_sequentially() ){
+		// Check course level setting.
+		if ( $course && $course->must_complete_sequentially() ) {
 
 			$has_pre_req = true;
 
 		} else {
-			// Good ol' fashioned way
+			// Good ol' fashioned way.
 			$has_pre_req = ( 'yes' == $this->get( 'has_prerequisite' ) && $this->get( 'prerequisite' ) );
 
 		}
@@ -428,7 +432,7 @@ implements LLMS_Interface_Post_Audio
 		 * @since 3.37.1
 		 *
 		 * @param $has_pre_req bool whether the lesson has a prerequisite
-		 * @param $this LLMS_Lesson the lesson object
+		 * @param $this        LLMS_Lesson the lesson object
 		 */
 		return apply_filters( 'llms_lesson_has_prerequisite', $has_pre_req, $this );
 
@@ -439,13 +443,14 @@ implements LLMS_Interface_Post_Audio
 	 * Ensures that lessons created via the builder with "New Lesson" as the title (default slug "new-lesson-{$num}")
 	 * have their slug renamed when the title is renamed for the first time
 	 *
-	 * @return   bool
 	 * @since    3.14.8
 	 * @version  3.14.8
+	 * @return   bool
 	 */
 	public function has_modified_slug() {
 
 		$default = sanitize_title( __( 'New Lesson', 'lifterlms' ) );
+
 		return ( false === strpos( $this->get( 'name' ), $default ) );
 
 	}
@@ -453,9 +458,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a quiz is assigned to this lesson
 	 *
-	 * @return   boolean
 	 * @since    3.3.0
 	 * @version  3.29.0
+	 * @return   boolean
 	 */
 	public function has_quiz() {
 		return $this->get( 'quiz' ) ? true : false;
@@ -466,9 +471,9 @@ implements LLMS_Interface_Post_Audio
 	 * If no settings, this will return true if the posts's published
 	 * date is in the past
 	 *
-	 * @return   boolean
 	 * @since    3.16.0
 	 * @version  3.16.0
+	 * @return   boolean
 	 */
 	public function is_available() {
 
@@ -489,11 +494,13 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if the lesson has been completed by a specific user
 	 *
-	 * @param   int $user_id  WP_User ID of a student
-	 * @return  bool
 	 * @since   1.0.0
 	 * @version 3.0.0  refactored to utilize LLMS_Student->is_complete()
 	 *                 added $user_id param
+	 *
+	 * @param int $user_id WP_User ID of a student
+	 *
+	 * @return  bool
 	 */
 	public function is_complete( $user_id = null ) {
 
@@ -513,9 +520,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a the lesson is marked as "free"
 	 *
-	 * @return   boolean
 	 * @since    3.0.0
 	 * @version  3.0.0
+	 * @return   boolean
 	 */
 	public function is_free() {
 		return ( 'yes' === $this->get( 'free_lesson' ) );
@@ -524,9 +531,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if the lesson is an orphan
 	 *
-	 * @return   bool
 	 * @since    3.14.8
 	 * @version  3.14.8
+	 * @return   bool
 	 */
 	public function is_orphan() {
 
@@ -551,9 +558,9 @@ implements LLMS_Interface_Post_Audio
 	 * Determines if a quiz is enabled for the lesson
 	 * Lesson must have a quiz and the quiz must be enabled
 	 *
-	 * @return   bool
 	 * @since    3.16.0
 	 * @version  3.18.0
+	 * @return   bool
 	 */
 	public function is_quiz_enabled() {
 		return ( $this->has_quiz() && llms_parse_bool( $this->get( 'quiz_enabled' ) ) && 'publish' === get_post_status( $this->get( 'quiz' ) ) );
@@ -563,11 +570,13 @@ implements LLMS_Interface_Post_Audio
 	 * Add data to the course model when converted to array
 	 * Called before data is sorted and returned by $this->jsonSerialize()
 	 *
-	 * @param    array $arr   data to be serialized
-	 * @return   array
 	 * @since    3.3.0
 	 * @since    3.37.1 Add additional context for the prerequisite
 	 * @version  3.16.0
+	 *
+	 * @param array $arr data to be serialized
+	 *
+	 * @return   array
 	 */
 	public function toArrayAfter( $arr ) {
 
@@ -580,9 +589,9 @@ implements LLMS_Interface_Post_Audio
 		}
 
 		// handling in the event of course level prerequisite settings
-		if ( $this->has_prerequisite() ){
-			$arr[ 'has_prerequisite' ] = 'yes';
-			$arr[ 'prerequisite' ] = $this->get_prerequisite();
+		if ( $this->has_prerequisite() ) {
+			$arr['has_prerequisite'] = 'yes';
+			$arr['prerequisite']     = $this->get_prerequisite();
 		}
 
 		return $arr;
@@ -624,7 +633,8 @@ implements LLMS_Interface_Post_Audio
 	 * Set parent section
 	 * Set's parent section in database
 	 *
-	 * @param [int] $meta [id section post]
+	 * @param  [int] $meta [id section post]
+	 *
 	 * @return [mixed] $meta [if mta didn't exist returns the meta_id else t/f if update success]
 	 * Returns False if section id is already parent
 	 */
@@ -638,8 +648,9 @@ implements LLMS_Interface_Post_Audio
 	 * Set parent section
 	 * Set's parent section in database
 	 *
-	 * @param [int] $meta [id section post]
-	 * @return [mixed] $meta [if mta didn't exist returns the meta_id else t/f if update success]
+	 * @param  [int] $meta [id section post]
+	 *
+	 * @return [mixed] $meta [if meta didn't exist returns the meta_id else t/f if update success]
 	 * Returns False if section id is already parent
 	 */
 	public function set_order( $order ) {
@@ -652,7 +663,8 @@ implements LLMS_Interface_Post_Audio
 	 * Set parent course
 	 * Set's parent course in database
 	 *
-	 * @param [int] $meta [id course post]
+	 * @param  [int] $meta [id course post]
+	 *
 	 * @return [mixed] $meta [if meta didn't exist returns the meta_id else t/f if update success]
 	 * Returns False if course id is already parent
 	 */
@@ -674,9 +686,9 @@ implements LLMS_Interface_Post_Audio
 	 * Get Next lesson
 	 * Finds and returns next lesson id
 	 *
-	 * @return   int [ID of next lesson]
 	 * @since    1.0.0
 	 * @version  3.24.0
+	 * @return   int [ID of next lesson]
 	 */
 	public function get_next_lesson() {
 
@@ -754,9 +766,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get previous lesson id
 	 *
-	 * @return   int [ID of previous lesson]
 	 * @since    1.0.0
 	 * @version  3.24.0
+	 * @return   int [ID of previous lesson]
 	 */
 	public function get_previous_lesson() {
 
@@ -830,6 +842,7 @@ implements LLMS_Interface_Post_Audio
 					if ( ! $lessons ) {
 						return false;
 					}
+
 					return $lessons[ count( $lessons ) - 1 ]->ID;
 				} else {
 					return false;
@@ -858,10 +871,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the quiz associated with the lesson
 	 *
-	 * @return     false|int
-	 * @deprecated 3.0.2
 	 * @since      1.0.0
 	 * @version    3.16.0
+	 * @deprecated 3.0.2
+	 * @return     false|int
 	 */
 	public function get_assigned_quiz() {
 
@@ -879,8 +892,8 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the lesson drip days
 	 *
-	 * @return      int [ID of the prerequisite post]
 	 * @deprecated  3.16.0
+	 * @return      int [ID of the prerequisite post]
 	 */
 	public function get_drip_days() {
 
@@ -896,16 +909,21 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Marks the current lesson complete
 	 *
-	 * @param      int     $user_id              WP User ID of the user
-	 * @param      boolean $prevent_autoadvance  Deprecated
-	 * @return     boolean
-	 * @deprecated 3.3.1
 	 * @since      1.0.0
 	 * @version    3.3.1
+	 *
+	 * @deprecated 3.3.1
+	 *
+	 * @param boolean $prevent_autoadvance Deprecated
+	 *
+	 * @param int     $user_id             WP User ID of the user
+	 *
+	 * @return     boolean
 	 */
 	public function mark_complete( $user_id, $prevent_autoadvance = false ) {
 
 		llms_deprecated_function( 'LLMS_Lesson::mark_complete()', '3.3.1', 'llms_mark_complete()' );
+
 		return llms_mark_complete( $user_id, $this->get( 'id' ), 'lesson', 'lesson_' . $this->get( 'id' ) );
 
 	}

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -377,7 +377,7 @@ implements LLMS_Interface_Post_Audio
 
 		$course = $this->get_course();
 
-		// Check course level setting
+		// Check course level setting.
 		if ( $course && $course->must_complete_sequentially() ){
 			// might be false so we are okay
 			$pre_req = $this->get_previous_lesson();

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -368,6 +368,8 @@ implements LLMS_Interface_Post_Audio
 	 * Get the lesson prerequisite
 	 *
 	 * @return int [ID of the prerequisite post]
+	 *
+	 * @since 3.37.1 added filter and compatibility for course level prerequisite setting
 	 */
 	public function get_prerequisite() {
 
@@ -379,15 +381,21 @@ implements LLMS_Interface_Post_Audio
 		if ( $course && $course->must_complete_sequentially() ){
 			// might be false so we are okay
 			$pre_req = $this->get_previous_lesson();
+
+		} else if( $this->has_prerequisite ){
+			// Good ol' fashioned way
+			$pre_req = $this->prerequisite;
+
 		}
 
-		// Good ol' fashioned way
-		if ( ! $pre_req ){
-			if ( $this->has_prerequisite ) {
-				$pre_req = $this->prerequisite;
-			}
-		}
-
+		/**
+		 * Allow plugins to modify the prerequisite property.
+		 *
+		 * @since 3.37.1
+		 *
+		 * @param $pre_req int|false the ID of the prerequisite or false if none is available
+		 * @param $this LLMS_Lesson the lesson object
+		 */
 		return apply_filters( 'llms_lesson_get_prerequisite', $pre_req, $this );
 	}
 
@@ -396,23 +404,32 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @return   boolean
 	 * @since    3.0.0
+	 * @cince    3.37.1 Add filter and compatibility for course level prerequisite setting.
 	 * @version  3.0.0
 	 */
 	public function has_prerequisite() {
-
-		$has_pre_req = false;
 
 		$course = $this->get_course();
 
 		// check course level setting
 		if ( $course && $course->must_complete_sequentially() ){
+
 			$has_pre_req = true;
-		}
 
-		if ( ! $has_pre_req ){
+		} else {
+			// Good ol' fashioned way
 			$has_pre_req = ( 'yes' == $this->get( 'has_prerequisite' ) && $this->get( 'prerequisite' ) );
+
 		}
 
+		/**
+		 * Allow plugins to modify the has_prerequisite property.
+		 *
+		 * @since 3.37.1
+		 *
+		 * @param $has_pre_req bool whether the lesson has a prerequisite
+		 * @param $this LLMS_Lesson the lesson object
+		 */
 		return apply_filters( 'llms_lesson_has_prerequisite', $has_pre_req, $this );
 
 	}
@@ -549,6 +566,7 @@ implements LLMS_Interface_Post_Audio
 	 * @param    array $arr   data to be serialized
 	 * @return   array
 	 * @since    3.3.0
+	 * @since    3.37.1 Add additional context for the prerequisite
 	 * @version  3.16.0
 	 */
 	public function toArrayAfter( $arr ) {

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -373,7 +373,6 @@ class LLMS_Lesson
 	 *
 	 * @since 3.37.1 added filter and compatibility for course level prerequisite setting
 	 * @return int ID of the prerequisite post
-	 *
 	 */
 	public function get_prerequisite() {
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Tests for LifterLMS Course Model
  * @group    LLMS_Course
@@ -23,80 +24,80 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Get properties, used by test_getters_setters
 	 * This should match, exactly, the object's $properties array
-	 * @return   array
 	 * @since    3.4.0
 	 * @version  3.20.0
+	 * @return   array
 	 */
 	protected function get_properties() {
 		return array(
-			'audio_embed' => 'text',
-			'capacity' => 'absint',
-			'capacity_message' => 'text',
-			'course_closed_message' => 'text',
-			'course_opens_message' => 'text',
+			'audio_embed'                => 'text',
+			'capacity'                   => 'absint',
+			'capacity_message'           => 'text',
+			'course_closed_message'      => 'text',
+			'course_opens_message'       => 'text',
 			'content_restricted_message' => 'text',
-			'enable_capacity' => 'yesno',
-			'end_date' => 'text',
-			'enrollment_closed_message' => 'text',
-			'enrollment_end_date' => 'text',
-			'enrollment_opens_message' => 'text',
-			'enrollment_period' => 'yesno',
-			'enrollment_start_date' => 'text',
-			'has_prerequisite' => 'yesno',
-			'length' => 'text',
-			'prerequisite' => 'absint',
-			'prerequisite_track' => 'absint',
+			'enable_capacity'            => 'yesno',
+			'end_date'                   => 'text',
+			'enrollment_closed_message'  => 'text',
+			'enrollment_end_date'        => 'text',
+			'enrollment_opens_message'   => 'text',
+			'enrollment_period'          => 'yesno',
+			'enrollment_start_date'      => 'text',
+			'has_prerequisite'           => 'yesno',
+			'length'                     => 'text',
+			'prerequisite'               => 'absint',
+			'prerequisite_track'         => 'absint',
 			'sales_page_content_page_id' => 'absint',
-			'sales_page_content_type' => 'string',
-			'sales_page_content_url' => 'string',
-			'tile_featured_video' => 'yesno',
-			'time_period' => 'yesno',
-			'start_date' => 'text',
-			'video_embed' => 'text',
+			'sales_page_content_type'    => 'string',
+			'sales_page_content_url'     => 'string',
+			'tile_featured_video'        => 'yesno',
+			'time_period'                => 'yesno',
+			'start_date'                 => 'text',
+			'video_embed'                => 'text',
 		);
 	}
 
 	/**
 	 * Get data to fill a create post with
 	 * This is used by test_getters_setters
-	 * @return   array
 	 * @since    3.4.0
 	 * @version  3.20.0
+	 * @return   array
 	 */
 	protected function get_data() {
 		return array(
-			'audio_embed' => 'http://example.tld/audio_embed',
-			'capacity' => 25,
-			'capacity_message' => 'Capacity Reached',
-			'course_closed_message' => 'Course has closed',
-			'course_opens_message' => 'Course is not yet open',
+			'audio_embed'                => 'http://example.tld/audio_embed',
+			'capacity'                   => 25,
+			'capacity_message'           => 'Capacity Reached',
+			'course_closed_message'      => 'Course has closed',
+			'course_opens_message'       => 'Course is not yet open',
 			'content_restricted_message' => 'You cannot access this content',
-			'enable_capacity' => 'yes',
-			'end_date' => '2017-05-05',
-			'enrollment_closed_message' => 'Enrollment is closed',
-			'enrollment_end_date' => '2017-05-05',
-			'enrollment_opens_message' => 'Enrollment opens later',
-			'enrollment_period' => 'yes',
-			'enrollment_start_date' => '2017-05-01',
-			'has_prerequisite' => 'no',
-			'length' => '1 year',
-			'prerequisite' => 0,
-			'prerequisite_track' => 0,
-			'tile_featured_video' => 'yes',
-			'time_period' => 'yes',
+			'enable_capacity'            => 'yes',
+			'end_date'                   => '2017-05-05',
+			'enrollment_closed_message'  => 'Enrollment is closed',
+			'enrollment_end_date'        => '2017-05-05',
+			'enrollment_opens_message'   => 'Enrollment opens later',
+			'enrollment_period'          => 'yes',
+			'enrollment_start_date'      => '2017-05-01',
+			'has_prerequisite'           => 'no',
+			'length'                     => '1 year',
+			'prerequisite'               => 0,
+			'prerequisite_track'         => 0,
+			'tile_featured_video'        => 'yes',
+			'time_period'                => 'yes',
 			'sales_page_content_page_id' => 0,
-			'sales_page_content_type' => 'none',
-			'sales_page_content_url' => 'https://lifterlms.com',
-			'start_date' => '2017-05-01',
-			'video_embed' => 'http://example.tld/video_embed',
+			'sales_page_content_type'    => 'none',
+			'sales_page_content_url'     => 'https://lifterlms.com',
+			'start_date'                 => '2017-05-01',
+			'video_embed'                => 'http://example.tld/video_embed',
 		);
 	}
 
 	/**
 	 * Test the get_available_points() method
-	 * @return   [type]
 	 * @since    3.24.0
 	 * @version  3.24.0
+	 * @return   [type]
 	 */
 	public function test_get_available_points() {
 
@@ -118,9 +119,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test Audio and Video Embeds
-	 * @return   void
 	 * @since    3.4.0
 	 * @version  3.4.0
+	 * @return   void
 	 */
 	public function test_get_embeds() {
 
@@ -157,13 +158,13 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test get percent complete from course
-	 * @return   void
 	 * @since    3.17.2
 	 * @version  3.17.2
+	 * @return   void
 	 */
 	public function test_get_percent_complete() {
 
-		$course = llms_get_post( $this->generate_mock_courses( 1, 4, 4, 0, 0 )[0] );
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 4, 4, 0, 0 )[0] );
 		$student = $this->get_mock_student();
 
 		$student->enroll( $course->get( 'id' ) );
@@ -194,15 +195,15 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test prerequisite functions related to courses
-	 * @return   void
 	 * @since    3.4.0
 	 * @version  3.7.3
+	 * @return   void
 	 */
 	public function test_get_prerequisites() {
 
-		$course = new LLMS_Course( 'new', 'Course Name' );
+		$course        = new LLMS_Course( 'new', 'Course Name' );
 		$prereq_course = new LLMS_Course( 'new', 'Course Prereq' );
-		$prereq_track = wp_create_term( 'test track', 'course_track' );
+		$prereq_track  = wp_create_term( 'test track', 'course_track' );
 
 		// no prereqs
 		$this->assertFalse( $course->has_prerequisite( 'any' ) );
@@ -245,9 +246,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the get lessons function
-	 * @return   void
 	 * @since    3.12.0
 	 * @version  3.12.0
+	 * @return   void
 	 */
 	public function test_get_lessons() {
 
@@ -256,21 +257,21 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		// get just ids
 		$lessons = $course->get_lessons( 'ids' );
 		$this->assertEquals( 4, count( $lessons ) );
-		array_map( function( $id ) {
+		array_map( function ( $id ) {
 			$this->assertTrue( is_numeric( $id ) );
 		}, $lessons );
 
 		// wp post objects
 		$lessons = $course->get_lessons( 'posts' );
 		$this->assertEquals( 4, count( $lessons ) );
-		array_map( function( $post ) {
+		array_map( function ( $post ) {
 			$this->assertTrue( is_a( $post, 'WP_Post' ) );
 		}, $lessons );
 
 		// lesson objects
 		$lessons = $course->get_lessons( 'lessons' );
 		$this->assertEquals( 4, count( $lessons ) );
-		array_map( function( $lesson ) {
+		array_map( function ( $lesson ) {
 			$this->assertTrue( is_a( $lesson, 'LLMS_Lesson' ) );
 		}, $lessons );
 
@@ -278,9 +279,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the get quizzes function
-	 * @return   void
 	 * @since    3.12.0
 	 * @version  3.12.0
+	 * @return   void
 	 */
 	public function test_get_quizzes() {
 
@@ -288,7 +289,7 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 		$quizzes = $course->get_quizzes();
 		$this->assertEquals( 3, count( $quizzes ) );
-		array_map( function( $id ) {
+		array_map( function ( $id ) {
 			$this->assertTrue( is_numeric( $id ) );
 		}, $quizzes );
 
@@ -296,9 +297,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test get_sales_page_url method
-	 * @return   void
 	 * @since    3.20.0
 	 * @version  3.20.0
+	 * @return   void
 	 */
 	public function test_get_sales_page_url() {
 
@@ -325,9 +326,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the get sections function
-	 * @return   void
 	 * @since    3.12.0
 	 * @version  3.12.0
+	 * @return   void
 	 */
 	public function test_get_sections() {
 
@@ -336,21 +337,21 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		// get just ids
 		$sections = $course->get_sections( 'ids' );
 		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $id ) {
+		array_map( function ( $id ) {
 			$this->assertTrue( is_numeric( $id ) );
 		}, $sections );
 
 		// wp post objects
 		$sections = $course->get_sections( 'posts' );
 		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $post ) {
+		array_map( function ( $post ) {
 			$this->assertTrue( is_a( $post, 'WP_Post' ) );
 		}, $sections );
 
 		// section objects
 		$sections = $course->get_sections( 'sections' );
 		$this->assertEquals( 4, count( $sections ) );
-		array_map( function( $section ) {
+		array_map( function ( $section ) {
 			$this->assertTrue( is_a( $section, 'LLMS_Section' ) );
 		}, $sections );
 
@@ -358,9 +359,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the get students function
-	 * @return   void
 	 * @since    3.12.0
 	 * @version  3.12.0
+	 * @return   void
 	 */
 	public function test_get_students() {
 
@@ -378,9 +379,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the has_capacity function
-	 * @return   void
 	 * @since    3.12.0
 	 * @version  3.12.0
+	 * @return   void
 	 */
 	public function test_has_capacity() {
 
@@ -415,9 +416,9 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test the has_sales_page_redirect method
-	 * @return   void
 	 * @since    3.20.0
 	 * @version  3.20.0
+	 * @return   void
 	 */
 	public function test_has_sales_page_redirect() {
 
@@ -442,12 +443,11 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Tests the must_complete_sequentially method
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_must_complete_sequentially()
-	{
+	public function test_must_complete_sequentially() {
 
 		$course = new LLMS_Course( 'new', 'Course Name' );
 
@@ -463,13 +463,12 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test the new functionality for the course level setting for prerequiesites
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
 	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_course_level_prerequisite()
-	{
+	public function test_course_level_prerequisite() {
 		/**
 		 * @var $course LLMS_Course
 		 */
@@ -484,16 +483,15 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		 */
 		$lessons = $course->get_lessons();
 
-		foreach ( $lessons as $lesson ){
+		foreach ( $lessons as $lesson ) {
 
 			$prev_lesson_id = $lesson->get_previous_lesson();
 
-			if ( ! $prev_lesson_id ){
+			if ( ! $prev_lesson_id ) {
 
 				// Ensure has_prereq is false
 				$this->assertEquals( false, $lesson->has_prerequisite() );
-			}
-			else {
+			} else {
 
 				// Ensure pre_req is the same as the previous lesson ID
 				$this->assertEquals( $prev_lesson_id, $lesson->get_prerequisite() );
@@ -501,8 +499,8 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 				// test toArray
 				$array = $lesson->toArray();
 
-				$this->assertEquals( 'yes', $array[ 'has_prerequisite' ] );
-				$this->assertEquals( $prev_lesson_id, $array[ 'prerequisite' ] );
+				$this->assertEquals( 'yes', $array['has_prerequisite'] );
+				$this->assertEquals( $prev_lesson_id, $array['prerequisite'] );
 			}
 		}
 	}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -439,4 +439,72 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Tests the must_complete_sequentially method
+	 *
+	 * @return void
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_must_complete_sequentially()
+	{
+
+		$course = new LLMS_Course( 'new', 'Course Name' );
+
+		$this->assertEquals( false, $course->must_complete_sequentially() );
+
+		$course->set( 'complete_sequentially', 'yes' );
+		$this->assertEquals( true, $course->must_complete_sequentially() );
+
+		$course->set( 'complete_sequentially', 'no' );
+		$this->assertEquals( false, $course->must_complete_sequentially() );
+	}
+
+	/**
+	 * Test the new functionality for the course level setting for prerequiesites
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_course_level_prerequisite()
+	{
+		/**
+		 * @var $course LLMS_Course
+		 */
+		$course = llms_get_post( $this->generate_mock_courses( 1, 2, 3, 0, 0 )[0] );
+
+		// Set sequential completion
+		// @see $course->must_complete_sequentially();
+		$course->set( 'complete_sequentially', 'yes' );
+
+		/**
+		 * @var $lessons LLMS_Lesson[]
+		 */
+		$lessons = $course->get_lessons();
+
+		foreach ( $lessons as $lesson ){
+
+			$prev_lesson_id = $lesson->get_previous_lesson();
+
+			if ( ! $prev_lesson_id ){
+
+				// Ensure has_prereq is false
+				$this->assertEquals( false, $lesson->has_prerequisite() );
+			}
+			else {
+
+				// Ensure pre_req is the same as the previous lesson ID
+				$this->assertEquals( $prev_lesson_id, $lesson->get_prerequisite() );
+
+				// test toArray
+				$array = $lesson->toArray();
+
+				$this->assertEquals( 'yes', $array[ 'has_prerequisite' ] );
+				$this->assertEquals( $prev_lesson_id, $array[ 'prerequisite' ] );
+			}
+		}
+	}
+
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -466,7 +466,6 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	 * @since   [version]
 	 * @version [version]
 	 * @return void
-	 *
 	 */
 	public function test_course_level_prerequisite() {
 		/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -417,4 +417,46 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test the new functionality for the course level setting for prerequiesites
+	 */
+	public function test_course_level_prerequisite()
+	{
+		/**
+		 * @var $course LLMS_Course
+		 */
+		$course = llms_get_post( $this->generate_mock_courses( 1, 2, 3, 0, 0 )[0] );
+
+		// Set sequential completion
+		// @see $course->must_complete_sequentially();
+		$course->set( 'complete_sequentially', 'yes' );
+
+		/**
+		 * @var $lessons LLMS_Lesson[]
+		 */
+		$lessons = $course->get_lessons();
+
+		foreach ( $lessons as $lesson ){
+
+			$prev_lesson_id = $lesson->get_previous_lesson();
+
+			if ( ! $prev_lesson_id ){
+
+				// Ensure has_prereq is false
+				$this->assertEquals( false, $lesson->has_prerequisite() );
+			}
+			else {
+
+				// Ensure pre_req is the same as the previous lesson ID
+				$this->assertEquals( $prev_lesson_id, $lesson->get_prerequisite() );
+
+				// test toArray
+				$array = $lesson->toArray();
+
+				$this->assertEquals( 'yes', $array[ 'has_prerequisite' ] );
+				$this->assertEquals( $prev_lesson_id, $array[ 'prerequisite' ] );
+			}
+		}
+	}
+
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -432,7 +432,6 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 * @since   [version]
 	 * @version [version]
 	 * @return void
-	 *
 	 */
 	public function test_has_prerequisite() {
 
@@ -450,7 +449,6 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 * @since   [version]
 	 * @version [version]
 	 * @return void
-	 *
 	 */
 	public function test_has_prerequisite_complete_sequentially_enabled() {
 		/**
@@ -478,7 +476,6 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 * @since   [version]
 	 * @version [version]
 	 * @return void
-	 *
 	 */
 	public function test_has_prerequisite_complete_sequentially_disabled() {
 		/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -418,17 +418,39 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test the new functionality for the course level setting for prerequiesites
+	 * Test the has prerequisite method
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
 	 */
-	public function test_course_level_prerequisite()
+	public function test_has_prerequisite()
+	{
+
+		$lesson = new LLMS_Lesson( 'new', 'New Lesson' );
+
+		$this->assertFalse( $lesson->has_prerequisite() );
+
+		$lesson->set( 'has_prerequisite', 'yes' );
+		$this->assertTrue( $lesson->has_prerequisite() );
+	}
+
+	/**
+	 * Test has_prerequisite() when the course must be completed sequentially
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_has_prerequisite_complete_sequentially_enabled()
 	{
 		/**
 		 * @var $course LLMS_Course
 		 */
 		$course = llms_get_post( $this->generate_mock_courses( 1, 2, 3, 0, 0 )[0] );
 
-		// Set sequential completion
-		// @see $course->must_complete_sequentially();
 		$course->set( 'complete_sequentially', 'yes' );
 
 		/**
@@ -436,27 +458,119 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		 */
 		$lessons = $course->get_lessons();
 
-		foreach ( $lessons as $lesson ){
-
-			$prev_lesson_id = $lesson->get_previous_lesson();
-
-			if ( ! $prev_lesson_id ){
-
-				// Ensure has_prereq is false
-				$this->assertEquals( false, $lesson->has_prerequisite() );
-			}
-			else {
-
-				// Ensure pre_req is the same as the previous lesson ID
-				$this->assertEquals( $prev_lesson_id, $lesson->get_prerequisite() );
-
-				// test toArray
-				$array = $lesson->toArray();
-
-				$this->assertEquals( 'yes', $array[ 'has_prerequisite' ] );
-				$this->assertEquals( $prev_lesson_id, $array[ 'prerequisite' ] );
-			}
-		}
+		// First Lesson will not have a prerequisite because no lesson comes before it
+		$this->assertFalse( $lessons[0]->has_prerequisite() );
+		// Second & Third Lesson will have a prerequisite because a lesson comes before it
+		$this->assertTrue( $lessons[1]->has_prerequisite() );
+		$this->assertTrue( $lessons[2]->has_prerequisite() );
 	}
+
+	/**
+	 * Test has_prerequisite() when sequential completion is disabled
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_has_prerequisite_complete_sequentially_disabled()
+	{
+		/**
+		 * @var $course LLMS_Course
+		 */
+		$course = llms_get_post( $this->generate_mock_courses( 1, 2, 3, 0, 0 )[0] );
+
+		// Explicit
+		$course->set( 'complete_sequentially', 'no' );
+
+		/**
+		 * @var $lessons LLMS_Lesson[]
+		 */
+		$lessons = $course->get_lessons();
+
+		// No lessons will have prerequisites
+		$this->assertFalse( $lessons[0]->has_prerequisite() );
+		$this->assertFalse( $lessons[1]->has_prerequisite() );
+		$this->assertFalse( $lessons[2]->has_prerequisite() );
+	}
+
+	/**
+	 * Test the get_prerequisite() method
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_get_prerequisite()
+	{
+		$lesson = new LLMS_Lesson( 'new', 'New Lesson' );
+
+		$this->assertFalse( $lesson->get_prerequisite() );
+
+		$lesson->set( 'has_prerequisite', 'yes' );
+		$lesson->set( 'prerequisite', 1234 );
+		$this->assertEquals( 1234, $lesson->get_prerequisite() );
+	}
+
+	/**
+	 * Test course_prerequisite() when the course must be completed sequentially
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_get_prerequisite_complete_sequentially_enabled()
+	{
+		/**
+		 * @var $course LLMS_Course
+		 */
+		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 3, 0, 0 )[0] );
+
+		$course->set( 'complete_sequentially', 'yes' );
+
+		/**
+		 * @var $lessons LLMS_Lesson[]
+		 */
+		$lessons = $course->get_lessons();
+
+		// First Lesson will not have a prerequisite because no lesson comes before it
+		$this->assertFalse( $lessons[0]->get_prerequisite() );
+		// Second lesson will have first lesson as a prerequisite
+		$this->assertEquals( $lessons[0]->ID, $lessons[1]->get_prerequisite() );
+		// Third lesson will have second lesson as a prerequisite
+		$this->assertEquals( $lessons[1]->ID, $lessons[2]->get_prerequisite() );
+	}
+
+	/**
+	 * Test get_prerequisite() when sequential completion is disabled
+	 *
+	 * @return void
+	 *
+	 * @since 3.37.1
+	 * @version 3.37.1
+	 */
+	public function test_get_prerequisite_complete_sequentially_disabled()
+	{
+		/**
+		 * @var $course LLMS_Course
+		 */
+		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 3, 0, 0 )[0] );
+
+		// Explicit
+		$course->set( 'complete_sequentially', 'no' );
+
+		/**
+		 * @var $lessons LLMS_Lesson[]
+		 */
+		$lessons = $course->get_lessons();
+
+		// No lessons will have prerequisites
+		$this->assertFalse( $lessons[0]->get_prerequisite() );
+		$this->assertFalse( $lessons[1]->get_prerequisite() );
+		$this->assertFalse( $lessons[2]->get_prerequisite() );
+	}
+
 
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -1,15 +1,16 @@
 <?php
+
 /**
  * Tests for LifterLMS Lesson Model
  * @group     post_models
  * @group     lessons
  *
- * @since  3.14.8
- * @since 3.29.0 Unknown.
- * @since 3.36.2 Added tests on lesson's availability with drip method set as 3 days after
+ * @since     3.14.8
+ * @since     3.29.0 Unknown.
+ * @since     3.36.2 Added tests on lesson's availability with drip method set as 3 days after
  *               the course start date and empty course start date.
  *               Also added `$date_delta` property to be used to test dates against current time.
- * @version 3.36.2
+ * @version   3.36.2
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
@@ -31,38 +32,39 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 * @var integer
 	 */
 	private $date_delta = 60;
+
 	/**
 	 * Get properties, used by test_getters_setters
 	 * This should match, exactly, the object's $properties array
-	 * @return   array
 	 * @since    3.14.8
 	 * @version  3.16.11
+	 * @return   array
 	 */
 	protected function get_properties() {
 		return array(
 
-			'order' => 'absint',
+			'order'                 => 'absint',
 
 			// drippable
 			'days_before_available' => 'absint',
-			'date_available' => 'text',
-			'drip_method' => 'text',
-			'time_available' => 'text',
+			'date_available'        => 'text',
+			'drip_method'           => 'text',
+			'time_available'        => 'text',
 
 			// parent element
-			'parent_course' => 'absint',
-			'parent_section' => 'absint',
+			'parent_course'         => 'absint',
+			'parent_section'        => 'absint',
 
-			'audio_embed' => 'text',
-			'free_lesson' => 'yesno',
-			'has_prerequisite' => 'yesno',
-			'prerequisite' => 'absint',
+			'audio_embed'           => 'text',
+			'free_lesson'           => 'yesno',
+			'has_prerequisite'      => 'yesno',
+			'prerequisite'          => 'absint',
 			'require_passing_grade' => 'yesno',
-			'video_embed' => 'text',
+			'video_embed'           => 'text',
 
 			// quizzes
-			'quiz' => 'absint',
-			'quiz_enabled' => 'yesno',
+			'quiz'                  => 'absint',
+			'quiz_enabled'          => 'yesno',
 
 		);
 	}
@@ -70,27 +72,27 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Get data to fill a create post with
 	 * This is used by test_getters_setters
-	 * @return   array
 	 * @since    3.14.8
 	 * @version  3.16.11
+	 * @return   array
 	 */
 	protected function get_data() {
 		return array(
-			'audio_embed' => 'http://example.tld/audio_embed',
-			'date_available' => '11/21/2018',
+			'audio_embed'           => 'http://example.tld/audio_embed',
+			'date_available'        => '11/21/2018',
 			'days_before_available' => '24',
-			'drip_method' => 'date',
-			'free_lesson' => 'no',
-			'has_prerequisite' => 'yes',
-			'order' => 1,
-			'parent_course' => 85,
-			'parent_section' => 32,
-			'prerequisite' => 344,
-			'quiz' => 123,
-			'quiz_enabled' => 'yes',
+			'drip_method'           => 'date',
+			'free_lesson'           => 'no',
+			'has_prerequisite'      => 'yes',
+			'order'                 => 1,
+			'parent_course'         => 85,
+			'parent_section'        => 32,
+			'prerequisite'          => 344,
+			'quiz'                  => 123,
+			'quiz_enabled'          => 'yes',
 			'require_passing_grade' => 'yes',
-			'time_available' => '12:34 PM',
-			'video_embed' => 'http://example.tld/video_embed',
+			'time_available'        => '12:34 PM',
+			'video_embed'           => 'http://example.tld/video_embed',
 		);
 	}
 
@@ -120,10 +122,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$format = 'Y-m-d';
 
 		$course_id = $this->generate_mock_courses( 1, 1, 2, 0 )[0];
-		$course = llms_get_post( $course_id );
-		$lesson = $course->get_lessons()[0];
+		$course    = llms_get_post( $course_id );
+		$lesson    = $course->get_lessons()[0];
 		$lesson_id = $lesson->get( 'id' );
-		$student = $this->get_mock_student();
+		$student   = $this->get_mock_student();
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
@@ -181,9 +183,9 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test Audio and Video Embeds
-	 * @return   void
 	 * @since    3.14.8
 	 * @version  3.14.8
+	 * @return   void
 	 */
 	public function test_get_embeds() {
 
@@ -234,9 +236,9 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test has_modified_slug function
-	 * @return   void
 	 * @since    3.14.8
 	 * @version  3.14.8
+	 * @return   void
 	 */
 	public function test_has_modified_slug() {
 
@@ -260,9 +262,9 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test the has_quiz() method
 	 *
-	 * @return  void
 	 * @since   3.29.0
 	 * @version 3.29.0
+	 * @return  void
 	 */
 	public function test_has_quiz() {
 
@@ -277,10 +279,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	public function test_is_available() {
 
 		$course_id = $this->generate_mock_courses( 1, 1, 2, 0 )[0];
-		$course = llms_get_post( $course_id );
-		$lesson = $course->get_lessons()[0];
+		$course    = llms_get_post( $course_id );
+		$lesson    = $course->get_lessons()[0];
 		$lesson_id = $lesson->get( 'id' );
-		$student = $this->get_mock_student();
+		$student   = $this->get_mock_student();
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
@@ -340,43 +342,50 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * test the is_orphan function
-	 * @return   [type]
 	 * @since    3.14.8
 	 * @version  3.14.8
+	 * @return   [type]
 	 */
 	public function test_is_orphan() {
 
-		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
 		$section = llms_get_post( $course->get_sections( 'ids' )[0] );
-		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
+		$lesson  = llms_get_post( $course->get_lessons( 'ids' )[0] );
 
 		// not an orphan
 		$this->assertFalse( $lesson->is_orphan() );
 
- 		$test_statuses = get_post_stati( array( '_builtin' => true ) );
+		$test_statuses = get_post_stati( array( '_builtin' => true ) );
 		foreach ( array_keys( $test_statuses ) as $status ) {
 
-			$assert = in_array( $status, array( 'publish', 'future', 'draft', 'pending', 'private', 'auto-draft' ) ) ? 'assertFalse' : 'assertTrue';
+			$assert = in_array( $status, array(
+				'publish',
+				'future',
+				'draft',
+				'pending',
+				'private',
+				'auto-draft'
+			) ) ? 'assertFalse' : 'assertTrue';
 
 			// check parent course
 			wp_update_post( array(
-				'ID' => $course->get( 'id' ),
+				'ID'          => $course->get( 'id' ),
 				'post_status' => $status,
 			) );
 			$this->$assert( $lesson->is_orphan() );
 			wp_update_post( array(
-				'ID' => $course->get( 'id' ),
+				'ID'          => $course->get( 'id' ),
 				'post_status' => 'publish',
 			) );
 
 			// check parent section
 			wp_update_post( array(
-				'ID' => $section->get( 'id' ),
+				'ID'          => $section->get( 'id' ),
 				'post_status' => $status,
 			) );
 			$this->$assert( $lesson->is_orphan() );
 			wp_update_post( array(
-				'ID' => $section->get( 'id' ),
+				'ID'          => $section->get( 'id' ),
 				'post_status' => 'publish',
 			) );
 
@@ -420,13 +429,12 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test the has prerequisite method
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
 	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_has_prerequisite()
-	{
+	public function test_has_prerequisite() {
 
 		$lesson = new LLMS_Lesson( 'new', 'New Lesson' );
 
@@ -439,13 +447,12 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test has_prerequisite() when the course must be completed sequentially
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
 	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_has_prerequisite_complete_sequentially_enabled()
-	{
+	public function test_has_prerequisite_complete_sequentially_enabled() {
 		/**
 		 * @var $course LLMS_Course
 		 */
@@ -468,13 +475,12 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test has_prerequisite() when sequential completion is disabled
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
 	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_has_prerequisite_complete_sequentially_disabled()
-	{
+	public function test_has_prerequisite_complete_sequentially_disabled() {
 		/**
 		 * @var $course LLMS_Course
 		 */
@@ -497,13 +503,11 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test the get_prerequisite() method
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
-	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_get_prerequisite()
-	{
+	public function test_get_prerequisite() {
 		$lesson = new LLMS_Lesson( 'new', 'New Lesson' );
 
 		$this->assertFalse( $lesson->get_prerequisite() );
@@ -516,13 +520,11 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test course_prerequisite() when the course must be completed sequentially
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
-	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_get_prerequisite_complete_sequentially_enabled()
-	{
+	public function test_get_prerequisite_complete_sequentially_enabled() {
 		/**
 		 * @var $course LLMS_Course
 		 */
@@ -546,13 +548,11 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test get_prerequisite() when sequential completion is disabled
 	 *
+	 * @since   [version]
+	 * @version [version]
 	 * @return void
-	 *
-	 * @since 3.37.1
-	 * @version 3.37.1
 	 */
-	public function test_get_prerequisite_complete_sequentially_disabled()
-	{
+	public function test_get_prerequisite_complete_sequentially_disabled() {
 		/**
 		 * @var $course LLMS_Course
 		 */


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR adds functionality to allow the user to define that all lessons must be completed sequentially.

With a course level setting, all lessons (except the first lesson) will have the lesson prerequisite set to the lesson preceding it.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
Tested on a localhost, latest version of WP and LifterLMS as well as test cases added to LLMS_Test_LLMS_Lesson class

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->
Current possible issues:
- In the course builder, the prerequisite is auto-set to the previous lesson. When saving, the lesson Id is saved to the prerequisite attribute. When disabling the course level settings, lessons will retain the prerequisite of the previous lesson ID. However, the pre-requisite checkbox will be disabled.

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script phpcs`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

