### PR TITLE
Is instructor fix

### DIFF
--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.13.0
- * @version 3.36.5
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.34.0 Added methods and logic for managing user management of other users.
  *                  Add logic for `view_students`, `edit_students`, and `delete_students` capabilities.
  * @since 3.36.5 Add `llms_user_caps_edit_others_posts_post_types` filter to allow 3rd parties to utilize core methods for modifying other users posts.
+ * @since [version] Use strict comparisons where needed.
  */
 class LLMS_User_Permissions {
 
@@ -26,6 +27,8 @@ class LLMS_User_Permissions {
 	 *
 	 * @since 3.13.0
 	 * @since 3.34.0 Always add the `editable_roles` filter.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -35,13 +38,14 @@ class LLMS_User_Permissions {
 	}
 
 	/**
-	 * Determines what other user roles can be managed by a user role.
+	 * Determines what other user roles can be managed by a user role
 	 *
 	 * Allows LMS Managers to create instructors and other managers.
 	 * Allows instructors to create & manage assistants.
 	 *
 	 * @since 3.13.0
 	 * @since 3.34.0 Moved the `llms_editable_roles` filter to the class method get_editable_roles().
+	 * @since [version] Use strict comparison.
 	 *
 	 * @link https://codex.wordpress.org/Plugin_API/Filter_Reference/editable_roles
 	 *
@@ -56,10 +60,10 @@ class LLMS_User_Permissions {
 
 		foreach ( $lms_roles as $role => $allowed_roles ) {
 
-			if ( in_array( $role, $user->roles ) ) {
+			if ( in_array( $role, $user->roles, true ) ) {
 
 				foreach ( $all_roles as $the_role => $caps ) {
-					if ( ! in_array( $the_role, $allowed_roles ) ) {
+					if ( ! in_array( $the_role, $allowed_roles, true ) ) {
 						unset( $all_roles[ $the_role ] );
 					}
 				}
@@ -75,19 +79,26 @@ class LLMS_User_Permissions {
 	 *
 	 * @since 3.13.0
 	 *
-	 * @param array $allcaps  All the capabilities of the user
-	 * @param array $cap      [0] Required capability
-	 * @param array $args     [0] Requested capability
-	 *                        [1] User ID
-	 *                        [2] Associated object ID
+	 * @param bool[]   $allcaps Array of key/value pairs where keys represent a capability name and boolean values
+	 *                          represent whether the user has that capability.
+	 * @param string[] $caps    Required primitive capabilities for the requested capability.
+	 * @param array    $args {
+	 *     Arguments that accompany the requested capability check.
+	 *
+	 *     @type string    $0 Requested capability.
+	 *     @type int       $1 Concerned user ID.
+	 *     @type mixed  ...$2 Optional second and further parameters, typically object ID.
+	 * }
 	 * @return array
 	 */
 	public function edit_others_lms_content( $allcaps, $cap, $args ) {
 
-		// this might be a problem
-		// this happens when in wp-admin/includes/post.php
-		// when actually creating/updating a course
-		// and no post_id is passed in $args[2]
+		/**
+		 * this might be a problem
+		 * this happens when in wp-admin/includes/post.php
+		 * when actually creating/updating a course
+		 * and no post_id is passed in $args[2].
+		 */
 		if ( empty( $args[2] ) ) {
 			$allcaps[ $cap[0] ] = true;
 			return $allcaps;
@@ -135,14 +146,20 @@ class LLMS_User_Permissions {
 	 *
 	 * @since 3.13.0
 	 * @since 3.34.0 Add logic for `edit_users` and `delete_users` capabilities with regards to LifterLMS user roles.
-	 *                  Add logic for `view_students`, `edit_students`, and `delete_students` capabilities.
+	 *               Add logic for `view_students`, `edit_students`, and `delete_students` capabilities.
 	 * @since 3.36.5 Add `llms_user_caps_edit_others_posts_post_types` filter.
+	 * @since [version] Use strict comparison.
 	 *
-	 * @param array $allcaps  All the capabilities of the user
-	 * @param array $cap      [0] Required capability
-	 * @param array $args     [0] Requested capability
-	 *                        [1] User ID
-	 *                        [2] Associated object ID
+	 * @param bool[]   $allcaps Array of key/value pairs where keys represent a capability name and boolean values
+	 *                          represent whether the user has that capability.
+	 * @param string[] $caps    Required primitive capabilities for the requested capability.
+	 * @param array    $args {
+	 *     Arguments that accompany the requested capability check.
+	 *
+	 *     @type string    $0 Requested capability.
+	 *     @type int       $1 Concerned user ID.
+	 *     @type mixed  ...$2 Optional second and further parameters, typically object ID.
+	 * }
 	 * @return array
 	 */
 	public function handle_caps( $allcaps, $cap, $args ) {
@@ -156,9 +173,8 @@ class LLMS_User_Permissions {
 		 */
 		$post_types = apply_filters( 'llms_user_caps_edit_others_posts_post_types', array( 'courses', 'lessons', 'sections', 'quizzes', 'questions', 'memberships' ) );
 		foreach ( $post_types as $cpt ) {
-			// allow any instructor to edit courses
-			// they're attached to
-			if ( in_array( sprintf( 'edit_others_%s', $cpt ), $cap ) ) {
+			// allow any instructor to edit courses they're attached to.
+			if ( in_array( sprintf( 'edit_others_%s', $cpt ), $cap, true ) ) {
 				$allcaps = $this->edit_others_lms_content( $allcaps, $cap, $args );
 			}
 		}

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -796,16 +796,31 @@ function llms_get_post( $post, $error = false ) {
 /**
  * Retrieve the parent course for a section, lesson, or quiz
  *
- * @param    WP_Post|int $post WP Post ID or instance of WP_Post
- * @return   LLMS_Course|null Instance of the LLMS_Course or null
- * @since    3.6.0
- * @version  3.17.7
+ * @since 3.6.0
+ * @since 3.17.7 Unknown.
+ * @since [version] Bail if `$post` is not an istance of `LLMS_Post_Model`.
+ *                Use strict comparison.
+ *
+ * @param WP_Post|int $post WP Post ID or instance of WP_Post.
+ * @return LLMS_Course|null Instance of the LLMS_Course or null.
  */
 function llms_get_post_parent_course( $post ) {
 
-	$post       = llms_get_post( $post );
+	$post = llms_get_post( $post );
+
+	if ( ! $post || ! is_a( $post, 'LLMS_Post_Model' ) ) {
+		return null;
+	}
+
+	/**
+	 * Filter the course children post types
+	 *
+	 * @since Unknown
+	 *
+	 * @param $post_type string[] Names of the post types that can be children of a course.
+	 */
 	$post_types = apply_filters( 'llms_course_children_post_types', array( 'section', 'lesson', 'llms_quiz' ) );
-	if ( ! $post || ! in_array( $post->get( 'type' ), $post_types ) ) {
+	if ( ! in_array( $post->get( 'type' ), $post_types, true ) ) {
 		return null;
 	}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -2,25 +2,28 @@
 /**
  * Tests for LifterLMS Core Functions
  *
- * @group    functions
- * @group    functions_core
+ * @group functions
+ * @group functions_core
  *
  * @since 3.3.1
  * @since 3.35.0 Test ipv6 addresses.
  * @since 3.36.1 Use exception from lifterlms-tests lib.
  * @since 3.37.12 Fix errors thrown due to usage of `llms_section` instead of `section`.
+ * @since [version] When testing `llms_get_post_parent_course()` added tests on other LLMS post types which are not instance of `LLMS_Post_Model`.
+ * @version [version]
  */
 class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
-	 * test the llms_assoc_array_insert
-	 * @return   void
-	 * @since    3.21.0
-	 * @version  3.21.0
+	 * Test the llms_assoc_array_insert
+	 *
+	 * @since 3.21.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_assoc_array_insert() {
 
-		// base array
+		// base array.
 		$array = array(
 			'test' => 'asrt',
 			'tester' => 'asrtarst',
@@ -28,7 +31,7 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			'another' => 'arst',
 		);
 
-		// after first item
+		// after first item.
 		$expect = array(
 			'test' => 'asrt',
 			'new_key' => 'item',
@@ -38,33 +41,33 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 		);
 		$this->assertEquals( $expect, llms_assoc_array_insert( $array, 'test', 'new_key', 'item' ) );
 
-		// add in the middle
+		// add in the middle.
 		$expect = array(
-			'test' => 'asrt',
-			'tester' => 'asrtarst',
-			'new_key' => 'item',
+			'test'         => 'asrt',
+			'tester'       => 'asrtarst',
+			'new_key'      => 'item',
 			'moretest_key' => 'arst',
-			'another' => 'arst',
+			'another'      => 'arst',
 		);
 		$this->assertEquals( $expect, llms_assoc_array_insert( $array, 'tester', 'new_key', 'item' ) );
 
-		// requested key doesn't exist so it'll be added to the end
+		// requested key doesn't exist so it'll be added to the end.
 		$expect = array(
-			'test' => 'asrt',
-			'tester' => 'asrtarst',
+			'test'         => 'asrt',
+			'tester'       => 'asrtarst',
 			'moretest_key' => 'arst',
-			'another' => 'arst',
-			'new_key' => 'item',
+			'another'      => 'arst',
+			'new_key'      => 'item',
 		);
 		$this->assertEquals( $expect, llms_assoc_array_insert( $array, 'noexist', 'new_key', 'item' ) );
 
-		// after last item
+		// after last item.
 		$expect = array(
-			'test' => 'asrt',
-			'new_key' => 'item',
-			'tester' => 'asrtarst',
+			'test'         => 'asrt',
+			'new_key'      => 'item',
+			'tester'       => 'asrtarst',
 			'moretest_key' => 'arst',
-			'another' => 'arst',
+			'another'      => 'arst',
 		);
 		$this->assertEquals( $expect, llms_assoc_array_insert( $array, 'another', 'new_key', 'item' ) );
 
@@ -72,9 +75,10 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_get_core_supported_themes()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_core_supported_themes() {
 
@@ -84,10 +88,11 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * test llms_get_date_diff()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 * Test llms_get_date_diff()
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_date_diff() {
 
@@ -108,10 +113,11 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * test llms_get_engagement_triggers()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 * Test llms_get_engagement_triggers()
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_engagement_triggers() {
 		$this->assertFalse( empty( llms_get_engagement_triggers() ) );
@@ -119,10 +125,11 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * test llms_get_engagement_types()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 * Test llms_get_engagement_types()
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_engagement_types() {
 		$this->assertFalse( empty( llms_get_engagement_types() ) );
@@ -131,43 +138,42 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test the llms_get_option_page_anchor() function
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_option_page_anchor() {
 
 		$id = $this->factory->post->create( array(
 			'post_title' => 'The Page Title',
-			'post_type' => 'page',
+			'post_type'  => 'page',
 		) );
 
 		$option_name = 'llms_test_page_anchor';
 
-		// returns empty if option isn't set
+		// returns empty if option isn't set.
 		$this->assertEmpty( llms_get_option_page_anchor( $option_name ) );
 
 		update_option( $option_name, $id );
 
-		// title found in string
+		// title found in string.
 		$this->assertTrue( false !== strpos( llms_get_option_page_anchor( $option_name ), get_the_title( $id ) ) );
 
-		// URL found
+		// URL found.
 		$this->assertTrue( false !== strpos( llms_get_option_page_anchor( $option_name ), get_the_permalink( $id ) ) );
 
-		// target found
-		$this->assertTrue( false !== strpos( llms_get_option_page_anchor( $option_name ), 'target="_blank"' ) );
-
-		// no target found
+		// no target found.
 		$this->assertTrue( false === strpos( llms_get_option_page_anchor( $option_name, false ), 'target="_blank"' ) );
 
 	}
 
 	/**
 	 * Test llms_get_product_visibility_options()
-	 * @return   void
-	 * @since    3.6.0
-	 * @version  3.6.0
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_product_visibility_options() {
 		$this->assertFalse( empty( llms_get_product_visibility_options() ) );
@@ -176,30 +182,31 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_find_coupon()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_find_coupon() {
 
-		// create a coupon
+		// create a coupon.
 		$id = $this->factory->post->create( array(
 			'post_title' => 'coopond',
-			'post_type' => 'llms_coupon',
+			'post_type'  => 'llms_coupon',
 		) );
 		$this->assertEquals( $id, llms_find_coupon( 'coopond' ) );
 
-		// create a dup
+		// create a dup.
 		$dup = $this->factory->post->create( array(
 			'post_title' => 'coopond',
-			'post_type' => 'llms_coupon',
+			'post_type'  => 'llms_coupon',
 		) );
 		$this->assertEquals( $dup, llms_find_coupon( 'coopond' ) );
 
-		// test dupcheck
+		// test dupcheck.
 		$this->assertEquals( $id, llms_find_coupon( 'coopond', $dup ) );
 
-		// delete the coupon
+		// delete the coupon.
 		wp_delete_post( $id );
 		wp_delete_post( $dup );
 		$this->assertEmpty( llms_find_coupon( 'coopond' ) );
@@ -208,9 +215,9 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_get_enrolled_students()
-	 * @return   void
-	 * @since    3.6.0
-	 * @version  3.6.0
+	 *
+	 * @since 3.6.0
+	 * @return void
 	 */
 	function test_llms_get_enrolled_students() {
 
@@ -225,20 +232,20 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			$student->enroll( $course_id );
 		}
 
-		// test basic enrollment query passing in a string
+		// test basic enrollment query passing in a string.
 		$this->assertEquals( $students, llms_get_enrolled_students( $course_id, 'enrolled', 50, 0 ) );
-		// test basic enrollment query passing in an array
+		// test basic enrollment query passing in an array.
 		$this->assertEquals( $students, llms_get_enrolled_students( $course_id, array( 'enrolled' ), 50, 0 ) );
 
-		// test pagination
+		// test pagination.
 		$this->assertEquals( array_splice( $students, 0, 10 ), llms_get_enrolled_students( $course_id, 'enrolled', 10, 0 ) );
 		$this->assertEquals( array_splice( $students, 0, 10 ), llms_get_enrolled_students( $course_id, 'enrolled', 10, 10 ) );
 		$this->assertEquals( $students, llms_get_enrolled_students( $course_id, 'enrolled', 10, 20 ) );
 
-		// should be no one expired
+		// should be no one expired.
 		$this->assertEquals( array(), llms_get_enrolled_students( $course_id, 'expired', 10, 0 ) );
 
-		// sleeping makes unenrollment tests work
+		// sleeping makes unenrollment tests work.
 		sleep( 1 );
 
 		$i = 0;
@@ -250,19 +257,20 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			$i++;
 		}
 
-		// test expired alone
+		// test expired alone.
 		$this->assertEquals( $expired, llms_get_enrolled_students( $course_id, 'expired', 10, 0 ) );
 
-		// test multiple statuses
+		// test multiple statuses.
 		$this->assertEquals( $students_copy, llms_get_enrolled_students( $course_id, array( 'enrolled', 'expired' ), 50, 0 ) );
 
 	}
 
 	/**
-	 * test llms_get_enrollment_statuses()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 * Test llms_get_enrollment_statuses()
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_enrollment_statuses() {
 		$this->assertFalse( empty( llms_get_enrollment_statuses() ) );
@@ -271,9 +279,10 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_get_enrollment_status_name()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_enrollment_status_name() {
 		$this->assertNotEquals( 'asrt', llms_get_enrollment_status_name( 'cancelled' ) );
@@ -331,7 +340,7 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	 * @since 3.16.11 Unknown.
 	 * @since 3.37.12 Fix errors thrown due to usage of `llms_section` instead of `section`.
 	 *
-	 * @return   void
+	 * @return void
 	 */
 	public function test_llms_get_post() {
 
@@ -364,10 +373,12 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test llms_get_post_parent_course()
-	 * @return   void
-	 * @since    3.6.0
-	 * @version  3.6.0
+	 * Test `llms_get_post_parent_course()`
+	 *
+	 * @since 3.6.0
+	 * @since [version] Added tests on other LLMS post types which are not instance of `LLMS_Post_Model`.
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_post_parent_course() {
 
@@ -390,26 +401,35 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 			$post = get_post( $obj->get( 'id' ) );
 
-			// pass in post id
+			// pass in post id.
 			$this->assertEquals( $course, llms_get_post_parent_course( $post->ID ) );
 
-			// pass in an object
+			// pass in an object.
 			$this->assertEquals( $course, llms_get_post_parent_course( $post ) );
 
 		}
 
-		// other post types don't have a parent course
+		// other non lms post types don't have a parent course.
 		$reg_post = $this->factory->post->create();
 		$this->assertNull( llms_get_post_parent_course( $reg_post ) );
 
+		// make sure an LLMS post type, which is not an istance of `LLMS_Post_Model` doesn't have a parent course.
+		// and no fatals are produced.
+		$certificate_post = $this->factory->post->create(
+			array(
+				'post_type' => 'llms_certificate',
+			)
+		);
+		$this->assertNull( llms_get_post_parent_course( $certificate_post ) );
 	}
 
 
 	/**
-	 * test llms_get_transaction_statuses()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 * Test llms_get_transaction_statuses()
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_get_transaction_statuses() {
 		$this->assertFalse( empty( llms_get_transaction_statuses() ) );
@@ -418,9 +438,10 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_is_site_https()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_llms_is_site_https() {
 		update_option( 'home', 'https://is.ssl' );
@@ -432,9 +453,10 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test the llms_parse_bool function
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_llms_parse_bool() {
 
@@ -500,9 +522,11 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
 	/**
 	 * Test llms_trim_string()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.6.0
+	 *
+	 * @since 3.3.1
+	 * @since 3.6.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function test_llms_trim_string() {
 


### PR DESCRIPTION
## Description

Fixes #1064 

As said I'm not able to reproduce it programmatically, if not forcing some filter here and there, or directly hacking the code.
How 3rd party code (I guess) can produce this issue it's kinda a mystery to me.

Anyways this PR fixed that eventuality with the least possible impact (IMHO).
Although I think that a we could fix it in another way...
`llms_get_post()`, according to the function summary:
 https://github.com/gocodebox/lifterlms/blob/3.37.13/includes/llms.functions.core.php#L760 

should retrieve the _LLMS Post Model for a given post by ID or WP_Post Object_
but actually it retrieves the LLMS_* object for a given post, the only thing required is that the post type starts with `llms_` and that exists a class of the type `LLMS_{post_type_without_llms_}`  well, _youknowhatimean_.
So either the method summary should be amended or we have to restrict the post's post types that can be turned into an `LLMS_*` object. I'm not sure, though, of the impact such a change might have since that function is widely used... (should I open a new issue? let me know)

## How has this been tested?

I've tested it by running the code added in the unit-test BEFORE writing the fix.

## Screenshots <!-- if applicable -->
n/a

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.