### PR TITLE
fix regression, use safe=false when redirecting to allow redirecting to other domains

### DIFF
--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -156,8 +156,8 @@ abstract class LLMS_Payment_Gateway {
 	 * @since 3.30.0 Unknown.
 	 * @since 3.34.3 Use `llms_redirect_and_exit()` instead of `wp_redirect()` and `exit()`.
 	 *
-	 * @param obj    $order      Instance of an LLMS_Order object
-	 * @param string $deprecated (Deprecated) Optional message to display on the redirect screen.
+	 * @param LLMS_Order $order      Instance of an LLMS_Order object.
+	 * @param string     $deprecated (Deprecated) Optional message to display on the redirect screen.
 	 * @return void
 	 */
 	public function complete_transaction( $order, $deprecated = '' ) {

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @version 3.34.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -156,9 +156,9 @@ abstract class LLMS_Payment_Gateway {
 	 * @since 3.30.0 Unknown.
 	 * @since 3.34.3 Use `llms_redirect_and_exit()` instead of `wp_redirect()` and `exit()`.
 	 *
-	 * @param    obj    $order       Instance of an LLMS_Order object
-	 * @param    string $deprecated  (deprecated) optional message to display on the redirect screen
-	 * @return   void
+	 * @param obj    $order      Instance of an LLMS_Order object
+	 * @param string $deprecated (Deprecated) Optional message to display on the redirect screen.
+	 * @return void
 	 */
 	public function complete_transaction( $order, $deprecated = '' ) {
 
@@ -166,7 +166,7 @@ abstract class LLMS_Payment_Gateway {
 
 		$redirect = $this->get_complete_transaction_redirect_url( $order );
 
-		// deprecated msg if supplied, will be removed in a future release
+		// Deprecated msg if supplied, will be removed in a future release.
 		if ( $deprecated ) {
 
 			llms_deprecated_function( 'LLMS_Payment_Gateway::complete_transaction() with message', '3.8.0', 'LifterLMS enrollment notices' );
@@ -179,8 +179,13 @@ abstract class LLMS_Payment_Gateway {
 		// ensure notification processors get dispatched since shutdown wont be called.
 		do_action( 'llms_dispatch_notification_processors' );
 
-		// execute a redirect
-		llms_redirect_and_exit( $redirect );
+		// Execute a redirect.
+		llms_redirect_and_exit(
+			$redirect,
+			array(
+				'safe' => false,
+			)
+		);
 
 	}
 


### PR DESCRIPTION
## Description

Returns checkout redirect to use wp_redirect() instead of wp_safe_redirect() to ensure off-site redirects are allowed.

<!-- Please describe what you have changed or added -->

Fixes #1095 

## How has this been tested?

Existing tests and manual tests on checkout

## Types of changes

Regression fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

