### PR TITLE
Fix PHP Notice when entering Appearance -> Menus IF a student dashboa…

### DIFF
--- a/includes/class.llms.nav.menus.php
+++ b/includes/class.llms.nav.menus.php
@@ -1,45 +1,56 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * LifterLMS Navigation Menus
  *
- * @since    3.14.7
- * @version  3.24.0
+ * @since 3.14.7
+ * @version [version]
+ */
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS Navigation Menus class.
+ *
+ * @since 3.14.7
+ * @since 3.24.0 Unknown.
+ * @since [version] Fixed possible access to undefined index.
+ *                Excluded endpoints with an empty url.
+ *                Made sure to use strict comparisons.
  */
 class LLMS_Nav_Menus {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
-	 * @since    3.14.7
-	 * @version  3.22.0
+	 * @since 3.14.7
+	 * @since 3.22.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
-		// filter menu items on frontend to add real URLs to menu items
+		// filter menu items on frontend to add real URLs to menu items.
 		add_filter( 'wp_nav_menu_objects', array( $this, 'filter_nav_items' ) );
 
-		// add meta box to the Appearance -> Menus screen on admin panel
+		// add meta box to the Appearance -> Menus screen on admin panel.
 		add_action( 'load-nav-menus.php', array( $this, 'add_metabox' ) );
 
-		// add LifterLMS menu item type section to customizer
+		// add LifterLMS menu item type section to customizer.
 		add_filter( 'customize_nav_menu_available_item_types', array( $this, 'customize_add_type' ) );
 
-		// add LifterLMS menu items links to the customizer
+		// add LifterLMS menu items links to the customizer.
 		add_filter( 'customize_nav_menu_available_items', array( $this, 'customize_add_items' ), 10, 4 );
 
-		// add active classes for nav items for catalog pages
+		// add active classes for nav items for catalog pages.
 		add_filter( 'wp_nav_menu_objects', array( $this, 'menu_item_classes' ) );
 
 	}
 
 	/**
-	 * Add nav menu metabox
+	 * Add nav menu metabox.
 	 *
-	 * @return   void
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * @since 3.14.7
+	 *
+	 * @return void
 	 */
 	public function add_metabox() {
 
@@ -49,15 +60,15 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Adds LifterLMS menu items to the customizer
+	 * Adds LifterLMS menu items to the customizer.
 	 *
-	 * @param    array   $items   menu items
-	 * @param    string  $type    requested menu item type
-	 * @param    string  $object  requested menu item object
-	 * @param    integer $page    requested page number
-	 * @return   array
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * @since 3.14.7
+	 *
+	 * @param array   $items  Optional. Menu items. Default empty array.
+	 * @param string  $type   Optional. Requested menu item type. Default empty string.
+	 * @param string  $object Optional. Requested menu item object. Default empty string.
+	 * @param integer $page   Optional. Requested page number. Default `0`.
+	 * @return array
 	 */
 	public function customize_add_items( $items = array(), $type = '', $object = '', $page = 0 ) {
 
@@ -81,12 +92,12 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Add the LifterLMS menu item section to the customizer
+	 * Add the LifterLMS menu item section to the customizer.
 	 *
-	 * @param    array $types  existing menu item types
-	 * @return   array
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * @since 3.14.7
+	 *
+	 * @param array $types Existing menu item types.
+	 * @return array
 	 */
 	public function customize_add_type( $types ) {
 
@@ -100,13 +111,15 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Filters Nav Menu Items to convert #llms- urls into actual URLs
-	 * Also hides URLs that should only be available to logged in users
+	 * Filters Nav Menu Items to convert #llms- urls into actual URLs.
 	 *
-	 * @param    array $items  nav menu items
-	 * @return   array
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * Also hides URLs that should only be available to logged in users.
+	 *
+	 * @since 3.14.7
+	 * @since [version] Use `in_array` with strict types comparison.
+	 *
+	 * @param array $items Nav menu items.
+	 * @return array
 	 */
 	public function filter_nav_items( $items ) {
 
@@ -117,7 +130,7 @@ class LLMS_Nav_Menus {
 
 		foreach ( $items as $i => &$data ) {
 
-			if ( in_array( $data->url, $urls ) ) {
+			if ( in_array( $data->url, $urls, true ) ) {
 
 				if ( '#llms-signin' === $data->url ) {
 					if ( is_user_logged_in() ) {
@@ -139,11 +152,12 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Retrieve a filtered array of custom LifterLMS nav menu items
+	 * Retrieve a filtered array of custom LifterLMS nav menu items.
 	 *
-	 * @return   array
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * @return array
+	 * @since 3.14.7
+	 * @since [version] Fixed possible access to undefined index.
+	 *                Excluded endpoints with an empty url.
 	 */
 	private function get_nav_items() {
 
@@ -153,10 +167,23 @@ class LLMS_Nav_Menus {
 
 			if ( ! empty( $data['nav_item'] ) ) {
 
+				$url = ! empty( $data['endpoint'] ) ? llms_get_endpoint_url( $data['endpoint'], '', llms_get_page_url( 'myaccount' ) ) : '';
+
+				// no URL no nav item.
+				if ( empty( $url ) ) {
+					if ( empty( $data['url'] ) ) {
+						continue;
+					} else {
+						$url = $data['url'];
+					}
+				}
+
+				$title = empty( $data['title'] ) ? '' : $data['title'];
+
 				$items[ $id ] = array(
-					'url'   => $data['endpoint'] ? llms_get_endpoint_url( $data['endpoint'], '', llms_get_page_url( 'myaccount' ) ) : $data['url'],
-					'label' => $data['title'],
-					'title' => $data['title'],
+					'url'   => $url,
+					'label' => $title,
+					'title' => $title,
 				);
 
 			}
@@ -178,12 +205,14 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Add "active" classes to menu items for LLMS catalog pages
+	 * Add "active" classes to menu items for LLMS catalog pages.
 	 *
-	 * @param    array $menu_items  menu items
-	 * @return   array
-	 * @since    3.22.0
-	 * @version  3.22.0
+	 * @since 3.22.0
+	 * @since [version] Use strict comparisons.
+	 *                  Cast `page_for_posts` option to int in order to use strict comparisons.
+	 *
+	 * @param array $menu_items Menu items.
+	 * @return array
 	 */
 	public function menu_item_classes( $menu_items ) {
 
@@ -193,29 +222,30 @@ class LLMS_Nav_Menus {
 
 		$courses_id     = llms_get_page_id( 'courses' );
 		$memberships_id = llms_get_page_id( 'memberships' );
-		$blog_id        = get_option( 'page_for_posts' );
+		$blog_id        = absint( get_option( 'page_for_posts', 0 ) );
 
 		foreach ( $menu_items as $key => $item ) {
 
-			$classes = $item->classes;
+			$classes   = $item->classes;
+			$object_id = absint( $item->object_id );
 
-			// remove active class from blog archive
-			if ( $blog_id == $item->object_id ) {
+			// remove active class from blog archive.
+			if ( $blog_id === $object_id ) {
 
 				$menu_items[ $key ]->current = false;
 				foreach ( array( 'current_page_parent', 'current-menu-item' ) as $class ) {
-					if ( in_array( $class, $classes ) ) {
-						unset( $classes[ array_search( $class, $classes ) ] );
+					if ( in_array( $class, $classes, true ) ) {
+						unset( $classes[ array_search( $class, $classes, true ) ] );
 					}
 				}
-			} elseif ( 'page' === $item->object && ( ( is_courses() && $courses_id == $item->object_id ) || ( is_memberships() && $memberships_id == $item->object_id ) ) ) {
+			} elseif ( 'page' === $item->object && ( ( is_courses() && $courses_id === $object_id ) || ( is_memberships() && $memberships_id === $object_id ) ) ) {
 
 				$menu_items[ $key ]->current = true;
 				$classes[]                   = 'current-menu-item';
 				$classes[]                   = 'current_page_item';
 
-				// set parent links for courses & memberships
-			} elseif ( ( $courses_id == $item->object_id && ( is_singular( 'course' ) || is_course_taxonomy() ) ) || ( $memberships_id == $item->object_id && ( is_singular( 'llms_membership' ) || is_membership_taxonomy() ) ) ) {
+				// set parent links for courses & memberships.
+			} elseif ( ( $courses_id === $object_id && ( is_singular( 'course' ) || is_course_taxonomy() ) ) || ( $memberships_id === $object_id && ( is_singular( 'llms_membership' ) || is_membership_taxonomy() ) ) ) {
 
 				$classes[] = 'current_page_parent';
 
@@ -229,11 +259,12 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Output the metabox
+	 * Output the metabox.
 	 *
-	 * @return   void
-	 * @since    3.14.7
-	 * @version  3.24.0
+	 * @since 3.14.7
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function output() {
 
@@ -274,11 +305,11 @@ class LLMS_Nav_Menus {
 	}
 
 	/**
-	 * Output JS to ensure that users don't edit the #llms-signout URL that's replaced dynamically with an actual signout link
+	 * Output JS to ensure that users don't edit the #llms-signout URL that's replaced dynamically with an actual signout link.
 	 *
-	 * @return   void
-	 * @since    3.14.7
-	 * @version  3.14.7
+	 * @since 3.14.7
+	 *
+	 * @return void
 	 */
 	public function output_scripts() {
 		?>


### PR DESCRIPTION
…rd endpoint has been cleared

## Description
I've also made some cs and docs clean-up, e.g. making sure we always use strict comparison, hence 'casting' the `'page_for_posts'` option and the menu item object_id property to integers.
Additionally when getting (building) the lifterlms nav items I made sure to exclude those endpoints which had no URLs at all.

Fixes #1041 


## How has this been tested?
Manually following the reproduction steps described in #1041 and making sure the PHP notice issue wasn't reproducing anymore.
I also checked the "major" strict comparison adjustments made in the method `menu_item_classes()` were not producing undesired side effects.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

