### PR TITLE
Refactor builder "process_trash" method

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -716,7 +716,7 @@ class LLMS_Admin_Builder {
 		if ( $type ) {
 			$status = self::process_trash_item_post_type( $id, $type );
 		} else {
-			$status = self::process_trash_item_custom( $id );
+			$status = self::process_trash_item_non_post_type( $id );
 		}
 
 		// Error deleting.
@@ -734,12 +734,10 @@ class LLMS_Admin_Builder {
 	}
 
 	/**
-	 * Delete a question choice
+	 * Delete non-post type elements
 	 *
-	 * This method is called via the `llms_builder_trash_custom_item` filter. The filter
-	 * is applied and removed in the `LLMS_Admin_Builder::process_trash()`.
-	 *
-	 * Note that while this is a public method, it's not intended to be used outside of the
+	 * Currently handles deletion of question choices. In the future additional non-post type elements
+	 * may be handled by this method.
 	 *
 	 * @since [version]
 	 *
@@ -748,7 +746,7 @@ class LLMS_Admin_Builder {
 	 *                            `true` on success.
 	 *                            `WP_Error` when an error is encountered.
 	 */
-	private static function process_trash_item_custom( $id ) {
+	private static function process_trash_item_non_post_type( $id ) {
 
 		// Can't process.
 		if ( false === strpos( $id, ':' ) ) {

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -100,13 +100,13 @@ class LLMS_Admin_Builder {
 			}
 
 			$quiz_fields[ sprintf( '%s_backwards_theme_group', $theme->get_stylesheet() ) ] = array(
+				// Translators: %s = Theme name.
 				'title'      => sprintf( __( '%s Theme Settings', 'lifterlms' ), $theme->get( 'Name' ) ),
 				'toggleable' => true,
 				'fields'     => array( array( $field ) ),
 			);
 
 		}
-		// end backwards compat
 
 		return apply_filters(
 			'llms_builder_register_custom_fields',
@@ -198,9 +198,11 @@ class LLMS_Admin_Builder {
 					}
 
 					if ( $lesson_id ) {
+						// Translators: %1$s = Lesson title; %2$d = Lesson id.
 						$parents['lesson'] = sprintf( __( 'Lesson: %1$s (#%2$d)', 'lifterlms' ), '<em>' . get_the_title( $lesson_id ) . '</em>', $lesson_id );
 					}
 					if ( $course_id ) {
+						// Translators: %1$s = Course title; %2$d - Course id.
 						$parents['course'] = sprintf( __( 'Course: %1$s (#%2$d)', 'lifterlms' ), '<em>' . get_the_title( $course_id ) . '</em>', $course_id );
 					}
 				}
@@ -601,6 +603,7 @@ class LLMS_Admin_Builder {
 		foreach ( $data['detach'] as $id ) {
 
 			$res = array(
+				// Translators: %s = Item id.
 				'error' => sprintf( esc_html__( 'Unable to detach "%s". Invalid ID.', 'lifterlms' ), $id ),
 				'id'    => $id,
 			);
@@ -680,6 +683,7 @@ class LLMS_Admin_Builder {
 
 		// Default response.
 		$res = array(
+			// Translators: %s = Item id.
 			'error' => sprintf( esc_html__( 'Unable to delete "%s". Invalid ID.', 'lifterlms' ), $id ),
 			'id'    => $id,
 		);
@@ -761,7 +765,8 @@ class LLMS_Admin_Builder {
 
 		// Error.
 		if ( ! $question->delete_choice( $split[1] ) ) {
-			return new WP_Error( 'llms_builder_trash_custom_item', sprintf( esc_html__( 'Error deleting the question choice "%d"', 'lifterlms' ), $id ) );
+			// Translators: %s = Question choice ID.
+			return new WP_Error( 'llms_builder_trash_custom_item', sprintf( esc_html__( 'Error deleting the question choice "%s"', 'lifterlms' ), $id ) );
 		}
 
 		// Success.
@@ -798,6 +803,7 @@ class LLMS_Admin_Builder {
 		 */
 		$post_types = apply_filters( 'llms_builder_trashable_post_types', array( 'lesson', 'llms_quiz', 'llms_question', 'section' ) );
 		if ( ! in_array( $post_type, $post_types, true ) ) {
+			// Translators: %s = Post type name.
 			return new WP_Error( 'llms_builder_trash_unsupported_post_type', sprintf( esc_html__( '%s cannot be deleted via the Course Builder.', 'lifterlms' ), $obj->labels->name ) );
 		}
 
@@ -821,6 +827,7 @@ class LLMS_Admin_Builder {
 		// Delete or trash the post.
 		$res = $force ? wp_delete_post( $id, true ) : wp_trash_post( $id );
 		if ( ! $res ) {
+			// Translators: %1$s = Post type singular name; %2$d = Post id.
 			return new WP_Error( 'llms_builder_trash_post_type', sprintf( esc_html__( 'Error deleting the %1$s "%2$d".', 'lifterlms' ), $obj->labels->singular_name, $id ) );
 		}
 
@@ -973,6 +980,7 @@ class LLMS_Admin_Builder {
 
 			if ( empty( $lesson ) || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 
+				// Translators: %s = Lesson post id.
 				$res['error'] = sprintf( esc_html__( 'Unable to update lesson "%s". Invalid lesson ID.', 'lifterlms' ), $lesson_data['id'] );
 
 			} else {
@@ -1069,6 +1077,7 @@ class LLMS_Admin_Builder {
 
 			if ( ! $question_id ) {
 
+				// Translators: %s = Question post id.
 				$ret['error'] = sprintf( esc_html__( 'Unable to update question "%s". Invalid question ID.', 'lifterlms' ), $q_data['id'] );
 
 			} else {
@@ -1099,6 +1108,7 @@ class LLMS_Admin_Builder {
 
 						$choice_id = $question->update_choice( $c_data );
 						if ( ! $choice_id ) {
+							// Translators: %s = Question choice ID.
 							$choice_res['error'] = sprintf( esc_html__( 'Unable to update choice "%s". Invalid choice ID.', 'lifterlms' ), $c_data['id'] );
 						} else {
 							$choice_res['id'] = $choice_id;
@@ -1158,6 +1168,7 @@ class LLMS_Admin_Builder {
 		// we don't have a proper quiz to work with...
 		if ( empty( $quiz ) || ! is_a( $quiz, 'LLMS_Quiz' ) ) {
 
+			// Translators: %s = Quiz post id.
 			$res['error'] = sprintf( esc_html__( 'Unable to update quiz "%s". Invalid quiz ID.', 'lifterlms' ), $quiz_data['id'] );
 
 		} else {
@@ -1233,6 +1244,7 @@ class LLMS_Admin_Builder {
 
 		// we don't have a proper section to work with...
 		if ( empty( $section ) || ! is_a( $section, 'LLMS_Section' ) ) {
+			// Translators: %s = Section post id.
 			$res['error'] = sprintf( esc_html__( 'Unable to update section "%s". Invalid section ID.', 'lifterlms' ), $section_data['id'] );
 		} else {
 

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -20,6 +20,11 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Admin_Builder {
 
+	/**
+	 * Search term string used by `get_existing_posts_where()` when querying for existing posts to clone/add to a course.
+	 *
+	 * @var string
+	 */
 	private static $search_term = '';
 
 	/**
@@ -208,8 +213,8 @@ class LLMS_Admin_Builder {
 					'text'    => sprintf( '%1$s (#%2$d)', $post->get( 'title' ), $post->get( 'id' ) ),
 				);
 
-			}// End foreach().
-		}// End if().
+			}
+		}
 
 		$ret = array(
 			'results'    => $posts,
@@ -330,7 +335,7 @@ class LLMS_Admin_Builder {
 				wp_send_json( self::get_existing_posts( absint( $request['course_id'] ), $post_type, $term, $page ) );
 				break;
 
-		}// End switch().
+		}
 
 		return array();
 
@@ -388,7 +393,6 @@ class LLMS_Admin_Builder {
 		$data = $data['llms_builder'];
 
 		// Escape slashes.
-		// $data = json_decode( str_replace( '\\', '\\\\', $data ), true );
 		$data = json_decode( $data, true );
 
 		// setup our return
@@ -912,7 +916,7 @@ class LLMS_Admin_Builder {
 					}
 				}
 			}
-		}// End foreach().
+		}
 
 	}
 
@@ -1013,14 +1017,14 @@ class LLMS_Admin_Builder {
 				if ( ! empty( $lesson_data['quiz'] ) && is_array( $lesson_data['quiz'] ) ) {
 					$res['quiz'] = self::update_quiz( $lesson_data['quiz'], $lesson );
 				}
-			}// End if().
+			}
 
 			// allow 3rd parties to update custom data
 			$res = apply_filters( 'llms_builder_update_lesson', $res, $lesson_data, $lesson, $created );
 
 			array_push( $ret, $res );
 
-		}// End foreach().
+		}
 
 		return $ret;
 
@@ -1108,11 +1112,11 @@ class LLMS_Admin_Builder {
 					$ret['questions'] = self::update_questions( $questions, $question );
 
 				}
-			}// End if().
+			}
 
 			array_push( $res, $ret );
 
-		}// End foreach().
+		}
 
 		return $res;
 
@@ -1190,7 +1194,7 @@ class LLMS_Admin_Builder {
 			// update all custom fields
 			self::update_custom_schemas( 'quiz', $quiz, $quiz_data );
 
-		}// End if().
+		}
 
 		return $res;
 

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Admin_Builder class.
  *
  * @since 3.13.0
- * @since 3.30.0  Fixed issues related to custom field sanitization.
+ * @since 3.30.0 Fixed issues related to custom field sanitization.
  * @since 3.37.11 Made method `get_existing_posts_where()` static.
  * @since [version] Refactored the `process_trash()` method.
  *                Added new filter, `llms_builder_{$post_type}_force_delete` to allow control of how post type deletion is handled
@@ -655,7 +655,7 @@ class LLMS_Admin_Builder {
 	 * @since [version] Refactored method to reduce method complexity.
 	 *
 	 * @param array $data Array of ids to trash/delete.
-	 * @return array[]    Array of arrays containing information about the deleted items.
+	 * @return array[] Array of arrays containing information about the deleted items.
 	 */
 	private static function process_trash( $data ) {
 
@@ -674,10 +674,10 @@ class LLMS_Admin_Builder {
 	 *
 	 * @since [version]
 	 *
-	 * @param  mixed $id Item id. Usually a WP_Post ID but can also be custom ID strings.
-	 * @return array     Associative array containing information about the trashed item.
-	 *                   On success returns an array with an `id` key corresponding to the item's id.
-	 *                   On failure returns the `id` as well as an `error` key which is a string describing the error.
+	 * @param mixed $id Item id. Usually a WP_Post ID but can also be custom ID strings.
+	 * @return array Associative array containing information about the trashed item.
+	 *               On success returns an array with an `id` key corresponding to the item's id.
+	 *               On failure returns the `id` as well as an `error` key which is a string describing the error.
 	 */
 	private static function process_trash_item( $id ) {
 
@@ -741,7 +741,7 @@ class LLMS_Admin_Builder {
 	 *
 	 * Note that while this is a public method, it's not intended to be used outside of the
 	 *
-	 * @since  [version]
+	 * @since [version]
 	 *
 	 * @param  string $id Custom item ID. This should be a question choice id in the format of "${question_id}:{$choice_id}".
 	 * @return null|true|WP_Error `null` when the $id cannot be parsed into a question choice id.
@@ -777,12 +777,12 @@ class LLMS_Admin_Builder {
 	/**
 	 * Delete / Trash a post type
 	 *
-	 * @since  [version]
+	 * @since [version]
 	 *
-	 * @param  int    $id        WP_Post ID.
-	 * @param  string $post_type Post type name.
-	 * @return boolean|WP_Error  `true` when successfully deleted or trashed.
-	 *                           `WP_Error` for unsupported post types or when a deletion error is encountered.
+	 * @param int    $id        WP_Post ID.
+	 * @param string $post_type Post type name.
+	 * @return boolean|WP_Error `true` when successfully deleted or trashed.
+	 *                          `WP_Error` for unsupported post types or when a deletion error is encountered.
 	 */
 	private static function process_trash_item_post_type( $id, $post_type ) {
 

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -662,7 +662,7 @@ class LLMS_Admin_Builder {
 		$ret = array();
 
 		foreach ( $data['trash'] as $id ) {
-			array_push( $ret, self::process_trash_item( $id ) );
+			$ret[] = self::process_trash_item( $id );
 		}
 
 		return $ret;

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Test Admin Builder API
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group builder
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = 'LLMS_Admin_Builder';
+
+	}
+
+	/**
+	 * Filter callback for `llms_builder_trash_custom_item` used to mock a custom item deletion.
+	 *
+	 * @since  [version]
+	 *
+	 * @param null|array $trash_response Denotes the trash response. See description above for details.
+	 * @param array      $res            The initial default error response which can be modified for your needs and then returned.
+	 * @param mixed      $id             The ID of the course element. Usually a WP_Post id.
+	 * @return array
+	 */
+	public function filter_llms_builder_trash_custom_item( $ret, $res, $id ) {
+		return compact( 'id' );
+	}
+
+	/**
+	 * Test process_trash() for an invalid post id (one that doesn't exist).
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_invalid_post_id() {
+
+		$data = array(
+			'trash' => array( $this->factory->post->create() + 1 ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		$this->assertEquals( $data['trash'][0], $res[0]['id'] );
+		$this->assertStringContains( 'Invalid ID.', $res[0]['error'] );
+
+	}
+
+
+	/**
+	 * Test process_trash() for a custom / 3rd party item.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_custom_item() {
+
+		add_filter( 'llms_builder_trash_custom_item', array( $this, 'filter_llms_builder_trash_custom_item' ), 10, 3 );
+
+		$data = array(
+			'trash' => array( $this->factory->post->create() + 1 ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		$this->assertEquals( array( 'id' => $data['trash'][0] ), $res[0] );
+
+		remove_filter( 'llms_builder_trash_custom_item', array( $this, 'filter_llms_builder_trash_custom_item' ));
+
+	}
+
+	/**
+	 * Test process_trash() for an invalid post type.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_invalid_post_type() {
+
+		$data = array(
+			'trash' => array( $this->factory->post->create() ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		$this->assertEquals( $data['trash'][0], $res[0]['id'] );
+		$this->assertEquals( 'Posts cannot be deleted via the Course Builder.', $res[0]['error'] );
+
+	}
+
+	/**
+	 * Test process_trash() for success when the post is force-deleted.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_force_delete_success() {
+
+		$types = array( 'section', 'llms_question', 'llms_quiz' );
+		foreach ( $types as $type ) {
+
+			$post_id = $this->factory->post->create( array( 'post_type' => $type ) );
+
+			$data = array(
+				'trash' => array( $post_id ),
+			);
+
+			$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+			// Proper return.
+			$this->assertEquals( array( 'id' => $post_id ), $res[0] );
+
+			// Post has been force deleted.
+			$this->assertNull( get_post( $post_id ) );
+
+		}
+
+	}
+
+	/**
+	 * Test process_trash() when an error is encountered deleting the post.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_deletion_error() {
+
+		// Mock the return of `wp_delete_post()` to simulate an error.
+		add_filter( 'pre_delete_post', '__return_false' );
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'section' ) );
+
+		$data = array(
+			'trash' => array( $post_id ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		$this->assertEquals( $post_id, $res[0]['id'] );
+		$this->assertStringContains( 'Error deleting the Section', $res[0]['error'] );
+
+		remove_filter( 'pre_delete_post', '__return_false' );
+
+	}
+
+	/**
+	 * Test process_trash() success when moving an item to the trash.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_move_to_trash() {
+
+		$post_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
+
+		$data = array(
+			'trash' => array( $post_id ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		// Proper return.
+		$this->assertEquals( array( 'id' => $post_id ), $res[0] );
+
+		// Post has been trashed
+		$this->assertEquals( 'trash', get_post_status( $post_id ) );
+
+	}
+
+	/**
+	 * Test process_trash() when deleting a question choice.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_process_trash_question_choice() {
+
+		$course    = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+		$quiz      = $course->get_lessons()[0]->get_quiz();
+		$question  = $quiz->get_questions()[0];
+		$choice    = $question->get_choices()[0];
+		$choice_id = $choice->get( 'id' );
+
+		$id = sprintf( '%1$d:%2$s', $question->get( 'id' ), $choice_id );
+
+		$data = array(
+			'trash' => array( $id ),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'process_trash', array( $data ) );
+
+		// Proper return.
+		$this->assertEquals( array( 'id' => $id ), $res[0] );
+
+		// Choice has been deleted.
+		$this->assertFalse( $question->get_choice( $choice_id ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -59,7 +59,6 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 
 	}
 
-
 	/**
 	 * Test process_trash() for a custom / 3rd party item.
 	 *


### PR DESCRIPTION

## Description

Refactored for code readability and simplicity, make methods more atomic.

The `process_trash()` method loops through items to trash passing each item to the `process_trash_item()` which actually handles trashing a single item.

Refactored the code here to pass "custom items" (defined as a non-post item) to one method and all other items to another method for deleting/trashing post types.

In this latter method added a filter that allows determining whether the post type should be trashed or force deleted. This last part helps address issues identified in gocodebox/lifterlms-assignments#29

## How has this been tested?

New unit tests were written to test all scenarios encountered in the `process_trash()` method. The tests were written *prior* to the refactor so I could ensure after refactoring these tests still passed. I had to adjust a few of the test assertions after the refactor because I also made the error messages a little nicer which caused the original message assertions to fail after the refactor.

I also manually tested the deletion behavior of all affected course elements via the course builder. After each deletion I checked the database to ensure the item was successfully deleted (or trashed) and visually inspected the builder interface to ensure no regressions have been introduced.

## Types of changes

+ New filter: "llms_builder_{$post_type}_force_delete"
+ Improved error messages (more i18n friendly).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

