### PR TITLE
Membership associations

### DIFF
--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -48,7 +48,7 @@ class LLMS_Post_Types {
 	 * @since 3.0.0
 	 * @since 3.0.4 Unknown.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public static function add_membership_restriction_support() {
 

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -32,8 +32,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Membership
 extends LLMS_Post_Model
-implements LLMS_Interface_Post_Instructors
-		 , LLMS_Interface_Post_Sales_Page {
+implements LLMS_Interface_Post_Instructors, LLMS_Interface_Post_Sales_Page {
 
 	/**
 	 * Membership post meta.
@@ -293,12 +292,13 @@ implements LLMS_Interface_Post_Instructors
 	 * Determine if sales page redirection is enabled
 	 *
 	 * @since 3.20.0
+	 * @since [version] Use strict array comparison.
 	 *
 	 * @return string
 	 */
 	public function has_sales_page_redirect() {
 		$type = $this->get( 'sales_page_content_type' );
-		return apply_filters( 'llms_membership_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ) ), $this, $type );
+		return apply_filters( 'llms_membership_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ), true ), $this, $type );
 	}
 
 	/**
@@ -379,9 +379,9 @@ implements LLMS_Interface_Post_Instructors
 				   AND metas.meta_key = %s
 				   AND metas.meta_value REGEXP %s;",
 					$post_type,
-				    $enabled_key,
-				    $enabled_value,
-				    $list_key,
+					$enabled_key,
+					$enabled_value,
+					$list_key,
 					'a:[0-9][0-9]*:{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . $this->get( 'id' ) . '"?;)'
 				)
 			);

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -2,7 +2,7 @@
 /**
  * LifterLMS Membership Model
  *
- * @package LifterLMS/Models/Classes
+ * @package LifterLMS/Models
  *
  * @since 3.0.0
  * @version [version]

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -147,8 +147,8 @@ implements LLMS_Interface_Post_Instructors, LLMS_Interface_Post_Sales_Page {
 			return isset( $posts[ $post_type ] ) ? $posts[ $post_type ] : array();
 		}
 
-		// Otherwise return everything.
-		return $posts;
+		// Remove empty arrays and return the rest.
+		return array_filter( $posts );
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-membership.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-membership.php
@@ -79,12 +79,7 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 
 		$membership = $this->factory->membership->create_and_get();
 
-		$expected = array(
-			'post'   => array(),
-			'page'   => array(),
-			'course' => array(),
-		);
-		$this->assertEquals( $expected, $membership->get_associated_posts() );
+		$this->assertEquals( array(), $membership->get_associated_posts() );
 
 		$this->assertEquals( array(), $membership->get_associated_posts( 'course' ) );
 		$this->assertEquals( array(), $membership->get_associated_posts( 'page' ) );


### PR DESCRIPTION
## Description

In working on https://github.com/gocodebox/lifterlms-groups/issues/61 I determined that it's currently impossible to easily determine what content on a LLMS-powered site is considered to be "part" of a membership.

This PR tackles the very early stages of answering this question.

This code puts forth that what belongs to a membership is:

https://github.com/gocodebox/lifterlms/blob/4da2a032b25bdb46ac3415df2e40f9c034232236/includes/models/model.llms.membership.php#L99-L102

This PR adds a single public method, `LLMS_Membership::get_associated_posts()` which queries for associations as defined by the above statement.

Initially, this method will be used to solve the groups reporting issue identified by https://github.com/gocodebox/lifterlms-groups/issues/61 but in the future we should build an editor block and possibly a widget and maybe a shortcode (even though I really don't want to build any new shortcodes ever) that can be used on membership pages and etc... to provide membership members with lists of content available through the membership, instead of forcing site admins to list this content out manually.

## How has this been tested?

Since the new method won't actually be used anywhere in the core codebase there's no way to actually see it in action except via the new tests that have been written and which are included in this PR.

## Types of changes

 New public function added to the internal api.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

