### PR TITLE
Refactor the notification background processor dispatching methods

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -240,12 +240,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gocodebox/lifterlms-tests.git",
-                "reference": "dc4975c053a96dc854e123759dc73a68caa30d06"
+                "reference": "bc1527bf67733b205d21dcb4583e561a89db935a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gocodebox/lifterlms-tests/zipball/dc4975c053a96dc854e123759dc73a68caa30d06",
-                "reference": "dc4975c053a96dc854e123759dc73a68caa30d06",
+                "url": "https://api.github.com/repos/gocodebox/lifterlms-tests/zipball/bc1527bf67733b205d21dcb4583e561a89db935a",
+                "reference": "bc1527bf67733b205d21dcb4583e561a89db935a",
                 "shasum": ""
             },
             "require": {
@@ -268,7 +268,7 @@
                 }
             ],
             "description": "Testing framework for LifterLMS projects",
-            "time": "2020-04-08T21:01:16+00:00"
+            "time": "2020-04-22T20:52:27+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/includes/abstracts/llms.abstract.notification.processor.php
+++ b/includes/abstracts/llms.abstract.notification.processor.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.8.0
- * @version 3.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,13 +17,14 @@ require_once LLMS_PLUGIN_DIR . 'includes/libraries/wp-background-processing/wp-b
  * LifterLMS Notification Background Processor abstract class
  *
  * @since 3.8.0
