### PR TITLE
Issues/comments

### DIFF
--- a/includes/class.llms.comments.php
+++ b/includes/class.llms.comments.php
@@ -15,7 +15,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.0.0
  * @since [version] Use strict comparisons.
- *                Fix issue encountered when when `wp_comment_counts()` returns an empty array.
+ *                Handle empty array from `wp_count_comments` filter.
+ *                Properly exclude "llms_order_note" comment types from comment counts..
  */
 class LLMS_Comments {
 
@@ -130,6 +131,7 @@ class LLMS_Comments {
 	 * @since 3.0.0
 	 * @since [version] Use strict comparisons.
 	 *                Fix issue encountered when $stats is an empty array.
+	 *                Properly exclude "llms_order_note" comment types.
 	 *
 	 * @param obj $stats   Original comment stats.
 	 * @param int $post_id WP Post ID
@@ -153,7 +155,7 @@ class LLMS_Comments {
 					"
 					SELECT comment_approved, COUNT( * ) AS num_comments
 					  FROM {$wpdb->comments}
-					 WHERE comment_type = 'llms_order_note'
+					 WHERE comment_type != 'llms_order_note'
 				  GROUP BY comment_approved;
 					",
 					ARRAY_A

--- a/includes/class.llms.comments.php
+++ b/includes/class.llms.comments.php
@@ -1,25 +1,39 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
 /**
  * Custom filters & actions for LifterLMS Comments
  *
- * @since  3.0.0
- * @version  3.0.0
+ * @since 3.0.0
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Comments class
+ *
+ * @since 3.0.0
+ * @since [version] Use strict comparators.
  */
 class LLMS_Comments {
 
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function __construct() {
 
-		// secure order notes
+		// Secure order notes.
 		add_filter( 'comments_clauses', array( __CLASS__, 'exclude_order_comments' ), 10, 1 );
 		add_action( 'comment_feed_join', array( __CLASS__, 'exclude_order_comments_from_feed_join' ) );
 		add_action( 'comment_feed_where', array( __CLASS__, 'exclude_order_comments_from_feed_where' ) );
 
-		// remove order notes when counting comments
+		// Remove order notes when counting comments.
 		add_filter( 'wp_count_comments', array( __CLASS__, 'wp_count_comments' ), 777, 2 );
 
-		// Delete comments count cache whenever there is a new comment or a comment status changes
+		// Delete comments count cache whenever there is a new comment or a comment status changes.
 		add_action( 'wp_insert_comment', array( __CLASS__, 'delete_comments_count_cache' ) );
 		add_action( 'wp_set_comment_status', array( __CLASS__, 'delete_comments_count_cache' ) );
 
@@ -27,12 +41,12 @@ class LLMS_Comments {
 
 	/**
 	 * Delete transient data when inserting new comments or updating comment status
+	 *
 	 * Next time wp_count_comments is called it'll be automatically regenerated
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.0.0
-	 * @note thanks WooCommerce :-D
+	 * @since 3.0.0
+	 *
+	 * @return void
 	 */
 	public static function delete_comments_count_cache() {
 		delete_transient( 'llms_count_comments' );
@@ -41,18 +55,18 @@ class LLMS_Comments {
 	/**
 	 * Exclude order comments from queries and RSS.
 	 *
-	 * @param  array $clauses
+	 * @since 3.0.0
+	 * @since [version] Use strict comparison for `in_array()`.
+	 *
+	 * @param array $clauses Array of SQL clauses.
 	 * @return array
-	 * @since  3.0.0
-	 * @version  3.0.0
-	 * @see thanks WooCommerce :-D
 	 */
 	public static function exclude_order_comments( $clauses ) {
 
 		global $wpdb, $typenow;
 
-		// allow queries when in the admin
-		if ( is_admin() && in_array( $typenow, array( 'llms_order' ) ) && current_user_can( apply_filters( 'lifterlms_admin_order_access', 'manage_options' ) ) ) {
+		// Allow queries when in the admin.
+		if ( is_admin() && in_array( $typenow, array( 'llms_order' ), true ) && current_user_can( apply_filters( 'lifterlms_admin_order_access', 'manage_options' ) ) ) {
 			return $clauses;
 		}
 
@@ -71,16 +85,16 @@ class LLMS_Comments {
 		$clauses['where'] .= " $wpdb->posts.post_type NOT IN ('" . implode( "','", array( 'llms_order' ) ) . "') ";
 
 		return $clauses;
+
 	}
 
 	/**
 	 * Exclude order comments from queries and RSS.
 	 *
-	 * @param  string $join
+	 * @since 3.0.0
+	 *
+	 * @param string $join SQL join clause.
 	 * @return string
-	 * @since  3.0.0
-	 * @version  3.0.0
-	 * @see thanks WooCommerce :-D
 	 */
 	public static function exclude_order_comments_from_feed_join( $join ) {
 		global $wpdb;
@@ -93,11 +107,10 @@ class LLMS_Comments {
 	/**
 	 * Exclude order comments from queries and RSS.
 	 *
-	 * @param  string $where
+	 * @since 3.0.0
+	 *
+	 * @param string $where SQL where clause.
 	 * @return string
-	 * @since  3.0.0
-	 * @version  3.0.0
-	 * @see thanks WooCommerce :-D
 	 */
 	public static function exclude_order_comments_from_feed_where( $where ) {
 		global $wpdb;
@@ -111,19 +124,19 @@ class LLMS_Comments {
 	/**
 	 * Remove order notes from the count when counting comments
 	 *
-	 * @param    object $stats    original comment stats
-	 * @param    int    $post_id  WP Post ID
-	 * @return   object
-	 * @since    3.0.0
-	 * @version  3.0.0
-	 * @see thanks WooCommerce :-D
+	 * @since 3.0.0
+	 * @since [version] Use strict comparisons.
+	 *
+	 * @param obj $stats   Original comment stats.
+	 * @param int $post_id WP Post ID
+	 * @return obj
 	 */
 	public static function wp_count_comments( $stats, $post_id ) {
 		global $wpdb;
 		if ( 0 === $post_id ) {
 			$trans = get_transient( 'llms_count_comments' );
 			if ( ! $trans ) {
-				$count    = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type = 'llms_order_note' GROUP BY comment_approved;", ARRAY_A );
+				$count    = $wpdb->get_results( "SELECT comment_approved, COUNT( * ) AS num_comments FROM {$wpdb->comments} WHERE comment_type = 'llms_order_note' GROUP BY comment_approved;", ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 				$approved = array(
 					'0'            => 'moderated',
 					'1'            => 'approved',
@@ -132,8 +145,8 @@ class LLMS_Comments {
 					'post-trashed' => 'post-trashed',
 				);
 				foreach ( $count as $row ) {
-					// Don't count post-trashed toward totals
-					if ( 'post-trashed' != $row['comment_approved'] && 'trash' != $row['comment_approved'] ) {
+					// Don't count post-trashed toward totals.
+					if ( 'post-trashed' !== $row['comment_approved'] && 'trash' !== $row['comment_approved'] ) {
 						$stats->total_comments -= $row['num_comments'];
 					}
 
@@ -149,7 +162,6 @@ class LLMS_Comments {
 		}
 		return $stats;
 	}
-
 
 }
 return new LLMS_Comments();

--- a/includes/class.llms.comments.php
+++ b/includes/class.llms.comments.php
@@ -184,7 +184,6 @@ class LLMS_Comments {
 			if ( isset( $approved[ $row['comment_approved'] ] ) ) {
 				$stats[ $approved[ $row['comment_approved'] ] ] = $row['num_comments'];
 			}
-
 		}
 
 		// Fill in remaining items with 0.

--- a/tests/phpunit/unit-tests/class-llms-test-comments.php
+++ b/tests/phpunit/unit-tests/class-llms-test-comments.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Test LLMS_Comments
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group comments
+ *
+ * @since [version]
+ */
+class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Test wp_count_comments() when passing in a specific post id.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_wp_count_comments_specific_post() {
+
+		$expect = array();
+		$this->assertEquals( $expect, LLMS_Comments::wp_count_comments( $expect, 123 ) );
+
+	}
+
+	/**
+	 * Test wp_count_comments() when the transient already exists.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_wp_count_comments_transient_exists() {
+
+		$expect = array( 1 );
+		set_transient( 'llms_count_comments', $expect, 10 );
+
+		$this->assertEquals( $expect, LLMS_Comments::wp_count_comments( $expect, 0 ) );
+
+	}
+
+	/**
+	 * Test wp_count_comments()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_wp_count_comments() {
+
+		// Insert 5 regular comments.
+		$this->factory->comment->create_many( 5 );
+
+		// Insert 5 other custom comment types (we don't want to mess with other plugins).
+		$this->factory->comment->create_many( 5, array( 'comment_type' => 'custom_type' ) );
+
+		// Insert 5 order notes, these will be excluded.
+		$this->factory->comment->create_many( 5, array( 'comment_type' => 'llms_order_note' ) );
+
+		$res = LLMS_Comments::wp_count_comments( array(), 0 );
+
+		// Ensure the function creates the stats object in the correct format.
+		$keys = array( 'approved', 'moderated', 'spam', 'trash', 'post-trashed', 'total_comments', 'all' );
+		$this->assertEqualSets( $keys, array_keys( get_object_vars( $res ) ) );
+
+		// Order notes should be excluded.
+		$this->assertEquals( 10, $res->total_comments );
+		$this->assertEquals( 10, $res->all );
+		$this->assertEquals( 10, $res->approved );
+
+		// All of these are default 0.
+		$this->assertEquals( 0, $res->moderated );
+		$this->assertEquals( 0, $res->spam );
+		$this->assertEquals( 0, $res->trash );
+		$this->assertEquals( 0, $res->{'post-trashed'} );
+
+	}
+
+}


### PR DESCRIPTION
## Description

Reworks comment counting methods attached to the `wp_count_comments` filter.

Fixes #1049 and fixes #901 

## How has this been tested?

Manually tested following recreation steps in related issues.

Added new phpunit integration tests to test for the various scenarios encountered in the offending method.

## Types of changes

Bug fixes

Updates to documentation

Unrelated cs: updated functions in class to use strict comparisons

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

