### PR TITLE
Don't localize HTML Attributes

### DIFF
--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -16,7 +16,7 @@
 defined( 'ABSPATH' ) || exit;
 
 // create a "step" attribute for price fields
-$price_step = '0.01';
+$price_step = number_format( 0.01, get_lifterlms_decimals() );
 
 if ( ! isset( $plan ) ) {
 

--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -15,8 +15,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// create a "step" attribute for price fields according to LLMS settings
-$price_step = number_format( 0.01, get_lifterlms_decimals(), get_lifterlms_decimal_separator(), get_lifterlms_thousand_separator() );
+// create a "step" attribute for price fields
+$price_step = '0.01';
 
 if ( ! isset( $plan ) ) {
 

--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -15,7 +15,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-// create a "step" attribute for price fields
+// create a "step" attribute for price fields according to LLMS settings.
 $price_step = number_format( 0.01, get_lifterlms_decimals() );
 
 if ( ! isset( $plan ) ) {


### PR DESCRIPTION
This will fix https://wordpress.org/support/topic/access-plan-price-input-invalid/

## Description
Don't localize HTML Attributes

Fixes https://wordpress.org/support/topic/access-plan-price-input-invalid/

## How has this been tested?
 - Saved course Access Plans before changes: saving failed
 - Saved course Access Plans after changes: saving worked
 - No automated tests because the change is trivial.

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