+ * @since [version] Modified return of `dispatch()` override to return the return value of the parent method.
  */
 abstract class LLMS_Abstract_Notification_Processor extends WP_Background_Process {
 
 	/**
 	 * Enables event logging
 	 *
-	 * @var  boolean
+	 * @var boolean
 	 */
 	private $enable_logging = true;
 
@@ -62,9 +63,10 @@ abstract class LLMS_Abstract_Notification_Processor extends WP_Background_Proces
 	/**
 	 * Starts the queue
 	 *
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 * @since [version] Added return from parent method.
+	 *
+	 * @return array|WP_Error Response from `wp_remote_post()`.
 	 */
 	public function dispatch() {
 
@@ -75,6 +77,8 @@ abstract class LLMS_Abstract_Notification_Processor extends WP_Background_Proces
 		if ( is_wp_error( $dispatched ) ) {
 			$this->log( sprintf( 'Unable to dispatch %1$s: %2$s' ), $this->action, $dispatched->get_error_message() );
 		}
+
+		return $dispatched;
 
 	}
 

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -25,14 +25,14 @@ class LLMS_Notifications {
 	/**
 	 * Singleton instance
 	 *
-	 * @var  LLMS_Notifications
+	 * @var LLMS_Notifications
 	 */
 	protected static $_instance = null;
 
 	/**
 	 * Controller instances
 	 *
-	 * @var  LLMS_Abstract_Notification_Controller[]
+	 * @var LLMS_Abstract_Notification_Controller[]
 	 */
 	private $controllers = array();
 
@@ -46,30 +46,30 @@ class LLMS_Notifications {
 	/**
 	 * Background processor instances
 	 *
-	 * @var  LLMS_Abstract_Notification_Processor[]
+	 * @var LLMS_Abstract_Notification_Processor[]
 	 */
 	private $processors = array();
 
 	/**
 	 * Array of processors needing to be dispatched on shutdown
 	 *
-	 * @var  string[]
+	 * @var string[]
 	 */
 	private $processors_to_dispatch = array();
 
 	/**
 	 * [string $view_classname => string $trigger ]
 	 *
-	 * @var  string[]
+	 * @var string[]
 	 */
 	private $views = array();
 
 	/**
 	 * Main Instance
 	 *
-	 * @return    LLMS_Notifications
-	 * @since     3.8.0
-	 * @version   3.8.0
+	 * @since 3.8.0
+	 *
+	 * @return LLMS_Notifications
 	 */
 	public static function instance() {
 		if ( is_null( self::$_instance ) ) {
@@ -220,9 +220,9 @@ class LLMS_Notifications {
 	/**
 	 * Get the directory path for core notification classes
 	 *
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @return string
 	 */
 	private function get_directory() {
 		return LLMS_PLUGIN_DIR . 'includes/notifications/';
@@ -231,10 +231,10 @@ class LLMS_Notifications {
 	/**
 	 * Get a single controller instance
 	 *
-	 * @param    string $controller  trigger id (eg: lesson_complete)
-	 * @return   LLMS_Abstract_Notification_Controller|false
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $controller Trigger id (eg: lesson_complete)/
+	 * @return LLMS_Abstract_Notification_Controller|false
 	 */
 	public function get_controller( $controller ) {
 		if ( isset( $this->controllers[ $controller ] ) ) {
@@ -246,9 +246,9 @@ class LLMS_Notifications {
 	/**
 	 * Get loaded controllers
 	 *
-	 * @return   LLMS_Abstract_Notification_Controller[]
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @return LLMS_Abstract_Notification_Controller[]
 	 */
 	public function get_controllers() {
 		return $this->controllers;
@@ -257,10 +257,10 @@ class LLMS_Notifications {
 	/**
 	 * Retrieve a single processor instance
 	 *
-	 * @param    string $processor  name of the processor (eg: email)
-	 * @return   LLMS_Abstract_Notification_Processor|false
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $processor Name of the processor (eg: email).
+	 * @return LLMS_Abstract_Notification_Processor|false
 	 */
 	public function get_processor( $processor ) {
 		if ( isset( $this->processors[ $processor ] ) ) {
@@ -272,9 +272,9 @@ class LLMS_Notifications {
 	/**
 	 * Get loaded processors
 	 *
-	 * @return   LLMS_Abstract_Notification_Processor[]
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @return LLMS_Abstract_Notification_Processor[]
 	 */
 	public function get_processors() {
 		return $this->processors;
@@ -308,11 +308,12 @@ class LLMS_Notifications {
 	/**
 	 * Get the classname for the view of a given notification based off it's trigger
 	 *
-	 * @param    string $trigger  trigger id (eg: lesson_complete).
-	 * @param    string $prefix   default = 'LLMS'
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.24.0
+	 * @since 3.8.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param string $trigger Trigger id (eg: lesson_complete).
+	 * @param string $prefix  Default = 'LLMS'.
+	 * @return string
 	 */
 	private function get_view_classname( $trigger, $prefix = null ) {
 
@@ -325,9 +326,10 @@ class LLMS_Notifications {
 	/**
 	 * Load all notifications
 	 *
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.24.0
+	 * @since 3.8.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @return void
 	 */
 	private function load() {
 
@@ -365,9 +367,15 @@ class LLMS_Notifications {
 		}
 
 		/**
+		 * Run an action after all core notification classes are loaded.
+		 *
 		 * Third party notifications can hook into this action
-		 * Use $this->load_view(), $this->load_controller(), & $this->load_processor()
-		 * to load notifications into the class and be auto-called by the APIs herein
+		 * Use `load_view()`, `load_controller()`, and `load_processor()` methods
+		 * to load notifications into the class and be auto-called by the core APIs.
+		 *
+		 * @since Unknown
+		 *
+		 * @param LLMS_Notifications $this Instance of the notifications singleton.
 		 */
 		do_action( 'llms_notifications_loaded', $this );
 
@@ -376,15 +384,15 @@ class LLMS_Notifications {
 	/**
 	 * Load and initialize a single controller
 	 *
-	 * @param    string $trigger  trigger id (eg: lesson_complete)
-	 * @param    string $path     full path to the controller file, allows third parties to load external controllers
-	 * @return   boolean              true if the controller is added and loaded, false otherwise
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $trigger Trigger id (eg: lesson_complete).
+	 * @param string $path    Full path to the controller file, allows third parties to load external controllers.
+	 * @return boolean ` true` if the controller is added and loaded, `false` otherwise.
 	 */
 	public function load_controller( $trigger, $path = null ) {
 
-		// default path for core views
+		// Default path for core views.
 		if ( ! $path ) {
 			$path = $this->get_directory() . 'controllers/class.llms.notification.controller.' . $this->name_to_file( $trigger ) . '.php';
 		}
@@ -403,15 +411,15 @@ class LLMS_Notifications {
 	/**
 	 * Load a single processor
 	 *
-	 * @param    string $type   processor type id
-	 * @param    string $path   optional path (for allowing 3rd party processor loading)
-	 * @return   boolean
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $type Processor type id.
+	 * @param string $path Optional path (for allowing 3rd party processor loading).
+	 * @return boolean
 	 */
 	public function load_processor( $type, $path = null ) {
 
-		// default path for core processors
+		// Default path for core processors.
 		if ( ! $path ) {
 			$path = $this->get_directory() . 'processors/class.llms.notification.processor.' . $type . '.php';
 		}
@@ -429,17 +437,18 @@ class LLMS_Notifications {
 	/**
 	 * Load a single view
 	 *
-	 * @param    string $trigger  trigger id (eg: lesson_complete)
-	 * @param    string $path     full path to the view file, allows third parties to load external views
-	 * @param    string $prefix   Classname prefix. Defaults to "LLMS". Can be used by 3rd parties to adjust
-	 *                            the prefix in accordance with the projects standards.
-	 * @return   boolean              true if the view is added and loaded, false otherwise
-	 * @since    3.8.0
-	 * @version  3.24.0
+	 * @since 3.8.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param  string $trigger Trigger id (eg: lesson_complete).
+	 * @param  string $path    Full path to the view file, allows third parties to load external views.
+	 * @param  string $prefix  Classname prefix. Defaults to "LLMS". Can be used by 3rd parties to adjust
+	 *                         the prefix in accordance with the projects standards.
+	 * @return boolean `true` if the view is added and loaded, `false` otherwise.
 	 */
 	public function load_view( $trigger, $path = null, $prefix = null ) {
 
-		// default path for core views
+		// Default path for core views.
 		if ( ! $path ) {
 			$path = $this->get_directory() . 'views/class.llms.notification.view.' . $this->name_to_file( $trigger ) . '.php';
 		}
@@ -458,12 +467,13 @@ class LLMS_Notifications {
 
 	/**
 	 * Convert a trigger name to a filename string
-	 * Eg lesson_complete to lesson.complete
 	 *
-	 * @param    string $name  trigger name
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * EG: "lesson_complete" to "lesson.complete".
+	 *
+	 * @since 3.8.0
+	 *
+	 * @param string $name Trigger name.
+	 * @return string
 	 */
 	private function name_to_file( $name ) {
 		return str_replace( '_', '.', $name );

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -558,7 +558,7 @@ class LLMS_Notifications {
 		// If there's no event scheduled already, schedule one.
 		if ( ! $timestamp ) {
 
-			$timestamp = llms_current_time( 'timestamp' );
+			$timestamp = llms_current_time( 'timestamp', 1 );
 
 			// Error encountered scheduling the event.
 			if ( ! as_schedule_single_action( $timestamp, $hook, $args ) ) {

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -167,6 +167,7 @@ class LLMS_Notifications {
 	 *
 	 * @since 3.22.0
 	 * @since 3.36.1 Don't automatically mark notifications as read.
+	 * @since [version] Use `wp_json_decode()` in favor of `json_decode()`.
 	 *
 	 * @return void
 	 */
@@ -177,7 +178,7 @@ class LLMS_Notifications {
 			return;
 		}
 
-		// get 5 most recent new notifications for the current user
+		// Get 5 most recent new notifications for the current user.
 		$query = new LLMS_Notifications_Query(
 			array(
 				'per_page'   => 5,
@@ -189,10 +190,10 @@ class LLMS_Notifications {
 
 		$this->displayed = $query->get_notifications();
 
-		// push to JS
+		// Push to JS.
 		LLMS_Frontend_Assets::enqueue_inline_script(
 			'llms-queued-notifications',
-			'window.llms = window.llms || {};window.llms.queued_notifications = ' . json_encode( $this->displayed ) . ';'
+			'window.llms = window.llms || {};window.llms.queued_notifications = ' . wp_json_encode( $this->displayed ) . ';'
 		);
 
 	}
@@ -282,16 +283,18 @@ class LLMS_Notifications {
 	/**
 	 * Retrieve a view instance of a notification
 	 *
-	 * @param    LLMS_Notification $notification  instance of an LLMS_Notification
-	 * @return   LLMS_Abstract_Notification_View|false
-	 * @since    3.8.0
-	 * @version  3.24.0
+	 * @since 3.8.0
+	 * @since 3.24.0 Unknown.
+	 * @since [version] Use strict comparison.
+	 *
+	 * @param LLMS_Notification $notification Notification instance.
+	 * @return LLMS_Abstract_Notification_View|false
 	 */
 	public function get_view( $notification ) {
 
 		$trigger = $notification->get( 'trigger_id' );
 
-		if ( in_array( $trigger, $this->views ) ) {
+		if ( in_array( $trigger, $this->views, true ) ) {
 			$views = array_flip( $this->views );
 			$class = $views[ $trigger ];
 			$view  = new $class( $notification );
@@ -555,7 +558,6 @@ class LLMS_Notifications {
 					sprintf( __( 'There was an error dispatching the "%s" processor.', 'lifterlms' ), $id )
 				);
 			}
-
 		}
 
 		return $timestamp;

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -118,13 +118,13 @@ class LLMS_Notifications {
 	 * Saves & dispatches those processors.
 	 *
 	 * @since 3.8.0
-	 * @deprecated [version] Deprecated in favor of async dispatching via `LLMS_Notifications::schedule_prcosesors_dispatch()`.
+	 * @deprecated [version] Deprecated in favor of async dispatching via `LLMS_Notifications::schedule_processors_dispatch()`.
 	 *
 	 * @return void
 	 */
 	public function dispatch_processors() {
 
-		llms_log( 'LLMS_Notifications::dispatch_processors() is deprecated. Use LLMS_Notifications::schedule_prcosesors_dispatch() instead.' );
+		llms_log( 'LLMS_Notifications::dispatch_processors() is deprecated. Use LLMS_Notifications::schedule_processors_dispatch() instead.' );
 
 		foreach ( $this->processors_to_dispatch as $key => $name ) {
 			$processor = $this->get_processor( $name );
@@ -141,7 +141,7 @@ class LLMS_Notifications {
 	 *
 	 * Locates the processor by ID and dispatches it for processing.
 	 *
-	 * The trigger hook `llms_dispatch_notification_processor_async` is called by the action scheduler library
+	 * The trigger hook `llms_dispatch_notification_processor_async` is called by the action scheduler library.
 	 *
 	 * @since [version]
 	 *
@@ -233,7 +233,7 @@ class LLMS_Notifications {
 	 *
 	 * @since 3.8.0
 	 *
-	 * @param string $controller Trigger id (eg: lesson_complete)/
+	 * @param string $controller Trigger id (eg: lesson_complete).
 	 * @return LLMS_Abstract_Notification_Controller|false
 	 */
 	public function get_controller( $controller ) {
@@ -388,7 +388,7 @@ class LLMS_Notifications {
 	 *
 	 * @param string $trigger Trigger id (eg: lesson_complete).
 	 * @param string $path    Full path to the controller file, allows third parties to load external controllers.
-	 * @return boolean ` true` if the controller is added and loaded, `false` otherwise.
+	 * @return boolean `true` if the controller is added and loaded, `false` otherwise.
 	 */
 	public function load_controller( $trigger, $path = null ) {
 

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
@@ -1,45 +1,108 @@
 <?php
 /**
  * LLMS_Notifications Tests
+ *
+ * @package LifterLMS/Tests/Notifications
+ *
+ * @since 3.8.0
+ * @since [version] "DRY"ed existing tests and added tests for processor scheduling related functions.
+ *
+ * @group notifications
  */
-
 class LLMS_Test_Notifications extends LLMS_UnitTestCase {
 
-	// public function test_dispatch_processors() {}
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = LLMS()->notifications();
+
+	}
+
+	/**
+	 * Tear down the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+
+		// Clear data for later tests.
+		LLMS_Unit_Test_Util::set_private_property( $this->main, 'processors_to_dispatch', array() );
+
+	}
+
+	/**
+	 * Test dispatch_processor_async() for a fake processor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_dispatch_processor_async_fake() {
+
+		$res = $this->main->dispatch_processor_async( 'fake-processor' );
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'invalid-processor', $res );
+
+	}
+
+	/**
+	 * Test dispatch_processor_async() for a fake processor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_dispatch_processor() {
+
+		$res = $this->main->dispatch_processor_async( 'email' );
+		$this->assertTrue( ! is_wp_error( $res ) );
+
+	}
 
 	/**
 	 * Test the get_controller() method
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Use $this->main for code DRYness.
+	 *
+	 * @return void
 	 */
 	public function test_get_controller() {
 
-		$main = LLMS()->notifications();
-
 		// return the controller instance
-		$this->assertTrue( is_a( $main->get_controller( 'lesson_complete' ), 'LLMS_Notification_Controller_Lesson_Complete' ) );
+		$this->assertTrue( is_a( $this->main->get_controller( 'lesson_complete' ), 'LLMS_Notification_Controller_Lesson_Complete' ) );
 
 		// return false
-		$this->assertFalse( $main->get_controller( 'thisisveryveryfake' ) );
+		$this->assertFalse( $this->main->get_controller( 'thisisveryveryfake' ) );
 
 	}
 
 	/**
 	 * Test get_controllers() method
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Use $this->main for code DRYness.
+	 *
+	 * @return void
 	 */
 	public function test_get_controllers() {
 
-		$main = LLMS()->notifications();
-
 		// should always return an array
-		$this->assertTrue( is_array( $main->get_controllers() ) );
+		$this->assertTrue( is_array( $this->main->get_controllers() ) );
 
 		// each item in the array must extend the controller abstract
-		foreach ( $main->get_controllers() as $controller ) {
+		foreach ( $this->main->get_controllers() as $controller ) {
 			$this->assertTrue( is_subclass_of( $controller, 'LLMS_Abstract_Notification_Controller' ) );
 		}
 
@@ -47,50 +110,145 @@ class LLMS_Test_Notifications extends LLMS_UnitTestCase {
 
 	/**
 	 * Test get_processor() method
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Use $this->main for code DRYness.
+	 *
+	 * @return void
 	 */
 	public function test_get_processor() {
 
-		$main = LLMS()->notifications();
-
 		// return the controller instance
-		$this->assertTrue( is_a( $main->get_processor( 'email' ), 'LLMS_Notification_Processor_Email' ) );
+		$this->assertTrue( is_a( $this->main->get_processor( 'email' ), 'LLMS_Notification_Processor_Email' ) );
 
 		// return false
-		$this->assertFalse( $main->get_processor( 'thisisveryveryfake' ) );
+		$this->assertFalse( $this->main->get_processor( 'thisisveryveryfake' ) );
 
 	}
 
 	/**
 	 * test get_processors() method
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Use $this->main for code DRYness.
+	 *
+	 * @return void
 	 */
 	public function test_get_processors() {
 
-		$main = LLMS()->notifications();
-
 		// should always return an array
-		$this->assertTrue( is_array( $main->get_processors() ) );
+		$this->assertTrue( is_array( $this->main->get_processors() ) );
 
 		// each item in the array must extend the processor abstract
-		foreach ( $main->get_processors() as $processor ) {
+		foreach ( $this->main->get_processors() as $processor ) {
 			$this->assertTrue( is_subclass_of( $processor, 'LLMS_Abstract_Notification_Processor' ) );
 		}
 
 	}
 
-	// public function get_view( $notification ) {}
+	/**
+	 * Test schedule_processing()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_schedule_processing() {
 
-	// public function load_controller( $trigger, $path = null ) {}
+		$expect = array( 'email' );
 
-	// public function load_processor( $type, $path = null ) {}
+		// Schedule.
+		$this->main->schedule_processing( 'email' );
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'processors_to_dispatch' ) );
 
-	// public function load_view( $trigger, $path = null ) {}
+		// Don't add duplicates.
+		$this->main->schedule_processing( 'email' );
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'processors_to_dispatch' ) );
 
-	// public function schedule_processing( $type ) {}
+	}
+
+	/**
+	 * Test schedule_processors_dispatch()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_schedule_processors_dispatch() {
+
+		$now = time();
+		llms_tests_mock_current_time( $now );
+
+		$this->main->schedule_processing( 'email' );
+		$this->main->schedule_processing( 'fake-processor' );
+
+		$res = $this->main->schedule_processors_dispatch();
+
+		$this->assertArrayHaskey( 'email', $res );
+		$this->assertArrayHaskey( 'fake-processor', $res );
+
+		$this->assertEquals( $now, $res['email'] );
+
+		$this->assertIsWPError( $res['fake-processor'] );
+		$this->assertWPErrorCodeEquals( 'invalid-processor', $res['fake-processor'] );
+
+	}
+
+	/**
+	 * Test schedule_processors_dispatch() when none are scheduled
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_schedule_processors_dispatch_none_scheduled() {
+
+		$this->assertEquals( array(), $this->main->schedule_processors_dispatch() );
+
+	}
+
+	/**
+	 * Test schedule_single_processor() when an event is already scheduled
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_schedule_single_processor_already_scheduled() {
+
+		$email = $this->main->get_processor( 'email' )->push_to_queue( 1 );
+
+		// Schedule the event.
+		$orig = LLMS_Unit_Test_Util::call_method( $this->main, 'schedule_single_processor', array( $email, 'email' ) );
+
+		// Time travel.
+		llms_tests_mock_current_time( time() + HOUR_IN_SECONDS );
+
+		// Schedule the event again.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'schedule_single_processor', array( $email, 'email' ) );
+
+		// Original timestamp should be returned.
+		$this->assertEquals( $orig, $res );
+
+	}
+
+	/**
+	 * Test schedule_single_processor() when an existing event does not already exist.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_schedule_single_processor_new() {
+
+		$email = $this->main->get_processor( 'email' )->push_to_queue( 1 );
+
+		$now = time();
+		llms_tests_mock_current_time( $now );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'schedule_single_processor', array( $email, 'email' ) );
+		$this->assertEquals( $now, $res );
+
+	}
 
 }


### PR DESCRIPTION
## Description

This update refactors the code associated with the asynchronous scheduling of notification processor classes.

This doesn't actually fix any issues in the LifterLMS core, but in working on https://github.com/gocodebox/lifterlms-integration-twilio/issues/19 I discovered that there is a potential issue with the way processors are scheduled.

The SMS notification processor in the Twilio plugin is unreliable when tested on my local machine (although these issues cannot be reliably reproduced outside of my environment as @eri-trabiccolo has been unable to find any errors on his local machine).

In any event the issue appears to be related to having multiple processors scheduled to be dispatched using the background processor in the core plugin.

This refactor offloads the async scheduling to the (more reliable) action scheduler library included with the LifterLMS core.

There are some minor changes in this code (like using strict comparisons and wp recommended functions) as well as doc / cs updates to some of the modified files.


EDIT: 
There is a really small downside to this: this method is *slightly* slower than the old method. Using the old method it looks like *mostly* emails were never pushed to a queue where the cron healthcheck would end up sending them. Instead, they would be sent almost instantly via the background process that's spawned upon dispatch. With this method it will *always* be triggered by a cron (via the action schedule) which runs once per minute. So there's the possibility of having at 1 minute delay on the notifications. I don't think this is really a concern *at all* but it's worth noting...

EDIT EDIT:

Furthermore since it will *always* be handled by a cron, sites with malfunctioning or broken crons will never send emails at all. So that's something. But if the cron is broken they're going to get in touch with us about it at some point anyway and we can provide them with steps they can take to get the cron working

## How has this been tested?

+ I have written new unit tests to test all the individual methods introduced in this PR 
+ I have manually tested the existing (and Twilio) notification processors continue to work in the following ways: 

1) Tested notifications processed during enrollment via manual enrollment on the admin panel
2) Notifications processed when a student enrolls in free or paid courses from the frontend
3) Other notifications (like course complete) continue to work

## Screenshots <!-- if applicable -->

## Types of changes

This introduces a new method of scheduling the background processes that is backwards compatible
However, it does add a new function and deprecates the previous function. The previous function is still a publicly callbable function, however it now logs a deprecation notice when used.

A new filter as been introduced which will allow users to switch to the "old" method that doesn't utilize the action scheduler. This will allow us to quickly switch users back to the old method if for some reason that I can't conceive of currently but someone will likely come up with someone wants the old method.

I am not aware of any 3rd party plugins we recommend that have implemented their own processors but unless they are doing something very custom these changes should improve the reliability of their processors with no negative impact.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

