### PR TITLE
Fix bbpress forums not private

### DIFF
--- a/includes/integrations/class.llms.integration.bbpress.php
+++ b/includes/integrations/class.llms.integration.bbpress.php
@@ -258,7 +258,7 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 			 WHERE metas.meta_key = '_llms_bbp_forum_ids'
 			   AND metas.meta_value REGEXP %s
 			   AND posts.post_status = 'publish';",
-				'(?<!;)(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . sprintf( '%d', absint( $forum_id ) ) . '"?;)'
+				'a:[0-9][0-9]*:{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . sprintf( '%d', absint( $forum_id ) ) . '"?;)'
 			)
 		);
 


### PR DESCRIPTION
## Description

Fixes #1132 

## How has this been tested?
Manually and with new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

The new query to retrieve the courses associated to a fourm takes care of the backward compatibility, when we used to save forum ids as array of integers.
It also fixes a possible very edge case where when looking for forum ids we could also erroneously match the index of the serialized array.

@thomasplevy in our bug scrub we talked about an alternative method to avoid the wrong match, well we were tired, that just couldn't work - we said that we would have checked the the retrieved posts were actually courses - because the edge case of course would have matched courses since only courses have the meta key we match against :D

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

