### PR TITLE
Ensure redirect url params (from access plans) are persisted on gateways requiring a payment confirmation

### DIFF
--- a/includes/functions/llms.functions.page.php
+++ b/includes/functions/llms.functions.page.php
@@ -40,7 +40,7 @@ function llms_confirm_payment_url( $order_key = null ) {
 
 	$redirect = urldecode( llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) );
 	if ( $redirect ) {
-		$args['redirect'] = urlencode( $redirect );
+		$args['redirect'] = rawurlencode( $redirect );
 	}
 
 	$url = llms_get_endpoint_url( 'confirm-payment', '', get_permalink( llms_get_page_id( 'checkout' ) ) );

--- a/includes/functions/llms.functions.page.php
+++ b/includes/functions/llms.functions.page.php
@@ -2,9 +2,10 @@
 /**
  * Page functions
  *
- * @since    1.0.0
- * @version  3.26.3
+ * @since 1.0.0
+ * @version [version]
  */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -23,15 +24,37 @@ function llms_cancel_payment_url() {
 /**
  * Get url for redirect when user confirms payment
  *
- * @return string [url to redirect user to on form post]
+ * @since 1.0.0
+ * @since [version] Added redirect query string parameter.
+ *
+ * @return string
  */
 function llms_confirm_payment_url( $order_key = null ) {
 
-	$confirm_payment_url = llms_get_endpoint_url( 'confirm-payment', '', get_permalink( llms_get_page_id( 'checkout' ) ) );
+	$args = array();
 
-	$confirm_payment_url = add_query_arg( 'order', $order_key, $confirm_payment_url );
+	if ( $order_key ) {
+		$args['order'] = $order_key;
+	}
 
-	return apply_filters( 'lifterlms_checkout_confirm_payment_url', $confirm_payment_url );
+	$redirect = urldecode( llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) );
+	if ( $redirect ) {
+		$args['redirect'] = urlencode( $redirect );
+	}
+
+	$url = llms_get_endpoint_url( 'confirm-payment', '', get_permalink( llms_get_page_id( 'checkout' ) ) );
+	if ( $args ) {
+		$url = add_query_arg( $args, $url );
+	}
+
+	/**
+	 * Filter the checkout confirmation URL
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param $string $url URL to the payment confirmation screen.
+	 */
+	return apply_filters( 'lifterlms_checkout_confirm_payment_url', $url );
 
 }
 

--- a/includes/functions/llms.functions.page.php
+++ b/includes/functions/llms.functions.page.php
@@ -11,7 +11,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Get url for when user cancels payment
  *
- * @return string [url to redirect user to on form post]
+ * @since 1.0.0
+ *
+ * @return string
  */
 function llms_cancel_payment_url() {
 
@@ -19,7 +21,6 @@ function llms_cancel_payment_url() {
 	return apply_filters( 'lifterlms_checkout_confirm_payment_url', $cancel_payment_url );
 
 }
-
 
 /**
  * Get url for redirect when user confirms payment
@@ -52,7 +53,7 @@ function llms_confirm_payment_url( $order_key = null ) {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param $string $url URL to the payment confirmation screen.
+	 * @param string $url URL to the payment confirmation screen.
 	 */
 	return apply_filters( 'lifterlms_checkout_confirm_payment_url', $url );
 
@@ -62,18 +63,21 @@ function llms_confirm_payment_url( $order_key = null ) {
 /**
  * Retrieve the full URL to a LifterLMS endpoint
  *
- * @param    string $endpoint   ID of the endpoint, eg "view-courses"
- * @param    string $value
- * @param    string $permalink  base URL to append the endpoint to
- * @return   string
- * @since    1.0.0
- * @version  3.26.3
+ * @since 1.0.0
+ * @since 3.26.3 Unknown.
+ *
+ * @param string $endpoint  ID of the endpoint, eg "view-courses".
+ * @param string $value     Endpoint query arg value (Optional as the presence of the arg is enough in most scenarios).
+ * @param string $permalink Base URL to append the endpoint to. Optional, uses the current page when not supplied.
+ * @return string
  */
 function llms_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
-	if ( ! $permalink ) {
-		$permalink = get_permalink(); }
 
-	// Map endpoint to options
+	if ( ! $permalink ) {
+		$permalink = get_permalink();
+	}
+
+	// Map endpoint to options.
 	$vars     = LLMS()->query->get_query_vars();
 	$endpoint = isset( $vars[ $endpoint ] ) ? $vars[ $endpoint ] : $endpoint;
 
@@ -90,27 +94,57 @@ function llms_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 		$url = add_query_arg( $endpoint, $value, $permalink );
 	}
 
+	/**
+	 * Filter the final endpoint URL.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $url      The endpoint URL.
+	 * @param string $endpoint The requested endpoint.
+	 */
 	return apply_filters( 'lifterlms_get_endpoint_url', $url, $endpoint );
 }
 
 
 /**
- * Retrieve the WordPress Page ID of a LifterLMS Page
+ * Retrieve the WordPress Page ID of a LifterLMS Core Page
  *
- * core pages: myaccount, checkout, memberships, courses
+ * Available core pages are:
+ * + checkout (formerly "shop")
+ * + courses (Course catalog)
+ * + myaccount (Student Dashboard)
+ * + memberships (Membership catalog)
  *
- * @param  string $page name of the page
- * @return int
+ * @since 1.0.0
+ *
+ * @param string $page The page slug/name.
+ * @return int The WP_Post ID of the page or -1 if the page is not found.
  */
 function llms_get_page_id( $page ) {
 
-	// normalize some pages to make more sense without having to migrate options
+	// Normalize some pages to make more sense without having to migrate options.
 	if ( 'courses' === $page ) {
 		$page = 'shop';
 	}
 
-	$page = apply_filters( 'lifterlms_get_' . $page . '_page_id', get_option( 'lifterlms_' . $page . '_page_id' ) );
+	$id = get_option( 'lifterlms_' . $page . '_page_id' );
+
+	/**
+	 * Filter the ID of the requested LifterLMS Page
+	 *
+	 * The dynamic portion of this filter, {$page}, refers to the LifterLMS page slug/name.
+	 *
+	 * Note that, historically, the course catalog was called the "shop" and therefore when requesting
+	 * the filter will be "lifterlms_get_shop_page_id" instead of "lifterlms_get_courses_page_id".
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int|string $id The WP_Post ID of the requested page or an empty string if the page doesn't exist.
+	 */
+	$page = apply_filters( "lifterlms_get_{$page}_page_id", $id );
+
 	return $page ? absint( $page ) : -1;
+
 }
 
 
