### PR TITLE
Upgrade actions-scheduler library to latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,9 @@
     }
   ],
   "require": {
-    "prospress/action-scheduler": "dev-master",
     "lifterlms/lifterlms-blocks": "^1.1",
-    "lifterlms/lifterlms-rest": "^1.0.0-beta.3"
+    "lifterlms/lifterlms-rest": "^1.0.0-beta.3",
+    "woocommerce/action-scheduler": "3.1.6"
   },
   "require-dev": {
     "lifterlms/lifterlms-tests": "dev-master",
@@ -72,9 +72,6 @@
       "!/vendor",
 
       "/vendor/bin",
-      "/vendor/prospress/action-scheduler/codecov.yml",
-      "/vendor/prospress/action-scheduler/docs",
-      "/vendor/prospress/action-scheduler/tests",
       "/vendor/**/**/composer.*",
       "/vendor/**/**/*.md",
       "/vendor/**/**/.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "245f35bb797363b8e243f2e3ced03117",
+    "content-hash": "02297134257218229475a2f3dca006f2",
     "packages": [
         {
             "name": "lifterlms/lifterlms-blocks",
@@ -74,33 +74,56 @@
             "time": "2020-05-27T22:58:20+00:00"
         },
         {
-            "name": "prospress/action-scheduler",
-            "version": "dev-master",
+            "name": "woocommerce/action-scheduler",
+            "version": "3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "c9a9e8c95aca616046820e9a53f76190d2f7700c"
+                "reference": "275d0ba54b1c263dfc62688de2fa9a25a373edf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/c9a9e8c95aca616046820e9a53f76190d2f7700c",
-                "reference": "c9a9e8c95aca616046820e9a53f76190d2f7700c",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/275d0ba54b1c263dfc62688de2fa9a25a373edf8",
+                "reference": "275d0ba54b1c263dfc62688de2fa9a25a373edf8",
                 "shasum": ""
             },
             "require-dev": {
-                "wp-cli/wp-cli": "1.5.1"
+                "phpunit/phpunit": "^5.6",
+                "woocommerce/woocommerce-sniffs": "0.0.8",
+                "wp-cli/wp-cli": "~1.5.1"
             },
             "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "test": "Run unit tests",
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "phpcs": [
+                    "phpcs -s -p"
+                ],
+                "phpcs-pre-commit": [
+                    "phpcs -s -p -n"
+                ],
+                "phpcbf": [
+                    "phpcbf -p"
+                ]
+            },
             "license": [
-                "GPL-3.0"
+                "GPL-3.0-or-later"
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
+            "homepage": "https://actionscheduler.org/",
             "support": {
-                "source": "https://github.com/Prospress/action-scheduler/tree/master",
-                "issues": "https://github.com/Prospress/action-scheduler/issues"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.1.6",
+                "issues": "https://github.com/woocommerce/action-scheduler/issues"
             },
-            "abandoned": "woocommerce/action-scheduler",
-            "time": "2019-05-07T21:36:13+00:00"
+            "time": "2020-05-12T16:22:33+00:00"
         }
     ],
     "packages-dev": [
@@ -2362,7 +2385,6 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "prospress/action-scheduler": 20,
         "lifterlms/lifterlms-tests": 20,
         "lifterlms/lifterlms-cs": 20
     },

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -286,7 +286,7 @@ class LLMS_Loader {
 		}
 
 		// Action Scheduler.
-		require_once LLMS_PLUGIN_DIR . 'vendor/prospress/action-scheduler/action-scheduler.php';
+		require_once LLMS_PLUGIN_DIR . 'vendor/woocommerce/action-scheduler/action-scheduler.php';
 
 	}
 


### PR DESCRIPTION
## Description

Switches from prospress/action-scheduler to woocommerce/action-scheduler -- The repository has been moved but it's the same library.

Upgrades to latest version (3.1.6)

Resolves #1011

## How has this been tested?

Existing unit tests already cover much of functionality supplied by the library. They still pass.

I've also manually tested the following areas of the codebase to ensure the action scheduler continues to function as expected:
+ Background processes to fire emails still fire
+ Scheduled payments fire as expected
+ new recurring orders (and recurring trial orders) have their next payment properly scheduled
+ a recurring payment that fires in the background fires and properly schedules it's next payment

## Screenshots <!-- if applicable -->

## Types of changes

While this is a semantically major upgrade of the 3rd-party library there are no backwards incompatible changes to the public API. Although there have been several deprecated functions/classes. The LifterLMS core does not directly use any of these deprecated functions but 3rd parties might and should review the changelog of the library to see if they are affected by any deprecations: https://github.com/woocommerce/action-scheduler/releases

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

