### PR TITLE
Fix: Issue/1034 (bbPress forum info on course)

### DIFF
--- a/includes/integrations/class.llms.integration.bbpress.php
+++ b/includes/integrations/class.llms.integration.bbpress.php
@@ -379,11 +379,18 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	 *
 	 * @since 3.12.0
 	 * @since 3.35.0 Sanitize input data.
+	 * @since [version] Don't update saved values during quick and bulk edits.
 	 *
-	 * @param    int $post_id  WP_Post ID of the course
-	 * @return   void
+	 * @param int $post_id WP_Post ID of the course.
+	 * @return void
 	 */
 	public function save_course_settings( $post_id ) {
+
+		// Return early on quick and bulk edits.
+		$action = llms_filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
+		if ( 'inline-save' === $action ) {
+			return;
+		}
 
 		$ids = array();
 

--- a/includes/integrations/class.llms.integration.bbpress.php
+++ b/includes/integrations/class.llms.integration.bbpress.php
@@ -3,7 +3,7 @@
  * bbPress Integration
  *
  * @since 3.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,20 +14,21 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.30.3 Fixed spelling errors.
  * @since 3.35.0 Sanitize input data.
+ * @since [version] Don't update saved forum values during course quick edits.
  */
 class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 	/**
 	 * Integration ID
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	public $id = 'bbpress';
 
 	/**
 	 * Display order on Integrations tab
 	 *
-	 * @var  integer
+	 * @var integer
 	 */
 	protected $priority = 5;
 
@@ -78,10 +79,11 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Register the custom course property with the LLMS_Course Model
 	 *
-	 * @param    array $props   default properties
-	 * @param    obj   $course  instance of the LLMS_Course
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param array       $props  Default properties.
+	 * @param LLMS_Course $course Course object.
+	 * @return array
 	 */
 	public function add_course_props( $props, $course ) {
 		$props['bbp_forum_ids'] = 'array';
@@ -91,9 +93,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Add the membership restrictions metabox to bbPress forums on admin panel
 	 *
-	 * @param    array $post_types    array of existing post types
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string[] $post_types Array of existing post types.
+	 * @return string[]
 	 */
 	public function add_membership_restrictions( $post_types ) {
 		$post_types[] = bbp_get_forum_post_type();
@@ -103,10 +106,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Register custom bbPress tab with the LLMS Course metabox
 	 *
-	 * @param    array $fields  existing fields
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param array $fields Existing fields.
+	 * @return array
 	 */
 	public function course_settings_fields( $fields ) {
 
@@ -141,12 +144,12 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Parse action arguments for bbPress engagements and pass them back to the LLMS Engagements handler
 	 *
-	 * @param    array  $query_args  query args for handler
-	 * @param    string $action      triggering action name
-	 * @param    array  $orig_args   original arguments from the action (indexed array)
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param array  $query_args Query args for handler.
+	 * @param string $action     Triggering action name.
+	 * @param array  $orig_args  Original arguments from the action (indexed array).
+	 * @return array
 	 */
 	public function engagement_query_args( $query_args, $action, $orig_args ) {
 
@@ -157,11 +160,11 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 			if ( 'bbp_new_reply' === $action ) {
 
-				$query_args['user_id'] = $orig_args[4]; // $reply_author
+				$query_args['user_id'] = $orig_args[4]; // Reply Author.
 
 			} elseif ( 'bbp_new_topic' === $action ) {
 
-				$query_args['user_id'] = $orig_args[3]; // $topic_author
+				$query_args['user_id'] = $orig_args[3]; // Topic Author.
 
 			}
 		}
@@ -172,27 +175,28 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 	/**
 	 * Handle course forum restrictions
+	 *
 	 * Add a notice and redirect to the course
 	 *
-	 * @param    array $restriction  restriction results from llms_page_restricted()
-	 * @return   void
-	 * @since    3.12.0
-	 * @version  3.13.0
+	 * @since 3.12.0
+	 * @since 3.13.0 Unknown.
+	 *
+	 * @param array $restriction Restriction results from `llms_page_restricted()`.
+	 * @return void
 	 */
 	public function handle_course_forum_restriction( $restriction ) {
 		llms_add_notice( apply_filters( 'llms_bbp_course_forum_restriction_msg', __( 'You must be enrolled in this course to access the course forum', 'lifterlms' ), $restriction ), 'error' );
 		wp_redirect( get_permalink( $restriction['restriction_id'] ) );
 		exit;
-
 	}
 
 	/**
 	 * Retrieve course ids restricted to a LifterLMS course
 	 *
-	 * @param    mixed $course  WP_Post, LLMS_Course, or WP_Post ID
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param mixed $course WP_Post, LLMS_Course, or WP_Post ID.
+	 * @return array
 	 */
 	public function get_course_forum_ids( $course ) {
 
@@ -213,10 +217,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Check if a forum is restricted to a course(s)
 	 *
-	 * @param    int $forum_id  WP_Post ID of the forum
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param int $forum_id WP_Post ID of the forum.
+	 * @return int[]
 	 */
 	public function get_forum_course_restrictions( $forum_id ) {
 
@@ -242,9 +246,9 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Determine if bbPress is installed and activated
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return boolean
 	 */
 	public function is_installed() {
 		return ( class_exists( 'bbPress' ) );
@@ -253,10 +257,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Register shortcodes via LifterLMS core registration methods
 	 *
-	 * @param    array $classes  existing shortcode classes
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param string[] $classes Existing shortcode classes.
+	 * @return array
 	 */
 	public function register_shortcodes( $classes ) {
 		$classes[] = 'LLMS_BBP_Shortcode_Course_Forums_List';
@@ -266,10 +270,11 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Check forum restrictions for course restrictions
 	 *
-	 * @param    array $results  array of restriction results
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.2
+	 * @since 3.12.0
+	 * @since 3.12.2 Unknown.
+	 *
+	 * @param array $results Array of restriction results.
+	 * @return array
 	 */
 	public function restriction_checks_courses( $results ) {
 
@@ -321,10 +326,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Check membership restrictions for Topics and Forum Archive pages
 	 *
-	 * @param    array $results  array of restriction results
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param array $results Array of restriction results.
+	 * @return array
 	 */
 	public function restriction_checks_memberships( $results ) {
 
@@ -363,10 +368,10 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	/**
 	 * Register engagement triggers
 	 *
-	 * @param    array $triggers  existing triggers
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param string[] $triggers Existing triggers.
+	 * @return array
 	 */
 	public function register_engagement_triggers( $triggers ) {
 		$triggers['bbp_new_topic'] = __( 'Student creates a new forum topic', 'lifterlms' );
@@ -379,14 +384,14 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	 *
 	 * @since 3.12.0
 	 * @since 3.35.0 Sanitize input data.
-	 * @since [version] Don't update saved values during quick and bulk edits.
+	 * @since [version] Don't update saved forum values during course quick edits.
 	 *
 	 * @param int $post_id WP_Post ID of the course.
 	 * @return void
 	 */
 	public function save_course_settings( $post_id ) {
 
-		// Return early on quick and bulk edits.
+		// Return early on quick edits.
 		$action = llms_filter_input( INPUT_POST, 'action', FILTER_SANITIZE_STRING );
 		if ( 'inline-save' === $action ) {
 			return;

--- a/includes/integrations/class.llms.integration.bbpress.php
+++ b/includes/integrations/class.llms.integration.bbpress.php
@@ -47,7 +47,7 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 		if ( $this->is_available() ) {
 
-			// custom engagements
+			// Custom engagements.
 			add_filter( 'lifterlms_engagement_triggers', array( $this, 'register_engagement_triggers' ) );
 
 			add_action( 'bbp_new_topic', array( LLMS()->engagements(), 'maybe_trigger_engagement' ), 10, 4 );
@@ -55,17 +55,17 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 			add_filter( 'lifterlms_external_engagement_query_arguments', array( $this, 'engagement_query_args' ), 10, 3 );
 
-			// register shortcode
+			// Register shortcode.
 			add_filter( 'llms_load_shortcodes', array( $this, 'register_shortcodes' ) );
 
-			// add memberships restriction metabox
+			// Add memberships restriction metabox.
 			add_filter( 'llms_membership_restricted_post_types', array( $this, 'add_membership_restrictions' ) );
 
-			// check forum/bbp template restrictions
+			// Check forum/bbp template restrictions.
 			add_filter( 'llms_page_restricted_before_check_access', array( $this, 'restriction_checks_memberships' ), 40, 1 );
 			add_filter( 'llms_page_restricted_before_check_access', array( $this, 'restriction_checks_courses' ), 50, 1 );
 
-			// add and save custom fields
+			// Add and save custom fields.
 			add_filter( 'llms_metabox_fields_lifterlms_course_options', array( $this, 'course_settings_fields' ) );
 			add_action( 'llms_metabox_after_save_lifterlms-course-options', array( $this, 'save_course_settings' ) );
 			add_filter( 'llms_get_course_properties', array( $this, 'add_course_props' ), 10, 2 );
@@ -285,20 +285,19 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 			$user_id = get_current_user_id();
 			$courses = $this->get_forum_course_restrictions( $results['content_id'] );
 
-			// no user and at least one course restriction, return the first
+			// No user and at least one course restriction, return the first.
 			if ( $courses && ! $user_id ) {
 
 				$post_id = $courses[0];
 
-				// courses and a user, find at least one enrollment
+				// Courses and a user, find at least one enrollment.
 			} elseif ( $courses && $user_id ) {
 
 				foreach ( $courses as $course_id ) {
-					// not enrolled, use this for the restriction
-					// but dont break because we may find an enrollment later
+					// Not enrolled, use this for the restriction but dont break because we may find an enrollment later.
 					if ( ! llms_is_user_enrolled( $user_id, $course_id ) ) {
 						$post_id = $course_id;
-						// enrolled in one, reset the post id and break
+						// Enrolled in one, reset the post id and break.
 					} else {
 						$post_id = null;
 						break;
@@ -335,7 +334,7 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
 		$post_id = null;
 
-		// forum archive, grab the page (if set)
+		// Forum archive, grab the page (if set).
 		if ( bbp_is_forum_archive() ) {
 
 			$page    = bbp_get_page_by_path( bbp_get_root_slug() );

--- a/tests/phpunit/unit-tests/integrations/class-llms-test-integration-bbpress.php
+++ b/tests/phpunit/unit-tests/integrations/class-llms-test-integration-bbpress.php
@@ -1,0 +1,568 @@
+<?php
+/**
+ * Tests for LLMS_Admin_Review class
+ *
+ * @package LifterLMS/Tests/Integrations
+ *
+ * @group integrations
+ * @group integration_bbpress
+ *
+ * @since [version]
+ */
+class LLMS_Test_Integration_BBPress extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Instance of a mock bbPress class.
+	 *
+	 * @var bbPress
+	 */
+	protected $mock_bbPress = null;
+
+	/**
+	 * Instance of the bbPress integration class.
+	 *
+	 * @var LLMS_Integration_BBPress
+	 */
+	protected $main = null;
+
+	/**
+	 * Array of hooks added by the integration.
+	 *
+	 * @var array
+	 */
+	protected $hooks = array();
+
+	/**
+	 * Add or remove hooks based on hooks defined in the $this->hooks array.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $action Either "add" or "remove".
+	 * @return void
+	 */
+	private function update_hooks( $action = 'add' ) {
+
+		foreach ( $this->hooks as $hook ) {
+
+			$function = sprintf( '%1$s_%2$s', $action, $hook['type'] );
+			$function( $hook['hook'], $hook['method'], $hook['priority'] );
+
+		}
+
+	}
+
+	/**
+	 * Run assertions for all hooks in the $this->hooks array.
+	 *
+	 * @since  [version]
+	 *
+	 * @param  mixed $equals If `null`, asserts that the priority matches the configured priority. Otherwise all hooks equal this value.
+	 * @return void
+	 */
+	private function assertHooks( $equals = null ) {
+
+		foreach( $this->hooks as $hook ) {
+
+			$function = sprintf( 'has_%s', $hook['type'] );
+			$this->assertEquals( is_null( $equals ) ? $hook['priority'] : $equals, $function( $hook['hook'], $hook['method'] ), $hook['hook'] );
+
+		}
+
+	}
+
+	/**
+	 * Setup all the hooks defined in the configuration method.
+	 *
+	 * @since  [version]
+	 *
+	 * @return void
+	 */
+	private function setup_hooks() {
+
+		$this->hooks = array(
+			array(
+				'type'     => 'filter',
+				'hook'     => 'lifterlms_engagement_triggers',
+				'method'   => array( $this->main, 'register_engagement_triggers' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'lifterlms_external_engagement_query_arguments',
+				'method'   => array( $this->main, 'engagement_query_args' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_load_shortcodes',
+				'method'   => array( $this->main, 'register_shortcodes' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_membership_restricted_post_types',
+				'method'   => array( $this->main, 'add_membership_restrictions' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_page_restricted_before_check_access',
+				'method'   => array( $this->main, 'restriction_checks_memberships' ),
+				'priority' => 40,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_page_restricted_before_check_access',
+				'method'   => array( $this->main, 'restriction_checks_courses' ),
+				'priority' => 50,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_metabox_fields_lifterlms_course_options',
+				'method'   => array( $this->main, 'course_settings_fields' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'filter',
+				'hook'     => 'llms_get_course_properties',
+				'method'   => array( $this->main, 'add_course_props' ),
+				'priority' => 10,
+			),
+
+			array(
+				'type'     => 'action',
+				'hook'     => 'bbp_new_topic',
+				'method'   => array( LLMS()->engagements(), 'maybe_trigger_engagement' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'action',
+				'hook'     => 'bbp_new_reply',
+				'method'   => array( LLMS()->engagements(), 'maybe_trigger_engagement' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'action',
+				'hook'     => 'llms_metabox_after_save_lifterlms-course-options',
+				'method'   => array( $this->main, 'save_course_settings' ),
+				'priority' => 10,
+			),
+			array(
+				'type'     => 'action',
+				'hook'     => 'llms_content_restricted_by_bbp_course_forum',
+				'method'   => array( $this->main, 'handle_course_forum_restriction' ),
+				'priority' => 10,
+			),
+		);
+
+	}
+
+	/**
+	 * Setup the mock bbPress class and functions.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function setup_mock_bbPress() {
+
+		// Mock functions.
+		if ( ! function_exists( 'bbp_get_forum_post_type' ) ) {
+			function bbp_get_forum_post_type() {
+				return 'mock_forum_post_type';
+			}
+		}
+
+		// Create the mock bbPress class.
+		$this->mock_bbPress = $this->getMockBuilder( 'bbPress' )
+			->getMock();
+
+		// Enable the integration.
+		update_option( 'llms_integration_bbpress_enabled', 'yes' );
+
+		// Refresh cached available integrations list.
+		LLMS()->integrations()->get_available_integrations();
+
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+
+		// Load mock.
+		if ( ! $this->mock_bbPress ) {
+			$this->setup_mock_bbPress();
+		}
+
+		$this->main = LLMS()->integrations()->get_integration( 'bbpress' );
+
+		if ( ! $this->hooks ) {
+			$this->setup_hooks();
+		}
+
+	}
+
+	/**
+	 * Test that attributes are setup properly.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_attributes() {
+
+		$this->assertEquals( 'bbPress', $this->main->title );
+		$this->assertTrue( ! empty( $this->main->description ) );
+
+	}
+
+	/**
+	 * Test configure()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_configure() {
+
+		// Disable the integration.
+		update_option( 'llms_integration_bbpress_enabled', 'no' );
+
+		// Remove all the set hooks.
+		$this->update_hooks( 'remove' );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'configure' );
+
+		// All hooks should be false when calling has_action()/has_filter().
+		$this->assertHooks( false );
+
+
+		// Re-enable the integration.
+		$this->setup_mock_bbPress();
+		LLMS_Unit_Test_Util::call_method( $this->main, 'configure' );
+
+		// All hooks should be configured.
+		$this->assertHooks();
+
+	}
+
+	/**
+	 * Test add_course_props()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_course_props() {
+
+		$this->assertEquals( array( 'bbp_forum_ids' => 'array' ), $this->main->add_course_props( array(), 'mock' ) );
+
+	}
+
+	/**
+	 * Test add_membership_restrictions()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_membership_restrictions() {
+
+		$this->assertEquals( array( 'mock_forum_post_type' ), $this->main->add_membership_restrictions( array() ) );
+
+	}
+
+	/**
+	 * Test course_settings_field()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_course_settings_fields() {
+
+		$res = $this->main->course_settings_fields( array() )[0];
+
+		$this->assertEquals( 'bbPress', $res['title'] );
+		$this->assertEquals( 1, count( $res['fields'] ) );
+
+		$this->assertequals( '_llms_bbp_forum_ids', $res['fields'][0]['id'] );
+
+	}
+
+	/**
+	 * Test engagement_query_args() for non bbPress hooks.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_engagement_query_args_not_supported() {
+
+		$expect = array(
+			'trigger_type'    => 'mock',
+			'related_post_id' => 123,
+			'user_id'         => 456,
+		);
+		$this->assertEquals( $expect, $this->main->engagement_query_args( $expect, 'mock_action', array() ) );
+
+	}
+
+	/**
+	 * Test engagement_query_args() for a new reply hook.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_engagement_query_args_new_reply() {
+
+		$args = array(
+			'trigger_type'    => 'mock',
+			'related_post_id' => 123,
+			'user_id'         => 456,
+		);
+
+		$expect = array(
+			'trigger_type'    => 'bbp_new_reply',
+			'related_post_id' => '',
+			'user_id'         => 4,
+		);
+
+		$this->assertEquals( $expect, $this->main->engagement_query_args( $args, 'bbp_new_reply', array( 0, 1, 2, 3, 4, ) ) );
+
+	}
+
+	/**
+	 * Test engagement_query_args() for a new topic
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_engagement_query_args_new_topic() {
+
+		$args = array(
+			'trigger_type'    => 'mock',
+			'related_post_id' => 123,
+			'user_id'         => 456,
+		);
+
+		$expect = array(
+			'trigger_type'    => 'bbp_new_topic',
+			'related_post_id' => '',
+			'user_id'         => 3,
+		);
+
+		$this->assertEquals( $expect, $this->main->engagement_query_args( $args, 'bbp_new_topic', array( 0, 1, 2, 3 ) ) );
+
+	}
+
+	/**
+	 * Test handle_course_forum_restriction()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_course_forum_restriction() {
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( sprintf( '%s [302] YES', get_permalink( $id ) ) );
+
+		try {
+
+			$this->main->handle_course_forum_restriction( array( 'restriction_id' => $id ) );
+
+		} catch( LLMS_Unit_Test_Exception_Redirect $exception ) {
+
+			$notices = llms_get_notices();
+
+			$this->assertStringContains( 'llms-error', $notices );
+			$this->assertStringContains( 'You must be enrolled in this course to access the course forum.', $notices );
+
+			throw $exception;
+		}
+
+	}
+
+	/**
+	 * Test get_course_forum_ids()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_course_forum_ids() {
+
+		// Ensure property filter is applied.
+		LLMS_Unit_Test_Util::call_method( $this->main, 'configure' );
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+
+		// Nothing set.
+		$this->assertEquals( array(), $this->main->get_course_forum_ids( $id ) );
+
+		// Empty string.
+		update_post_meta( $id, '_llms_bbp_forum_ids', '' );
+		$this->assertEquals( array(), $this->main->get_course_forum_ids( $id ) );
+
+		// Empty array.
+		update_post_meta( $id, '_llms_bbp_forum_ids', array() );
+		$this->assertEquals( array(), $this->main->get_course_forum_ids( $id ) );
+
+		// Has forums.
+		update_post_meta( $id, '_llms_bbp_forum_ids', array( 1, 2, 3 ) );
+		$this->assertEquals( array( 1, 2, 3 ), $this->main->get_course_forum_ids( $id ) );
+
+	}
+
+	/**
+	 * Test get_forum_course_restrictions()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_forum_course_restrictions() {
+
+		// No restrictions for a fake forum.
+		$this->assertEquals( array(), $this->main->get_forum_course_restrictions( 3452 ) );
+
+		// Restricted to one course.
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		update_post_meta( $id, '_llms_bbp_forum_ids', array( 9239 ) );
+		$this->assertEquals( array( $id ), $this->main->get_forum_course_restrictions( 9239 ) );
+
+		// Restricted to two courses.
+		$id2 = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		update_post_meta( $id2, '_llms_bbp_forum_ids', array( 9239 ) );
+		$this->assertEquals( array( $id, $id2 ), $this->main->get_forum_course_restrictions( 9239 ) );
+
+	}
+
+	/**
+	 * Test is_installed()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_is_installed() {
+
+		$this->assertTrue( $this->main->is_installed() );
+
+	}
+
+	/**
+	 * Test register_shortcodes()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_register_shortcodes() {
+
+		$this->assertEquals( array( 'LLMS_BBP_Shortcode_Course_Forums_List' ), $this->main->register_shortcodes( array() ) );
+
+	}
+
+	// @todo these tests should be written but I'm tired.
+	// public function test_restriction_checks_courses() {}
+	// public function test_restriction_checks_memberships() {}
+
+	/**
+	 * Test register_engagement_triggers()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_register_engagement_triggers() {
+
+		$this->assertEquals( array( 'bbp_new_topic', 'bbp_new_reply' ), array_keys( $this->main->register_engagement_triggers( array() ) ) );
+
+	}
+
+	/**
+	 * Test save_course_settings() when a quick edit is performed on a course.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_course_settings_quick_edit() {
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$expect = array( 1, 2, 3 );
+		update_post_meta( $id, '_llms_bbp_forum_ids', $expect );
+
+		$this->mockPostRequest( array( 'action' => 'inline-save' ) );
+		$this->assertNull( $this->main->save_course_settings( $id ) );
+		$this->assertEquals( $expect, get_post_meta( $id, '_llms_bbp_forum_ids', true ) );
+
+	}
+
+	/**
+	 * Test save_course_settings() when there's no new ids passed to the form.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_course_settings_not_set() {
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		update_post_meta( $id, '_llms_bbp_forum_ids', array( 1 ) );
+
+		$this->assertEquals( array(), $this->main->save_course_settings( $id ) );
+		$this->assertEquals( array(), get_post_meta( $id, '_llms_bbp_forum_ids', true ) );
+
+	}
+
+	/**
+	 * Test save_course_settiongs()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_course_settings() {
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$expect = array( 1, 2, 3 );
+		$this->mockPostRequest( array( '_llms_bbp_forum_ids' => $expect ) );
+
+		$this->assertEquals( $expect, $this->main->save_course_settings( $id ) );
+		$this->assertEquals( $expect, get_post_meta( $id, '_llms_bbp_forum_ids', true ) );
+
+	}
+
+	/**
+	 * Test save_course_settings() to delete existing courses.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_course_settings_delete() {
+
+		$id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		update_post_meta( $id, '_llms_bbp_forum_ids', array( 1 ) );
+		$this->mockPostRequest( array( '_llms_bbp_forum_ids' => array() ) );
+
+		$this->assertEquals( array(), $this->main->save_course_settings( $id ) );
+		$this->assertEquals( array(), get_post_meta( $id, '_llms_bbp_forum_ids', true ) );
+
+	}
+
+}


### PR DESCRIPTION
## Description

Added an early return on the method responsible for saving bbPress related meta data for a course when the quick-edit interface on the courses post table is used.

Fixes #1034 

## How has this been tested?

Manually tested against reproduction steps:

1) Restrict a forum to a course
2) Quick edit the course
3) Check that the forum is still attached to the course

Manually tested to ensure forums can still be added and removed via the course edit page

## Types of changes

Bug fix and documentation cleanup.

Added new phpunit tests to cover the affected class and functions

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

