### PR TITLE
Debug log

### DIFF
--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -277,7 +277,20 @@ class LLMS_Admin_Page_Status {
 		}
 
 		if ( $logs ) {
+
+			// Nonce URL to delete a log file.
+			$delete_url = 'debug-log' === $current ? '' : wp_nonce_url(
+				add_query_arg(
+					array(
+						'llms_delete_log' => $current,
+					),
+					self::get_url( 'logs' )
+				),
+				'delete_log'
+			);
+
 			include_once 'views/status/view-log.php';
+
 		} else {
 			echo '<div class="llms-log-viewer">' . __( 'There are currently no logs to view.', 'lifterlms' ) . '</div>';
 		}

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -27,13 +27,14 @@ class LLMS_Admin_Page_Status {
 	 *
 	 * @since 3.11.2
 	 * @since 3.35.0 Sanitize input data.
-	 * @since [version] Use `llms_redirect_and_exit()` in favor of `wp_safe_redirect()`.
+	 * @since [version] Verify user capabilities when doing a tool action.
+	 *                Use `llms_redirect_and_exit()` in favor of `wp_safe_redirect()`.
 	 *
 	 * @return void
 	 */
 	private static function do_tool() {
 
-		if ( ! llms_verify_nonce( '_wpnonce', 'llms_tool' ) ) {
+		if ( ! llms_verify_nonce( '_wpnonce', 'llms_tool' ) || ! current_user_can( 'manage_lifterlms' ) ) {
 			wp_die( __( 'Action failed. Please refresh the page and retry.', 'lifterlms' ) );
 		}
 
@@ -58,11 +59,7 @@ class LLMS_Admin_Page_Status {
 			case 'clear-cache':
 				global $wpdb;
 				$wpdb->query( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-					$wpdb->prepare(
-						"DELETE FROM {$wpdb->prefix}usermeta WHERE meta_key = %s or meta_key = %s;",
-						'llms_overall_progress',
-						'llms_overall_grade'
-					)
+					"DELETE FROM {$wpdb->usermeta} WHERE meta_key = 'llms_overall_progress' or meta_key = 'llms_overall_grade';"
 				);
 
 				break;

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -101,7 +101,7 @@ class LLMS_Admin_Page_Status {
 	 *
 	 * @since 3.11.2
 	 *
-	 * @param string $tab Cptionally add a tab.
+	 * @param string $tab Optionally add a tab.
 	 * @return string
 	 */
 	public static function get_url( $tab = null ) {
@@ -145,7 +145,7 @@ class LLMS_Admin_Page_Status {
 		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
 			$path = ini_get( 'error_log' );
 			if ( $path ) {
-				$result['debug-log'] = ini_get( 'error_log' );
+				$result['debug-log'] = $path;
 			}
 		}
 

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -126,7 +126,7 @@ class LLMS_Admin_Page_Status {
 
 		$result = array();
 
-		// Retrieve all the files in logs in our log directory.
+		// Retrieve all the files in our log directory.
 		$files = @scandir( LLMS_LOG_DIR ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- It's okay though.
 		if ( ! empty( $files ) ) {
 			foreach ( $files as $key => $value ) {
@@ -141,12 +141,10 @@ class LLMS_Admin_Page_Status {
 			}
 		}
 
-		// Add the site's debug.log file if it exists.
-		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-			$path = ini_get( 'error_log' );
-			if ( $path ) {
-				$result['debug-log'] = $path;
-			}
+		// Add the site's debug.log or native error log file if it exists.
+		$err_path = ini_get( 'error_log' );
+		if ( $err_path ) {
+			$result['debug-log'] = $err_path;
 		}
 
 		return $result;

--- a/includes/admin/views/status/index.php
+++ b/includes/admin/views/status/index.php
@@ -1,0 +1,1 @@
+<?php // be quiet.

--- a/includes/admin/views/status/view-log.php
+++ b/includes/admin/views/status/view-log.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Log file viewer
+ *
+ * Used on the LifterLMS Admin Status Logs tab to output a single log file.
+ *
+ * @package LifterLMS/Admin/Views
+ *
+ * @since [version]
+ * @version [version]
+ *
+ * @property array[] $logs    Associative array of log files. The array key is the file "slug" and the value is the file's absolute path.
+ * @property string  $current Slug of the current log file.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+// Nonce URL to delete a log file.
+$delete_url = 'debug-log' === $current ? '' : wp_nonce_url(
+	add_query_arg(
+		array(
+			'llms_delete_log' => $current,
+		),
+		admin_url( 'admin.php?page=llms-status&tab=logs' )
+	),
+	'delete_log'
+);
+?>
+
+<form action="<?php echo esc_url( LLMS_Admin_Page_Status::get_url( 'logs' ) ); ?>" method="POST">
+	<select name="llms_log_file">
+		<?php foreach ( $logs as $name => $file ) : ?>
+			<option value="<?php echo esc_attr( $name ); ?>" <?php selected( $current, $name ); ?>>
+				<?php echo esc_html( basename( $file ) ); ?>
+				(<?php echo date_i18n( $date_format, filemtime( $file ) ); ?>)
+			</option>
+		<?php endforeach; ?>
+	</select>
+	<button class="llms-button-secondary small" type="submit"><?php _e( 'View Log', 'lifterlms' ); ?></button>
+</form>
+
+<h2>
+	<?php printf( esc_html__( 'Viewing: %s', 'lifterlms' ), basename( $logs[ $current ] ) ); ?>
+	<?php if ( $delete_url ) : ?>
+		<a class="llms-button-danger small" href="<?php echo esc_url( $delete_url ); ?>"><?php _e( 'Delete', 'lifterlms' ); ?></a>
+	<?php endif; ?>
+</h2>
+
+<div class="llms-log-viewer">
+	<pre><?php echo esc_html( file_get_contents( $logs[ $current ] ) ); ?></pre>
+</div>

--- a/includes/admin/views/status/view-log.php
+++ b/includes/admin/views/status/view-log.php
@@ -9,22 +9,13 @@
  * @since [version]
  * @version [version]
  *
- * @property array[] $logs    Associative array of log files. The array key is the file "slug" and the value is the file's absolute path.
- * @property string  $current Slug of the current log file.
+ * @property array[] $logs       Associative array of log files. The array key is the file "slug" and the value is the file's absolute path.
+ * @property string  $current    Slug of the current log file.
+ * @property string  $delete_url Nonce url to delete the log file (if the log is deletable).
  */
 
 defined( 'ABSPATH' ) || exit;
 
-// Nonce URL to delete a log file.
-$delete_url = 'debug-log' === $current ? '' : wp_nonce_url(
-	add_query_arg(
-		array(
-			'llms_delete_log' => $current,
-		),
-		admin_url( 'admin.php?page=llms-status&tab=logs' )
-	),
-	'delete_log'
-);
 ?>
 
 <form action="<?php echo esc_url( LLMS_Admin_Page_Status::get_url( 'logs' ) ); ?>" method="POST">
@@ -40,7 +31,11 @@ $delete_url = 'debug-log' === $current ? '' : wp_nonce_url(
 </form>
 
 <h2>
-	<?php printf( esc_html__( 'Viewing: %s', 'lifterlms' ), basename( $logs[ $current ] ) ); ?>
+	<?php printf(
+		// Translators: %s = File name of the log.
+		esc_html__( 'Viewing: %s', 'lifterlms' ), basename( $logs[ $current ]
+		)
+	); ?>
 	<?php if ( $delete_url ) : ?>
 		<a class="llms-button-danger small" href="<?php echo esc_url( $delete_url ); ?>"><?php _e( 'Delete', 'lifterlms' ); ?></a>
 	<?php endif; ?>

--- a/includes/admin/views/status/view-log.php
+++ b/includes/admin/views/status/view-log.php
@@ -31,16 +31,20 @@ defined( 'ABSPATH' ) || exit;
 </form>
 
 <h2>
-	<?php printf(
+	<?php
+	printf(
 		// Translators: %s = File name of the log.
-		esc_html__( 'Viewing: %s', 'lifterlms' ), basename( $logs[ $current ]
+		esc_html__( 'Viewing: %s', 'lifterlms' ),
+		basename(
+			$logs[ $current ]
 		)
-	); ?>
+	);
+	?>
 	<?php if ( $delete_url ) : ?>
 		<a class="llms-button-danger small" href="<?php echo esc_url( $delete_url ); ?>"><?php _e( 'Delete', 'lifterlms' ); ?></a>
 	<?php endif; ?>
 </h2>
 
 <div class="llms-log-viewer">
-	<pre><?php echo esc_html( file_get_contents( $logs[ $current ] ) ); ?></pre>
+	<pre><?php echo esc_html( file_get_contents( $logs[ $current ] ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Not a remote URL. ?></pre>
 </div>

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-page-status.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-page-status.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * Test Admin Status page
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group status
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Page_Status extends LLMS_Unit_Test_Case {
+
+	public static function setUpBeforeClass() {
+
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.page.status.php';
+
+	}
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = 'LLMS_Admin_Page_Status';
+
+	}
+
+	/**
+	 * Test do_tool() when no nonce is submitted.
+	 *
+	 * @since [version]
+	 *
+	 * @expectedException WPDieException
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_no_nonce() {
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+
+	}
+
+	/**
+	 * Test do_tool() when invalid nonce is submitted.
+	 *
+	 * @since [version]
+	 *
+	 * @expectedException WPDieException
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_invalid_nonce() {
+
+		$this->mockPostRequest( array(
+			'_wpnonce' => 'fake',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+	}
+
+	/**
+	 * Test do_tool() when no user permissions
+	 *
+	 * @since [version]
+	 *
+	 * @expectedException WPDieException
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_no_user_caps() {
+
+		$this->mockPostRequest( array(
+			'_wpnonce' => wp_create_nonce( 'llms_tool' ),
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+	}
+
+	/**
+	 * Test do_tool() valid.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_valid_user() {
+
+		$actions = did_action( 'llms_status_tool' );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'custom',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+		$this->assertEquals( ++$actions, did_action( 'llms_status_tool' ) );
+
+	}
+
+	/**
+	 * Test the automatic payments reset tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_reset_auto_payments() {
+
+		// Get the original values of options to be cleared.
+		$orig_url    = get_option( 'llms_site_url' );
+		$orig_ignore = get_option( 'llms_site_url_ignore' );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'automatic-payments',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+		$this->assertEquals( '', get_option( 'llms_site_url' ) );
+		$this->assertEquals( 'no', get_option( 'llms_site_url_ignore' ) );
+
+		// Reset to the orig values.
+		update_option( 'llms_site_url', $orig_url );
+		update_option( 'llms_site_url_ignore', $orig_ignore );
+
+	}
+
+	/**
+	 * Test the overall progress cache clear tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_clear_cache() {
+
+		// Add mock data.
+		foreach ( $this->factory->student->create_many( 3 ) as $uid ) {
+			update_user_meta( $uid, 'llms_overall_progress', 'mock' );
+			update_user_meta( $uid, 'llms_overall_grade', 'mock' );
+		}
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'clear-cache',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+		global $wpdb;
+		$res = $wpdb->get_results( "SELECT * FROM {$wpdb->usermeta} WHERE meta_key = 'llms_overall_progress' OR meta_key = 'llms_overall_grade';" );
+
+		$this->assertEquals( array(), $res );
+
+	}
+
+	/**
+	 * Test the session data clear tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_clear_sessions() {
+
+		// Create mock data.
+		WP_Session_Utils::create_dummy_session();
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'clear-sessions',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+		global $wpdb;
+		$res = $wpdb->get_results( "SELECT * FROM {$wpdb->options} WHERE option_name LIKE '_wp_session_%';" );
+
+		$this->assertEquals( array(), $res );
+
+	}
+
+	/**
+	 * Test the tracking reset tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_reset_tracking() {
+
+		update_option( 'llms_allow_tracking', 'yes' );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'reset-tracking',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+		$this->assertEquals( 'no', get_option( 'llms_allow_tracking' ) );
+
+	}
+
+	/**
+	 * Test the setup wizard redirect tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_tool_setup_wizard() {
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( sprintf( '%s?page=llms-setup [302] YES', admin_url() ) );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->mockPostRequest( array(
+			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
+			'llms_tool' => 'setup-wizard',
+		) );
+		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
+
+	}
+
+}


### PR DESCRIPTION
## Description

+ Hardened admin "tools" by requiring the `manage_lifterlms` cap in addition to nonce verifications
+ Use strict comparisons where possible
+ Added the ability to view (but not delete) the WP core debug.log file (if it exists)

I wrote this because @nrherron92 was asking if there's an easier way to get the debug.log file from a non-technical user who's having an issue. This is really a feature to help us do better support than anything else. If we need to review logs (which we frequently do) we can just review them instead of trying to explain to somehow how to find an error log on their server.

## How has this been tested?

+ Manually tested
+ Added some new unit tests to test related functionality

## Types of changes

Feature enhancements
THe "hardening" of user capabilities won't affect any users since that capability is already required to view the page. This would harden against someone trying to exploit the code through a custom plugin that calls our methods.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

