### PR TITLE
Membership redirection

### DIFF
--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -3,7 +3,7 @@
  * Template loader.
  *
  * @since 1.0.0
- * @version 3.37.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.20.0 Unknown.
  * @since 3.37.2 Made sure notices are printed on sales pages too.
+ * @since [version] Made sure notices are printed on a sitewide restricted by membership redirection page.
  */
 class LLMS_Template_Loader {
 
@@ -296,6 +297,7 @@ class LLMS_Template_Loader {
 	 * Parses and obeys Membership "Restriction Behavior" settings.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Flag to print notices, if there are, when landing on the redirected page.
 	 *
 	 * @param array $info Array of restriction info from `llms_page_restricted()`.
 	 * @return void
@@ -313,6 +315,12 @@ class LLMS_Template_Loader {
 			$msg      = '';
 			$redirect = '';
 
+			if ( 'yes' === $membership->get( 'restriction_add_notice' ) ) {
+
+				$msg = $membership->get( 'restriction_notice' );
+
+			}
+
 			// get the redirect based on the redirect type (if set).
 			switch ( $membership->get( 'restriction_redirect_type' ) ) {
 
@@ -326,13 +334,14 @@ class LLMS_Template_Loader {
 
 				case 'page':
 					$redirect = get_permalink( $membership->get( 'redirect_page_id' ) );
+					// Make sure to print notices in wp pages.
+					$redirect = empty( $msg ) ? $redirect : add_query_arg(
+						array(
+							'llms_print_notices' => 1,
+						),
+						$redirect
+					);
 					break;
-
-			}
-
-			if ( 'yes' === $membership->get( 'restriction_add_notice' ) ) {
-
-				$msg = $membership->get( 'restriction_notice' );
 
 			}
 

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -26,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
  * @since [version] Made `$user_id` parameter optional for the function `llms_is_page_restricted`.
  *                Use strict comparison '===' in place of '=='.
  *                Call `in_array()` with strict comparison.
+ *                Excude the privacy policy from the sitewide membership restriction.
  */
 
 /**
@@ -586,6 +587,7 @@ function llms_is_post_restricted_by_membership( $post_id, $user_id = null ) {
  *
  * @since 3.0.0
  * @since [version] Made sure to not apply the restriction on the WordPress page set as memebership's restriction redirection page.
+ *                  Excude the privacy policy from the restriction as well.
  *                  Call `in_array()` with strict comparison.
  *
  * @param int      $post_id WP Post ID.
@@ -621,6 +623,7 @@ function llms_is_post_restricted_by_sitewide_membership( $post_id, $user_id = nu
 					llms_get_page_id( 'memberships' ), // membership archives.
 					llms_get_page_id( 'myaccount' ), // lifterlms account page.
 					llms_get_page_id( 'checkout' ), // lifterlms checkout page.
+					absint( get_option( 'wp_page_for_privacy_policy' ) ), // wp privacy policy page.
 					$redirect_page_id, // Restricted contents redirection page id.
 				)
 			)

--- a/tests/phpunit/unit-tests/class-llms-test-functions-access.php
+++ b/tests/phpunit/unit-tests/class-llms-test-functions-access.php
@@ -1,14 +1,19 @@
 <?php
 /**
- * Tests for LifterLMS Access Functions
- * @group    access
- * @since    3.7.3
- * @version  3.16.0
+ * Tests for LifterLMS Access Functions.
+ *
+ * @group access
+ *
+ * @since 3.7.3
+ * @since 3.16.0 Unknown.
+ * @since [version] Added tests on sitewide membership restriction.
+ * @version [version]
  */
 class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
 	/**
-	 * Get a formatted date for setting time period related restrictions
+	 * Get a formatted date for setting time period related restrictions.
+	 *
 	 * @param    string     $offset  adjust day via strtotime
 	 * @param    string     $format  desired returned format, passed to date()
 	 * @return   string
@@ -20,10 +25,11 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test drip restrictions
-	 * @return   [type]
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * Test drip restrictions.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_is_post_restricted_by_drip_settings() {
 
@@ -35,26 +41,26 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
-		// no drip settings, lesson is currently available
+		// no drip settings, lesson is currently available.
 		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
-		// date in past so the lesson is available
+		// date in past so the lesson is available.
 		$lesson = llms_get_post( $lesson_id );
 		$lesson->set( 'drip_method', 'date' );
 		$lesson->set( 'date_available', '12/12/2012' );
 		$lesson->set( 'time_available', '12:12 AM' );
 		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
-		// date in future so lesson not available
+		// date in future so lesson not available.
 		$lesson->set( 'date_available', date( 'm/d/Y', current_time( 'timestamp' ) + DAY_IN_SECONDS ) );
 		$this->assertEquals( $lesson_id, llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
-		// available 3 days after enrollment
+		// available 3 days after enrollment.
 		$lesson->set( 'drip_method', 'enrollment' );
 		$lesson->set( 'days_before_available', '3' );
 		$this->assertEquals( $lesson_id, llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
-		// now available
+		// now available.
 		llms_mock_current_time( '+4 days' );
 		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
@@ -62,15 +68,22 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 		$lesson->set( 'drip_method', 'start' );
 		$course->set( 'start_date', date( 'm/d/Y', current_time( 'timestamp' ) + DAY_IN_SECONDS ) );
 
-		// not available until 3 days after course start date
+		// not available until 3 days after course start date.
 		$this->assertEquals( $lesson_id, llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
-		// now available
+		// now available.
 		llms_mock_current_time( '+4 days' );
 		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
 
 	}
 
+	/**
+	 * Test restricted by membership.
+	 *
+	 * @since Unknown.
+	 *
+	 * @return void
+	 */
 	public function test_llms_is_post_restricted_by_membership() {
 
 		$memberships = $this->factory->post->create_many( 2, array(
@@ -99,10 +112,124 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test the llms_is_post_restricted_by_prerequisite() function
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * Test restriction by membership sitewide.
+	 *
+	 * @since Unknown.
+	 *
+	 * @return void
+	 */
+	public function test_llms_is_post_restricted_by_sitewide_membership() {
+
+		$memberships = $this->factory->post->create_many( 2, array(
+			'post_type' => 'llms_membership',
+		) );
+		$post_id     = $this->factory->post->create();
+
+		// create a page where redirect to.
+		$redirect_id = $this->factory->post->create( array(
+			'post_type' => 'page'
+		) );
+
+		/**
+		 * Create pages that must be always accessible.
+		 */
+
+		// create and set privacy policy page.
+		update_option( 'wp_page_for_privacy_policy', $this->factory->post->create( array(
+			'post_type' => 'page'
+		) ) );
+
+		// create and set terms page.
+		update_option( 'lifterlms_terms_page_id', $this->factory->post->create( array(
+			'post_type' => 'page'
+		) ) );
+
+		// create and set memberships catalog page.
+		update_option( 'lifterlms_memberships_page_id', $this->factory->post->create( array(
+			'post_type' => 'page'
+		) ) );
+
+		// create and set myaccount page.
+		update_option( 'lifterlms_myaccount_page_id', $this->factory->post->create( array(
+			'post_type' => 'page'
+		) ) );
+
+		// create and set checkout page.
+		update_option( 'lifterlms_checkout_page_id', $this->factory->post->create( array(
+			'post_type' => 'page'
+		) ) );
+
+		// require membership sitewide.
+		update_option( 'lifterlms_membership_required', $memberships[1] );
+
+		// set membership's restriction redirection.
+		update_post_meta( $memberships[1], '_llms_redirect_page_id', $redirect_id );
+		update_post_meta( $memberships[1], '_llms_restriction_redirect_type', 'page' );
+
+		// I expect a post or another membership to be restricted.
+		// While I expect the redirection page and the membership set as requirement to be accessible.
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $post_id ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $memberships[0] ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $memberships[1] ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $redirect_id ) );
+
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'lifterlms_terms_page_id' ) ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'memberships' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'myaccount' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'checkout' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'wp_page_for_privacy_policy' ) ) ) );
+
+		// unset the redirection page.
+		// I expect a post, the former redirection page or another membership to be restricted.
+		// While I expect membership set as requirement to be accessible.
+		update_post_meta( $memberships[1], '_llms_redirect_page_id', '' );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $post_id ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $memberships[0] ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $redirect_id ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $memberships[1] ) );
+
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'lifterlms_terms_page_id' ) ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'memberships' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'myaccount' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'checkout' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'wp_page_for_privacy_policy' ) ) ) );
+
+		// re-set the redirection page, but set the restriction redirect type as 'custom'.
+		// I expect a post, the former redirection page or another membership to be restricted.
+		// While I expect membership set as requirement to be accessible.
+		update_post_meta( $memberships[1], '_llms_redirect_page_id', $redirect_id );
+		update_post_meta( $memberships[1], '_llms_restriction_redirect_type', 'custom' );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $post_id ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $memberships[0] ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_sitewide_membership( $redirect_id ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $memberships[1] ) );
+
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'lifterlms_terms_page_id' ) ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'memberships' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'myaccount' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'checkout' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'wp_page_for_privacy_policy' ) ) ) );
+
+		// unset the membership enrollment requirement.
+		// I expect 'everything' to be not restricted.
+		update_option( 'lifterlms_membership_required', '' );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $post_id ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $memberships[0] ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $memberships[1] ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( $redirect_id ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'lifterlms_terms_page_id' ) ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'memberships' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'myaccount' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( llms_get_page_id( 'checkout' ) ) );
+		$this->assertFalse( llms_is_post_restricted_by_sitewide_membership( absint( get_option( 'wp_page_for_privacy_policy' ) ) ) );
+	}
+
+	/**
+	 * Test the llms_is_post_restricted_by_prerequisite() function.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_is_post_restricted_by_prerequisite() {
 
@@ -130,10 +257,10 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
 		$student_id = $this->factory->user->create( array( 'role' => 'student' ) );
 
-		// results should all be the same with the student b/c nothing completed
+		// results should all be the same with the student b/c nothing completed.
 		$this->prereq_tests( $test_ids, $course, $prereq_course_id, $track_id, $student_id );
 
-		// results differ once student completes courses
+		// results differ once student completes courses.
 		$this->complete_courses_for_student( $student_id, $courses );
 
 		$this->prereq_tests( $test_ids, $course, $prereq_course_id, $track_id, $student_id );
@@ -141,15 +268,17 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * test_llms_is_post_restricted_by_prerequisite() runs this series of assertions several times
-	 * @param    array      $test_ids          array of post ids to test the llms_is_post_restricted_by_prerequisite() against
-	 * @param    obj        $course            course object
-	 * @param    int        $prereq_course_id  post id of the prereq course
-	 * @param    int        $track_id          term id of the prereq track
-	 * @param    int        $user_id           wp user id of a student
-	 * @return   void
-	 * @since    3.7.3
-	 * @version  3.12.0
+	 * test_llms_is_post_restricted_by_prerequisite() runs this series of assertions several times.
+	 *
+	 * @since 3.7.3
+	 * @since 3.12.0 Unknown.
+	 *
+	 * @param array $test_ids         Array of post ids to test the llms_is_post_restricted_by_prerequisite() against.
+	 * @param obj   $course           Course object.
+	 * @param int   $prereq_course_id Post id of the prereq course.
+	 * @param int   $track_id         Term id of the prereq track.
+	 * @param int   $user_id          Wp user id of a student.
+	 * @return void
 	 */
 	private function prereq_tests( $test_ids = array(), $course, $prereq_course_id, $track_id, $user_id = null ) {
 
@@ -174,7 +303,7 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
 			}
 
