### PR TITLE
Fix fileheaders for various includes/admin sub directories: reporting…

### DIFF
--- a/includes/admin/post-types/class.llms.meta.boxes.php
+++ b/includes/admin/post-types/class.llms.meta.boxes.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Admin base Metabox Class
+ * Admin base Metabox
  *
- * sets up base metabox functionality and global save.
+ * @package LifterLMS/Admin/PostTypes/Classes
  *
- * @since   1.0.0
+ * @since 1.0.0
  * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Admin_Meta_Boxes
+ * LLMS_Admin_Meta_Boxes class
+ *
+ * Sets up base metabox functionality and global save.
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -2,7 +2,7 @@
 /**
  * Post Table management for LifterLMS custom post types
  *
- * @package LifterLMS/Admin/Classes
+ * @package LifterLMS/Admin/PostTypes/Classes
  *
  * @since 3.0.0
  * @version 3.33.1

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.access.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.access.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox: Membership Access Restrictions
+ * Membership Access Restrictions meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.36.1
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Access class.
+ * LLMS_Meta_Box_Access class
  *
  * @since 1.0.0
  * @since 3.0.0 Updated for 3.0.0 compatibility.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Achievements Metabox
+ * Achievements meta box
  *
- * Generates main metabox and builds forms.
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.37.12
@@ -11,9 +11,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Achievements Metabox class.
+ * Achievements meta box class
  *
- * Generates main metabox and builds forms.
+ * Generates main meta box and builds forms.
  *
  * @since 1.0.0
  * @since 3.0.0 Unknown.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Certificates metabox
+ * Certificates meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.37.12
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Certificates metabox class.
+ * Certificates meta box class
  *
  * @since 1.0.0
  * @since 3.17.4 Unknown.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.coupon.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.coupon.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Coupon Metabox
+ * Coupon meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.35.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Coupon Metabox class.
+ * Coupon meta box class
  *
  * @since 1.0.0
  * @since 3.32.0 Coupons can now be restricted also to a draft or scheduled Course/Membership.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.builder.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.builder.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Course Builder Metabox
+ * Course Builder meta box
  *
- * @package LifterLMS/Admin/Metaboxes
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.13.0
  * @version 3.30.1
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metabox for the "Course Builder" launcher/browser
+ * Meta box for the "Course Builder" launcher/browser
  *
  * @since 3.13.0
  * @since 3.30.1 Add `llms-mb-container` CSS class to container element in the `output()` method.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Course Options
+ * Course Options meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.36.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Course_Options class.
+ * LLMS_Meta_Box_Course_Options class
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.short.description.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.short.description.php
@@ -1,11 +1,21 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Course Short Description meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
+ *
+ * @since unknown
+ * @version unknown
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Meta Box Short Description
+ * Course Short Description meta box class
  *
- * Overrides WP short description
+ * Overrides WP short description.
+ *
+ * @since unknown
  */
 class LLMS_Meta_Box_Course_Short_Description {
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.email.settings.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.email.settings.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Meta Box Certificate Options
+ * Certificate Options meta box
  *
- * Displays email settings metabox. only displays on email post.
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.37.12
@@ -11,9 +11,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Meta Box Certificate Options class.
+ * Meta box Certificate Options class.
  *
- * Displays email settings metabox. only displays on email post.
+ * Displays email settings meta box. Only displays on email post.
  *
  * @since 1.0.0
  * @since 3.1.0 Unknown.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Engagements Metabox
+ * Engagements meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.35.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Engagements Metabox
+ * Engagements meta box class
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonce and access $_POST data via `llms_filter_input()`.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.expiration.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.expiration.php
@@ -1,21 +1,23 @@
 <?php
 /**
  * Meta Box Expiration
- * Displays expiration fields for membership post. Displays only on membership post.
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since Unknown
  * @version 3.24.0
- *
- * @deprecated 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Expiration
+ * LLMS_Meta_Box_Expiration class
+ *
+ * Displays expiration fields for membership post. Displays only on membership post.
  *
  * @since Unknown
  * @since 3.35.0 Verify nonce before processing data; sanitize $_POST data with `llms_filter_input()`.
+ * @deprecated 3.35.0
  */
 class LLMS_Meta_Box_Expiration {
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.instructors.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.instructors.php
@@ -1,8 +1,10 @@
 <?php
 /**
- * Course / Membership Instructors Metabox
+ * Course / Membership Instructors meta box
  *
- * @since   3.13.0
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
+ *
+ * @since 3.13.0
  * @version 3.25.0
  */
 
@@ -10,6 +12,9 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Metabox_Instructors class
+ *
+ * @since 3.13.0
+ * @since 3.25.0 Unknown.
  */
 class LLMS_Metabox_Instructors extends LLMS_Admin_Metabox {
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.lesson.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.lesson.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Lesson Settings Metabox
+ * Lesson Settings meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.36.2
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Lesson Settings Metabox
+ * Lesson Settings meta box class
  *
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Membership Settings Metabox
+ * Membership Settings meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.36.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Membership Settings Metabox
+ * Membership Settings meta box class
  *
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors; removed duplicate array keys.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.details.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.details.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Order Details Metabox
+ * Order Details meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.0.0
  * @version 3.35.0

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox for Student Enrollment Information via the Order interface
+ * Meta box for Student Enrollment Information via the Order interface
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.0.0
  * @version 3.33.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metabox for Student Enrollment Information via the Order interface
+ * LLMS_Meta_Box_Order_Enrollment class
  *
  * @since 3.0.0
  * @since 3.33.0 Added the logic to handle the Enrollment 'deleted' status on save.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.notes.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.notes.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Metaboxes for Orders
+ * Meta boxes for order notes
  *
- * @since  3.0.0
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
+ *
+ * @since 3.0.0
  * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metaboxes for Orders
+ * Meta boxes for orders notes class
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
  */
 class LLMS_Meta_Box_Order_Notes extends LLMS_Admin_Metabox {

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.submit.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Order update/submit box.
+ * Order update/submit box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.36.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Order_Submit
+ * LLMS_Meta_Box_Order_Submit class
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.transactions.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.transactions.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Order transactions metabox.
+ * Order transactions metabox
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.0.0
  * @version 3.35.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Order_Transactions
+ * LLMS_Meta_Box_Order_Transactions class
  *
  * @since 3.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Access Plan metabox
+ * Access Plan meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
  * @version 3.30.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Product class.
+ * LLMS_Meta_Box_Product class
  *
  * @since 1.0.0
  * @since 3.30.0 Added checkout redirect settings

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.students.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.students.php
@@ -1,16 +1,23 @@
 <?php
 /**
- * Students Metabox for Courses & Memberships
+ * Students meta box for Courses & Memberships
  *
- * Add & remove students
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
- * @since    3.0.0
- * @version  3.13.0
+ * @since 3.0.0
+ * @version 3.13.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Meta_Box_Students class
+ *
+ * Add & remove students.
+ *
+ * @since 3.0.0
+ * @version 3.13.0
+ */
 class LLMS_Meta_Box_Students extends LLMS_Admin_Metabox {
 
 	/**

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.video.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.video.php
@@ -1,11 +1,21 @@
 <?php
+/**
+ * Meta box Video
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
+ *
+ * @since ??
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Meta Box Video
- * displays text input for oembed video
+ * Meta box Video class
  *
- * @since    ??
+ * Displays text input for oembed video.
+ *
+ * @since ??
  * @version  3.24.0
  * @deprecated 3.35.0
  */

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.visibility.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.visibility.php
@@ -1,7 +1,8 @@
 <?php
 /**
- * Product Visibility Settings
- * Adds radios to the publishing misc. actions box for courses and memberships
+ * Product Visibility Settings meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.6.0
  * @version 3.35.0
@@ -11,6 +12,8 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Meta_Box_Visibility class
+ *
+ * Adds radios to the publishing misc. actions box for courses and memberships.
  *
  * @since 3.6.0
  * @since 3.35.0 Sanitize `$_POST` data and add nonce verification.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Meta Box Voucher Export
+ * Meta box Voucher Export
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since Unknown
  * @version 3.30.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Meta Box Voucher Export
+ * Meta box Voucher Export class
  *
  * @since Unknown
  * @since 3.30.3 Fixed typo in export content-disposition header.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Vouchers Metabox
+ * Vouchers meta box
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since Unknown
  * @version 3.36.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Vouchers Metabox class
+ * Vouchers Meta box class
  *
  * @since Unknown
  * @since 3.32.0 Vouchers can now be restricted also to a draft or scheduled Course/Membership.

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.button.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.button.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Button
+ * Meta box Field: Button
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Button_Field
+ * LLMS_Metabox_Button_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.checkbox.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.checkbox.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Checkbox
+ * Meta box Field: Checkbox
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Checkbox_Field
+ * LLMS_Metabox_Checkbox_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.color.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.color.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Color picker
+ * Meta box Field: Color picker
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Color_Field
+ * LLMS_Metabox_Color_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.custom.html.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.custom.html.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Custom HTML
+ * Meta box Field: Custom HTML
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Custom_Html_Field
+ * LLMS_Metabox_Custom_Html_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Date Picker Field
+ * Meta box Field: Date Picker Field
  *
- * Pass in 'llms-datepicker' for the class for the field to automatically use jQuery datepicker.
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since  Unknown
  * @version  3.11.0
@@ -11,7 +11,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Date_Field
+ * LLMS_Metabox_Date_Field class
+ *
+ * Pass in 'llms-datepicker' for the class for the field to automatically use jQuery datepicker.
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.editor.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * WP Editor metabox field
+ * WP Editor meta box field
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version 3.30.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * WP Editor metabox field
+ * WP Editor meta box field class
  *
  * @since Unknown
  * @since 3.30.3 Explicitly define class properties.

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
@@ -1,12 +1,22 @@
 <?php
+/**
+ * Abstract Metabox_Field
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
+ *
+ * @since ??
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metabox_Field Parent Class
- * Contains base code for each of the Metabox Fields
+ * Metabox_Field parent class
  *
- * @since    ??
- * @version  3.24.0
+ * Contains base code for each of the Metabox Fields.
+ *
+ * @since ??
+ * @since 3.24.0 Unknown.
  */
 abstract class LLMS_Metabox_Field {
 
@@ -69,7 +79,7 @@ abstract class LLMS_Metabox_Field {
 				if ( isset( $this->field['required'] ) && $this->field['required'] ) :
 					?>
 					<em>(required)</em><?php endif; ?>
-			</div> 
+			</div>
 			<?php
 	}
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.image.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.image.php
@@ -1,12 +1,20 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+/**
+ * Meta box field: Image meta box field
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
+ *
+ * @since ??
+ * @version 3.24.0
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Image metabox field
+ * Image meta box field class
  *
- * @since    ??
- * @version  3.24.0
+ * @since ??
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Metabox_Image_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface {
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Number
+ * Meta box Field: Number
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Number_Field
+ * LLMS_Metabox_Number_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.post.content.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.post.content.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Content editor
+ * Meta box Field: Content editor
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Post_Content_Field
+ * LLMS_Metabox_Post_Content_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.post.excerpt.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.post.excerpt.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Post Excerpt
+ * Meta box Field: Post Excerpt
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Post_Excerpt_Field
+ * LLMS_Metabox_Post_Excerpt_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.repeater.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.repeater.php
@@ -1,13 +1,20 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+/**
+ * Meta box Field: Repeater
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
+ *
+ * @since 3.11.0
+ * @version 3.17.3
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Metabox Repeater Field
+ * Meta box Repeater Field class
  *
- * @since    3.11.0
- * @version  3.17.3
+ * @since 3.11.0
+ * @version 3.17.3
  */
 class LLMS_Metabox_Repeater_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface {
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.search.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.search.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Search
+ * Meta box Field: Search
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Select
+ * Meta box field: Select
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Select_Field
+ * LLMS_Metabox_Select_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.table.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.table.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Table
+ * Meta box Field: Table
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Table_Field
+ * LLMS_Metabox_Table_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.text.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.text.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Text
+ * Meta box Field: Text
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version 3.36.0
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Text_Field
+ * LLMS_Metabox_Text_Field class
  *
  * @since Unknown
  * @since 3.36.0 When outputting the field's value convert quotes (double and single) HTML entities back to characters.

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.textarea.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.textarea.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Textarea
+ * Meta box Field: Textarea
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Textarea_Field
+ * LLMS_Metabox_Textarea_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.textarea.tags.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.textarea.tags.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Metabox Field: Textarea with Tags
+ * Meta box Field: Textarea with Tags
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
  * @since Unknown
  * @version Unknown
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Metabox_Textarea_W_Tags_Field
+ * LLMS_Metabox_Textarea_W_Tags_Field class
  *
  * @since Unknown
  */

--- a/includes/admin/post-types/meta-boxes/fields/llms.interface.meta.box.field.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.interface.meta.box.field.php
@@ -1,5 +1,20 @@
 <?php
+/**
+ * Meta box Field interface
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Interfaces
+ *
+ * @since unknown
+ * @version unknown
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Meta_Box_Field_Interface interface
+ *
+ * @since Unknown
+ */
 interface Meta_Box_Field_Interface {
 
 	public function output();

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.coupons.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.coupons.php
@@ -1,17 +1,26 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
 /**
  * Add, Customize, and Manage LifterLMS Coupon Post Table Columns
  *
- * @since  3.0.0
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.0.0
+ * @version 3.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Admin_Post_Table_Coupons class
+ *
+ * @since 3.0.0
  */
 class LLMS_Admin_Post_Table_Coupons {
 
 	/**
 	 * Constructor
 	 *
-	 * @return  void
+	 * @return void
 	 *
 	 * @since 3.0.0
 	 */

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
@@ -1,11 +1,20 @@
 <?php
+/**
+ * Add, Customize, and Manage LifterLMS Course Post Table Columns
+ *
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.3.0
+ * @version 3.24.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Add, Customize, and Manage LifterLMS Course
+ * LLMS_Admin_Post_Table_Courses class
  *
- * @since    3.3.0
- * @version  3.24.0
+ * @since 3.3.0
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Admin_Post_Table_Courses {
 

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.engagements.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.engagements.php
@@ -2,13 +2,20 @@
 /**
  * Add, Customize, and Manage LifterLMS Engagement Post Table Columns
  *
- * @since    3.1.0
- * @version  3.7.0
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.1.0
+ * @version 3.7.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Admin_Post_Table_Engagements class
+ *
+ * @since 3.1.0
+ * @since 3.7.0 Unknown.
+ */
 class LLMS_Admin_Post_Table_Engagements {
 
 	/**

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.instructors.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.instructors.php
@@ -1,17 +1,18 @@
 <?php
 /**
- * Post table stuff for courses and memberships who have custom "instructor" stuff
- * which replaces "Author"
+ * Post table stuff for courses and memberships who have custom "instructor" stuff * which replaces "Author"
  *
- * @since    3.13.0
- * @version  3.24.0
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.13.0
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;
 /**
- * LLMS_Admin_Post_Table_Instructors
+ * LLMS_Admin_Post_Table_Instructors class
  *
- * @since    3.13.0
+ * @since 3.13.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
  */
 class LLMS_Admin_Post_Table_Instructors {

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.lessons.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.lessons.php
@@ -1,11 +1,20 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Add, Customize, and Manage LifterLMS Lesson posts table Columns
  *
- * @since    3.2.3
- * @version  3.24.0
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.2.3
+ * @version 3.24.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Admin_Post_Table_Lessons class
+ *
+ * @since 3.2.3
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Admin_Post_Table_Lessons {
 

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.orders.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.orders.php
@@ -1,16 +1,20 @@
 <?php
 /**
- * Add, Customize, and Manage LifterLMS Order Post Type Post Table Columns.
+ * Add, Customize, and Manage LifterLMS Order Post Type Post Table Columns
  *
- * @package  LifterLMS\Admin\Classes
- * @since    3.0.0
- * @version  3.24.0
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.0.0
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * LLMS_Admin_Post_Table_Orders class
+ *
+ * @since 3.0.0
+ * @since 3.24.0 Unknown.
  */
 class LLMS_Admin_Post_Table_Orders {
 

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.pages.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.pages.php
@@ -2,13 +2,20 @@
 /**
  * Customize display of the "Page" post tables
  *
- * @since    3.0.0
- * @version  3.7.5
+ * @package LifterLMS/Admin/PostTypes/PostTables/Classes
+ *
+ * @since 3.0.0
+ * @version 3.7.5
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Admin_Post_Table_Pages class
+ *
+ * @since 3.0.0
+ * @since 3.7.5 Unknown.
+ */
 class LLMS_Admin_Post_Table_Pages {
 
 	public $pages = array();

--- a/includes/admin/post-types/tables/class.llms.table.student.management.php
+++ b/includes/admin/post-types/tables/class.llms.table.student.management.php
@@ -2,6 +2,8 @@
 /**
  * Student Management table on Courses and Memberships
  *
+ * @package LifterLMS/Admin/PostTypes/Tables/Classes
+ *
  * @since 3.4.0
  * @version 3.33.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Student Management table on Courses and Memberships class.
+ * Student Management table on Courses and Memberships class
  *
  * @since 3.4.0
  * @since 3.33.0 Added table action button to delete a cancelled enrollment.

--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -2,6 +2,8 @@
 /**
  * Admin Reporting Base Class
  *
+ * @package LifterLMS/Admin/Reporting/Classes
+ *
  * @since 3.2.0
  * @version 3.36.3
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Reporting Base Class
+ * Admin Reporting Base class
  *
  * @since 3.2.0
  * @since 3.31.0 Fix redundant `if` statement in the `output_widget` method.

--- a/includes/admin/reporting/tables/llms.table.achievements.php
+++ b/includes/admin/reporting/tables/llms.table.achievements.php
@@ -2,16 +2,18 @@
 /**
  * Admin Achievements Table
  *
- * @since   3.2.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
  * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Table_Achievements
+ * LLMS_Table_Achievements class
  *
- * @since   3.2.0
+ * @since 3.2.0
  * @since 3.35.0 Get student ID more reliably.
  */
 class LLMS_Table_Achievements extends LLMS_Admin_Table {

--- a/includes/admin/reporting/tables/llms.table.certificates.php
+++ b/includes/admin/reporting/tables/llms.table.certificates.php
@@ -1,17 +1,19 @@
 <?php
 /**
- * Admin Achievements Table
+ * Admin Student Certificates Table
  *
- * @since   3.2.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
  * @version 3.18.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Table_Student_Certificates
+ * LLMS_Table_Student_Certificates class
  *
- * @since   3.2.0
+ * @since 3.2.0
  * @since 3.35.0 Get student ID more reliably.
  */
 class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {

--- a/includes/admin/reporting/tables/llms.table.course.students.php
+++ b/includes/admin/reporting/tables/llms.table.course.students.php
@@ -1,12 +1,19 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * Display students enrolled in a given course on the course students subtab
  *
- * @since   3.15.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
+ * @version 3.18.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Table_Course_Students class
+ *
+ * @since 3.15.0
  * @version 3.17.6
  */
 class LLMS_Table_Course_Students extends LLMS_Admin_Table {

--- a/includes/admin/reporting/tables/llms.table.courses.php
+++ b/includes/admin/reporting/tables/llms.table.courses.php
@@ -2,13 +2,20 @@
 /**
  * Courses Reporting Table
  *
- * @since    3.15.0
- * @version  3.16.14
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.15.0
+ * @version 3.16.14
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Courses Reporting Table class
+ *
+ * @since 3.15.0
+ * @version 3.16.14
+ */
 class LLMS_Table_Courses extends LLMS_Admin_Table {
 
 	/**

--- a/includes/admin/reporting/tables/llms.table.membership.students.php
+++ b/includes/admin/reporting/tables/llms.table.membership.students.php
@@ -1,16 +1,19 @@
 <?php
 /**
- * Display students enrolled in a given membership on the membership students subtab.
+ * Display students enrolled in a given membership on the membership students subtab
  *
- * @since   3.32.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.32.0
  * @version 3.32.0
  */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Display students enrolled in a given membership on the membership students subtab class.
+ * LLMS_Table_Membership_Students class
  *
- * @since   3.32.0
+ * @since 3.32.0
  */
 class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 

--- a/includes/admin/reporting/tables/llms.table.memberships.php
+++ b/includes/admin/reporting/tables/llms.table.memberships.php
@@ -2,6 +2,8 @@
 /**
  * Memberships Reporting Table
  *
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
  * @since 3.32.0
  * @version 3.32.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Memberships Reporting Table class.
+ * Memberships Reporting Table class
  *
  * @since 3.32.0
  */

--- a/includes/admin/reporting/tables/llms.table.questions.php
+++ b/includes/admin/reporting/tables/llms.table.questions.php
@@ -1,14 +1,21 @@
 <?php
 /**
- * Admin GradeBook Tables
+ * Questions Reporting Table
  *
- * @since   3.2.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
  * @version 3.7.7
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Questions Table class
+ *
+ * @since 3.2.0
+ * @since 3.7.7 Unknown.
+ */
 class LLMS_Table_Questions extends LLMS_Admin_Table {
 
 	/**

--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Quizzes Reporting Table.
+ * Quizzes Reporting Table
  *
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Quizzes Reporting Table class.
+ * Quizzes Reporting Table class
  *
  * @since 3.16.0
  * @since 3.36.1 Fixed an issue that allow instructors, who can only see their own reports,

--- a/includes/admin/reporting/tables/llms.table.student.course.php
+++ b/includes/admin/reporting/tables/llms.table.student.course.php
@@ -1,17 +1,20 @@
 <?php
 /**
- * Individual Student's Courses Table
+ * Individual Student's Course Table
  *
- * @since   3.2.0
- * @version 3.21.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
+ * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Table_Student_Course class.
+ * LLMS_Table_Student_Course class
  *
- * @since  3.2.0
+ * @since 3.2.0
+ * @since 3.21.0 Unknown.
  * @since 3.35.0 Get student ID more reliably.
  */
 class LLMS_Table_Student_Course extends LLMS_Admin_Table {

--- a/includes/admin/reporting/tables/llms.table.student.courses.php
+++ b/includes/admin/reporting/tables/llms.table.student.courses.php
@@ -2,12 +2,20 @@
 /**
  * Individual Student's Courses Table
  *
- * @since   3.2.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
  * @version 3.13.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Table_Student_Courses class
+ *
+ * @since 3.2.0
+ * @since 3.13.0 Unknown.
+ */
 class LLMS_Table_Student_Courses extends LLMS_Admin_Table {
 
 	/**

--- a/includes/admin/reporting/tables/llms.table.student.memberships.php
+++ b/includes/admin/reporting/tables/llms.table.student.memberships.php
@@ -2,7 +2,9 @@
 /**
  * Individual Student's Memberships Table
  *
- * @since   3.2.0
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since 3.2.0
  * @version 3.7.5
  */
 
@@ -11,7 +13,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * LLMS_Table_Student_Memberships
  *
- * @since   3.2.0
+ * @since 3.2.0
+ * @since 3.7.5 Unknown.
  * @since 3.35.0 Get student ID more reliably.
  */
 class LLMS_Table_Student_Memberships extends LLMS_Admin_Table {

--- a/includes/admin/reporting/tables/llms.table.students.php
+++ b/includes/admin/reporting/tables/llms.table.students.php
@@ -2,6 +2,8 @@
 /**
  * Students Reporting Table
  *
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
  * @since 3.2.0
  * @version 3.37.2
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Table_Students class.
+ * LLMS_Table_Students class
  *
  * @since 3.2.0
  * @since 3.28.0 Unknown.

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.courses.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.courses.php
@@ -2,6 +2,8 @@
 /**
  * Courses Tab on Reporting Screen
  *
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
+ *
  * @since 3.15.0
  * @version 3.35.0
  */

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.enrollments.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.enrollments.php
@@ -1,11 +1,21 @@
 <?php
 /**
- * Students Tab on Reporting Screen
+ * Enrollments Tab on Reporting Screen
+ *
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
+ *
+ * @since 3.2.0
+ * @version 3.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Admin_Reporting_Tab_Enrollments class
+ *
+ * @since 3.2.0
+ * @since 3.5.0 Unknown.
+ */
 class LLMS_Admin_Reporting_Tab_Enrollments {
 
 	/**

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.memberships.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.memberships.php
@@ -2,6 +2,8 @@
 /**
  * Memberships Tab on Reporting Screen
  *
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
+ *
  * @since 3.32.0
  * @version 3.32.0
  */
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Memberships Tab on Reporting Screen class.
+ * Memberships Tab on Reporting Screen class
  *
  * @since 3.32.0
  * @since 3.35.0 Sanitize input data.

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.quizzes.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.quizzes.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Courses Tab on Reporting Screen
+ * Quizzes Tab on Reporting Screen
+ *
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
  *
  * @since 3.16.0
  * @version 3.35.0

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.sales.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.sales.php
@@ -1,11 +1,20 @@
 <?php
 /**
- * Students Tab on Reporting Screen
+ * Sales Tab on Reporting Screen
+ *
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
+ *
+ * @since 3.2.0
+ * @version 3.2.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Admin_Reporting_Tab_Sales class
+ *
+ * @since 3.2.0
+ */
 class LLMS_Admin_Reporting_Tab_Sales {
 
 	/**

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
@@ -2,15 +2,18 @@
 /**
  * Students Tab on Reporting Screen
  *
- * @since  3.2.0
+ * @package LifterLMS/Admin/Reporting/Tabs/Classes
+ *
+ * @since 3.2.0
  * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * LLMS_Admin_Reporting_Tab_Students class
  *
- * @since  3.2.0
+ * @since 3.2.0
  * @since 3.35.0 Sanitize input data.
  */
 class LLMS_Admin_Reporting_Tab_Students {

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
@@ -2,16 +2,18 @@
 /**
  * Register WordPress AJAX methods for Analytics Widgets
  *
- * @since  3.0.0
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.0.0
  * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Analytics_Widget_Ajax
+ * LLMS_Analytics_Widget_Ajax class
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @since 3.35.0 Sanitize `$_REQUEST` data.
  */
 class LLMS_Analytics_Widget_Ajax {

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.coupons.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.coupons.php
@@ -1,13 +1,23 @@
 <?php
+/**
+ * Coupons analytics widget
+ *
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.0.0
+ * @version 3.18.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Coupons analytics widget
- * Locates number of active / completed orders from a given date range
- * by a given group of students
+ * Coupons analytics widget class
  *
- * @since   3.0.0
- * @version 3.18.0
+ * Locates number of active / completed orders from a given date range
+ * by a given group of students.
+ *
+ * @since 3.0.0
+ * @since 3.18.0 Unknown.
  */
 class LLMS_Analytics_Coupons_Widget extends LLMS_Analytics_Widget {
 

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.coursecompletions.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.coursecompletions.php
@@ -2,13 +2,20 @@
 /**
  * Course Completions analytics widget
  *
- * @since   3.5.0
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.5.0
  * @version 3.5.3
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Course Completions analytics widget class
+ *
+ * @since 3.5.0
+ * @version 3.5.3
+ */
 class LLMS_Analytics_Coursecompletions_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.discounts.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.discounts.php
@@ -2,15 +2,21 @@
 /**
  * Total amount of coupon discount savings
  *
- * Totals all coupon discounts applied to orders in the given filters
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @version 3.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Analytics_Discounts_Widget class
+ *
+ * Totals all coupon discounts applied to orders in the given filters.
+ *
+ * @since 3.0.0
+ */
 class LLMS_Analytics_Discounts_Widget extends LLMS_Analytics_Widget {
 
 	public function set_query() {

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.enrollments.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.enrollments.php
@@ -2,13 +2,21 @@
 /**
  * Enrollments analytics widget
  *
- * @since  3.0.0
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.0.0
  * @version 3.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Analytics_Enrollments_Widget class
+ *
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.0.0
+ */
 class LLMS_Analytics_Enrollments_Widget extends LLMS_Analytics_Widget {
 
 

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.lessoncompletions.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.lessoncompletions.php
@@ -2,13 +2,20 @@
 /**
  * Lesson Completions analytics widget
  *
- * @since   3.5.0
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.5.0
  * @version 3.5.3
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Analytics_Lessoncompletions_Widget class
+ *
+ * @since 3.5.0
+ * @since 3.5.3 Unknown.
+ */
 class LLMS_Analytics_Lessoncompletions_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.refunded.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.refunded.php
@@ -2,17 +2,19 @@
 /**
  * Refunded Amount Widget
  *
- * Retrieves the total amount of all refunded transactions
- * according to active filters
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @version 3.36.3
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Refunded Amount Widget.
+ * Refunded Amount Widget class
+ *
+ * Retrieves the total amount of all refunded transactions
+ * according to active filters.
  *
  * @since 3.0.0
  * @since 3.36.3 In `format_response()` method avoid running `wp_list_pluck()` on non arrays.

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.refunds.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.refunds.php
@@ -2,18 +2,27 @@
 /**
  * Refunds analytics widget
  *
- * Locates number of refunded orders from a given date range
- * by a given group of students
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
- * Uses "post_modified" rather than "post_date" for date query
+ * @since 3.0.0
+ * @version 3.0.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Refunds analytics widget class
+ *
+ * Locates number of refunded orders from a given date range
+ * by a given group of students.
+ *
+ * Uses "post_modified" rather than "post_date" for date query.
+ *
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
  * @since  3.0.0
  * @version 3.0.0
  */
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
-
 class LLMS_Analytics_Refunds_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.registrations.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.registrations.php
@@ -2,13 +2,19 @@
 /**
  * Registrations analytics widget
  *
- * @since   3.5.0
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.5.0
  * @version 3.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * Registrations analytics widget class
+ *
+ * @since 3.5.0
+ */
 class LLMS_Analytics_Registrations_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.revenue.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.revenue.php
@@ -2,16 +2,22 @@
 /**
  * Revenue widget
  *
- * Retrieves the total amount of all succeeded transactions
- * according to active filters
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @version 3.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Analytics_Revenue_Widget class
+ *
+ * Retrieves the total amount of all succeeded transactions
+ * according to active filters.
+ *
+ * @since 3.0.0
+ */
 class LLMS_Analytics_Revenue_Widget extends LLMS_Analytics_Widget {
 
 	public function set_query() {

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.sales.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.sales.php
@@ -2,16 +2,24 @@
 /**
  * Sales analytics widget
  *
- * Locates number of active / completed orders from a given date range
- * by a given group of students
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
- * @since  3.0.0
+ * @since 3.0.0
  * @version 3.0.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Analytics_Sales_Widget class
+ *
+ * Locates number of active / completed orders from a given date range
+ * by a given group of students.
+ *
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
+ *
+ * @since 3.0.0
+ */
 class LLMS_Analytics_Sales_Widget extends LLMS_Analytics_Widget {
 
 	public $charts = true;

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.sold.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Sold Amount Widget.
+ * Sold Amount Widget
  *
- * Retrieves the total amount of all successful transactions
- * according to active filters.
+ * @package LifterLMS/Admin/Reporting/Widgets/Classes
  *
  * @since 3.0.0
  * @version 3.36.3
@@ -12,7 +11,10 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Sold Amount Widget.
+ * Sold Amount Widget class
+ *
+ * Retrieves the total amount of all successful transactions
+ * according to active filters.
  *
  * @since 3.0.0
  * @since 3.30.3 Explicitly define class properties.

--- a/includes/admin/settings/class.llms.settings.accounts.php
+++ b/includes/admin/settings/class.llms.settings.accounts.php
@@ -2,6 +2,8 @@
 /**
  * Admin Settings Page, Accounts Tab
  *
+ * @package LifterLMS/Admin/Settings/Classes
+ *
  * @since 1.0.0
  * @version 3.37.3
  */
@@ -9,13 +11,13 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Settings Page, Accounts Tab
+ * Admin Settings Page, Accounts Tab class
  *
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors.
  * @since 3.37.3 Renamed setting field IDs to be unique.
- *              Removed redundant functions defined in the `LLMS_Settings_Page` class.
- *              Removed constructor and added `get_label()` method to be compatible with changes in `LLMS_Settings_Page`.
+ *               Removed redundant functions defined in the `LLMS_Settings_Page` class.
+ *               Removed constructor and added `get_label()` method to be compatible with changes in `LLMS_Settings_Page`.
  * @since 3.37.4 Revert $id to "account".
  */
 class LLMS_Settings_Accounts extends LLMS_Settings_Page {

--- a/includes/admin/settings/class.llms.settings.checkout.php
+++ b/includes/admin/settings/class.llms.settings.checkout.php
@@ -2,13 +2,16 @@
 /**
  * Admin Settings Page, Checkout Tab
  *
+ * @package LifterLMS/Admin/Settings/Classes
+ *
  * @since 3.0.0
  * @version 3.35.1
  */
 
 defined( 'ABSPATH' ) || exit;
+
 /**
- * Admin Settings Page, Checkout Tab
+ * Admin Settings Page, Checkout Tab class
  *
  * @since 3.0.0
  * @since 3.30.3 Fixed spelling errors.

--- a/includes/admin/settings/class.llms.settings.courses.php
+++ b/includes/admin/settings/class.llms.settings.courses.php
@@ -2,12 +2,19 @@
 /**
  * Admin Settings Page "Courses" Tab
  *
- * @since   3.5.0
+ * @package LifterLMS/Admin/Settings/Classes
+ *
+ * @since 3.5.0
  * @version 3.5.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin Settings Page "Courses" Tab class
+ *
+ * @since 3.5.0
+ */
 class LLMS_Settings_Courses extends LLMS_Settings_Page {
 
 	/**

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -2,7 +2,7 @@
 /**
  * Admin Settings Page: Engagements
  *
- * @package LifterLMS/Admin/Classes
+ * @package LifterLMS/Admin/Settings/Classes
  *
  * @since 1.0.0
  * @version 3.37.3
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Settings_Engagements class.
+ * LLMS_Settings_Engagements class
  *
  * @since 1.0.0
  * @since 3.8.0 Unknown.

--- a/includes/admin/settings/class.llms.settings.general.php
+++ b/includes/admin/settings/class.llms.settings.general.php
@@ -1,11 +1,20 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Admin Settings Page, General Tab
  *
- * @since    1.0.0
- * @version  3.22.0
+ * @package LifterLMS/Admin/Settings/Classes
+ *
+ * @since 1.0.0
+ * @version 3.22.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin Settings Page, General Tab class
+ *
+ * @since 1.0.0
+ * @since 3.22.0 Unknown.
  */
 class LLMS_Settings_General extends LLMS_Settings_Page {
 

--- a/includes/admin/settings/class.llms.settings.integrations.php
+++ b/includes/admin/settings/class.llms.settings.integrations.php
@@ -1,11 +1,22 @@
 <?php
-defined( 'ABSPATH' ) || exit;
-
 /**
  * Admin Settings Page, Integrations Tab
  *
- * @since    1.0.0
- * @version  3.18.2
+ * @package LifterLMS/Admin/Settings/Classes
+ *
+ * @since 1.0.0
+ * @version 3.18.2
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin Settings Page, Integrations Tab class
+ *
+ * @package LifterLMS/Admin/Settings/Classes
+ *
+ * @since 1.0.0
+ * @since 3.18.2 Unknown.
  */
 class LLMS_Settings_Integrations extends LLMS_Settings_Page {
 

--- a/includes/admin/settings/class.llms.settings.memberships.php
+++ b/includes/admin/settings/class.llms.settings.memberships.php
@@ -2,12 +2,19 @@
 /**
  * Admin Settings Page "Memberships" Tab
  *
- * @since   3.5.0
+ * @package LifterLMS/Admin/Settings/Classes
+ *
+ * @since 3.5.0
  * @version 3.5.0
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin Settings Page "Memberships" Tab class
+ *
+ * @since 3.5.0
+ */
 class LLMS_Settings_Memberships extends LLMS_Settings_Page {
 
 	/**

--- a/includes/admin/settings/class.llms.settings.notifications.php
+++ b/includes/admin/settings/class.llms.settings.notifications.php
@@ -2,13 +2,18 @@
 /**
  * Admin Settings: Notifications Tab
  *
+ * @package LifterLMS/Admin/Settings/Classes
+ *
  * @since 3.8.0
  * @version 3.35.0
  */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Settings: Notifications Tab
+ * LLMS_Settings_Notifications class
+ *
+ * Admin Settings: Notifications Tab.
  *
  * @since 3.8.0
  * @since 3.30.3 Explicitly define class properties; fix typo in title element id.

--- a/includes/admin/settings/class.llms.settings.page.php
+++ b/includes/admin/settings/class.llms.settings.page.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Admin Settings Page Base Class
+ * Admin Settings Page Base
+ *
+ * @package LifterLMS/Admin/Settings/Classes
  *
  * @since 1.0.0
  * @version 3.37.3
@@ -9,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Settings Page Base Class
+ * Admin Settings Page Base class
  *
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.

--- a/includes/admin/settings/tables/class.llms.table.notification.settings.php
+++ b/includes/admin/settings/tables/class.llms.table.notification.settings.php
@@ -2,13 +2,22 @@
 /**
  * Student Management table on Courses and Memberships
  *
- * @since   3.8.0
+ * @package LifterLMS/Admin/Settings/Tables/Classes
+ *
+ * @since 3.8.0
  * @version 3.10.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
+/**
+ * LLMS_Table_NotificationSettings class
+ *
+ * Student Management table on Courses and Memberships.
+ *
+ * @since 3.8.0
+ * @since 3.10.0 Unknown.
+ */
 class LLMS_Table_NotificationSettings extends LLMS_Admin_Table {
 
 	/**


### PR DESCRIPTION
…|settings|post-types

still missing: analytics and **views**
but analytics is completely excluded by any phpcs check as it only contains deprecated files

Per #946


## How has this been tested?
Passes existing cs and phpunit tests

## Screenshots <!-- if applicable -->

## Types of changes
Documentation and coding standards, non-breaking

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
