### PR TITLE
Fixed 'courses' pagination not working in buddypress member's profile

### DIFF
--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -844,7 +844,7 @@ endif;
 
 /**
  * Modify the pagination links displayed on endpoints using the default LLMS loop
-
+ *
  * @since 3.24.0
  * @since 3.26.3 Unknown.
  *

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -175,7 +175,7 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	 */
 	public function courses_screen() {
 
-		// Prevent paginate links alteration performed in includes/functions/llms.functions.templates.dashboard.php
+		// Prevent paginate links alteration performed in includes/functions/llms.functions.templates.dashboard.php.
 		add_filter( 'llms_modify_dashboard_pagination_links_disable', '__return_true', 999 );
 
 		// Add specific paginate links filter.

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -312,7 +312,7 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 
 		$post_id = null;
 
-		// activity.
+		// Activity.
 		if ( bp_is_activity_component() ) {
 
 			$post_id = bp_core_get_directory_page_id( 'activity' );

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -305,7 +305,7 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	 */
 	public function restriction_checks( $results ) {
 
-		// only check directories.
+		// Only check directories.
 		if ( ! bp_is_directory() ) {
 			return $results;
 		}

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -2,13 +2,24 @@
 /**
  * BuddyPress Integration
  *
- * @since    1.0.0
- * @version  3.14.4
+ * @package LifterLMS/Integrations/Classes
+ *
+ * @since 1.0.0
+ * @version [version]
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * BuddyPress Integration
+ *
+ * @package LifterLMS/Integrations/Classes
+ *
+ * @since 1.0.0
+ * @since 3.12.2 Unknown.
+ * @since 3.14.4 Unknown.
+ * @since [version] Fixed `courses` pagination.
+ */
 class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 
 	public $id = 'buddypress';
@@ -16,17 +27,18 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Display order on Integrations tab
 	 *
-	 * @var  integer
+	 * @var integer
 	 */
 	protected $priority = 5;
 
 	/**
 	 * Configure the integration
-	 * Do things like configure ID and title here
 	 *
-	 * @return   void
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * Do things like configure ID and title here.
+	 *
+	 * @since 3.12.0
+	 *
+	 * @return void
 	 */
 	protected function configure() {
 
@@ -46,14 +58,14 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Add LLMS navigation items to the BuddyPress User Profile
 	 *
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @since 1.0.0
 	 *
 	 * @return  void
 	 */
 	public function add_profile_nav_items() {
 		global $bp;
-		// add the main nav menu
+
+		// add the main nav menu.
 		bp_core_new_nav_item(
 			array(
 				'name'                    => __( 'Courses', 'lifterlms' ),
@@ -66,9 +78,9 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 		);
 
 		$parent_url    = $bp->loggedin_user->domain . 'courses/';
-		$is_my_profile = bp_is_my_profile(); // only let the logged in user access subnav screens
+		$is_my_profile = bp_is_my_profile(); // only let the logged in user access subnav screens.
 
-		// add sub nav items
+		// add sub nav items.
 		bp_core_new_subnav_item(
 			array(
 				'name'            => __( 'Courses', 'lifterlms' ),
@@ -112,14 +124,15 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 				'user_has_access' => $is_my_profile,
 			)
 		);
+
 	}
 
 	/**
 	 * Checks if the BuddyPress plugin is installed & activated
 	 *
-	 * @return boolean
-	 * @since   1.0.0
-	 * @version 1.0.0
+	 * @since 1.0.0
+	 *
+	 * @return bool
 	 */
 	public function is_installed() {
 		return ( class_exists( 'BuddyPress' ) );
@@ -128,8 +141,8 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Callback for "Achievements" profile screen
 	 *
-	 * @since   1.0.0
-	 * @version 3.14.4
+	 * @since 1.0.0
+	 * @since 3.14.4 Unknown.
 	 *
 	 * @return void
 	 */
@@ -141,8 +154,8 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Callback for "Certificates" profile screen
 	 *
-	 * @since   1.0.0
-	 * @version 3.14.4
+	 * @since 1.0.0
+	 * @since 3.14.4 Unknown.
 	 *
 	 * @return void
 	 */
@@ -154,21 +167,126 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Callback for "Courses" profile screen
 	 *
-	 * @since   1.0.0
-	 * @version 3.14.4
+	 * @since 1.0.0
+	 * @since 3.14.4 Unknown.
+	 * @since [version] Added action and filters to fix handling pagination links mofication.
 	 *
 	 * @return void
 	 */
 	public function courses_screen() {
+
+		// Prevent paginate links alteration performed in includes/functions/llms.functions.templates.dashboard.php
+		add_filter( 'llms_modify_dashboard_pagination_links_disable', '__return_true', 999 );
+
+		// Add specific paginate links filter.
+		add_filter( 'paginate_links', array( $this, 'modify_courses_paginate_links' ) );
+
 		add_action( 'bp_template_content', 'lifterlms_template_student_dashboard_my_courses' );
+
+		// Remove specific paginate links filter after the template has been rendered.
+		add_action( 'bp_template_content', array( $this, 'remove_courses_paginate_links_filter' ), 15 );
+
 		bp_core_load_template( apply_filters( 'bp_core_template_plugin', 'members/single/plugins' ) );
+
+	}
+
+	/**
+	 * Remove specific paginate links filter after the template has been rendered
+	 *
+	 * @since [version]
+	 */
+	public function remove_courses_paginate_links_filter() {
+		remove_filter( 'paginate_links', array( $this, 'modify_courses_paginate_links' ) );
+	}
+
+	/**
+	 * Modify the pagination links displayed on the courses endpoint in the bp member profile
+	 *
+	 * @since [version]
+	 *
+	 * @param string $link Default link.
+	 * @return string
+	 */
+	public function modify_courses_paginate_links( $link ) {
+
+		global $wp_rewrite;
+
+		// Retrieve the `courses` subnav item.
+		$courses_subnav_item = buddypress()->members->nav->get_secondary(
+			array(
+				'parent_slug' => 'courses',
+				'slug'        => 'courses',
+			)
+		);
+
+		if ( is_array( $courses_subnav_item ) ) {
+			$courses_subnav_item = reset( $courses_subnav_item );
+		} else {
+			return $link;
+		}
+
+		$query = parse_url( $link, PHP_URL_QUERY );
+
+		if ( $query ) {
+			$link = str_replace( '?' . $query, '', $link );
+		}
+
+		$parts = explode( '/', untrailingslashit( $link ) );
+		$page  = end( $parts );
+
+		/**
+		 * Here's the core of this filter.
+		 *
+		 * What happens is that the paginate links on the 'courses' tab are of this type:
+		 * `example.local/members/admin/courses/page/N`
+		 * where 'courses' is the slug of the main nav item.
+		 * While the "working" paginate links must be of the type:
+		 * `example.local/members/admin/courses/courses/page/N`
+		 * where the first 'courses' is the slug of the main nav item, and the second is the slug of
+		 * the subnav item, which is also the default "endpoint" for the main nav item.
+		 *
+		 * So what we do here is to replace all the occurrences of something like
+		 * `example.local/members/admin/courses/page/N` to something like
+		 * `example.local/members/admin/courses/courses/page/N`
+		 *
+		 * Despite one might expect `$courses_subnav_item->link` doesn't point to `example.local/members/admin/courses/courses/`
+		 * but to `example.local/members/admin/courses/`, which is the link of the parent nav, the main nav item,
+		 * this because the 'courses' subnav item is the default of the 'courses' nav item.
+		 *
+		 * (the fact that both the slugs are "courses" doesn't matter here, it doesn't determine any conflict).
+		 */
+		$search  = $courses_subnav_item->link . $wp_rewrite->pagination_base . '/' . $page . '/';
+		$replace = $courses_subnav_item->link . $courses_subnav_item->slug . '/' . $wp_rewrite->pagination_base . '/' . $page . '/';
+
+		/**
+		 * For links to page/1 let's back on the main nav item link to avoid ugly URLs, so we replace something like
+		 * `example.local/members/admin/courses/courses/page/1`
+		 * to something like
+		 * `example.local/members/admin/courses/`
+		 */
+		if ( 1 === absint( $page ) ) {
+			$search  = $replace;
+			$replace = $courses_subnav_item->link;
+		}
+
+		$link = str_replace(
+			$search,
+			$replace,
+			$link
+		);
+
+		if ( $query ) {
+			$link .= '?' . $query;
+		}
+
+		return $link;
 	}
 
 	/**
 	 * Callback for "memberships" profile screen
 	 *
-	 * @since   1.0.0
-	 * @version 3.14.4
+	 * @since 1.0.0
+	 * @since 3.14.4 Unknown.
 	 *
 	 * @return void
 	 */
@@ -180,21 +298,21 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	/**
 	 * Allows restricting of BP Directory Pages for Activity and Members via LifterLMS membership restrictions
 	 *
-	 * @param    array $results  array of restriction results
-	 * @return   array
-	 * @since    3.12.0
-	 * @version  3.12.0
+	 * @since 3.12.0
+	 *
+	 * @param array $results Array of restriction results.
+	 * @return array
 	 */
 	public function restriction_checks( $results ) {
 
-		// only check directories
+		// only check directories.
 		if ( ! bp_is_directory() ) {
 			return $results;
 		}
 
 		$post_id = null;
 
-		// activity
+		// activity.
 		if ( bp_is_activity_component() ) {
 
 			$post_id = bp_core_get_directory_page_id( 'activity' );


### PR DESCRIPTION
## Description
Fixes #1077 

note:
if it wasn't for what I think is a bp bug, we only needed this line:
`		add_filter( 'llms_modify_dashboard_pagination_links_disable', '__return_true', 999 );`

## How has this been tested?
I tested it manually with both buddypress and buddyboss.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