-			// set a course prereq
+			// set a course prereq.
 			$course->set( 'has_prerequisite', 'yes' );
 			$course->set( 'prerequisite', $prereq_course_id );
 			$prereq_course_res = $student && $student->is_complete( $prereq_course_id, 'course' ) ? false : array(
@@ -183,13 +312,13 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 			);
 			$this->assertEquals( $prereq_course_res, llms_is_post_restricted_by_prerequisite( $test_id, $user_id ) );
 
-			// set a track prereq
+			// set a track prereq.
 			$course->set( 'prerequisite_track', $track_id );
 
-			// checks course prereq first and only returns one
+			// checks course prereq first and only returns one.
 			$this->assertEquals( $prereq_course_res, llms_is_post_restricted_by_prerequisite( $test_id, $user_id ) );
 
-			// no course prereq, returns track id
+			// no course prereq, returns track id.
 			$course->set( 'prerequisite', '' );
 			$prereq_track_res = $student && $student->is_complete( $track_id, 'course_track' ) ? false : array(
 				'type' => 'course_track',
@@ -202,10 +331,11 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test the llms_is_post_restricted_by_time_period() function
-	 * @return   void
-	 * @since    3.7.3
-	 * @version  3.7.3
+	 * Test the llms_is_post_restricted_by_time_period() function.
+	 *
+	 * @since 3.7.3
+	 *
+	 * @return void
 	 */
 	public function test_llms_is_post_restricted_by_time_period() {
 
@@ -219,38 +349,37 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
 			$course->set( 'time_period', 'no' );
 
-			// no time period
+			// no time period.
 			$this->assertFalse( llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// enable the restriction
+			// enable the restriction.
 			$course->set( 'time_period', 'yes' );
 
-			// no dates set the course is closed without dates
+			// no dates set the course is closed without dates.
 			$this->assertEquals( $course_id, llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// start date in the future
+			// start date in the future.
 			$course->set( 'start_date', $this->get_date( '+7 days' ) );
 			$this->assertEquals( $course_id, llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// start date in past
+			// start date in past.
 			$course->set( 'start_date', $this->get_date( '-7 days' ) );
 			$this->assertFalse( llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// start date in past and end date in past
+			// start date in past and end date in past.
 			$course->set( 'end_date', $this->get_date( '-5 days' ) );
 			$this->assertEquals( $course_id, llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// no start date, end date in past
+			// no start date, end date in past.
 			$course->set( 'start_date', '' );
 			$this->assertEquals( $course_id, llms_is_post_restricted_by_time_period( $test_post_id ) );
 
-			// no start date end in future
+			// no start date end in future.
 			$course->set( 'end_date', $this->get_date( '+7 days' ) );
 			$this->assertEquals( $course_id, llms_is_post_restricted_by_time_period( $test_post_id ) );
 
 		}
 
 	}
-
 
 }


### PR DESCRIPTION
## Description
Fixes #1023 
Also:
- added tests for sitewide membership restriction.
- fix cs/docs in includes/functions/llms.functions.access.php
- made sure "restriction notices" are print in wp pages too when redirected from a sitewide membership restriction.
- excluded privacy police page from sitewide restriction, see https://github.com/gocodebox/lifterlms/issues/1023#issuecomment-585839349

## How has this been tested?
manually, existing unit tests, new unit tests

## Screenshots
n/a 

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

