### PR TITLE
Make sure a question's question_type is always available, 'choice' by…

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.13.0
- * @version 3.38.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  *                Added new filter, `llms_builder_{$post_type}_force_delete` to allow control of how post type deletion is handled
  *                when deleted via the builder.
  * @since 3.38.0 Improve backwards compatibility handling for the `llms_get_quiz_theme_settings` filter.
+ * @since [version] On quiz saving, made sure that a question as a type set, otherwise set it by default to `'choice'`.
  */
 class LLMS_Admin_Builder {
 
@@ -1051,11 +1052,13 @@ class LLMS_Admin_Builder {
 	/**
 	 * Update quiz questions from heartbeat data
 	 *
-	 * @param    array $questions  question data array
-	 * @param    obj   $parent    instance of an LLMS_Quiz or LLMS_Question (group)
-	 * @return   array
-	 * @since    3.16.0
-	 * @version  3.16.11
+	 * @since 3.16.0
+	 * @since 3.16.11 Unknown.
+	 * @since [version] Make sure that a question as a type set, otherwise set it by default to `'choice'`.
+	 *
+	 * @param array $questions Question data array.
+	 * @param obj   $parent    Instance of an LLMS_Quiz or LLMS_Question (group).
+	 * @return array
 	 */
 	private static function update_questions( $questions, $parent ) {
 
@@ -1070,16 +1073,16 @@ class LLMS_Admin_Builder {
 				)
 			);
 
-			// remove temp id if we have one so we'll create a new question
+			// Remove temp id if we have one so we'll create a new question.
 			if ( self::is_temp_id( $q_data['id'] ) ) {
 				unset( $q_data['id'] );
 			}
 
-			// remove choices because we'll add them individually after creation
+			// Remove choices because we'll add them individually after creation.
 			$choices = ( isset( $q_data['choices'] ) && is_array( $q_data['choices'] ) ) ? $q_data['choices'] : false;
 			unset( $q_data['choices'] );
 
-			// remove child questions if it's a question group
+			// Remove child questions if it's a question group.
 			$questions = ( isset( $q_data['questions'] ) && is_array( $q_data['questions'] ) ) ? $q_data['questions'] : false;
 			unset( $q_data['questions'] );
 
@@ -1096,6 +1099,14 @@ class LLMS_Admin_Builder {
 
 				$question = $parent->questions()->get_question( $question_id );
 
+				/**
+				 * When saving a question, make sure that it has a question type set
+				 * otherwise set it by default to `'choice'`.
+				 */
+				if ( ! $question->get( 'question_type', true ) ) {
+					$question->set( 'question_type', 'choice' );
+				}
+
 				if ( $choices ) {
 
 					$ret['choices'] = array();
@@ -1111,7 +1122,7 @@ class LLMS_Admin_Builder {
 
 						unset( $c_data['question_id'] );
 
-						// remove the temp ID so that we create it if it's new
+						// Remove the temp ID so that we create it if it's new.
 						if ( self::is_temp_id( $c_data['id'] ) ) {
 							unset( $c_data['id'] );
 						}

--- a/includes/models/model.llms.question.php
+++ b/includes/models/model.llms.question.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * LifterLMS Quiz Question Model.
+ * LifterLMS Quiz Question Model
  *
  * @package LifterLMS/Models
  *
  * @since 1.0.0
- * @version 3.35.0
+ * @version [version]
  *
  * @property  $question_type  (string)  type of question
  */
@@ -13,11 +13,12 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS Quiz Question Model.
+ * LLMS Quiz Question Model class
  *
  * @since 1.0.0
  * @since 3.30.1 Fixed choice sorting issues.
  * @since 3.35.0 Escape `LIKE` clause when retrieving choices.
+ * @since [version] When getting the 'not raw' question_type, made sure to always return a valid value.
  */
 class LLMS_Question extends LLMS_Post_Model {
 
@@ -172,6 +173,29 @@ class LLMS_Question extends LLMS_Post_Model {
 		);
 
 		return apply_filters( 'llms_' . $this->model_post_type . '_get_creation_args', $args, $this );
+
+	}
+
+
+	/**
+	 * Getter
+	 *
+	 * @since [version]
+	 *
+	 * @param string  $key The property key.
+	 * @param boolean $raw Optional. Whether or not we need to get the raw value. Default false.
+	 * @return mixed
+	 */
+	public function get( $key, $raw = false ) {
+
+		$value = parent::get( $key, $raw );
+
+		// When getting the 'not raw' value, make sure we always return a valid question type.
+		if ( ! $raw && ! $value && 'question_type' === $key ) {
+			$value = 'choice';
+		}
+
+		return $value;
 
 	}
 


### PR DESCRIPTION
… default

<!-- 
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/master/.github/CONTRIBUTING.md
-->

## Description
Fixes #1143 


## How has this been tested?

First reproduce the issue described in #1143 by emptying the question_type of a question in the db (either manually, with code, I used an exported course that had this problem). [EDIT: `emptying` here was a wrong concept, I meant: set the post meta `_llms_question_type` to an empty string]
Then apply this patch and see that the questions are correctly loaded in the builder.
Also make some change to the "broken" question so that on save the question type will be saved as 'choice'.
Check that this actually happened, either manually in the db or getting the question's `question_type` raw value:
`$question->get( 'question_type', true );`

## Screenshots

## Types of changes
Bug fix (non-breaking change which fixes an issue).
Well I think this is borderline, it's not a bug fix, but something that takes into account possible faults of the stored data, possibly because of a db update not went completely through!?

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

@thomasplevy 
I haven't written any unit test yet, can you tell me if you think this is a valid way to approach the issue?
