### PR TITLE
Coding Standards: File and Class header docs/tags

### DIFF
--- a/includes/class-llms-events-core.php
+++ b/includes/class-llms-events-core.php
@@ -2,7 +2,7 @@
 /**
  * Record events triggered by core/wp actions.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.36.0
  * @version 3.36.0
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Events_Core class..
+ * LLMS_Events_Core class
  *
  * @since 3.36.0
  */

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -2,7 +2,7 @@
 /**
  * Perform db queries for events
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.36.0
  * @version 3.36.0

--- a/includes/class-llms-events.php
+++ b/includes/class-llms-events.php
@@ -2,7 +2,7 @@
 /**
  * LifterLMS Event management.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.36.0
  * @version 3.36.1

--- a/includes/class-llms-grades.php
+++ b/includes/class-llms-grades.php
@@ -1,11 +1,19 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Get & Set grades for gradable post types
  *
- * @since    3.24.0
- * @version  3.24.0
+ * @package LifterLMS/Classes
+ *
+ * @since 3.24.0
+ * @version 3.24.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Grades
+ *
+ * @since 3.24.0
  */
 class LLMS_Grades {
 

--- a/includes/class-llms-sessions.php
+++ b/includes/class-llms-sessions.php
@@ -2,7 +2,7 @@
 /**
  * User event session management.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.36.0
  * @version 3.37.2

--- a/includes/class-llms-staging.php
+++ b/includes/class-llms-staging.php
@@ -2,7 +2,7 @@
 /**
  * Handle warnings and notices when staging is enabled.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 3.32.0
  * @version 3.35.0

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Base Achievement Class
+ *
  * Handles generating Achievement
+ *
+ * @package LifterLMS/Classes/Achievements
  *
  * @since 1.0.0
  * @version 3.24.0

--- a/includes/class.llms.achievements.php
+++ b/includes/class.llms.achievements.php
@@ -2,16 +2,21 @@
 /**
  * Achievements Base Class
  *
- * @package  LifterLMS/Classes/Achievements
- * @since    1.0.0
- * @version  3.24.0
+ * @package LifterLMS/Classes/Achievements
+ *
+ * @since 1.0.0
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Main Achievements singleton
- * Accessible via LLMS()->achievements()
+ *
+ * @see LLMS()->achievements()
+ *
+ * @since 1.0.0
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Achievements {
 

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS AJAX Event Handler.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.37.2
  */

--- a/includes/class.llms.ajax.php
+++ b/includes/class.llms.ajax.php
@@ -1,11 +1,20 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * AJAX Event Handler
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.35.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_AJAX
+ *
+ * @since 1.0.0
+ * @since 3.35.0 Unknown.
  */
 class LLMS_AJAX {
 

--- a/includes/class.llms.analytics.php
+++ b/includes/class.llms.analytics.php
@@ -1,25 +1,22 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Analytics Class
  *
  * Manages large queries of grouped data
  *
+ * @since 1.0.0
+ * @version Unknown
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Analytics
+ *
+ * @since 1.0.0
  * @deprecated 3.35.0
  */
 class LLMS_Analytics {
-
-	/**
-	 * Constructor
-	 */
-	public function __construct() {
-
-	}
-
-	// sales data
-	// get all product orders
 
 	// get orders
 	public static function get_orders( $values ) {

--- a/includes/class.llms.background.updater.php
+++ b/includes/class.llms.background.updater.php
@@ -1,18 +1,27 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * LifterLMS Background Updater
+ *
+ * Process db updates in the background
+ *
+ * Replaces abstract updater and update classes from 3.4.2 and lower
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.4.3
+ * @version 3.16.10
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 require_once LLMS_PLUGIN_DIR . 'includes/libraries/wp-background-processing/wp-async-request.php';
 require_once LLMS_PLUGIN_DIR . 'includes/libraries/wp-background-processing/wp-background-process.php';
 
 /**
- * LifterLMS Background Updater
- * Process db updates in the background
+ * LLMS_Background_Updater
  *
- * Replaces abstract updater and update classes from 3.4.2 and lower
- *
- * @since    3.4.3
- * @version  3.16.10
+ * @since 3.4.3
+ * @since 3.16.10 Unknown.
  */
 class LLMS_Background_Updater extends WP_Background_Process {
 

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -1,20 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * LifterLMS Caching Helper
  *
- * @since    3.15.0
- * @version  3.15.0
+ * @package LifterLMS/Classes
+ *
+ * @since 3.15.0
+ * @version 3.15.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Cache_Helper
+ *
+ * @since 3.15.0]
  */
 class LLMS_Cache_Helper {
 
 	/**
 	 * Constructor
 	 *
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -24,11 +32,12 @@ class LLMS_Cache_Helper {
 
 	/**
 	 * Define nocache constants and set nocache headers on specified pages
-	 * Checkout & Student Dashboard
+	 *
+	 * This prevents caching for the Checkout & Student Dashboard pages.
+	 *
+	 * @since 3.15.0
 	 *
 	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
 	 */
 	public function maybe_no_cache() {
 
@@ -36,6 +45,13 @@ class LLMS_Cache_Helper {
 			return;
 		}
 
+		/**
+		 * Filter the list of pages that LifterLMS will send nocache headers for
+		 *
+		 * @since 3.15..0
+		 *
+		 * @param int[] $ids List of WP_Post IDs.
+		 */
 		$ids = apply_filters(
 			'llms_no_cache_page_ids',
 			array(

--- a/includes/class.llms.certificate.php
+++ b/includes/class.llms.certificate.php
@@ -4,6 +4,8 @@
  *
  * Handles generating certificates.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.30.3
  */

--- a/includes/class.llms.comments.php
+++ b/includes/class.llms.comments.php
@@ -4,6 +4,8 @@
  *
  * This class owes a great debt to WooCommerce.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.37.12
  */

--- a/includes/class.llms.course.basic.php
+++ b/includes/class.llms.course.basic.php
@@ -1,32 +1,43 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Basic course class
+ *
  * Extends LLMS_Course
  *
  * Basic course is the "standard" single purchase course.
  *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Course_Basic
+ *
+ * @since 1.0.0
  * @deprecated 3.30.3
  */
 class LLMS_Course_Basic extends LLMS_Course {
 
 	/**
+	 * Course Type
+	 *
 	 * @var string
-	 * @since 1.0.0
 	 */
 	public $course_type;
 
 	/**
-	 * post id
+	 * Course Post ID
 	 *
 	 * @var int
 	 */
 	public $id;
 
 	/**
-	 * post object
+	 * Course post object
 	 *
 	 * @var object
 	 */
@@ -34,11 +45,18 @@ class LLMS_Course_Basic extends LLMS_Course {
 
 	/**
 	 * Constructor
+	 *
 	 * Inherits from LLMS_Course
 	 *
-	 * @param object $course [The course object]
+	 * @since 1.0.0
+	 * @deprecated 3.30.3
+	 *
+	 * @param object $course Course object.
+	 * @return void
 	 */
 	public function __construct( $course ) {
+
+		llms_deprecated_function( 'LLMS_Course_Basic::__construct()', '3.30.3' );
 
 		$this->course_type = 'basic';
 		parent::__construct( $course );

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -2,6 +2,8 @@
 /**
  * Query data about a course
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.15.0
  * @version 3.31.0
  */

--- a/includes/class.llms.course.factory.php
+++ b/includes/class.llms.course.factory.php
@@ -1,97 +1,124 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Course Factory Class
  *
  * Methods for instantiating objects.
  *
- * @version 1.0
- * @author codeBOX
- * @project lifterLMS
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Course_Factory
+ *
+ * @since 1.0.0
+ * @deprecated [version]
  */
 class LLMS_Course_Factory {
 
 	/**
 	 * Get Course
 	 *
-	 * @param mixed $the_course = false, $args = array()
-	 * @return void
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param mixed $the_course Course object.
+	 * @param array $args       Arguments.
+	 * @return LLMS_Course_Basic
 	 */
 	public function get_course( $the_course = false, $args = array() ) {
-		global $post;
 
+		llms_deprecated_function( 'LLMS_Course_Factory::get_course()', '[version]' );
+
+		global $post;
 		if ( empty( $the_course->post_type ) ) {
 			$the_course = $post;
 		}
-
 		$classname = 'LLMS_Course_Basic';
-
 		return new LLMS_Course_Basic( $the_course, $args );
 	}
 
 	/**
 	 * Get Lesson
 	 *
-	 * @param mixed $the_lesson = false, $args = array()
-	 * @return void
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param mixed $the_lesson Lesson object.
+	 * @param array $args       Arguments.
+	 * @return LLMS_Lesson_Basic
 	 */
 	public function get_lesson( $the_lesson = false, $args = array() ) {
+
+		llms_deprecated_function( 'LLMS_Course_Factory::get_lesson()', '[version]' );
+
 		global $post;
-
 		$the_lesson = $post;
-
 		$classname = 'LLMS_Lesson_Basic';
-
 		return new LLMS_Lesson_Basic( $the_lesson, $args );
 	}
 
 	/**
 	 * Get Product
 	 *
-	 * @param mixed $the_lesson = false, $args = array()
-	 * @return void
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param mixed $the_lesson Product object.
+	 * @param array $args       Arguments.
+	 * @return LLMS_Product
 	 */
 	public function get_product( $the_product = false, $args = array() ) {
+
+		llms_deprecated_function( 'LLMS_Course_Factory::get_product()', '[version]' );
+
 		global $post;
-
 		$the_product = $post;
-
 		$classname = 'LLMS_Product';
-
 		return new LLMS_Product( $the_product, $args );
 	}
 
 	/**
 	 * Get Quiz
 	 *
-	 * @param mixed $the_quiz = false, $args = array()
-	 * @return void
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param mixed $the_quiz Quiz object.
+	 * @param array $args     Arguments.
+	 * @return LLMS_Quiz_Legacy
 	 */
 	public function get_quiz( $the_quiz = false, $args = array() ) {
+
+		llms_deprecated_function( 'LLMS_Course_Factory::get_quiz()', '[version]' );
+
 		global $post;
-
 		$the_quiz = $post;
-
 		$classname = 'LLMS_Quiz';
-
 		return new LLMS_Quiz_Legacy( $the_quiz, $args );
 	}
 
 	/**
 	 * Get Question
 	 *
-	 * @param mixed $the_question = false, $args = array()
-	 * @return void
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param mixed $the_question Question object.
+	 * @param array $args         Arguments.
+	 * @return LLMS_Question
 	 */
 	public function get_question( $the_question = false, $args = array() ) {
+
+		llms_deprecated_function( 'LLMS_Course_Factory::get_question()', '[version]' );
+
 		global $post;
-
 		$the_question = $post;
-
 		$classname = 'LLMS_Question';
-
 		return new LLMS_Question( $the_question, $args );
 	}
 

--- a/includes/class.llms.course.handler.php
+++ b/includes/class.llms.course.handler.php
@@ -1,29 +1,54 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Course Handler Class
  *
  * Main Handler for course management in LifterLMS
  *
- * @author codeBOX
+ * @since 1.0.0
+ * @version  1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Course_Handler
+ *
+ * @since 1.0.0
+ * @deprecated [version]
  */
 class LLMS_Course_Handler {
 
+	/**
+	 * Constructor
+	 *
+	 * @since [version]
+	 * @deprecated [version]
+	 *
+	 * @param mixed $lesson Lesson.
+	 * @return void
+	 */
 	public function __construct( $lesson ) {}
 
-
+	/**
+	 * Get users not enrolled
+	 *
+	 * @since 1.0.0
+	 * @deprecated [version]
+	 *
+	 * @param  int   $post_id           Post ID.
+	 * @param  int[] $enrolled_students Array of WP_User IDs.
+	 * @return array
+	 */
 	public static function get_users_not_enrolled( $post_id, $enrolled_students = array() ) {
 
-		// no post id no deal!
+		llms_deprecated_function( 'get_users_not_enrolled', '[version]', $replacement );
+
 		if ( empty( $post_id ) ) {
 			return false;
 		}
 
 		$enrolled_student_ids = array();
 
-		// if no enrolled users are supplied query them and generate array of user ids
 		if ( empty( $enrolled_students ) ) {
 
 			$user_args = array(
@@ -52,7 +77,6 @@ class LLMS_Course_Handler {
 			}
 		}
 
-		// query users not enrolled
 		$user_args = array(
 			'blog_id'     => $GLOBALS['blog_id'],
 			'include'     => array(),

--- a/includes/class.llms.course.handler.php
+++ b/includes/class.llms.course.handler.php
@@ -4,8 +4,10 @@
  *
  * Main Handler for course management in LifterLMS
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
- * @version  1.0.0
+ * @version 1.0.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -35,13 +37,13 @@ class LLMS_Course_Handler {
 	 * @since 1.0.0
 	 * @deprecated [version]
 	 *
-	 * @param  int   $post_id           Post ID.
-	 * @param  int[] $enrolled_students Array of WP_User IDs.
+	 * @param int   $post_id           Post ID.
+	 * @param int[] $enrolled_students Array of WP_User IDs.
 	 * @return array
 	 */
 	public static function get_users_not_enrolled( $post_id, $enrolled_students = array() ) {
 
-		llms_deprecated_function( 'get_users_not_enrolled', '[version]', $replacement );
+		llms_deprecated_function( 'LLMS_Course_Handler::get_users_not_enrolled', '[version]', $replacement );
 
 		if ( empty( $post_id ) ) {
 			return false;

--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -2,8 +2,10 @@
 /**
  * Retrieve data sets used by various other classes and functions
  *
- * @since    3.0.0
- * @version  3.24.0
+ * @package LifterLMS/Classes
+ *
+ * @since 3.0.0
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class.llms.date.php
+++ b/includes/class.llms.date.php
@@ -1,12 +1,22 @@
 <?php
+/**
+ * Dates Class
+ *
+ * Manages formatting dates for I/O and display
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since Unknown
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Dates Class
- * Manages formatting dates for I/O and display
+ * LLMS_Date class
  *
- * @since    ??
- * @version  3.24.0
+ * @since Unknown
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Date {
 

--- a/includes/class.llms.dot.com.api.php
+++ b/includes/class.llms.dot.com.api.php
@@ -1,11 +1,19 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Interact with the LifterLMS.com API
  *
- * @since    3.22.0
- * @version  3.22.0
+ * @package LifterLMS/Classes
+ *
+ * @since 3.22.0
+ * @version 3.22.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Dot_Com_API
+ *
+ * @since 3.22.0
  */
 class LLMS_Dot_Com_API extends LLMS_Abstract_API_Handler {
 

--- a/includes/class.llms.emails.php
+++ b/includes/class.llms.emails.php
@@ -2,15 +2,22 @@
 /**
  * LifterLMS Emails Class
  *
- * Manages finding the appropriate email
+ * Manages finding the appropriate email.
  *
- * @since    1.0.0
- * @version  3.8.0
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 3.8.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Emails
+ *
+ * @since 1.0.0
+ * @since 3.8.0 Unknown.
+ */
 class LLMS_Emails {
 
 	/**

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Engagements Class
+ *
  * Finds and triggers the appropriate engagement
+ *
+ * @package LifterLMS/Classes
  *
  * @since 2.3.0
  * @version 3.30.3

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -2,6 +2,8 @@
 /**
  * Frontend scripts class
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.36.0
  */

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -2,6 +2,8 @@
 /**
  * Manual Payment Gateway Class
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.30.3
  */

--- a/includes/class.llms.hasher.php
+++ b/includes/class.llms.hasher.php
@@ -1,15 +1,26 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * LifterLMS hash ID encrypt/decrypt
  *
- * Based on PseudoCrypt by KevBurns (http://blog.kevburnsjr.com/php-unique-hash)
- * Reference/source: http://stackoverflow.com/a/1464155/933782
- * Modified from original source to remove reliance on bcmath functions
+ * Based on PseudoCrypt by KevBurns (http://blog.kevburnsjr.com/php-unique-hash).
  *
- * @since    3.16.7
- * @version  3.24.0
+ * Modified from original source to remove reliance on bcmath functions.
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.16.7
+ * @version 3.24.0
+ *
+ * @link http://stackoverflow.com/a/1464155/933782
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Hasher
+ *
+ * @since 3.16.7
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Hasher {
 

--- a/includes/class.llms.https.php
+++ b/includes/class.llms.https.php
@@ -2,6 +2,8 @@
 /**
  * Handle HTTPS related redirects
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.35.1
  */

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -2,6 +2,8 @@
 /**
  * Plugin installation
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.36.0
  */

--- a/includes/class.llms.integrations.php
+++ b/includes/class.llms.integrations.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Integrations
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.33.2
  */

--- a/includes/class.llms.l10n.php
+++ b/includes/class.llms.l10n.php
@@ -1,31 +1,38 @@
 <?php
 /**
  * Localization Functions
- * Currently only used to translate strings output by Javascript functions
- * More robust features will be added in the future
  *
- * @since   2.7.3
+ * Currently only used to translate strings output by Javascript functions.
+ * More robust features will be added in the future.
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 2.7.3
  * @version 3.17.8
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_L10n
+ *
+ * @since 2.7.3
+ * @since 3.17.8 Unknown.
+ */
 class LLMS_L10n {
 
 	/**
 	 * Create an object of translatable strings
 	 *
-	 * This object is added to the LLMS.l10n JS object
-	 * the text used in JS *MUST* exactly match the string found in this object
-	 * which is redundant but is the best and lightest weight solution
-	 * I could dream up quickly
+	 * This object is added to the LLMS.l10n JS object.
 	 *
-	 * @param  boolean $json if true, convert to JSON, otherwise return the array
-	 * @return string|array
+	 * The text used in JS *MUST* exactly match the string found in this object.
 	 *
-	 * @since   2.7.3
-	 * @version 3.17.8
+	 * @since 2.7.3
+	 * @since 3.17.8 Unknown.
+	 *
+	 * @param  boolean $json If `true`, convert to JSON, otherwise return the array.
+	 * @return string|array If `$json` is `true`, returns a JSON string, otherwise an array.
 	 */
 	public static function get_js_strings( $json = true ) {
 

--- a/includes/class.llms.lesson.basic.php
+++ b/includes/class.llms.lesson.basic.php
@@ -1,12 +1,21 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Basic lesson class
  *
  * Basic lesson is the standard, single lesson.
  *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Lesson_Basic
+ *
+ * @since 1.0.0
  * @deprecated 3.30.3
  */
 class LLMS_Lesson_Basic extends LLMS_Lesson {
@@ -19,8 +28,9 @@ class LLMS_Lesson_Basic extends LLMS_Lesson {
 	public $id;
 
 	/**
+	 * Lesson Type
+	 *
 	 * @var string
-	 * @since 1.0.0
 	 */
 	public $lesson_type;
 
@@ -32,11 +42,18 @@ class LLMS_Lesson_Basic extends LLMS_Lesson {
 	public $post;
 
 	/**
-	 * [__construct description]
+	 * Constructor
 	 *
-	 * @param int $lesson [ID of lesson post]
+	 * @since 1.0.0
+	 * @deprecated 3.30.3
+	 *
+	 * @param int $lesson ID of lesson post.
+	 *
+	 * @return void
 	 */
 	public function __construct( $lesson ) {
+
+		llms_deprecated_function( 'LLMS_Lesson_Basic::__construct', '3.30.3' );
 
 		$this->lesson_type = 'basic';
 		parent::__construct( $lesson );

--- a/includes/class.llms.lesson.handler.php
+++ b/includes/class.llms.lesson.handler.php
@@ -1,13 +1,21 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Lesson Handler Class
  *
  * Main Handler for lesson management in LifterLMS
  *
- * @author codeBOX
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version Unknown
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Lesson_Handler
+ *
+ * @since 1.0.0
  */
 class LLMS_Lesson_Handler {
 

--- a/includes/class.llms.membership.data.php
+++ b/includes/class.llms.membership.data.php
@@ -2,6 +2,8 @@
 /**
  * Query data about a membership.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.32.0
  * @version 3.35.0
  */

--- a/includes/class.llms.nav.menus.php
+++ b/includes/class.llms.nav.menus.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Navigation Menus
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.14.7
  * @version 3.37.12
  */

--- a/includes/class.llms.number.php
+++ b/includes/class.llms.number.php
@@ -1,11 +1,21 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Number Class
  *
  * Manages formatting numbers for I/O and display
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Number Class
+ *
+ * @since 1.0.0
  */
 class LLMS_Number {
 
@@ -45,9 +55,7 @@ class LLMS_Number {
 	 * @return [int]        [whole number representation of decimal value]
 	 */
 	public static function whole_number( $decimal ) {
-
-			return round( $decimal * 100 );
-
+		return round( $decimal * 100 );
 	}
 
 }

--- a/includes/class.llms.oembed.php
+++ b/includes/class.llms.oembed.php
@@ -1,20 +1,28 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Handle custom oEmbed Providers
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.4.6
+ * @version 1.4.6
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Handle custom oEmbed Providers
  *
- * @author codeBOX
- * @project lifterLMS
- *
- * @since  1.4.6
+ * @since 1.4.6
  */
 class LLMS_OEmbed {
 
-
 	/**
 	 * Constructor
+	 *
+	 * @since 1.4.6
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -28,4 +36,5 @@ class LLMS_OEmbed {
 	}
 
 }
+
 return new LLMS_OEmbed();

--- a/includes/class.llms.payment.gateways.php
+++ b/includes/class.llms.payment.gateways.php
@@ -1,15 +1,21 @@
 <?php
 /**
- * Payment Gateway class
+ * Access and manage payment gateways
  *
- * Class for managing payment gateways
+ * @package LifterLMS/Classes
  *
- * @version  3.0.0
+ * @since 1.0.0
+ * @version 3.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Payment_Gateways class
+ *
+ * @since 1.0.0
+ * @since 3.0.0 Unknown.
+ */
 class LLMS_Payment_Gateways {
 
 	/**

--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -2,6 +2,8 @@
 /**
  * User Handling for login and registration (mostly)
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.35.0
  */

--- a/includes/class.llms.person.php
+++ b/includes/class.llms.person.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Person base class.
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since Unknown
+ * @version Unknown
+ */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Person base class.
  *
- * Class used for instantiating course object
+ * @since Unknown
  */
 class LLMS_Person {
 

--- a/includes/class.llms.post.handler.php
+++ b/includes/class.llms.post.handler.php
@@ -1,13 +1,21 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 /**
  * Post Handler Class
  *
  * Main Handler for post management in LifterLMS
  *
- * @author codeBOX
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Post_Handler
+ *
+ * @since 1.0.0
  */
 class LLMS_Post_Handler {
 
@@ -224,4 +232,4 @@ class LLMS_Post_Handler {
 		}
 	}
 
-} //end LLMS_POST_Handler
+}

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -2,6 +2,8 @@
 /**
  * Define post and record relationships to automate cleanup of information when posts are deleted from the DB.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.16.12
  * @version 3.37.8
  */

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Query base class
+ *
  * Handles queries and endpoints.
+ *
+ * @package LifterLMS/Classes
  *
  * @since 1.0.0
  * @version 3.36.4

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -1,12 +1,20 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Query LifterLMS Students for a given course / membership
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.16.0
+ * @version 3.35.0
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Query LifterLMS Students for a given course / membership
  *
- * @since    3.16.0
- * @version  3.35.0
+ * @since 3.16.0
+ * @since 3.35.0
  *
  * @arg  $attempt     (int)        Query by attempt number
  * @arg  $quiz_id     (int|array)  Query by Quiz WP post ID (locate multiple quizzes with an array of ids)

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -1,14 +1,22 @@
 <?php
+/**
+ * LifterLMS User Postmeta Query
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.15.0
+ * @version 3.15.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * LifterLMS User Postmeta Query
  *
- * @since    3.15.0
- * @version  3.15.0
+ * @since 3.15.0
+ * @version 3.15.0
  */
 class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
-
 
 	/**
 	 * Identify the extending query

--- a/includes/class.llms.question.manager.php
+++ b/includes/class.llms.question.manager.php
@@ -1,8 +1,11 @@
 <?php
 /**
  * LifterLMS Quiz Question Manager
+ *
  * Don't instantiate this directly, instead use the wrapper functions
  * found in the LLMS_Quiz and LLMS_Question classes
+ *
+ * @package LifterLMS/Classes
  *
  * @since 3.16.0
  * @version 3.27.0

--- a/includes/class.llms.question.types.php
+++ b/includes/class.llms.question.types.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Question Types
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.16.0
  * @version 3.30.3
  */

--- a/includes/class.llms.quiz.data.php
+++ b/includes/class.llms.quiz.data.php
@@ -2,6 +2,8 @@
 /**
  * Query data about a quiz
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.16.0
  * @version 3.31.0
  */

--- a/includes/class.llms.quiz.legacy.php
+++ b/includes/class.llms.quiz.legacy.php
@@ -1,13 +1,23 @@
 <?php
+/**
+ * Legacy Quizzes
+ *
+ * This class is deprecated.
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 3.30.3
+ */
 
 use LLMS\Users\User;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Base Question Class
  *
+ * @since 1.0.0
  * @deprecated 3.30.3
  */
 class LLMS_Quiz_Legacy {

--- a/includes/class.llms.review.php
+++ b/includes/class.llms.review.php
@@ -1,12 +1,23 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
+ * LifterLMS Course reviews
+ *
  * This class handles the front end of the reviews. It is responsible
  * for outputting the HTML on the course page (if reviews are activated)
  *
- * @since    ??
- * @version  3.24.0
+ * @package LifterLMS/Classes
+ *
+ * @since Unknown
+ * @version 3.24.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Reviews class
+ *
+ * @since Unknown
+ * @since 3.24.0
  */
 class LLMS_Reviews {
 	/**
@@ -30,8 +41,8 @@ class LLMS_Reviews {
 	 * if not, nothing will happen. This function also checks to
 	 * see if a user is allowed to review more than once.
 	 *
-	 * @since    ??
-	 * @version  3.24.0
+	 * @since Unknown
+	 * @since 3.24.0 Unknown.
 	 */
 	public static function output() {
 

--- a/includes/class.llms.roles.php
+++ b/includes/class.llms.roles.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Custom Roles and Capabilities
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.13.0
  * @version 3.34.0
  */

--- a/includes/class.llms.session.php
+++ b/includes/class.llms.session.php
@@ -2,6 +2,8 @@
 /**
  * LLMS_Session.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.37.7
  */

--- a/includes/class.llms.sidebars.php
+++ b/includes/class.llms.sidebars.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Sidebars
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.0.1
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS SIdebars
+ * LifterLMS Sidebars
  *
  * @since 3.0.0
  */
@@ -18,7 +20,7 @@ class LLMS_Sidebars {
 	/**
 	 * Static Constructor
 	 *
-	 * @since    3.0.0
+	 * @since 3.0.0
 	 */
 	public static function init() {
 

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -1,9 +1,13 @@
 <?php
 /**
+ * LifterLMS Site Information.
+ *
  * Handle Site switching to prevent recurring payment duplicates
  * when using stating sites
  *
- * Heavily inspired by WC Subscriptions, thanks <3
+ * Heavily inspired by WC Subscriptions. Thank you!
+ *
+ * @package LifterLMS/Classes
  *
  * @since 3.0.0
  * @version 3.7.4
@@ -15,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Site class.
  *
  * @since 3.0.0
+ * @since 3.7.4 Unknown.
  */
 class LLMS_Site {
 

--- a/includes/class.llms.student.dashboard.php
+++ b/includes/class.llms.student.dashboard.php
@@ -2,14 +2,19 @@
 /**
  * Retrieve data sets used by various other classes and functions
  *
- * @since    3.0.0
- * @version  3.28.2
+ * @package LifterLMS/Classes
+ *
+ * @since 3.0.0
+ * @version 3.28.2
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Student_Dashboard class.
+ *
+ * @since 3.0.0
+ * @since 3.28.2 Unknown.
  */
 class LLMS_Student_Dashboard {
 

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -2,12 +2,20 @@
 /**
  * Query LifterLMS Students for a given course / membership
  *
+ * @package LifterLMS/Classes
+ *
  * @since    3.4.0
  * @version  3.13.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Student_Query
+ *
+ * @since 3.4.0
+ * @since 3.13.0 Unknown.
+ */
 class LLMS_Student_Query extends LLMS_Database_Query {
 
 	/**

--- a/includes/class.llms.svg.php
+++ b/includes/class.llms.svg.php
@@ -1,23 +1,25 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * LLMS_Svg class
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Dates Class
+ * LLMS_Svg class
  *
- * Manages formatting dates for I/O and display
+ * @since 1.0.0
  */
 class LLMS_Svg {
 
 	/**
-	 * Constructor
-	 */
-	public function __construct() {
-
-	}
-
-	/**
 	 * Get SVG
+	 *
 	 * Returns svg icon from svg sprite file
 	 *
 	 * @param  string $id    [svg id value]

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -2,6 +2,8 @@
 /**
  * Template loader.
  *
+ * @package LifterLMS/Classes
+ *
  * @since 1.0.0
  * @version 3.37.10
  */

--- a/includes/class.llms.track.php
+++ b/includes/class.llms.track.php
@@ -2,6 +2,8 @@
 /**
  * LifterLMS Course Tracks
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.30.3
  */

--- a/includes/class.llms.tracker.php
+++ b/includes/class.llms.tracker.php
@@ -2,6 +2,8 @@
 /**
  * Handle sending data to LifterLMS when tracking is enabled
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.0.0
  * @version 3.0.0
  */
@@ -10,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * LifterLMS telemetry tracking data.
+ *
+ * @since 3.0.0
  */
 class LLMS_Tracker {
 

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -2,6 +2,8 @@
 /**
  * Filters and actions related to user permissions
  *
+ * @package LifterLMS/Classes
+ *
  * @since 3.13.0
  * @version 3.36.5
  */

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -1,9 +1,12 @@
 <?php
 /**
- * Allow admins to view as various user types
- * to make easier testing and editing of LLMS Content
+ * View Manager
  *
- * @since    3.7.0
+ * Allows qualifying user roles to view as various user types to make easier testing and editing of LLMS Content
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since 3.7.0
  * @version 3.35.0
  */
 

--- a/includes/class.llms.voucher.php
+++ b/includes/class.llms.voucher.php
@@ -2,13 +2,19 @@
 /**
  * Voucher Class
  *
- * @since    2.0.0
- * @version  3.27.0
+ * @package LifterLMS/Classes
+ *
+ * @since 2.0.0
+ * @version 3.27.0
  */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Voucher class,
+ * LLMS_Voucher class
+ *
+ * @since 2.0.0
+ * @since 3.27.0 Unknown.
  */
 class LLMS_Voucher {
 

--- a/includes/widgets/class.llms.bbp.widget.course.forums.list.php
+++ b/includes/widgets/class.llms.bbp.widget.course.forums.list.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * LifterLMS * LifterLMS bbPress forms list widget
+ * LifterLMS bbPress forms list widget
  *
- * @package  LifterLMS/Classes/bbPress
- * @since    3.12.0
- * @version  3.24.0
+ * @package LifterLMS/Integrations/bbPress
+ *
+ * @since 3.12.0
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * LifterLMS bbPress forms list widget
+ *
+ * @since 3.12.0
+ * @since 3.24.0 Unknown.
  */
 class LLMS_BBP_Widget_Course_Forums_List extends WP_Widget {
 

--- a/includes/widgets/class.llms.widget.course.progress.php
+++ b/includes/widgets/class.llms.widget.course.progress.php
@@ -1,15 +1,30 @@
 <?php
 /**
  * Course progress widget
+ *
  * Displays course progress
  *
- * @author codeBOX
- * @project lifterLMS
+ * @package LifterLMS/Widgets/Classes
+ *
+ * @since 1.0.0
+ * @version 1.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Widget_Course_Progress
+ *
+ * @since 1.0.0
  */
 class LLMS_Widget_Course_Progress extends LLMS_Widget {
 
 	/**
 	 * Register widget with WordPress.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -25,9 +40,11 @@ class LLMS_Widget_Course_Progress extends LLMS_Widget {
 
 	/**
 	 * Widget Content
+	 *
 	 * Overrides parent class
 	 *
-	 * @see  LLMS_Widget()
+	 * @since 1.0.0
+	 *
 	 * @return void
 	 */
 	public function widget_contents( $args, $instance ) {

--- a/includes/widgets/class.llms.widget.course.syllabus.php
+++ b/includes/widgets/class.llms.widget.course.syllabus.php
@@ -1,10 +1,21 @@
 <?php
 /**
  * Course syllabus widget
+ *
  * Displays all lessons in the course
  *
- * @author codeBOX
- * @project lifterLMS
+ * @package LifterLMS/Widgets/Classes
+ *
+ * @since 1.0.0
+ * @version Unknown
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Widget_Course_Syllabus
+ *
+ * @since 1.0.0
  */
 class LLMS_Widget_Course_Syllabus extends LLMS_Widget {
 

--- a/includes/widgets/class.llms.widget.php
+++ b/includes/widgets/class.llms.widget.php
@@ -1,11 +1,20 @@
 <?php
+/**
+ * Base LifterLMS Widget Class
+ *
+ * @package LifterLMS/Widgets/Classes
+ *
+ * @since 1.0.0
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Base LifterLMS Widget Class
  *
- * @since    1.0.0
- * @version  3.24.0
+ * @since 1.0.0
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Widget extends WP_Widget {
 

--- a/includes/widgets/class.llms.widgets.php
+++ b/includes/widgets/class.llms.widgets.php
@@ -1,18 +1,31 @@
 <?php
 /**
  * Base Widgets Class
+ *
  * Calls WP register widgets for each widget in filter lifterlms_widgets
  *
- * @since    1.0.0
- * @version  3.12.0
+ * @package LifterLMS/Widgets/Classes
+ *
+ * @since 1.0.0
+ * @version 3.12.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Widgets
+ *
+ * @since 1.0.0
+ * @since 3.12.0 Unknown.
  */
 class LLMS_Widgets {
 
 	/**
 	 * Constructor
 	 *
-	 * @since    1.0.0
-	 * @version  1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -23,9 +36,10 @@ class LLMS_Widgets {
 	/**
 	 * Registers all lifterlms_widgets
 	 *
-	 * @return   void
-	 * @since    1.0.0
-	 * @version  3.12.0
+	 * @since 1.0.0
+	 * @since 3.12.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function register_widgets() {
 


### PR DESCRIPTION
## Description

Updates classes in the `/includes` and `/includes/widgets` directory (not in subdirectories) to adhere to the following rules which are currently disabled in the phpcs.xml file:

```xml
		<exclude name="LifterLMS.Commenting.FileComment.PackageTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.SinceTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingSinceTag" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingVersionTag" />
		<exclude name="LifterLMS.Commenting.FileComment.VersionTagOrder" />
		<exclude name="LifterLMS.Commenting.FileComment.MissingPackageTag" />
		<exclude name="LifterLMS.Commenting.FileComment.DuplicateSinceTag" />
		<exclude name="Squiz.Commenting.FileComment.Missing" />
		<exclude name="Squiz.Commenting.FileComment.MissingSinceTag" />
		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />

		<exclude name="Squiz.Commenting.ClassComment.Missing" />
```

Per #946 

Additionally adds some deprecation tags and functions to already deprecated classes.

Added a few new deprecations (as noted in @deprecated tags)

## How has this been tested?

Doc updates, does not affect codebase.

Still passes unit tests.

Manually ran to ensure no new errors.

## Types of changes

Coding standards (documentation) fixes

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

