### PR TITLE
Fix docs cs (file header rules) for files in includes/abstracts

### DIFF
--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Admin Metabox Class
+ * Admin Metabox Abstract
+ *
+ * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
  * @version 3.37.12
@@ -14,7 +16,7 @@ foreach ( glob( LLMS_PLUGIN_DIR . '/includes/admin/post-types/meta-boxes/fields/
 }
 
 /**
- * Admin metabox abstract class.
+ * Admin metabox abstract class
  *
  * @since 3.0.0
  * @since 3.35.0 Sanitize and verify nonce when saving metabox data.

--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -1,19 +1,21 @@
 <?php
 /**
- * Admin Tables
+ * Admin Table Abstract
  *
- * @since   3.2.0
- * @version {version}
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.2.0
+ * @version 3.37.7
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Admin_Table abstract.
+ * LLMS_Admin_Table abstract class
  *
  * @since 3.2.0
  * @since 3.34.0 Added get_table_classes().
- * @since 3.37.7 Fix PHP 7.4 deprecation notice..
+ * @since 3.37.7 Fix PHP 7.4 deprecation notice.
  */
 abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Analytics Widget Abstract.
+ * Analytics Widget Abstract
+ *
+ * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
  * @version 3.36.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Analytics Widget Abstract.
+ * Analytics Widget abstract class
  *
  * @since 3.0.0
  * @since 3.30.3 Define undefined properties.

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Abstract Database Query
+ * Database Query Abstract
  *
- * @package LifterLMS/Classes/Abstracts
+ * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.8.0
  * @version 3.34.0
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Abstract Database Query Class
+ * Database Query abstract class
  *
  * @since 3.8.0
  * @since 3.30.3 `is_last_page()` method returns `true` when no results are found.

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -2,14 +2,16 @@
 /**
  * LifterLMS Payment Gateways Abstract
  *
- * @since    3.0.0
- * @version  3.34.3
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.0.0
+ * @version 3.34.3
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS Payment Gateways Abstract
+ * LifterLMS Payment Gateways abstract class
  *
  * @since 3.0.0
  * @since 3.30.0 Added access plan and query string checkout redirect settings.

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -2,7 +2,7 @@
 /**
  * Defines base methods and properties for programmatically interfacing with LifterLMS Custom Post Types
  *
- * @package LifterLMS/Abstracts
+ * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
  * @version 3.36.1
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Post_Model abstract
+ * LLMS_Post_Model abstract class
  *
  * @property      string  $author           ID of post author.
  * @property      string  $content          The post's content.

--- a/includes/abstracts/abstract.llms.shortcode.course.element.php
+++ b/includes/abstracts/abstract.llms.shortcode.course.element.php
@@ -2,13 +2,19 @@
 /**
  * Common Shortcode for course element templates
  *
- * @since    3.6.0
- * @version  3.6.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.6.0
+ * @version 3.6.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Common Shortcode for course element templates abstract class
+ *
+ * @since 3.6.0
+ */
 abstract class LLMS_Shortcode_Course_Element extends LLMS_Shortcode {
 
 	/**

--- a/includes/abstracts/abstract.llms.shortcode.php
+++ b/includes/abstracts/abstract.llms.shortcode.php
@@ -1,14 +1,21 @@
 <?php
 /**
- * Base Shortcode Class
+ * Base Shortcode
  *
- * @since    3.4.3
- * @version  3.4.3
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.4.3
+ * @version 3.5.1
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Base Shortcode abstract class
+ *
+ * @since 3.4.3
+ * @since 3.5.1 Unknown.
+ */
 abstract class LLMS_Shortcode {
 
 	/**

--- a/includes/abstracts/abstract.llms.update.php
+++ b/includes/abstracts/abstract.llms.update.php
@@ -2,6 +2,8 @@
 /**
  * Handle background database updates
  *
+ * @package LifterLMS/Abstracts/Classes
+ *
  * @since 3.0.0
  * @version 3.32.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Database background update abstract
+ * Database background update abstract class
  *
  * @since 3.0.0
  * @since 3.32.0 Update to use latest action-scheduler functions.

--- a/includes/abstracts/llms.abstract.api.handler.php
+++ b/includes/abstracts/llms.abstract.api.handler.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * 3rd Party API request handler abstract.
+ * 3rd Party API request handler abstract
+ *
+ * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.11.2
  * @version 3.30.1
@@ -9,11 +11,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * 3rd Party API request handler abstract.
+ * 3rd Party API request handler abstract class
  *
  * @since 3.11.2
- * @since 3.30.1 self::set_request_body() may respond with `null` in order to send a request with no `body`
- * @version 3.29.0
+ * @since 3.30.1 self::set_request_body() may respond with `null` in order to send a request with no `body`.
  */
 abstract class LLMS_Abstract_API_Handler {
 

--- a/includes/abstracts/llms.abstract.database.store.php
+++ b/includes/abstracts/llms.abstract.database.store.php
@@ -2,6 +2,8 @@
 /**
  * WPDB database interactions
  *
+ * @package LifterLMS/Abstracts/Classes
+ *
  * @since 3.14.0
  * @version 3.36.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WPDB database interactions
+ * WPDB database interactions abstract class
  *
  * @since 3.14.0
  * @since 3.33.0 setup() method returns self instead of void.

--- a/includes/abstracts/llms.abstract.exportable.admin.table.php
+++ b/includes/abstracts/llms.abstract.exportable.admin.table.php
@@ -2,6 +2,8 @@
 /**
  * Admin Table Export Functions
  *
+ * @package LifterLMS/Abstracts/Classes
+ *
  * @since 3.28.0
  * @version 3.30.3
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Admin_Table abstract.
+ * Exportable admin table abstract class
  *
  * @since 3.28.0
  * @since 3.30.3 Explicitly define undefined properties.

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS Integration Abstract
+ * LifterLMS Integration abstract class
  *
  * @since 3.0.0
  * @since 3.21.1 Updated.

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -2,6 +2,8 @@
 /**
  * Notification Controller Abstract
  *
+ * @package LifterLMS/Abstracts/Classes
+ *
  * @since 3.8.0
  * @version 3.30.3
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Notification Controller Abstract
+ * Notification Controller abstract class
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define undefined properties & fixed typo in output string.

--- a/includes/abstracts/llms.abstract.notification.processor.php
+++ b/includes/abstracts/llms.abstract.notification.processor.php
@@ -2,16 +2,22 @@
 /**
  * LifterLMS Notification Background Processor Abstract
  *
- * @since    3.8.0
- * @version  3.8.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.8.0
+ * @version 3.8.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
 require_once LLMS_PLUGIN_DIR . 'includes/libraries/wp-background-processing/wp-async-request.php';
 require_once LLMS_PLUGIN_DIR . 'includes/libraries/wp-background-processing/wp-background-process.php';
 
+/**
+ * LifterLMS Notification Background Processor abstract class
+ *
+ * @since 3.8.0
+ */
 abstract class LLMS_Abstract_Notification_Processor extends WP_Background_Process {
 
 	/**

--- a/includes/abstracts/llms.abstract.notification.view.php
+++ b/includes/abstracts/llms.abstract.notification.view.php
@@ -2,6 +2,8 @@
 /**
  * Notification View Abstract
  *
+ * @package LifterLMS/Abstracts/Classes
+ *
  * @since 3.8.0
  * @version 3.31.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Abstract_Notification_View abstract.
+ * LLMS_Abstract_Notification_View class
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define undefined properties.

--- a/includes/abstracts/llms.abstract.notification.view.quiz.completion.php
+++ b/includes/abstracts/llms.abstract.notification.view.quiz.completion.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Shared Notification View for quiz completions abstract
+ *
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.24.0
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Shared Notification View for quiz completions
+ * Shared Notification View for quiz completions abstract class
  *
- * @since    3.24.0
- * @version  3.24.0
+ * @since 3.24.0
  */
 abstract class LLMS_Abstract_Notification_View_Quiz_Completion extends LLMS_Abstract_Notification_View {
 

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -1,12 +1,20 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * LifterLMS Options Table Data Store Abstract
  *
- * @since   3.8.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.8.0
  * @version 3.17.8
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS Options Table Data Store abstract class
+ *
+ * @since 3.8.0
+ * @since 3.17.8 Added `set_option()` method.
  */
 abstract class LLMS_Abstract_Options_Data {
 

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -1,17 +1,17 @@
 <?php
 /**
- * Defines base methods and properties for querying data about LifterLMS Custom Post Types.
+ * Defines base methods and properties for querying data about LifterLMS Custom Post Types
  *
- * @package LifterLMS/Abstracts
+ * @package LifterLMS/Abstracts/Classes
  *
- * @since   3.31.0
+ * @since 3.31.0
  * @version 3.31.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Post_Data abstract.
+ * LLMS Post Data abstract class
  *
  * @since 3.31.0
  */

--- a/includes/abstracts/llms.abstract.privacy.php
+++ b/includes/abstracts/llms.abstract.privacy.php
@@ -1,12 +1,21 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * LifterLMS Privacy Export / Eraser Abstract
  *
- * @thanks   WooCommerce <3
- * @since    3.18.0
- * @version  3.18.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.18.0
+ * @version 3.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS Privacy Export / Eraser abstract class
+ *
+ * Thanks WooCommerce.
+ *
+ * @since 3.18.0
  */
 abstract class LLMS_Abstract_Privacy {
 

--- a/includes/abstracts/llms.abstract.processor.php
+++ b/includes/abstracts/llms.abstract.processor.php
@@ -1,12 +1,19 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Background Processor abstract
  *
- * @since    3.15.0
- * @version  3.15.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.15.0
+ * @version 3.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Background Processor abstract class
+ *
+ * @since 3.15.0
  */
 abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 

--- a/includes/abstracts/llms.abstract.user.data.php
+++ b/includes/abstracts/llms.abstract.user.data.php
@@ -2,16 +2,19 @@
 /**
  * LifterLMS User Data Abstract
  *
- * @since   3.9.0
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since 3.9.0
  * @version 3.17.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS User Data Abstract
+ * LifterLMS User Data Abstract class
  *
  * @since 3.9.0
+ * @since 3.17.0 Unknown.
  * @since 3.34.0 Allow `user_url` to be retrieved by `get()`.
  */
 abstract class LLMS_Abstract_User_Data {


### PR DESCRIPTION
## Description
partially fix for #946

rules commented out in phpcs.xml:
```
		<exclude name="LifterLMS.Commenting.FileComment.PackageTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.SinceTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingSinceTag" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingVersionTag" />
		<exclude name="LifterLMS.Commenting.FileComment.VersionTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingPackageTag" />
		<exclude name="LifterLMS.Commenting.FileComment.DuplicateSinceTag" />
		<exclude name="Squiz.Commenting.FileComment.Missing" />
		<exclude name="Squiz.Commenting.FileComment.MissingSinceTag" />
		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />

		<exclude name="Squiz.Commenting.ClassComment.Missing" />
```