### PR TITLE
fix deprecation warning resulting from theme support

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.13.0
- * @version 3.37.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.37.12 Refactored the `process_trash()` method.
  *                Added new filter, `llms_builder_{$post_type}_force_delete` to allow control of how post type deletion is handled
  *                when deleted via the builder.
+ * @since [version] Improve backwards compatibility handling for the `llms_get_quiz_theme_settings` filter.
  */
 class LLMS_Admin_Builder {
 
@@ -69,21 +70,21 @@ class LLMS_Admin_Builder {
 	/**
 	 * Retrieve custom field schemas
 	 *
-	 * @return   array
-	 * @since    3.17.0
-	 * @version  3.17.6
+	 * @since 3.17.0
+	 * @since 3.17.6 Add backwards compatibility for the deprecated `llms_get_quiz_theme_settings` filter.
+	 * @since [version] Only run backwards compatibility for `llms_get_quiz_theme_settings` when the filter is being used.
+	 *
+	 * @return array
 	 */
 	private static function get_custom_schemas() {
 
 		$quiz_fields = array();
 
 		/**
-		 * Handle old quiz layout compatibility API
-		 * translate the old filter into the new one for quizzes
+		 * Handle old quiz layout compatibility API:
+		 * Translate the old filter into the new one for quizzes.
 		 */
-		if ( get_theme_support( 'lifterlms-quizzes' ) ) {
-
-			llms_log( 'Filter `llms_get_quiz_theme_settings` deprecated since 3.17.6, for more information see new methods at https://lifterlms.com/docs/course-builder-custom-fields-for-developers/' );
+		if ( get_theme_support( 'lifterlms-quizzes' ) && has_filter( 'llms_get_quiz_theme_settings' ) ) {
 
 			$theme = wp_get_theme();
 
@@ -110,6 +111,15 @@ class LLMS_Admin_Builder {
 
 		}
 
+		/**
+		 * Add custom fields to the LifterLMS Builder.
+		 *
+		 * @since 3.17.0
+		 *
+		 * @link https://lifterlms.com/docs/course-builder-custom-fields-for-developers
+		 *
+		 * @param array[] $fields Array of post types containing arrays of custom field data.
+		 */
 		return apply_filters(
 			'llms_builder_register_custom_fields',
 			array(

--- a/includes/functions/llms.functions.quiz.php
+++ b/includes/functions/llms.functions.quiz.php
@@ -2,15 +2,13 @@
 /**
  * LifterLMS Quiz Functions
  *
- * @author    LifterLMS
- * @category  Core
  * @package   LifterLMS/Functions
- * @since     3.16.0
- * @version   3.16.12
+ *
+ * @since 3.16.0
+ * @version [version]
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; }
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Retrieve the number of columns needed for a picture choice question
@@ -110,14 +108,27 @@ function llms_get_quiz_attempt_statuses() {
 /**
  * Get quiz settings defined by supporting themes
  *
- * @param    string $setting  name of setting, if omitted returns all settings
- * @param    string $default  default fallback if setting not set
- * @return   array
- * @since    3.16.8
- * @version  3.16.8
+ * @since 3.16.8
+ * @since [version] Moved deprecation notice from `LLMS_Admin_Builder::get_custom_schemas()`.
+ * @deprecated [version] See https://lifterlms.com/docs/course-builder-custom-fields-for-developers for more information.
+ *
+ * @param string $setting Name of setting, if omitted returns all settings.
+ * @param string $default Default fallback if setting not set.
+ * @return array
  */
 function llms_get_quiz_theme_setting( $setting = '', $default = '' ) {
 
+	// Deprecation notice for filter (and function).
+	llms_log( 'Filter `llms_get_quiz_theme_settings` deprecated since 3.17.6. For more information see new methods at https://lifterlms.com/docs/course-builder-custom-fields-for-developers/' );
+
+	/**
+	 * Deprecated.
+	 *
+	 * @since 3.17.0
+	 * @deprecated 3.17.6 Deprecated. See https://lifterlms.com/docs/course-builder-custom-fields-for-developers for more information.
+	 *
+	 * @param array[] $settings Array of quiz theme settings.
+	 */
 	$settings = apply_filters(
 		'llms_get_quiz_theme_settings',
 		array(
@@ -125,7 +136,7 @@ function llms_get_quiz_theme_setting( $setting = '', $default = '' ) {
 				'id'      => '',
 				'name'    => __( 'Layout', 'lifterlms' ),
 				'options' => array(),
-				'type'    => 'select', // select, image_select
+				'type'    => 'select', // Either: select or image_select.
 			),
 		)
 	);

--- a/includes/models/model.llms.quiz.php
+++ b/includes/models/model.llms.quiz.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models
  *
  * @since 3.3.0
- * @version 3.19.2
+ * @version [version]
  *
  * @property  $allowed_attempts (int) Number of times a student is allowed to take the quiz before being locked out of it.
  * @property  $passing_percent (float) Grade required for a student to "pass" the quiz.
@@ -26,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.3.0
  * @since 3.19.2 Unkwnown.
  * @since 3.37.2 Added `llms_quiz_is_open` filter hook.
+ * @since [version] Only add theme metadata to the quiz array when the `llms_get_quiz_theme_settings` filter is being used.
  */
 class LLMS_Quiz extends LLMS_Post_Model {
 
@@ -210,6 +211,7 @@ class LLMS_Quiz extends LLMS_Post_Model {
 	 *
 	 * @since 3.3.0
 	 * @since 3.19.2 Unknown.
+	 * @since [version] Only add theme metadata to the quiz array when the `llms_get_quiz_theme_settings` filter is being used.
 	 *
 	 * @param array $arr Array of data to be serialized.
 	 * @return array
@@ -218,7 +220,7 @@ class LLMS_Quiz extends LLMS_Post_Model {
 
 		$arr['questions'] = array();
 
-		// builder lazy loads questions via ajax.
+		// Builder lazy loads questions via ajax.
 		global $llms_builder_lazy_load;
 		if ( ! $llms_builder_lazy_load ) {
 			foreach ( $this->get_questions() as $question ) {
@@ -226,8 +228,8 @@ class LLMS_Quiz extends LLMS_Post_Model {
 			}
 		}
 
-		// if theme support quizzes, add theme metadata to the array.
-		if ( get_theme_support( 'lifterlms-quizzes' ) ) {
+		// If theme has legacy support quiz layouts, add theme metadata to the array.
+		if ( get_theme_support( 'lifterlms-quizzes' ) && has_filter( 'llms_get_quiz_theme_settings' ) ) {
 			$layout = llms_get_quiz_theme_setting( 'layout' );
 			if ( $layout ) {
 				$arr[ $layout['id'] ] = get_post_meta( $this->get( 'id' ), $layout['id'], true );


### PR DESCRIPTION
## Description

This PR quiets ~~@eri-trabiccolo~~ deprecation logs encountered when using themes that add theme support for `lifterlms-quizzes` and do not utilize the deprecated filter `llms_get_quiz_theme_settings` 

## How has this been tested?

Undesired behavior (deprecation warning logged to the `llms.log` file despite the deprecated methods not being used) can be seen by adding theme support to any theme (like twentytwenty) using the following code:

```php
add_action( 'after_setup_theme', function() {
	add_theme_support( 'lifterlms-quizzes' );
} );
```

Without this PR a deprecated message is logged despite not using the deprecated method. After this PR the depercation warning is no longer logged.

When the filter is being used the warning is still recorded:

Add this code to the same theme:

```php
add_filter( 'llms_get_quiz_theme_settings', function( $settings ) {
	$settings['layout']['options'] = array( 'Full Width', 'Left', 'Right' );
	return $settings;
} );
```

With both snippets the custom fields will be displayed on the builder and the warning will also be logged to the llms.log file (as expected).

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

