### PR TITLE
Adds "revision" post type support to courses, lessons, and memberships

### DIFF
--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -244,7 +244,7 @@ class LLMS_Post_Types {
 	 * @since 3.13.0
 	 *
 	 * @param string|array $tax Taxonomy name/names (pass array of singular, plural to customize plural spelling).
-	 * @return  array
+	 * @return array
 	 */
 	public static function get_tax_caps( $tax ) {
 
@@ -442,7 +442,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Quizzes.
+		// Quiz.
 		self::register_post_type(
 			'llms_quiz',
 			array(
@@ -518,7 +518,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Memberships.
+		// Membership.
 		$membership_page_id = llms_get_page_id( 'memberships' );
 		self::register_post_type(
 			'llms_membership',
@@ -1239,7 +1239,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Membership cats.
+		// Membership cat.
 		self::register_taxonomy(
 			'membership_cat',
 			array( 'llms_membership' ),
@@ -1273,7 +1273,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Membership tags.
+		// Membership tag.
 		self::register_taxonomy(
 			'membership_tag',
 			array( 'llms_membership' ),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -292,8 +292,23 @@ class LLMS_Post_Types {
 	public static function register_post_type( $name, $data ) {
 
 		if ( ! post_type_exists( $name ) ) {
-			$filter_name = str_replace( 'llms_', '', $name );
-			register_post_type( $name, apply_filters( 'lifterlms_register_post_type_' . $filter_name, $data ) );
+
+			$unprefixed_name = str_replace( 'llms_', '', $name );
+
+			/**
+			 * Modify post type registration arguments of a LifterLMS custom post type.
+			 *
+			 * The dynamic portion of this hook refers to the post type's name with the `llms_` prefix
+			 * removed (if it exist). For example, to modify the arguments for the membership post type
+			 * (`llms_membership`) the full hook would be "lifterlms_register_post_type_membership".
+			 *
+			 * @since 3.13.0
+			 *
+			 * @param array $data Post type registration arguments passed to `register_post_type()`.
+			 */
+			$data = apply_filters( "lifterlms_register_post_type_${unprefixed_name}", $data );
+			register_post_type( $name, $data );
+
 		}
 
 	}

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -1134,7 +1134,7 @@ class LLMS_Post_Types {
 				'show_admin_column' => true,
 				'show_ui'           => true,
 				'rewrite'           => array(
-					'slug'         => _x( 'r-category', 'slug', 'lifterlms' ),
+					'slug'         => _x( 'course-category', 'slug', 'lifterlms' ),
 					'with_front'   => false,
 					'hierarchical' => true,
 				),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -211,7 +211,7 @@ class LLMS_Post_Types {
 		 * @param array $caps Array of capabilities.
 		 */
 		return apply_filters(
-			"llms_get_${$singular}_post_type_caps",
+			"llms_get_{$singular}_post_type_caps",
 			array(
 
 				'read_post'              => sprintf( 'read_%s', $singular ),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -24,8 +24,10 @@ class LLMS_Post_Types {
 	/**
 	 * Constructor
 	 *
-	 * @since    1.0.0
-	 * @version  3.0.4
+	 * @since 1.0.0
+	 * @since 3.0.4 Unknown.
+	 *
+	 * @return void
 	 */
 	public static function init() {
 
@@ -40,29 +42,46 @@ class LLMS_Post_Types {
 
 	/**
 	 * Add post type support for membership restrictions
+	 *
 	 * This enables the "Membership Access" metabox to display
 	 *
-	 * @since    3.0.0
-	 * @version  3.0.4
+	 * @since 3.0.0
+	 * @since 3.0.4 Unknown.
+	 *
+	 * @return  void
 	 */
 	public static function add_membership_restriction_support() {
+
+		/**
+		 * Add llms-membership-restrictions support for the following post types.
+		 *
+		 * Adding support for a post type enables the display of the Membership Restriction metabox
+		 * for each specified post type.
+		 *
+		 * These post types can then be "restricted" to enrollment in the selected memberships.
+		 *
+		 * @since Unknown
+		 *
+		 * @param string[] $post_types Array of post type names..
+		 */
 		$post_types = apply_filters( 'llms_membership_restricted_post_types', array( 'post', 'page' ) );
 		foreach ( $post_types as $post_type ) {
 			add_post_type_support( $post_type, 'llms-membership-restrictions' );
 		}
+
 	}
 
 	/**
 	 * Ensure LifterLMS Post Types have thumbnail support
 	 *
-	 * @return void
+	 * @since 2.4.1
+	 * @since 3.8.0 Unknown.
 	 *
-	 * @since    2.4.1
-	 * @version  3.8.0
+	 * @return void
 	 */
 	public static function add_thumbnail_support() {
 
-		// ensure theme support exists for LifterLMS post types
+		// Ensure theme support exists for LifterLMS post types.
 		if ( ! current_theme_supports( 'post-thumbnails' ) ) {
 			add_theme_support( 'post-thumbnails' );
 		}
@@ -86,21 +105,21 @@ class LLMS_Post_Types {
 	/**
 	 * Retrieve all registered order statuses
 	 *
-	 * @return   array
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 * @since 3.19.0
+	 *
+	 * @return array
 	 */
 	public static function get_order_statuses() {
 
 		$statuses = array(
 
-			// single payment only
+			// Single payment only.
 			'llms-completed'      => array(
 				'label'       => _x( 'Completed', 'Order status', 'lifterlms' ),
 				'label_count' => _n_noop( 'Completed <span class="count">(%s)</span>', 'Completed <span class="count">(%s)</span>', 'lifterlms' ),
 			),
 
-			// recurring only
+			// Recurring only.
 			'llms-active'         => array(
 				'label'       => _x( 'Active', 'Order status', 'lifterlms' ),
 				'label_count' => _n_noop( 'Active <span class="count">(%s)</span>', 'Active <span class="count">(%s)</span>', 'lifterlms' ),
@@ -118,7 +137,7 @@ class LLMS_Post_Types {
 				'label_count' => _n_noop( 'Pending Cancellation <span class="count">(%s)</span>', 'Pending Cancellation <span class="count">(%s)</span>', 'lifterlms' ),
 			),
 
-			// shared
+			// Shared.
 			'llms-pending'        => array(
 				'label'       => _x( 'Pending Payment', 'Order status', 'lifterlms' ),
 				'label_count' => _n_noop( 'Pending Payment <span class="count">(%s)</span>', 'Pending Payment <span class="count">(%s)</span>', 'lifterlms' ),
@@ -149,6 +168,13 @@ class LLMS_Post_Types {
 			$status = array_merge( $status, $defaults );
 		}
 
+		/**
+		 * Filter the list of order statuses that will be registered with WordPress.
+		 *
+		 * @since 3.19.0
+		 *
+		 * @param array[] $statuses Array of post status arrays.
+		 */
 		return apply_filters( 'lifterlms_register_order_post_statuses', $statuses );
 
 	}
@@ -156,12 +182,13 @@ class LLMS_Post_Types {
 	/**
 	 * Get an array of capabilities for a custom post type
 	 *
-	 * @note     core bug does not allow us to use capability_type in post type registration
-	 *           https://core.trac.wordpress.org/ticket/30991
-	 * @param    [type] $post_type  [description]
-	 * @return   [type]                 [description]
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * Due to core bug does not allow us to use capability_type in post type registration.
+	 * See https://core.trac.wordpress.org/ticket/30991.
+	 *
+	 * @since 3.13.0
+	 *
+	 * @param string $post_type Post type name.
+	 * @return array
 	 */
 	public static function get_post_type_caps( $post_type ) {
 
@@ -173,8 +200,18 @@ class LLMS_Post_Types {
 			$plural   = $post_type[1];
 		}
 
+		/**
+		 * Filter the list of post type capabilities for the given post type.
+		 *
+		 * The dynamic portion of this hook, `$singular` refers to the post type's
+		 * name, for example "course" or "llms_membership".
+		 *
+		 * @since 3.13.0
+		 *
+		 * @param array $caps Array of capabilities.
+		 */
 		return apply_filters(
-			'llms_get_' . $singular . '_post_type_caps',
+			"llms_get_${$singular}_post_type_caps",
 			array(
 
 				'read_post'              => sprintf( 'read_%s', $singular ),
@@ -204,10 +241,10 @@ class LLMS_Post_Types {
 	/**
 	 * Retrieve taxonomy capabilities for custom taxonomies
 	 *
-	 * @param    string|array $tax  tax name/names (pass array of singular, plural to customize plural spelling)
-	 * @return   array
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param string|array $tax Taxonomy name/names (pass array of singular, plural to customize plural spelling).
+	 * @return  array
 	 */
 	public static function get_tax_caps( $tax ) {
 
@@ -219,8 +256,18 @@ class LLMS_Post_Types {
 			$plural   = $tax[1];
 		}
 
+		/**
+		 * Customize the taxonomy capabilities for the given taxonomy.
+		 *
+		 * The dynamic portion of this hook, `$singular` refers to the taxonomy's
+		 * registered name.
+		 *
+		 * @since 3.13.0
+		 *
+		 * @param array $caps Array of capabilities.
+		 */
 		return apply_filters(
-			'llms_get_' . $singular . '_tax_caps',
+			"llms_get_{$singular}_tax_caps",
 			array(
 				'manage_terms' => sprintf( 'manage_%s', $plural ),
 				'edit_terms'   => sprintf( 'edit_%s', $plural ),
@@ -233,13 +280,14 @@ class LLMS_Post_Types {
 
 	/**
 	 * Register a custom post type
+	 *
 	 * Automatically checks for duplicates and filters data
 	 *
-	 * @param    string $name  post type name
-	 * @param    array  $data  post type data
-	 * @return   void
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param string $name Post type name.
+	 * @param array  $data Post type data.
+	 * @return void
 	 */
 	public static function register_post_type( $name, $data ) {
 
@@ -261,7 +309,7 @@ class LLMS_Post_Types {
 	 */
 	public static function register_post_types() {
 
-		// Course
+		// Course.
 		$catalog_id = llms_get_page_id( 'shop' );
 		self::register_post_type(
 			'course',
@@ -304,7 +352,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Section
+		// Section.
 		self::register_post_type(
 			'section',
 			array(
@@ -339,7 +387,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Lesson
+		// Lesson.
 		self::register_post_type(
 			'lesson',
 			array(
@@ -379,7 +427,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// quizzes
+		// Quizzes.
 		self::register_post_type(
 			'llms_quiz',
 			array(
@@ -419,7 +467,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Quiz Question
+		// Quiz Question.
 		self::register_post_type(
 			'llms_question',
 			array(
@@ -455,7 +503,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// Memberships
+		// Memberships.
 		$membership_page_id = llms_get_page_id( 'memberships' );
 		self::register_post_type(
 			'llms_membership',
@@ -499,9 +547,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Engagement Post type
-		 */
+		// Engagement.
 		register_post_type(
 			'llms_engagement',
 			apply_filters(
@@ -541,9 +587,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Order post type
-		 */
+		// Order.
 		register_post_type(
 			'llms_order',
 			apply_filters(
@@ -586,9 +630,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Transaction Post Type
-		 */
+		// Transaction.
 		register_post_type(
 			'llms_transaction',
 			apply_filters(
@@ -630,9 +672,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Achievement Post type
-		 */
+		// Achievement.
 		register_post_type(
 			'llms_achievement',
 			apply_filters(
@@ -671,9 +711,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Certificate Post type
-		 */
+		// Certificate.
 		register_post_type(
 			'llms_certificate',
 			apply_filters(
@@ -715,9 +753,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * User specific certificate
-		 */
+		// Earned certificate.
 		register_post_type(
 			'llms_my_certificate',
 			apply_filters(
@@ -759,9 +795,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Email Post Type
-		 */
+		// Email.
 		register_post_type(
 			'llms_email',
 			apply_filters(
@@ -800,9 +834,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Coupon Post type
-		 */
+		// Coupon.
 		register_post_type(
 			'llms_coupon',
 			apply_filters(
@@ -841,9 +873,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Voucher Post type
-		 */
+		// Voucher.
 		register_post_type(
 			'llms_voucher',
 			apply_filters(
@@ -882,9 +912,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Review Post Type
-		 */
+		// Review.
 		register_post_type(
 			'llms_review',
 			apply_filters(
@@ -923,9 +951,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		/**
-		 * Access Plan Post Type
-		 */
+		// Access Plan.
 		register_post_type(
 			'llms_access_plan',
 			apply_filters(
@@ -978,9 +1004,10 @@ class LLMS_Post_Types {
 	/**
 	 * Register post statuses
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.19.0
+	 * @since 3.0.0
+	 * @since 3.19.0 Unknwn.
+	 *
+	 * @return void
 	 */
 	public static function register_post_statuses() {
 
@@ -1036,12 +1063,12 @@ class LLMS_Post_Types {
 	 * Register a custom post type taxonomy
 	 * Automatically checks for duplicates and filters data
 	 *
-	 * @param    string       $name    taxonomy name
-	 * @param    string|array $object  post type object(s) to associate the taxonomy with
-	 * @param    array        $data    taxonomy data
-	 * @return   void
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param string       $name   Taxonomy name.
+	 * @param string|array $object Post type object(s) to associate the taxonomy with.
+	 * @param array        $data   Taxonomy data.
+	 * @return void
 	 */
 	public static function register_taxonomy( $name, $object, $data ) {
 
@@ -1067,7 +1094,7 @@ class LLMS_Post_Types {
 	 */
 	public static function register_taxonomies() {
 
-		// course cat
+		// Course cat.
 		self::register_taxonomy(
 			'course_cat',
 			array( 'course' ),
@@ -1100,7 +1127,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// course difficulty
+		// Course difficulty.
 		self::register_taxonomy(
 			'course_difficulty',
 			array( 'course' ),
@@ -1132,7 +1159,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// course tag
+		// Course tag.
 		self::register_taxonomy(
 			'course_tag',
 			array( 'course' ),
@@ -1164,7 +1191,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// course track
+		// Course track.
 		self::register_taxonomy(
 			'course_track',
 			array( 'course' ),
@@ -1197,7 +1224,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// membership cats
+		// Membership cats.
 		self::register_taxonomy(
 			'membership_cat',
 			array( 'llms_membership' ),
@@ -1231,7 +1258,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// membership tags
+		// Membership tags.
 		self::register_taxonomy(
 			'membership_tag',
 			array( 'llms_membership' ),
@@ -1264,7 +1291,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// course/membership visibility
+		// Course/membership visibility.
 		self::register_taxonomy(
 			'llms_product_visibility',
 			array( 'course', 'llms_membership' ),
@@ -1278,7 +1305,7 @@ class LLMS_Post_Types {
 			)
 		);
 
-		// access plan visibility
+		// Access plan visibility.
 		self::register_taxonomy(
 			'llms_access_plan_visibility',
 			array( 'llms_access_plan' ),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS\Classes
  *
  * @since 1.0.0
- * @version 3.34.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.30.3 Removed duplicate array keys when registering course_tag taxonomy.
  * @since 3.33.0 `llms_question` post type is not publicly queryable anymore.
  * @since 3.34.1 Add the custom property `show_in_llms_rest` set to true by default, to those taxonomies we want to be shown in LLMS REST api.
+ * @since [version] Added 'revisions' support to course, lesson, and llms_mebership post types.
  */
 class LLMS_Post_Types {
 
@@ -254,6 +255,7 @@ class LLMS_Post_Types {
 	 *
 	 * @since 1.0.0
 	 * @since 3.33.0 `llms_question` post type is not publicly queryable anymore.
+	 * @since [version] Added 'revisions' support to course, lesson, and llms_mebership post types.
 	 *
 	 * @return void
 	 */
@@ -295,7 +297,7 @@ class LLMS_Post_Types {
 					'feeds'      => true,
 				),
 				'query_var'           => true,
-				'supports'            => array( 'title', 'author', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'llms-clone-post', 'llms-export-post' ),
+				'supports'            => array( 'title', 'author', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-clone-post', 'llms-export-post' ),
 				'has_archive'         => ( $catalog_id && get_page( $catalog_id ) ) ? get_page_uri( $catalog_id ) : _x( 'courses', 'course archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,
@@ -373,7 +375,7 @@ class LLMS_Post_Types {
 				),
 				'show_in_nav_menus'   => false,
 				'query_var'           => true,
-				'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'author', 'llms-clone-post' ),
+				'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'author', 'llms-clone-post' ),
 			)
 		);
 
@@ -490,7 +492,7 @@ class LLMS_Post_Types {
 					'feeds'      => true,
 				),
 				'query_var'           => true,
-				'supports'            => array( 'title', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes' ),
+				'supports'            => array( 'title', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions' ),
 				'has_archive'         => ( $membership_page_id && get_page( $membership_page_id ) ) ? get_page_uri( $membership_page_id ) : _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,
@@ -527,7 +529,6 @@ class LLMS_Post_Types {
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => false,
 					'exclude_from_search' => true,
-					// 'show_in_menu' 			=> 'lifterlms',
 					'menu_position'       => 52,
 					'menu_icon'           => 'dashicons-awards',
 					'hierarchical'        => false,
@@ -1091,7 +1092,7 @@ class LLMS_Post_Types {
 				'show_admin_column' => true,
 				'show_ui'           => true,
 				'rewrite'           => array(
-					'slug'         => _x( 'course-category', 'slug', 'lifterlms' ),
+					'slug'         => _x( 'r-category', 'slug', 'lifterlms' ),
 					'with_front'   => false,
 					'hierarchical' => true,
 				),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -62,7 +62,7 @@ class LLMS_Post_Types {
 		 *
 		 * @since Unknown
 		 *
-		 * @param string[] $post_types Array of post type names..
+		 * @param string[] $post_types Array of post type names.
 		 */
 		$post_types = apply_filters( 'llms_membership_restricted_post_types', array( 'post', 'page' ) );
 		foreach ( $post_types as $post_type ) {


### PR DESCRIPTION
## Description

Resolves #1043 (feature request)

## How has this been tested?

+ Manual testing by updating affected post types in the WP editor.

## Screenshots <!-- if applicable -->

## Types of changes

Adds core WordPress support. There's no real potential for breaking any functionality with this addition. There's likely a small number of users who don't want revisions enabled at all and that would be done with wp core filters. In the strange event that someone doesn't want revisions enabled for our custom post types but does want them enabled for other post types this would have to be addressed by filtering the post type registration of the affected post types to remove support.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

