### PR TITLE
Issue/1128

### DIFF
--- a/includes/functions/llms.functions.templates.pricing.table.php
+++ b/includes/functions/llms.functions.templates.pricing.table.php
@@ -196,6 +196,7 @@ if ( ! function_exists( 'lifterlms_template_pricing_table' ) ) {
 	 * Include pricing table for a LifterLMS Product (course or membership)
 	 *
 	 * @since 3.0.0
+	 * @since [version] Fixed spelling error in variable passed to template.
 	 *
 	 * @param int $post_id Optional. WP Post ID of the product. Default is ID of the global $post.
 	 * @return void
@@ -220,13 +221,26 @@ if ( ! function_exists( 'lifterlms_template_pricing_table' ) ) {
 			llms_is_user_enrolled( get_current_user_id(), $product->get( 'id' ) )
 		);
 
-		$purchaseable     = $product->is_purchasable();
+		$purchasable      = $product->is_purchasable();
 		$has_free         = $product->has_free_access_plan();
 		$has_restrictions = $product->has_restrictions();
 
+		/**
+		 * Fix variable spelling in a backwards compatible way
+		 *
+		 * If the template "product/pricing-table.php" is overwritten and relies
+		 * on the misspelled variable, passing both versions in will ensure the
+		 * template continues to function as expected.
+		 *
+		 * @link https://github.com/gocodebox/lifterlms/issues/1128
+		 *
+		 * @deprecated [version]
+		 */
+		$purchaseable = $purchasable;
+
 		llms_get_template(
 			'product/pricing-table.php',
-			compact( 'product', 'is_enrolled', 'purchaseable', 'has_free', 'has_restrictions' )
+			compact( 'product', 'is_enrolled', 'purchasable', 'purchaseable', 'has_free', 'has_restrictions' )
 		);
 
 	}

--- a/includes/models/model.llms.product.php
+++ b/includes/models/model.llms.product.php
@@ -245,7 +245,7 @@ class LLMS_Product extends LLMS_Post_Model {
 	/**
 	 * Retrieve a list of restrictions on the product
 	 *
-	 * Restrictions are used to in conjunction with "is_purchaseable()" to
+	 * Restrictions are used to in conjunction with "is_purchasable()" to
 	 * determine if purchase/enrollment should be allowed for a given product.
 	 *
 	 * Restrictions in the core currently only exist on courses:

--- a/templates/product/pricing-table.php
+++ b/templates/product/pricing-table.php
@@ -9,17 +9,33 @@
  *
  * @property LLMS_Product $product          Product object of the course or membership.
  * @property bool         $is_enrolled      Determines if current viewer is enrolled in $product.
- * @property bool         $purchaseable     Determines if current product is purchasable.
+ * @property bool         $purchasable      Determines if current product is purchasable.
  * @property bool         $has_free         Determines if any free access plans are available for the product.
  * @property bool         $has_restrictions Determines if any free access plans are available for the product.
  */
 
 defined( 'ABSPATH' ) || exit;
 
-$free_only = ( $has_free && ! $purchaseable );
+/**
+ * Fix variable spelling in a backwards compatible way
+ *
+ * If the function `lifterlms_template_pricing_table()` is plugged or this template is loaded
+ * some other way, and the misspelled variable is still passed in this will ensure that the
+ * template continues to function as expected.
+ *
+ * @link https://github.com/gocodebox/lifterlms/issues/1128
+ *
+ * @deprecated [version]
+ */
+if ( $purchaseable && ! $purchasable ) {
+	llms_deprecated_function( 'Passing variable `$purchaseable` to template "product/pricing-table.php"', '[version]', '`$purchasable`' );
+	$purchasable = $purchaseable;
+}
+
+$free_only = ( $has_free && ! $purchasable );
 ?>
 
-<?php if ( ! $is_enrolled && ! $has_restrictions && ( $purchaseable || $has_free ) ) : ?>
+<?php if ( ! $is_enrolled && ! $has_restrictions && ( $purchasable || $has_free ) ) : ?>
 
 	<?php
 		/**

--- a/templates/product/pricing-table.php
+++ b/templates/product/pricing-table.php
@@ -27,7 +27,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @deprecated [version]
  */
-if ( $purchaseable && ! $purchasable ) {
+if ( isset( $purchaseable ) && ! isset( $purchasable ) ) {
 	llms_deprecated_function( 'Passing variable `$purchaseable` to template "product/pricing-table.php"', '[version]', '`$purchasable`' );
 	$purchasable = $purchaseable;
 }

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-pricing-table.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-pricing-table.php
@@ -59,7 +59,7 @@ class LLMS_Test_Functions_Templates_Pricing_Table extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lifterlms_template_pricing_table_purchaseable() {
+	public function test_lifterlms_template_pricing_table_purchasable() {
 
 		$this->setManualGatewayStatus( 'yes' );
 


### PR DESCRIPTION
## Description

Fixes spelling errors identified in #1128, preserving backwards compatibility.

Fixes #1128

## How has this been tested?

Existing tests pass
Manually tested pricing table output

## Screenshots <!-- if applicable -->

## Types of changes

Spelling errors in code and docs, maintains backwards compatibility

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

