### PR TITLE
remove classnames that conflict with bootstrap

### DIFF
--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Templates
  *
  * @since 3.0.0
- * @version 3.21.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,7 +31,7 @@ if ( ! empty( $message ) ) {
 
 <?php do_action( 'llms_before_person_login_form' ); ?>
 
-<div class="col-1 llms-person-login-form-wrapper">
+<div class="llms-person-login-form-wrapper">
 
 	<form action="" class="llms-login" method="POST">
 

--- a/templates/global/form-registration.php
+++ b/templates/global/form-registration.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Templates
  *
  * @since 3.0.0
- * @version 3.19.4
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -22,7 +22,7 @@ if ( get_current_user_id() ) {
 
 <?php do_action( 'lifterlms_before_person_register_form' ); ?>
 
-<div class="col-2 llms-new-person-form-wrapper">
+<div class="llms-new-person-form-wrapper">
 
 	<h4 class="llms-form-heading"><?php _e( 'Register', 'lifterlms' ); ?></h4>
 


### PR DESCRIPTION
## Description

Resolves #888

Removes classnames from student dashbord login and registration form wrapper elements which conflict with bootstrap causing visual issues.

These classes are not used by the LifterLMS core or add-ons and are a legacy class that hasn't been removed for fear of creating backwards compatibility issues with any custom css, 3rd party themes, etc...

## How has this been tested?

Visually inspected forms with common recommended themes and LaunchPad after removal


## Types of changes

**Breaking change**: removes css classes from the following templates:

+ templates/global/form-login.php: Removes `col-1` class from the `div.llms-person-login-form-wrapper` element.
+ templates/global/form-registration.php: : Removes `col-2` class from the `div.llms-new-person-form-wrapper` element.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

