### PR TITLE
Bail if the global `$post` is empty, before registering our admin met…

### DIFF
--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @version 3.37.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,6 +24,7 @@ foreach ( glob( LLMS_PLUGIN_DIR . '/includes/admin/post-types/meta-boxes/fields/
  * @since 3.36.1 Improve `save()` method.
  * @since 3.37.12 Simplify `save()` by moving logic to sanitize and update posted data to `save_field()`.
  *                Add field sanitize option "no_encode_quotes" which functions like previous "shortcode" but is more semantically accurate.
+ * @since [version] Bail if the global `$post` is empty, before registering our meta boxes.
  */
 abstract class LLMS_Admin_Metabox {
 
@@ -380,12 +381,18 @@ abstract class LLMS_Admin_Metabox {
 	 *
 	 * @since 3.0.0
 	 * @since 3.13.0 Unknown.
+	 * @since [version] Early bail if the global `$post` is empty.
 	 *
 	 * @return void
 	 */
 	public function register() {
 
 		global $post;
+
+		if ( empty( $post ) ) {
+			return;
+		}
+
 		$this->post = $post;
 
 		if ( current_user_can( $this->capability, $this->post->ID ) ) {


### PR DESCRIPTION
…a boxes.

## Description

Fixes #1108 

## How has this been tested?
Manually by following the steps described in the issue above.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
