### PR TITLE
Fix dashboard endpoints conflicts with WooCommerce

### DIFF
--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.1.3
  * @since 3.31.0 Resolve dashboard endpoint 404s resulting from changes in WC 3.6.
  * @since [version] Changed the way we handle the dashboard endpoints conflict, using a different wc filter hook.
+ *                 Deprecated `LLMS_PlayNice::wc_is_account_page()`.
  */
 class LLMS_PlayNice {
 
@@ -51,6 +52,28 @@ class LLMS_PlayNice {
 		if ( function_exists( 'WC' ) ) {
 			add_filter( 'woocommerce_account_endpoint_page_not_found', array( $this, 'wc_account_endpoint_page_not_found' ) );
 		}
+	}
+
+	/**
+	 * Allow our dashboard endpoints sharing a query var with WC to function
+	 *
+	 * Lie to WC and tell it we're on a WC account page when accessing endpoints which
+	 * share a query var with WC. See https://github.com/gocodebox/lifterlms/issues/849.
+	 *
+	 * @since 3.31.0
+	 * @deprecated [version]
+	 *
+	 * @param bool $is_acct_page False from `woocommerce_is_account_page` filter.
+	 * @return bool
+	 */
+	public function wc_is_account_page( $is_acct_page ) {
+
+		if ( ! $is_acct_page && is_llms_account_page() && is_wc_endpoint_url() ) {
+			$is_acct_page = true;
+		}
+
+		return $is_acct_page;
+
 	}
 
 	/**

--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -1,20 +1,21 @@
 <?php
 /**
- * Make LifterLMS play nicely with other plugins, themes, & webhosts.
+ * Make LifterLMS play nicely with other plugins, themes, & webhosts
  *
  * @package LifterLMS/Classes
  *
  * @since 3.1.3
- * @version 3.31.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_PlayNice class.
+ * LLMS_PlayNice class
  *
  * @since 3.1.3
  * @since 3.31.0 Resolve dashboard endpoint 404s resulting from changes in WC 3.6.
+ * @since [version] Changed the way we handle the dashboard endpoints conflict, using a different wc filter hook.
  */
 class LLMS_PlayNice {
 
@@ -28,10 +29,10 @@ class LLMS_PlayNice {
 	 */
 	public function __construct() {
 
-		// optimize press live editor initialization
+		// optimize press live editor initialization.
 		add_action( 'op_liveeditor_init', array( $this, 'wp_optimizepress_live_editor' ) );
 
-		// wpe heartbeat fix
+		// wpe heartbeat fix.
 		add_filter( 'wpe_heartbeat_allowed_pages', array( $this, 'wpe_heartbeat_allowed_pages' ) );
 
 		add_action( 'init', array( $this, 'plugins_loaded' ), 11 );
@@ -42,33 +43,34 @@ class LLMS_PlayNice {
 	 * Conditionally add hooks after the other plugin is loaded.
 	 *
 	 * @since 3.31.0
+	 * @since [version] Changed the way we handle endpoints conflict, using a different wc filter hook.
 	 *
 	 * @return void
 	 */
 	public function plugins_loaded() {
 		if ( function_exists( 'WC' ) ) {
-			add_filter( 'woocommerce_is_account_page', array( $this, 'wc_is_account_page' ) );
+			add_filter( 'woocommerce_account_endpoint_page_not_found', array( $this, 'wc_account_endpoint_page_not_found' ) );
 		}
 	}
 
 	/**
 	 * Allow our dashboard endpoints sharing a query var with WC to function
 	 *
-	 * Lie to WC and tell it we're on a WC account page when accessing endpoints which
-	 * share a query var with WC. See https://github.com/gocodebox/lifterlms/issues/849.
+	 * Inform WC that it should not force a 404 because we're on a valid endpoint.
+	 * See https://github.com/gocodebox/lifterlms/issues/849.
 	 *
-	 * @since 3.31.0
+	 * @since [version]
 	 *
-	 * @param bool $is_acct_page False from `woocommerce_is_account_page` filter.
+	 * @param bool $is_page_not_found True from `woocommerce_account_endpoint_page_not_found` filter.
 	 * @return bool
 	 */
-	public function wc_is_account_page( $is_acct_page ) {
+	public function wc_account_endpoint_page_not_found( $is_page_not_found ) {
 
-		if ( ! $is_acct_page && is_llms_account_page() && is_wc_endpoint_url() ) {
-			$is_acct_page = true;
+		if ( is_llms_account_page() && is_wc_endpoint_url() ) {
+			$is_page_not_found = false;
 		}
 
-		return $is_acct_page;
+		return $is_page_not_found;
 
 	}
 
@@ -86,11 +88,11 @@ class LLMS_PlayNice {
 	 */
 	public function wp_optimizepress_live_editor() {
 
-		// These files are necessary to get optimizepress ajax to play nicely in the liveeditor
+		// These files are necessary to get optimizepress ajax to play nicely in the liveeditor.
 		include_once 'class.llms.ajax.php';
 		include_once 'class.llms.ajax.handler.php';
 
-		// These files are all necessary to get the liveeditor to open
+		// These files are all necessary to get the liveeditor to open.
 		include_once 'llms.template.functions.php';
 		include_once 'class.llms.https.php';
 
@@ -108,12 +110,13 @@ class LLMS_PlayNice {
 
 	/**
 	 * WPE blocks the WordPress Heartbeat script from being loaded
-	 * Event when it's explicitly defined as a dependency
 	 *
-	 * @param    array $pages    list of pages that the heartbeat is allowed to load on
-	 * @return   array
-	 * @since    3.16.4
-	 * @version  3.16.4
+	 * Event when it's explicitly defined as a dependency.
+	 *
+	 * @since 3.16.4
+	 *
+	 * @param array $pages List of pages that the heartbeat is allowed to load on.
+	 * @return array
 	 */
 	public function wpe_heartbeat_allowed_pages( $pages ) {
 


### PR DESCRIPTION
## Description

Fixes #1037 and #849 (which was already fixed)

I removed a public method of the `LLMS_PlayNice` class instead of making it deprecated, I thought it was good since that class instance is not accessible from outside that file.

Additionally, we have also this in our integration:
https://github.com/gocodebox/lifterlms-integration-woocommerce/blob/2.0.15/includes/class-llms-wc-my-account.php#L30


I don't think we really need that anymore... I mean, it's not technically needed.
Shall we remove it?

## How has this been tested?
I tested manually that issue described in #1037 occurred before and that both #1037 and #849 do not occur with this PR applied.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