@@ -120,8 +154,8 @@ function llms_get_page_id( $page ) {
  *
  * @since  3.0.0
  *
- * @param  string $page name of the page
- * @param  array  $args optional array of query arguments that can be passed to add_query_arg()
+ * @param string $page Name of the page.
+ * @param array  $args Optional array of query arguments that can be passed to add_query_arg().
  * @return string
  */
 function llms_get_page_url( $page, $args = array() ) {

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Test page functions
+ *
+ * @package LifterLMS/Tests/Functions
+ *
+ * @group functions
+ * @group functions_page
+ *
+ * @since [version]
+ */
+class LLMS_Test_Functions_Fage extends LLMS_UnitTestCase {
+
+	/**
+	 * Test the llms_confirm_payment_url() function.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_confirm_payment_url() {
+
+		LLMS_Install::create_pages();
+
+		$base = get_permalink( llms_get_page_id( 'checkout' ) ) . '&confirm-payment';
+
+		// No additional args provided.
+		$this->assertEquals( $base, llms_confirm_payment_url() );
+
+		// Has order key.
+		$this->assertEquals( $base . '&order=fake', llms_confirm_payment_url( 'fake' ) );
+
+		// Has redirect.
+		$this->mockGetRequest( array(
+			'redirect' => get_site_url(),
+		) );
+		$this->assertEquals( $base . '&redirect=' . urlencode( get_site_url() ), llms_confirm_payment_url() );
+
+		// Has both.
+		$this->assertEquals( $base . '&order=fake&redirect=' . urlencode( get_site_url() ), llms_confirm_payment_url( 'fake' ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
@@ -41,4 +41,49 @@ class LLMS_Test_Functions_Fage extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test the llms_get_page_id() function.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_page_id() {
+
+		$pages = array(
+			'checkout' => 'checkout',
+			'courses' => 'shop',
+			'myaccount' => 'myaccount',
+			'memberships' => 'memberships',
+		);
+
+		// Options don't exist.
+
+		// Backwards compat.
+		$this->assertEquals( -1, llms_get_page_id( 'shop' ) );
+
+		foreach ( array_keys( $pages ) as $slug ) {
+			$this->assertEquals( -1, llms_get_page_id( $slug ) );
+		}
+
+		// Options do exist.
+		LLMS_Install::create_pages();
+
+		// Backwards compat.
+		$this->assertEquals( get_option( 'lifterlms_shop_page_id' ), llms_get_page_id( 'shop' ) );
+
+		foreach ( $pages as $slug => $option ) {
+
+			$id = llms_get_page_id( $slug );
+
+			// Number.
+			$this->assertTrue( is_int( $id ) );
+
+			// Equals expected option value.
+			$this->assertEquals( get_option( 'lifterlms_' . $option . '_page_id' ), $id );
+
+		}
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-page.php
@@ -57,6 +57,11 @@ class LLMS_Test_Functions_Fage extends LLMS_UnitTestCase {
 			'memberships' => 'memberships',
 		);
 
+		// Clear options maybe installed by other tests.
+		foreach ( array_values( $pages ) as $option ) {
+			delete_option( 'lifterlms_' . $option . '_page_id' );
+		}
+
 		// Options don't exist.
 
 		// Backwards compat.


### PR DESCRIPTION
## Description

This adds an additional check to the function used to create the confirmation page url.

This code in the core will ensure any payment gateways leveraging the confirm-payment endpoint will have the checkout redirect upon success that's found in other gateways that do not use the confirm-payment endoinpt

Fixes https://github.com/gocodebox/lifterlms-gateway-paypal/issues/37

This issue occurs because the `llms_confirm_payment_url()` method drops the redirect found in the URL so upon confirmation there's no redirect for the gateway `complete_transaction()` method to utilize for the custom redirct.

This PR also cleans up documentation in the updated file

## How has this been tested?

+ Added new unit tests
+ Manually tested checkout using gateways with and without confirmation pages and with and without access plans with redirects

## Types of changes

Non breaking bug-fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

