### PR TITLE
MailHawk integration

### DIFF
--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -292,11 +292,12 @@
 		 */
 		remoteInstall: function( $btn, data, callback ) {
 
+			$btn.parent().find( '.llms-error' ).remove();
 			$.post( ajaxurl, data, callback ).fail( function( jqxhr ) {
 				LLMS.Spinner.stop( $btn );
-				$btn.parent().find( '.llms-error' ).remove();
-				if ( jqxhr.responseJSON && jqxhr.responseJSON.message ) {
-					$( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': jqxhr.responseJSON.message } ) + '</p>' ).insertAfter( $btn );
+				var msg = jqxhr.responseJSON && jqxhr.responseJSON.message ? jqxhr.responseJSON.message : jqxhr.responseText;
+				if ( msg ) {
+					$( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': msg } ) + '</p>' ).insertAfter( $btn );
 				}
 			} );
 

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -1,10 +1,8 @@
 /**
  * LifterLMS Admin Panel Javascript
  *
- * @since ??
- * @since 3.32.0 `llmsPostsSelect2` function allows posts fecthing based on post statuses.
- * @since 3.37.2 `llmsPostsSelect2` function allows posts (llms posts) fetching filtered by their instructor id.
- * @version 3.37.2
+ * @since Unknown
+ * @version [version]
  *
  * @param obj $ Traditional jQuery reference.
  * @return void
@@ -160,7 +158,7 @@
 
 	};
 
-	// automatically setup any select with the `llms-posts-select2` class
+	// Automatically setup any select with the `llms-posts-select2` class.
 	$( 'select.llms-posts-select2' ).llmsPostsSelect2();
 
 	/**
@@ -238,4 +236,73 @@
 
 	};
 
+	/**
+	 * Scripts for use on the engagements settings tab for email provider connector plugins
+	 *
+	 * @since [version]
+	 */
+	window.llms.emailConnectors = {
+
+		/**
+		 * Register a client
+		 *
+		 * Builds and submits a form used to direct the user to the connector's oAuth
+		 * authorization endpoint.
+		 *
+		 * @since [version]
+		 *
+		 * @param {String} url    Redirect URL.
+		 * @param {Object} fields Hash of fields where the key is the field name and the value if the field value.
+		 * @return {Void}
+		 */
+		registerClient: function( url, fields ) {
+
+			var form = document.createElement( 'form' );
+			form.setAttribute( 'method', 'POST' );
+			form.setAttribute( 'action', url );
+
+			function appendInput( name, value ) {
+				var input = document.createElement( 'input' );
+				input.setAttribute( 'type', 'hidden' );
+				input.setAttribute( 'name', name );
+				input.setAttribute( 'value', value );
+				form.appendChild( input );
+			}
+
+			$.each( fields, function( key, val ) {
+				appendInput( key, val );
+			} );
+
+			document.body.appendChild( form );
+			form.submit();
+
+		},
+
+		/**
+		 * Performs an AJAX request to perform remote installation of the connector plugin
+		 *
+		 * The callback will more than likely use `registerClient()` on success.
+		 *
+		 * @since [version]
+		 *
+		 * @param {Object}   $btn     jQuery object for the connector button.
+		 * @param {Object}   data     Hash of data used for the ajax request.
+		 * @param {Function} callback Success callback function.
+		 * @return {Void}
+		 */
+		remoteInstall: function( $btn, data, callback ) {
+
+			$.post( ajaxurl, data, callback ).fail( function( jqxhr ) {
+				LLMS.Spinner.stop( $btn );
+				$btn.parent().find( '.llms-error' ).remove();
+				if ( jqxhr.responseJSON && jqxhr.responseJSON.message ) {
+					$( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': jqxhr.responseJSON.message } ) + '</p>' ).insertAfter( $btn );
+				}
+			} );
+
+		}
+
+	};
+
 } )( jQuery );
+

--- a/assets/scss/admin/_settings.scss
+++ b/assets/scss/admin/_settings.scss
@@ -69,9 +69,11 @@
 			margin: -20px -20px 20px;
 		}
 
-		// form elements
 		.form-table {
 			margin: 0;
+			tr:first-child .llms-subtitle {
+				margin-top: 0;
+			}
 		}
 
 		td[colspan="2"] {
@@ -116,6 +118,31 @@
 					background: #fff;
 				}
 			}
+		}
+	}
+
+	// Email Delivery providers.
+	#llms-mailhawk-connect {
+		font-size: 16px;
+		height: auto;
+		margin: 0 0 6px;
+		padding: 8px 14px;
+		position: relative;
+
+		.dashicons {
+			margin: -4px 4px 0 0;
+			vertical-align: middle;
+		}
+	}
+	#llms-sendwp-connect {
+		font-size: 16px;
+		height: auto;
+		margin: 0 0 6px;
+		padding: 8px 14px;
+		position: relative;
+
+		.fa {
+			margin-right: 4px;
 		}
 	}
 

--- a/includes/abstracts/llms-abstract-email-provider.php
+++ b/includes/abstracts/llms-abstract-email-provider.php
@@ -1,0 +1,371 @@
+<?php
+/**
+ * Base class used by email delivery provider "connector" classes
+ *
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Abstract_Email_Provider
+ *
+ * @since [version]
+ */
+abstract class LLMS_Abstract_Email_Provider {
+
+	/**
+	 * Connector's ID.
+	 *
+	 * @var string
+	 */
+	protected $id = '';
+
+	/**
+	 * Configures the response returned when `do_remote_install()` is successful.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	abstract protected function do_remote_install_success();
+
+
+	/**
+	 * Retrieve the settings area HTML for the connect button
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	abstract protected function get_connect_setting();
+
+	/**
+	 * Retrieve description text to be used in the settings area.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	abstract protected function get_description();
+
+	/**
+	 * Retrieve the connector's name / title.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	abstract protected function get_title();
+
+	/**
+	 * Determines if connector plugin is connected for sending.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	abstract protected function is_connected();
+
+	/**
+	 * Determines if connector plugin is installed
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	abstract protected function is_installed();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+
+		add_action( 'admin_init', array( $this, 'init' ) );
+
+	}
+
+	/**
+	 * Initialize the MailHawk Connector
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		/**
+		 * Disable the Connector class and settings
+		 *
+		 * The dynamic portion of this filter, `{$this->id}`, refers
+		 * to the id of the email provider. Available providers are:
+		 *
+		 * + mailhawk
+		 * + sendwp
+		 *
+		 * @since [version]
+		 *
+		 * @param bool $disabled Whether or not this class is disabled.
+		 */
+		if ( apply_filters( "llms_disable_{$this->id}", false ) ) {
+			return;
+		}
+
+		// Disable other email delivery services if MailHawk is already connected.
+		if ( $this->is_connected() ) {
+			$this->disable_other_providers();
+		}
+
+		add_filter( 'llms_email_delivery_services', array( $this, 'add_settings' ) );
+		add_action( 'wp_ajax_llms_' . $this->id . '_remote_install', array( $this, 'ajax_callback_remote_install' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_js' ) );
+
+	}
+
+	/**
+	 * Determines if the plugin is already installed and activates it if it is
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean|WP_Error `true` when plugin is installed and successfully activated.
+	 *                           `WP_Error` when plugin is installed and there was an error activating it.
+	 *                           `false` when plugin is not installed.
+	 */
+	protected function activate_already_installed_plugin() {
+
+		$is_plugin_installed = false;
+
+		foreach ( get_plugins() as $path => $details ) {
+			if ( false === strpos( $path, '/' . $this->id . '.php' ) ) {
+				continue;
+			}
+			$is_plugin_installed = true;
+			$activate            = activate_plugin( $path );
+			if ( is_wp_error( $activate ) ) {
+				return $activate;
+			}
+			break;
+		}
+
+		return $is_plugin_installed;
+
+	}
+
+	/**
+	 * Add Settings.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $settings Existing settings.
+	 * @return array
+	 */
+	public function add_settings( $settings ) {
+
+		// Short circuit if missing authorization.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return $settings;
+		}
+
+		$new_settings = array(
+			array(
+				'id'    => $this->id . '_title',
+				'type'  => 'subtitle',
+				'title' => $this->get_title(),
+				'desc'  => $this->is_connected() ? '' : $this->get_description(),
+			),
+			array(
+				'id'    => $this->id . '_connect',
+				'type'  => 'custom-html',
+				'value' => $this->get_connect_setting(),
+			),
+		);
+
+		return array_merge( $settings, $new_settings );
+
+	}
+
+	/**
+	 * Ajax callback for installing the connector's plugin.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function ajax_callback_remote_install() {
+
+		$ret = $this->do_remote_install();
+		ob_clean();
+		wp_send_json( $ret, ! empty( $ret['status'] ) ? $ret['status'] : 200 );
+
+	}
+
+	/**
+	 * Determines if the current user can perform the remote installation.
+	 *
+	 * @since [version]
+	 *
+	 * @return true|array
+	 */
+	protected function can_remote_install() {
+
+		if ( ! llms_verify_nonce( '_llms_' . $this->id . '_nonce', 'llms-' . $this->id . '-install' ) ) {
+			return array(
+				'code'    => 'llms_' . $this->id . '_install_nonce_failure',
+				'message' => esc_html__( 'Security check failed.', 'lifterlms' ),
+				'status'  => 401,
+			);
+		} elseif ( ! current_user_can( 'install_plugins' ) ) {
+			return array(
+				'code'    => 'llms_' . $this->id . '_install_unauthorized',
+				'message' => esc_html__( 'You do not have permission to perform this action.', 'lifterlms' ),
+				'status'  => 403,
+			);
+		}
+
+		return true;
+
+	}
+
+	protected function disable_other_providers() {
+
+		$disable = array_diff( array( $this->id ), array( 'mailhawk', 'sendwp' ) );
+		foreach ( $disable as $id ) {
+			add_filter( 'llms_disable_' . $id, '__return_true' );
+		}
+
+	}
+
+	/**
+	 * Validate installation request and perform the plugin install or return errors.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function do_remote_install() {
+
+		$can_install = $this->can_remote_install();
+		if ( true !== $can_install ) {
+			return $can_install;
+		}
+
+		$install = $this->install();
+
+		if ( is_wp_error( $install ) ) {
+			return array(
+				'code'    => $install->get_error_code(),
+				'message' => $install->get_error_message(),
+				'status'  => 400,
+			);
+		}
+
+		return $this->do_remote_install_success();
+
+	}
+
+	/**
+	 * Install the plugin via the WP plugin installer.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean|WP_Error Error object or `true` when successful.
+	 */
+	protected function install() {
+
+		// Check if the plugin already exists and activate it if it is.
+		$ret = $this->activate_already_installed_plugin();
+
+		// Plugin doesn't exist, install it.
+		if ( false === $ret ) {
+			$ret = $this->install_plugin();
+		}
+
+		// Final check to ensure the connector is installed and activated.
+		if ( true === $ret && ! $this->is_installed() ) {
+			// Translators: %s = title of the email delivery plugin.
+			return new WP_Error( 'llms_'. $this->id . '_not_found', sprtinf( __( '%s plugin not found. Please try again.', 'lifterlms' ), $this->get_title() ), $install );
+		}
+
+		return $ret;
+
+	}
+
+	/**
+	 * Install the plugin via the WP Plugin Repo.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean|WP_Error `true` on success, error object otherwise.
+	 */
+	protected function install_plugin() {
+
+		include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		include_once ABSPATH . 'wp-admin/includes/file.php';
+		include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		// Use the WordPress Plugins API to get the plugin download link.
+		$api = plugins_api(
+			'plugin_information',
+			array(
+				'slug' => $this->id,
+			)
+		);
+		if ( is_wp_error( $api ) ) {
+			return $api;
+		}
+
+		// Use the AJAX upgrader skin to quietly install the plugin.
+		$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
+		$install  = $upgrader->install( $api->download_link );
+		if ( is_wp_error( $install ) ) {
+			return $install;
+		}
+
+		$activate = activate_plugin( $upgrader->plugin_info() );
+		if ( is_wp_error( $activate ) ) {
+			return $activate;
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Determine if inline scripts and styles should be output.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool
+	 */
+	protected function should_output_inline() {
+
+		// Short circuit if unauthorized.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return ( 'lifterlms_page_llms-settings' === $screen->id && 'engagements' === llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING ) && ! $this->is_connected() );
+
+	}
+
+	/**
+	 * Deprecated.
+	 *
+	 * @since [version]
+	 * @deprecated [version]
+	 *
+	 * @return void
+	 */
+	public function output_css() {
+		llms_deprecated_function( 'LLMS_Abstract_Email_Provider::output_css()', '[version]' );
+	}
+
+}

--- a/includes/abstracts/llms-abstract-email-provider.php
+++ b/includes/abstracts/llms-abstract-email-provider.php
@@ -290,7 +290,7 @@ abstract class LLMS_Abstract_Email_Provider {
 		// Final check to ensure the connector is installed and activated.
 		if ( true === $ret && ! $this->is_installed() ) {
 			// Translators: %s = title of the email delivery plugin.
-			return new WP_Error( 'llms_'. $this->id . '_not_found', sprtinf( __( '%s plugin not found. Please try again.', 'lifterlms' ), $this->get_title() ), $install );
+			return new WP_Error( 'llms_' . $this->id . '_not_found', sprtinf( __( '%s plugin not found. Please try again.', 'lifterlms' ), $this->get_title() ), $install );
 		}
 
 		return $ret;

--- a/includes/admin/class-llms-mailhawk.php
+++ b/includes/admin/class-llms-mailhawk.php
@@ -99,13 +99,12 @@ class LLMS_MailHawk {
 			return $settings;
 		}
 
-
 		$new_settings = array(
 			array(
-				'id' => 'mailhawk_title',
-				'type' => 'subtitle',
+				'id'    => 'mailhawk_title',
+				'type'  => 'subtitle',
 				'title' => __( 'MailHawk', 'lifterlms' ),
-				'desc' => $this->get_desc_text(),
+				'desc'  => $this->get_desc_text(),
 			),
 			array(
 				'id'    => 'mailhawk_connect',
@@ -184,8 +183,8 @@ class LLMS_MailHawk {
 			return '';
 		}
 
-		$link  = '<a href="https://lifterlikes.com/mailhawk" target="_blank">MailHawk</a>';
-		$desc  = '<em>' .__( 'A better way to send email.', 'lifterlms' ) . '</em><br>';
+		$link = '<a href="https://lifterlikes.com/mailhawk" target="_blank">MailHawk</a>';
+		$desc = '<em>' . __( 'A better way to send email.', 'lifterlms' ) . '</em><br>';
 
 		// Translators: %s = Anchor tag html linking to MailHawk.io.
 		$desc .= sprintf( __( 'Never worry about sending email again. %s takes care of everything for you starting at <strong>$14.97 per month</strong>.', 'lifterlms' ), $link );

--- a/includes/admin/class-llms-mailhawk.php
+++ b/includes/admin/class-llms-mailhawk.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since [version]
  */
-class LLMS_MailHawk {
+class LLMS_MailHawk extends LLMS_Abstract_Email_Provider {
 
 	/**
 	 * LifterLMS MailHawk Partner ID.
@@ -25,172 +25,26 @@ class LLMS_MailHawk {
 	const PARTNER_ID = 1;
 
 	/**
-	 * Constructor.
+	 * Connector's ID.
 	 *
-	 * @since [version]
-	 *
-	 * @return void
+	 * @var string
 	 */
-	public function __construct() {
-
-		add_action( 'admin_init', array( $this, 'init' ) );
-
-	}
+	protected $id = 'mailhawk';
 
 	/**
-	 * Initialize the MailHawk Connector
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function init() {
-
-		/**
-		 * Disable the MailHawk Connector class and settings
-		 *
-		 * @since [version]
-		 *
-		 * @param bool $disabled Whether or not this class is disabled.
-		 */
-		if ( apply_filters( 'llms_disable_mailhawk', false ) ) {
-			return;
-		}
-
-		// Disable other email delivery services if MailHawk is already connected.
-		if ( $this->is_connected() ) {
-			add_filter( 'llms_disable_sendwp', '__return_true' );
-		}
-
-		add_filter( 'llms_email_delivery_services', array( $this, 'add_settings' ), 20 );
-		add_action( 'admin_print_styles', array( $this, 'output_css' ) );
-		add_action( 'admin_print_footer_scripts', array( $this, 'output_js' ) );
-		add_action( 'wp_ajax_llms_mailhawk_remote_install', array( $this, 'ajax_callback_remote_install' ) );
-
-	}
-
-	/**
-	 * Ajax callback for installing SendWP Plugin.
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function ajax_callback_remote_install() {
-
-		$ret = $this->do_remote_install();
-		ob_clean();
-		wp_send_json( $ret, ! empty( $ret['status'] ) ? $ret['status'] : 200 );
-
-	}
-
-	/**
-	 * Add Settings.
-	 *
-	 * @since [version]
-	 *
-	 * @param array $settings Existing settings.
-	 * @return array
-	 */
-	public function add_settings( $settings ) {
-
-		// Short circuit if missing authorization.
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return $settings;
-		}
-
-		$new_settings = array(
-			array(
-				'id'    => 'mailhawk_title',
-				'type'  => 'subtitle',
-				'title' => __( 'MailHawk', 'lifterlms' ),
-				'desc'  => $this->get_desc_text(),
-			),
-			array(
-				'id'    => 'mailhawk_connect',
-				'type'  => 'custom-html',
-				'value' => $this->get_connect_setting(),
-			),
-		);
-
-		return array_merge( $settings, $new_settings );
-
-	}
-
-	/**
-	 * Validate installation request and perform the plugin install or return errors.
+	 * Configures the response returned when `do_remote_install()` is successful.
 	 *
 	 * @since [version]
 	 *
 	 * @return array
 	 */
-	protected function do_remote_install() {
-
-		if ( ! llms_verify_nonce( '_llms_mailhawk_nonce', 'llms-mailhawk-install' ) ) {
-			return array(
-				'code'    => 'llms_mailhawk_install_nonce_failure',
-				'message' => esc_html__( 'Security check failed.', 'lifterlms' ),
-				'status'  => 401,
-			);
-		} elseif ( ! current_user_can( 'install_plugins' ) ) {
-			return array(
-				'code'    => 'llms_mailhawk_install_unauthorized',
-				'message' => esc_html__( 'You do not have permission to perform this action.', 'lifterlms' ),
-				'status'  => 403,
-			);
-		}
-
-		$install = $this->install();
-
-		if ( is_wp_error( $install ) ) {
-			return array(
-				'code'    => $install->get_error_code(),
-				'message' => $install->get_error_message(),
-				'status'  => 400,
-			);
-		}
-
-		if ( ! defined( 'MAILHAWK_VERSION' ) ) {
-			return array(
-				'code'    => 'mailhawk_missing',
-				'message' => 'MailHawk not installed.',
-				'status'  => 400,
-			);
-		}
-
-		// You can change this to redirect back to your own plugin...
-		$redirect = \MailHawk\get_admin_mailhawk_uri();
-
+	protected function do_remote_install_success() {
 		return array(
 			'partner_id'   => self::PARTNER_ID,
 			'register_url' => esc_url( trailingslashit( MAILHAWK_LICENSE_SERVER_URL ) ),
 			'client_state' => esc_html( \MailHawk\Keys::instance()->state() ),
-			'redirect_uri' => esc_url( $redirect ),
+			'redirect_uri' => esc_url( \MailHawk\get_admin_mailhawk_uri() ),
 		);
-
-	}
-
-	/**
-	 * Retrieve description text to be used in the settings area.
-	 *
-	 * @since [version]
-	 *
-	 * @return string
-	 */
-	public function get_desc_text() {
-
-		if ( $this->is_connected() ) {
-			return '';
-		}
-
-		$link = '<a href="https://lifterlikes.com/mailhawk" target="_blank">MailHawk</a>';
-		$desc = '<em>' . __( 'A better way to send email.', 'lifterlms' ) . '</em><br>';
-
-		// Translators: %s = Anchor tag html linking to MailHawk.io.
-		$desc .= sprintf( __( 'Never worry about sending email again. %s takes care of everything for you starting at <strong>$14.97 per month</strong>.', 'lifterlms' ), $link );
-
-		return $desc;
-
 	}
 
 	/**
@@ -200,7 +54,7 @@ class LLMS_MailHawk {
 	 *
 	 * @return string
 	 */
-	public function get_connect_setting() {
+	protected function get_connect_setting() {
 
 		if ( $this->is_connected() ) {
 
@@ -236,66 +90,31 @@ class LLMS_MailHawk {
 	}
 
 	/**
-	 * Install the plugin via the WP plugin installer.
+	 * Retrieve description text to be used in the settings area.
 	 *
 	 * @since [version]
 	 *
-	 * @return boolean|WP_Error Error object or `true` when successful.
+	 * @return string
 	 */
-	private function install() {
+	protected function get_description() {
 
-		$is_mailhawk_installed = false;
+		return sprintf(
+			// Translators: %s = Anchor tag html linking to MailHawk.io.
+			__( 'Never worry about sending email again. %s takes care of everything for you starting for a small monthly fee.', 'lifterlms' ),
+			'<a href="https://lifterlikes.com/mailhawk" target="_blank">' . $this->get_title() . '</a>'
+		);
 
-		foreach ( get_plugins() as $path => $details ) {
-			if ( false === strpos( $path, '/mailhawk.php' ) ) {
-				continue;
-			}
-			$is_mailhawk_installed = true;
-			$activate              = activate_plugin( $path );
-			if ( is_wp_error( $activate ) ) {
-				return $activate;
-			}
-			break;
-		}
+	}
 
-		$install = null;
-		if ( ! $is_mailhawk_installed ) {
-
-			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-			include_once ABSPATH . 'wp-admin/includes/file.php';
-			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-			// Use the WordPress Plugins API to get the plugin download link.
-			$api = plugins_api(
-				'plugin_information',
-				array(
-					'slug' => 'mailhawk',
-				)
-			);
-			if ( is_wp_error( $api ) ) {
-				return $api;
-			}
-
-			// Use the AJAX upgrader skin to quietly install the plugin.
-			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
-			$install  = $upgrader->install( $api->download_link );
-			if ( is_wp_error( $install ) ) {
-				return $install;
-			}
-
-			$activate = activate_plugin( $upgrader->plugin_info() );
-			if ( is_wp_error( $activate ) ) {
-				return $activate;
-			}
-		}
-
-		// Final check to see if MailHawk is available.
-		if ( ! defined( 'MAILHAWK_VERSION' ) ) {
-			return new WP_Error( 'llms_mailhawk_not_found', __( 'MailHawk plugin not found. Please try again.', 'lifterlms' ), $install );
-		}
-
-		return true;
-
+	/**
+	 * Retrieve the connector's name / title.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_title() {
+		return __( 'MailHawk', 'lifterlms' );
 	}
 
 	/**
@@ -306,59 +125,18 @@ class LLMS_MailHawk {
 	 * @return boolean
 	 */
 	protected function is_connected() {
-
 		return ( function_exists( '\MailHawk\mailhawk_is_connected' ) && \MailHawk\mailhawk_is_connected() );
-
 	}
 
 	/**
-	 * Determine if inline scripts and styles should be output.
+	 * Determines if connector plugin is installed
 	 *
 	 * @since [version]
 	 *
-	 * @return bool
+	 * @return boolean
 	 */
-	protected function should_output_inline() {
-
-		// Short circuit if unauthorized.
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
-		return ( 'lifterlms_page_llms-settings' === $screen->id && 'engagements' === llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING ) && ! $this->is_connected() );
-
-	}
-
-	/**
-	 * Output some quick and dirty inline CSS.
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function output_css() {
-
-		if ( ! $this->should_output_inline() ) {
-			return;
-		}
-
-		?>
-		<style type="text/css">
-			#llms-mailhawk-connect {
-				font-size: 16px;
-				height: auto;
-				margin: 0 0 6px;
-				padding: 8px 14px;
-				position: relative;
-			}
-			#llms-mailhawk-connect .dashicons {
-				margin: -4px 4px 0 0;
-				vertical-align: middle;
-			}
-		</style>
-		<?php
-
+	protected function is_installed() {
+		return defined( 'MAILHAWK_VERSION' );
 	}
 
 	/**
@@ -368,7 +146,7 @@ class LLMS_MailHawk {
 	 *
 	 * @return void
 	 */
-	public function output_js() {
+	public function output_js( $additional_js = '' ) {
 
 		if ( ! $this->should_output_inline() ) {
 			return;
@@ -376,73 +154,29 @@ class LLMS_MailHawk {
 
 		?>
 		<script>
+			jQuery( '#llms-mailhawk-connect' ).on( 'click', function( e ) {
 
-			var $llmsMailHawkBtn = jQuery( '#llms-mailhawk-connect' );
-			$llmsMailHawkBtn.on( 'click', function( e ) {
 				e.preventDefault();
-				LLMS.Spinner.start( $llmsMailHawkBtn, 'small' );
-				llms_mailhawk_remote_install();
-			} );
 
-			/**
-			 * Perform AJAX request to install MailHawk plugin.
-			 *
-			 * @since [version]
-			 *
-			 * @return void
-			 */
-			function llms_mailhawk_remote_install() {
+				LLMS.Spinner.start( jQuery( this ), 'small' );
+
 				var data = {
 					action: 'llms_mailhawk_remote_install',
 					_llms_mailhawk_nonce: '<?php echo wp_create_nonce( 'llms-mailhawk-install' ); ?>',
 				};
 
-				jQuery.post( ajaxurl, data, function ( res ) {
-					llms_mailhawk_register_client( res.register_url, res.client_state, res.redirect_uri, res.partner_id );
-				} ).fail( function( jqxhr ) {
-					LLMS.Spinner.stop( $llmsMailHawkBtn );
-					$llmsMailHawkBtn.parent().find( '.llms-error' ).remove();
-					if ( jqxhr.responseJSON && jqxhr.responseJSON.message ) {
-						jQuery( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': jqxhr.responseJSON.message } ) + '</p>' ).insertAfter( $llmsMailHawkBtn );
-						console.log( jqxhr );
-					}
+				window.llms.emailConnectors.remoteInstall( jQuery( this ), data, function( res ) {
+
+					window.llms.emailConnectors.registerClient( res.register_url, {
+						'mailhawk_plugin_signup': 'yes',
+						'state': res.client_state,
+						'redirect_uri': res.redirect_uri,
+						'partner_id': res.partner_id
+					} );
+
 				} );
-			}
 
-			/**
-			 * Register client with MailHawk.
-			 *
-			 * @since [version]
-			 *
-			 * @param {String}  register_url Registration URL.
-			 * @param {String}  client_state string state for oauth.
-			 * @param {String}  redirect_uri Client redirect URL.
-			 * @param {Integer} partner_id   MailHawk partner ID.
-			 * @return {Void}
-			 */
-			function llms_mailhawk_register_client( register_url, client_state, redirect_uri, partner_id ) {
-
-				var form = document.createElement( 'form' );
-				form.setAttribute( 'method', 'POST' );
-				form.setAttribute( 'action', register_url );
-
-				function llms_mailhawk_append_form_input( name, value ) {
-					var input = document.createElement( 'input' );
-					input.setAttribute( 'type', 'hidden' );
-					input.setAttribute( 'name', name );
-					input.setAttribute( 'value', value );
-					form.appendChild( input);
-				}
-
-				llms_mailhawk_append_form_input( 'mailhawk_plugin_signup', 'yes' );
-				llms_mailhawk_append_form_input( 'state', client_state );
-				llms_mailhawk_append_form_input( 'redirect_uri', redirect_uri );
-				llms_mailhawk_append_form_input( 'partner_id', partner_id );
-
-				document.body.appendChild( form );
-				form.submit();
-
-			}
+			} );
 		</script>
 		<?php
 

--- a/includes/admin/class-llms-mailhawk.php
+++ b/includes/admin/class-llms-mailhawk.php
@@ -22,7 +22,7 @@ class LLMS_MailHawk extends LLMS_Abstract_Email_Provider {
 	 *
 	 * @var int
 	 */
-	const PARTNER_ID = 1;
+	const PARTNER_ID = 3;
 
 	/**
 	 * Connector's ID.

--- a/includes/admin/class-llms-mailhawk.php
+++ b/includes/admin/class-llms-mailhawk.php
@@ -1,0 +1,454 @@
+<?php
+/**
+ * MailHawk Connect
+ *
+ * @package LifterLMS/Admin/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_MailHawk class
+ *
+ * @since [version]
+ */
+class LLMS_MailHawk {
+
+	/**
+	 * LifterLMS MailHawk Partner ID.
+	 *
+	 * @var int
+	 */
+	const PARTNER_ID = 1;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+
+		add_action( 'admin_init', array( $this, 'init' ) );
+
+	}
+
+	/**
+	 * Initialize the MailHawk Connector
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		/**
+		 * Disable the MailHawk Connector class and settings
+		 *
+		 * @since [version]
+		 *
+		 * @param bool $disabled Whether or not this class is disabled.
+		 */
+		if ( apply_filters( 'llms_disable_mailhawk', false ) ) {
+			return;
+		}
+
+		// Disable other email delivery services if MailHawk is already connected.
+		if ( $this->is_connected() ) {
+			add_filter( 'llms_disable_sendwp', '__return_true' );
+		}
+
+		add_filter( 'llms_email_delivery_services', array( $this, 'add_settings' ), 20 );
+		add_action( 'admin_print_styles', array( $this, 'output_css' ) );
+		add_action( 'admin_print_footer_scripts', array( $this, 'output_js' ) );
+		add_action( 'wp_ajax_llms_mailhawk_remote_install', array( $this, 'ajax_callback_remote_install' ) );
+
+	}
+
+	/**
+	 * Ajax callback for installing SendWP Plugin.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function ajax_callback_remote_install() {
+
+		$ret = $this->do_remote_install();
+		ob_clean();
+		wp_send_json( $ret, ! empty( $ret['status'] ) ? $ret['status'] : 200 );
+
+	}
+
+	/**
+	 * Add Settings.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $settings Existing settings.
+	 * @return array
+	 */
+	public function add_settings( $settings ) {
+
+		// Short circuit if missing authorization.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return $settings;
+		}
+
+
+		$new_settings = array(
+			array(
+				'id' => 'mailhawk_title',
+				'type' => 'subtitle',
+				'title' => __( 'MailHawk', 'lifterlms' ),
+				'desc' => $this->get_desc_text(),
+			),
+			array(
+				'id'    => 'mailhawk_connect',
+				'type'  => 'custom-html',
+				'value' => $this->get_connect_setting(),
+			),
+		);
+
+		return array_merge( $settings, $new_settings );
+
+	}
+
+	/**
+	 * Validate installation request and perform the plugin install or return errors.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function do_remote_install() {
+
+		if ( ! llms_verify_nonce( '_llms_mailhawk_nonce', 'llms-mailhawk-install' ) ) {
+			return array(
+				'code'    => 'llms_mailhawk_install_nonce_failure',
+				'message' => esc_html__( 'Security check failed.', 'lifterlms' ),
+				'status'  => 401,
+			);
+		} elseif ( ! current_user_can( 'install_plugins' ) ) {
+			return array(
+				'code'    => 'llms_mailhawk_install_unauthorized',
+				'message' => esc_html__( 'You do not have permission to perform this action.', 'lifterlms' ),
+				'status'  => 403,
+			);
+		}
+
+		$install = $this->install();
+
+		if ( is_wp_error( $install ) ) {
+			return array(
+				'code'    => $install->get_error_code(),
+				'message' => $install->get_error_message(),
+				'status'  => 400,
+			);
+		}
+
+		if ( ! defined( 'MAILHAWK_VERSION' ) ) {
+			return array(
+				'code'    => 'mailhawk_missing',
+				'message' => 'MailHawk not installed.',
+				'status'  => 400,
+			);
+		}
+
+		// You can change this to redirect back to your own plugin...
+		$redirect = \MailHawk\get_admin_mailhawk_uri();
+
+		return array(
+			'partner_id'   => self::PARTNER_ID,
+			'register_url' => esc_url( trailingslashit( MAILHAWK_LICENSE_SERVER_URL ) ),
+			'client_state' => esc_html( \MailHawk\Keys::instance()->state() ),
+			'redirect_uri' => esc_url( $redirect ),
+		);
+
+	}
+
+	/**
+	 * Retrieve description text to be used in the settings area.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_desc_text() {
+
+		if ( $this->is_connected() ) {
+			return '';
+		}
+
+		$link  = '<a href="https://lifterlikes.com/mailhawk" target="_blank">MailHawk</a>';
+		$desc  = '<em>' .__( 'A better way to send email.', 'lifterlms' ) . '</em><br>';
+
+		// Translators: %s = Anchor tag html linking to MailHawk.io.
+		$desc .= sprintf( __( 'Never worry about sending email again. %s takes care of everything for you starting at <strong>$14.97 per month</strong>.', 'lifterlms' ), $link );
+
+		return $desc;
+
+	}
+
+	/**
+	 * Retrieve the settings area HTML for the connect button
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_connect_setting() {
+
+		if ( $this->is_connected() ) {
+
+			$ret = array(
+				__( 'Your site is connected to MailHawk.', 'lifterlms' ),
+			);
+
+			$settings_url = esc_url( admin_url( '/tools.php?page=mailhawk' ) );
+
+			if ( function_exists( '\MailHawk\mailhawk_is_suspended' ) && ! \MailHawk\mailhawk_is_suspended() ) {
+				$ret[] = sprintf(
+					// Translators: %1$s = Opening anchor tag to WP MailHawk Settings; Opening anchor tag to MailHawk.io account page; %2$s = Closing anchor tag.
+					__( '%1$sView settings%3$s or %2$smanage your account%3$s.', 'lifterlms' ),
+					'<a href="' . $settings_url . '">',
+					'<a href="https://mailhawk.io/account/" target="_blank" rel="noopener noreferrer">',
+					'</a>'
+				);
+			} else {
+				$ret[] = sprintf(
+					// Translators: %1$s = Opening anchor tag; %2$s = Closing anchor tag.
+					'<em>' . __( 'Email sending is currently disabled. %1$sVisit MailHawk Settings%2$s to enable sending.', 'lifterlms' ) . '</em>',
+					'<a href="' . $settings_url . '">',
+					'</a>'
+				);
+			}
+
+			return '<p>' . implode( ' ', $ret ) . '</p>';
+
+		}
+
+		return sprintf( '<button type="button" class="button button-primary big-button" id="llms-mailhawk-connect"><span class="dashicons dashicons-email-alt"></span> %s</button>', __( 'Connect MailHawk', 'lifterlms' ) );
+
+	}
+
+	/**
+	 * Install the plugin via the WP plugin installer.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean|WP_Error Error object or `true` when successful.
+	 */
+	private function install() {
+
+		$is_mailhawk_installed = false;
+
+		foreach ( get_plugins() as $path => $details ) {
+			if ( false === strpos( $path, '/mailhawk.php' ) ) {
+				continue;
+			}
+			$is_mailhawk_installed = true;
+			$activate              = activate_plugin( $path );
+			if ( is_wp_error( $activate ) ) {
+				return $activate;
+			}
+			break;
+		}
+
+		$install = null;
+		if ( ! $is_mailhawk_installed ) {
+
+			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			include_once ABSPATH . 'wp-admin/includes/file.php';
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+			// Use the WordPress Plugins API to get the plugin download link.
+			$api = plugins_api(
+				'plugin_information',
+				array(
+					'slug' => 'mailhawk',
+				)
+			);
+			if ( is_wp_error( $api ) ) {
+				return $api;
+			}
+
+			// Use the AJAX upgrader skin to quietly install the plugin.
+			$upgrader = new \Plugin_Upgrader( new \WP_Ajax_Upgrader_Skin() );
+			$install  = $upgrader->install( $api->download_link );
+			if ( is_wp_error( $install ) ) {
+				return $install;
+			}
+
+			$activate = activate_plugin( $upgrader->plugin_info() );
+			if ( is_wp_error( $activate ) ) {
+				return $activate;
+			}
+		}
+
+		// Final check to see if MailHawk is available.
+		if ( ! defined( 'MAILHAWK_VERSION' ) ) {
+			return new \WP_Error( 'llms_mailhawk_not_found', __( 'MailHawk plugin not found. Please try again.', 'lifterlms' ), $install );
+		}
+
+		return true;
+
+	}
+
+	/**
+	 * Determines if MailHawk is installed and connected for sending.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	protected function is_connected() {
+
+		return ( function_exists( '\MailHawk\mailhawk_is_connected' ) && \MailHawk\mailhawk_is_connected() );
+
+	}
+
+	/**
+	 * Determine if inline scripts and styles should be output.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool
+	 */
+	protected function should_output_inline() {
+
+		// Short circuit if unauthorized.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return false;
+		}
+
+		$screen = get_current_screen();
+		return ( 'lifterlms_page_llms-settings' === $screen->id && 'engagements' === llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING ) && ! $this->is_connected() );
+
+	}
+
+	/**
+	 * Output some quick and dirty inline CSS.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function output_css() {
+
+		if ( ! $this->should_output_inline() ) {
+			return;
+		}
+
+		?>
+		<style type="text/css">
+			#llms-mailhawk-connect {
+				font-size: 16px;
+				height: auto;
+				margin: 0 0 6px;
+				padding: 8px 14px;
+				position: relative;
+			}
+			#llms-mailhawk-connect .dashicons {
+				margin: -4px 4px 0 0;
+				vertical-align: middle;
+			}
+		</style>
+		<?php
+
+	}
+
+	/**
+	 * Output some quick and dirty inline JS.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function output_js() {
+
+		if ( ! $this->should_output_inline() ) {
+			return;
+		}
+
+		?>
+		<script>
+
+			var $llmsMailHawkBtn = jQuery( '#llms-mailhawk-connect' );
+			$llmsMailHawkBtn.on( 'click', function( e ) {
+				e.preventDefault();
+				LLMS.Spinner.start( $llmsMailHawkBtn, 'small' );
+				llms_mailhawk_remote_install();
+			} );
+
+			/**
+			 * Perform AJAX request to install MailHawk plugin.
+			 *
+			 * @since [version]
+			 *
+			 * @return void
+			 */
+			function llms_mailhawk_remote_install() {
+				var data = {
+					action: 'llms_mailhawk_remote_install',
+					_llms_mailhawk_nonce: '<?php echo wp_create_nonce( 'llms-mailhawk-install' ); ?>',
+				};
+
+				jQuery.post( ajaxurl, data, function ( res ) {
+					llms_mailhawk_register_client( res.register_url, res.client_state, res.redirect_uri, res.partner_id );
+				} ).fail( function( jqxhr ) {
+					LLMS.Spinner.stop( $llmsMailHawkBtn );
+					$llmsMailHawkBtn.parent().find( '.llms-error' ).remove();
+					if ( jqxhr.responseJSON && jqxhr.responseJSON.message ) {
+						jQuery( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': jqxhr.responseJSON.message } ) + '</p>' ).insertAfter( $llmsMailHawkBtn );
+						console.log( jqxhr );
+					}
+				} );
+			}
+
+			/**
+			 * Register client with MailHawk.
+			 *
+			 * @since [version]
+			 *
+			 * @param {String}  register_url Registration URL.
+			 * @param {String}  client_state string state for oauth.
+			 * @param {String}  redirect_uri Client redirect URL.
+			 * @param {Integer} partner_id   MailHawk partner ID.
+			 * @return {Void}
+			 */
+			function llms_mailhawk_register_client( register_url, client_state, redirect_uri, partner_id ) {
+
+				var form = document.createElement( 'form' );
+				form.setAttribute( 'method', 'POST' );
+				form.setAttribute( 'action', register_url );
+
+				function llms_mailhawk_append_form_input( name, value ) {
+					var input = document.createElement( 'input' );
+					input.setAttribute( 'type', 'hidden' );
+					input.setAttribute( 'name', name );
+					input.setAttribute( 'value', value );
+					form.appendChild( input);
+				}
+
+				llms_mailhawk_append_form_input( 'mailhawk_plugin_signup', 'yes' );
+				llms_mailhawk_append_form_input( 'state', client_state );
+				llms_mailhawk_append_form_input( 'redirect_uri', redirect_uri );
+				llms_mailhawk_append_form_input( 'partner_id', partner_id );
+
+				document.body.appendChild( form );
+				form.submit();
+
+			}
+		</script>
+		<?php
+
+	}
+
+}
+
+return new LLMS_MailHawk();

--- a/includes/admin/class-llms-mailhawk.php
+++ b/includes/admin/class-llms-mailhawk.php
@@ -277,7 +277,7 @@ class LLMS_MailHawk {
 			}
 
 			// Use the AJAX upgrader skin to quietly install the plugin.
-			$upgrader = new \Plugin_Upgrader( new \WP_Ajax_Upgrader_Skin() );
+			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
 			$install  = $upgrader->install( $api->download_link );
 			if ( is_wp_error( $install ) ) {
 				return $install;
@@ -291,7 +291,7 @@ class LLMS_MailHawk {
 
 		// Final check to see if MailHawk is available.
 		if ( ! defined( 'MAILHAWK_VERSION' ) ) {
-			return new \WP_Error( 'llms_mailhawk_not_found', __( 'MailHawk plugin not found. Please try again.', 'lifterlms' ), $install );
+			return new WP_Error( 'llms_mailhawk_not_found', __( 'MailHawk plugin not found. Please try again.', 'lifterlms' ), $install );
 		}
 
 		return true;

--- a/includes/admin/class-llms-sendwp.php
+++ b/includes/admin/class-llms-sendwp.php
@@ -42,11 +42,11 @@ class LLMS_SendWP extends LLMS_Abstract_Email_Provider {
 	 *
 	 * @since 3.36.1
 	 * @since 3.37.0 Sanitize URLS returned by SendWP functions and add nonce verification.
-	 * @since [version] Use	parent method.
+	 * @since [version] Use parent method.
 	 *
 	 * @return array
 	 */
-	public function do_remote_install() {
+	public function do_remote_install() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Intentional for backwards compat.
 
 		return parent::do_remote_install();
 
@@ -81,7 +81,7 @@ class LLMS_SendWP extends LLMS_Abstract_Email_Provider {
 		return sprintf(
 			// Translators: %s = Anchor tag html linking to SendWP.com.
 			__( '%s makes WordPress email delivery as simple as a few clicks so you can relax, knowing your important emails are being delivered on time.', 'lifterlms' ),
-			'<a href="https://lifterlikes.com/sendwp" target="_blank" rel="noopener noreferrer">' . $this->get_title() . '</a>',
+			'<a href="https://lifterlikes.com/sendwp" target="_blank" rel="noopener noreferrer">' . $this->get_title() . '</a>'
 		);
 
 	}

--- a/includes/admin/class-llms-sendwp.php
+++ b/includes/admin/class-llms-sendwp.php
@@ -160,26 +160,6 @@ class LLMS_SendWP extends LLMS_Abstract_Email_Provider {
 	}
 
 	/**
-	 * Determine if inline scripts and styles should be output.
-	 *
-	 * @since 3.36.1
-	 * @since [version] Don't output inline CSS & JS when connected.
-	 *
-	 * @return bool
-	 */
-	protected function should_output_inline() {
-
-		// Short circuit if missing unauthorized.
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return false;
-		}
-
-		$screen = get_current_screen();
-		return ( 'lifterlms_page_llms-settings' === $screen->id && 'engagements' === llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING ) && ! $this->is_connected() );
-
-	}
-
-	/**
 	 * Output some quick and dirty inline JS.
 	 *
 	 * @since 3.36.1

--- a/includes/admin/class-llms-sendwp.php
+++ b/includes/admin/class-llms-sendwp.php
@@ -16,215 +16,85 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.36.1
  * @since 3.37.0 Sanitize URLs, clean up jQuery references, add loading feedback when connector button is clicked.
  * @since 3.37.3 Modify the ID used to determine where to splice in SendWP Options.
- * @since [version] Minor updates to accommodate UI with multiple delivery services.
+ * @since [version] Refactor to utiize `LLMS_Abstract_Email_Provider`.
  */
-class LLMS_SendWP {
+class LLMS_SendWP extends LLMS_Abstract_Email_Provider {
 
 	/**
-	 * Constructor.
+	 * LifterLMS MailHawk Partner ID.
 	 *
-	 * @since 3.36.1
-	 * @since [version] Initialize on `admin_init` instead of on `plugins_loaded`.
-	 *
-	 * @return void
+	 * @var int
 	 */
-	public function __construct() {
-
-		add_action( 'admin_init', array( $this, 'init' ) );
-
-	}
+	const PARTNER_ID = 2007;
 
 	/**
-	 * Initialize SendWP Connector.
+	 * Connector's ID.
 	 *
-	 * @since [version]
-	 *
-	 * @return void
+	 * @var string
 	 */
-	public function init() {
-
-		/**
-		 * Disable the SendWP Connector class and settings
-		 *
-		 * @since 3.36.1
-		 *
-		 * @param bool $disabled Whether or not this class is disabled.
-		 */
-		if ( apply_filters( 'llms_disable_sendwp', false ) ) {
-			return;
-		}
-
-		// Disable other email delivery services if SendWP is already connected.
-		if ( $this->is_connected() ) {
-			add_filter( 'llms_disable_mailhawk', '__return_true' );
-		}
-
-		add_filter( 'llms_email_delivery_services', array( $this, 'add_settings' ), 30 );
-		add_action( 'admin_print_styles', array( $this, 'output_css' ) );
-		add_action( 'admin_print_footer_scripts', array( $this, 'output_js' ) );
-		add_action( 'wp_ajax_llms_sendwp_remote_install', array( $this, 'ajax_callback_remote_install' ) );
-
-	}
+	protected $id = 'sendwp';
 
 	/**
-	 * Add Settings.
+	 * Validate installation request and perform the plugin install or return errors.
 	 *
-	 * @since 3.36.1
-	 * @since [version] Update settings to reduce redundancy.
-	 *
-	 * @param array $settings Existing settings.
-	 * @return array
-	 */
-	public function add_settings( $settings ) {
-
-		// Short circuit if missing unauthorized.
-		if ( ! current_user_can( 'install_plugins' ) ) {
-			return $settings;
-		}
-
-		$new_settings = array(
-			array(
-				'id'    => 'sendwp_title',
-				'title' => __( 'SendWP Email', 'lifterlms' ),
-				'type'  => 'subtitle',
-				'desc'  => sprintf(
-					// Translators: %1$s = Opening anchor tag; %2$s = Closing anchor tag.
-					__( '%1$sSendWP%2$s makes WordPress email delivery as simple as a few clicks so you can relax, knowing your important emails are being delivered on time.', 'lifterlms' ),
-					'<a href="https://lifterlikes.com/sendwp" target="_blank" rel="noopener noreferrer">',
-					'</a>'
-				),
-			),
-			array(
-				'id'    => 'sendwp_connect',
-				'type'  => 'custom-html',
-				'value' => $this->get_connect_setting(),
-			),
-		);
-
-		return array_merge( $settings, $new_settings );
-
-	}
-
-	/**
-	 * Ajax callback for installing SendWP Plugin.
-	 *
-	 * @since 3.36.1
-	 *
-	 * @hook wp_ajax_llms_sendwp_remote_install
-	 *
-	 * @return void
-	 */
-	public function ajax_callback_remote_install() {
-
-		$ret = $this->do_remote_install();
-		ob_clean();
-		wp_send_json( $ret, ! empty( $ret['status'] ) ? $ret['status'] : 200 );
-
-	}
-
-	/**
-	 * Remote installation method.
+	 * This method overrides the parent in order to keep the method public to maintain
+	 * backwards compatibility.
 	 *
 	 * @since 3.36.1
 	 * @since 3.37.0 Sanitize URLS returned by SendWP functions and add nonce verification.
+	 * @since [version] Use	parent method.
 	 *
 	 * @return array
 	 */
 	public function do_remote_install() {
 
-		if ( ! llms_verify_nonce( '_llms_sendwp_nonce', 'llms-sendwp-install' ) ) {
-			return array(
-				'code'    => 'llms_sendwp_install_nonce_failure',
-				'message' => esc_html__( 'Security check failed.', 'lifterlms' ),
-				'status'  => 401,
-			);
-		} elseif ( ! current_user_can( 'install_plugins' ) ) {
-			return array(
-				'code'    => 'llms_sendwp_install_unauthorized',
-				'message' => esc_html__( 'You do not have permission to perform this action.', 'lifterlms' ),
-				'status'  => 403,
-			);
-		}
+		return parent::do_remote_install();
 
-		$install = $this->install();
-		if ( is_wp_error( $install ) ) {
-			return array(
-				'code'    => $install->get_error_code(),
-				'message' => $install->get_error_message(),
-				'status'  => 400,
-			);
-		}
+	}
 
+	/**
+	 * Configures the response returned when `do_remote_install()` is successful.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function do_remote_install_success() {
 		return array(
-			'partner_id'      => 2007,
+			'partner_id'      => self::PARTNER_ID,
 			'register_url'    => esc_url( sendwp_get_server_url() . '_/signup' ),
 			'client_name'     => esc_url( sendwp_get_client_name() ),
 			'client_secret'   => esc_url( sendwp_get_client_secret() ),
 			'client_redirect' => esc_url( sendwp_get_client_redirect() ),
 		);
+	}
+
+	/**
+	 * Retrieve description text to be used in the settings area.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+
+		return sprintf(
+			// Translators: %s = Anchor tag html linking to SendWP.com.
+			__( '%s makes WordPress email delivery as simple as a few clicks so you can relax, knowing your important emails are being delivered on time.', 'lifterlms' ),
+			'<a href="https://lifterlikes.com/sendwp" target="_blank" rel="noopener noreferrer">' . $this->get_title() . '</a>',
+		);
 
 	}
 
 	/**
-	 * Install / Activate SendWP plugin.
+	 * Retrieve the connector's name / title.
 	 *
-	 * @since 3.36.1
+	 * @since [version]
 	 *
-	 * @return WP_Error|true
+	 * @return string
 	 */
-	private function install() {
-
-		$is_sendwp_installed = false;
-		foreach ( get_plugins() as $path => $details ) {
-			if ( false === strpos( $path, '/sendwp.php' ) ) {
-				continue;
-			}
-			$is_sendwp_installed = true;
-			$activate            = activate_plugin( $path );
-			if ( is_wp_error( $activate ) ) {
-				return $activate;
-			}
-			break;
-		}
-
-		$install = null;
-		if ( ! $is_sendwp_installed ) {
-
-			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-			include_once ABSPATH . 'wp-admin/includes/file.php';
-			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
-
-			// Use the WordPress Plugins API to get the plugin download link.
-			$api = plugins_api(
-				'plugin_information',
-				array(
-					'slug' => 'sendwp',
-				)
-			);
-			if ( is_wp_error( $api ) ) {
-				return $api;
-			}
-
-			// Use the AJAX upgrader skin to quietly install the plugin.
-			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
-			$install  = $upgrader->install( $api->download_link );
-			if ( is_wp_error( $install ) ) {
-				return $install;
-			}
-
-			$activate = activate_plugin( $upgrader->plugin_info() );
-			if ( is_wp_error( $activate ) ) {
-				return $activate;
-			}
-		}
-
-		// Final check to see if SendWP is available.
-		if ( ! function_exists( 'sendwp_get_server_url' ) ) {
-			return new WP_Error( 'llms_sendwp_not_found', __( 'SendWP Plugin not found. Please try again.', 'lifterlms' ), $install );
-		}
-
-		return true;
-
+	protected function get_title() {
+		return __( 'SendWP', 'lifterlms' );
 	}
 
 	/**
@@ -235,9 +105,18 @@ class LLMS_SendWP {
 	 * @return boolean
 	 */
 	protected function is_connected() {
-
 		return ( function_exists( 'sendwp_client_connected' ) && sendwp_client_connected() );
+	}
 
+	/**
+	 * Determines if connector plugin is installed
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	protected function is_installed() {
+		return function_exists( 'sendwp_get_server_url' );
 	}
 
 	/**
@@ -248,7 +127,7 @@ class LLMS_SendWP {
 	 *
 	 * @return string
 	 */
-	private function get_connect_setting() {
+	protected function get_connect_setting() {
 
 		if ( $this->is_connected() ) {
 
@@ -301,40 +180,11 @@ class LLMS_SendWP {
 	}
 
 	/**
-	 * Output some quick and dirty inline CSS.
-	 *
-	 * @since 3.36.1
-	 *
-	 * @return void
-	 */
-	public function output_css() {
-
-		if ( ! $this->should_output_inline() ) {
-			return;
-		}
-
-		?>
-		<style type="text/css">
-			#llms-sendwp-connect {
-				font-size: 16px;
-				height: auto;
-				margin: 0 0 6px;
-				padding: 8px 14px;
-				position: relative;
-			}
-			#llms-sendwp-connect .fa {
-				margin-right: 4px;
-			}
-		</style>
-		<?php
-	}
-
-
-	/**
 	 * Output some quick and dirty inline JS.
 	 *
 	 * @since 3.36.1
 	 * @since 3.37.0 Add nonce and replace references to `$` with `jQuery`.
+	 * @since [version] Refactored to utilize `window.llms.emailConnectors`.
 	 *
 	 * @return void
 	 */
@@ -346,76 +196,29 @@ class LLMS_SendWP {
 
 		?>
 		<script>
-			var btn  = document.getElementById( 'llms-sendwp-connect' ),
-				$btn = jQuery( btn );
-			btn.addEventListener( 'click', function( e ) {
-				e.preventDefault();
-				LLMS.Spinner.start( $btn, 'small' );
-				llms_sendwp_remote_install();
-			} );
+			jQuery( '#llms-sendwp-connect' ).on( 'click', function( e ) {
 
-			/**
-			 * Perform AJAX request to install SendWP plugin.
-			 *
-			 * @since 3.36.1
-			 * @since 3.37.0 Add nonce.
-			 *                Replace references to `$` with `jQuery`.
-			 *                Add loading feedback on button click.
-			 *
-			 * @return void
-			 */
-			function llms_sendwp_remote_install() {
+				e.preventDefault();
+
+				LLMS.Spinner.start( jQuery( this ), 'small' );
+
 				var data = {
 					action: 'llms_sendwp_remote_install',
 					_llms_sendwp_nonce: '<?php echo wp_create_nonce( 'llms-sendwp-install' ); ?>',
 				};
-				jQuery.post( ajaxurl, data, function( res ) {
-					llms_sendwp_register_client( res.register_url, res.client_name, res.client_secret, res.client_redirect, res.partner_id );
-				} ).fail( function( jqxhr ) {
-					LLMS.Spinner.stop( $btn );
-					$btn.parent().find( '.llms-error' ).remove();
-					if ( jqxhr.responseJSON && jqxhr.responseJSON.message ) {
-						jQuery( '<p class="llms-error">' + LLMS.l10n.replace( 'Error: %s', { '%s': jqxhr.responseJSON.message } ) + '</p>' ).insertAfter( $btn );
-						console.log( jqxhr );
-					}
+
+				window.llms.emailConnectors.remoteInstall( jQuery( this ), data, function( res ) {
+
+					window.llms.emailConnectors.registerClient( res.register_url, {
+						client_name: res.client_name,
+						client_secret: res.client_secret,
+						client_redirect: res.client_redirect,
+						partner_id: res.partner_id,
+					} );
+
 				} );
-			}
 
-			/**
-			 * Register client with SendWP.
-			 *
-			 * @since 3.36.1
-			 *
-			 * @param {string} register_url Registration URL.
-			 * @param {string} client_name Client name.
-			 * @param {string} client_secret Client secret.
-			 * @param {string} client_redirect Client redirect URL.
-			 * @param {int} partner_id SendWP partner ID.
-			 * @return {void}
-			 */
-			function llms_sendwp_register_client( register_url, client_name, client_secret, client_redirect, partner_id ) {
-
-				var form = document.createElement( 'form' );
-				form.setAttribute( 'method', 'POST' );
-				form.setAttribute( 'action', register_url );
-
-				function llms_sendwp_append_form_input( name, value ) {
-					var input = document.createElement( 'input' );
-					input.setAttribute( 'type', 'hidden' );
-					input.setAttribute( 'name', name );
-					input.setAttribute( 'value', value );
-					form.appendChild( input );
-				}
-
-				llms_sendwp_append_form_input( 'client_name', client_name );
-				llms_sendwp_append_form_input( 'client_secret', client_secret );
-				llms_sendwp_append_form_input( 'client_redirect', client_redirect );
-				llms_sendwp_append_form_input( 'partner_id', partner_id );
-
-				document.body.appendChild( form );
-				form.submit();
-
-			}
+			} );
 		</script>
 		<?php
 

--- a/includes/admin/class-llms-sendwp.php
+++ b/includes/admin/class-llms-sendwp.php
@@ -42,7 +42,7 @@ class LLMS_SendWP extends LLMS_Abstract_Email_Provider {
 	 *
 	 * @since 3.36.1
 	 * @since 3.37.0 Sanitize URLS returned by SendWP functions and add nonce verification.
-	 * @since [version] Use parent method.
+	 * @deprecated [version] Method to be made protected and should not be called publicly.
 	 *
 	 * @return array
 	 */

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -109,7 +109,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 				array(
 					'title'    => __( 'Legacy compatibility', 'lifterlms' ),
 					'desc'     => __( 'Use legacy certificate image sizes.', 'lifterlms' ) .
-									   '<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
+									'<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
 					'id'       => 'lifterlms_certificate_legacy_image_size',
 					'default'  => 'no',
 					'type'     => 'checkbox',
@@ -195,7 +195,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			'email_delivery',
 			__( 'Email Delivery', 'lifterlms' ),
 			'',
-			$services,
+			$services
 		);
 
 	}

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Settings/Classes
  *
  * @since 1.0.0
- * @version 3.37.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.37.3 Renamed setting field IDs to be unique.
  *              Removed redundant functions defined in the `LLMS_Settings_Page` class.
  *              Removed constructor and added `get_label()` method to be compatible with changes in `LLMS_Settings_Page`.
+ * @since [version] Add a section that displays conditionally for email delivery provider connections.
  */
 class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 
@@ -45,6 +46,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 * @since 1.0.0
 	 * @since 3.8.0 Unknown.
 	 * @since 3.37.3 Refactor to pull each settings group from its own method.
+	 * @since [version] Include an email delivery section.
 	 *
 	 * @return array
 	 */
@@ -61,6 +63,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			'lifterlms_engagements_settings',
 			array_merge(
 				$this->get_settings_group_email(),
+				$this->get_settings_group_email_delivery(),
 				$this->get_settings_group_certs()
 			)
 		);
@@ -160,6 +163,39 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 					'default' => '',
 				),
 			)
+		);
+
+	}
+
+	/**
+	 * Retrieve email delivery partner settings groups.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function get_settings_group_email_delivery() {
+
+		/**
+		 * Filter settings for available email delivery services.
+		 *
+		 * @since [version]
+		 *
+		 * @param array[] $settings Array of settings arrays.
+		 */
+		$services = apply_filters( 'llms_email_delivery_services', array() );
+
+		// If there's no services respond with an empty array so we don't output the whole section.
+		if ( ! $services ) {
+			return array();
+		}
+
+		// Output the a section.
+		return $this->generate_settings_group(
+			'email_delivery',
+			__( 'Email Delivery', 'lifterlms' ),
+			'',
+			$services,
 		);
 
 	}

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 3.38.1
+ * @version [version]
  *
  * Plugin Name: LifterLMS
  * Plugin URI: https://lifterlms.com/
@@ -48,6 +48,7 @@ require_once 'vendor/autoload.php';
  * @since 3.36.1 Include SendWP Connector.
  * @since 3.37.0 Move theme support methods to LLMS_Theme_Support.
  * @since 3.38.1 Include LLMS_Mime_Type_Extractor class.
+ * @since [version] Include LLMS_MailHawk connector.
  */
 final class LifterLMS {
 
@@ -281,6 +282,7 @@ final class LifterLMS {
 	 * @since 3.36.1 Include SendWP Connector.
 	 * @since 3.37.0 Include LLMS_Theme_Support class.
 	 * @since 3.38.1 Include LLMS_Mime_Type_Extractor class.
+	 * @since [version] Include LLMS_MailHawk class.
 	 *
 	 * @return void
 	 */
@@ -348,6 +350,7 @@ final class LifterLMS {
 
 			require_once 'includes/admin/class-llms-admin-review.php';
 			require_once 'includes/admin/class-llms-admin-export-download.php';
+			require_once 'includes/admin/class-llms-mailhawk.php';
 			require_once 'includes/admin/class-llms-sendwp.php';
 
 		}

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -350,6 +350,8 @@ final class LifterLMS {
 
 			require_once 'includes/admin/class-llms-admin-review.php';
 			require_once 'includes/admin/class-llms-admin-export-download.php';
+
+			require_once 'includes/abstracts/llms-abstract-email-provider.php';
 			require_once 'includes/admin/class-llms-mailhawk.php';
 			require_once 'includes/admin/class-llms-sendwp.php';
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
@@ -156,12 +156,12 @@ class LLMS_Test_MailHawk extends LLMS_Unit_Test_Case {
 		// Install.
 		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
 		$this->assertEquals( array( 'partner_id', 'register_url', 'client_state', 'redirect_uri', ), array_keys( $res ) );
-		$this->assertEquals( 1, $res['partner_id'] );
+		$this->assertEquals( 3, $res['partner_id'] );
 
 		// Already installed, activate.
 		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
 		$this->assertEquals( array( 'partner_id', 'register_url', 'client_state', 'redirect_uri', ), array_keys( $res ) );
-		$this->assertEquals( 1, $res['partner_id'] );
+		$this->assertEquals( 3, $res['partner_id'] );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Test MailHawk Connector
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group mailhawk
+ *
+ * @since [version]
+ */
+class LLMS_Test_MailHawk extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-mailhawk.php';
+		$this->mailhawk = new LLMS_MailHawk();
+
+	}
+
+	/**
+	 * Tear down the testcase.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+		wp_delete_file( WP_PLUGIN_DIR . '/mailhawk/uninstall.php' );
+		delete_plugins( array( 'mailhawk/mailhawk.php' ) );
+
+	}
+
+	/**
+	 * Test the add_settings() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_settings() {
+
+		// No settings for anyone without the `install_plugins` cap.
+		$this->assertEquals( array(), $this->mailhawk->add_settings( array() ) );
+
+		// Admin can see the settings.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$res = $this->mailhawk->add_settings( array() );
+		$this->assertEquals( array( 'mailhawk_title', 'mailhawk_connect' ), wp_list_pluck( $res, 'id' ) );
+
+	}
+
+	/**
+	 * Test do_remote_install() error with no nonce submitted.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_remote_install_no_nonce() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
+
+		$this->assertArrayHasKey( 'message', $res );
+		$this->assertEquals( 'llms_mailhawk_install_nonce_failure', $res['code'] );
+		$this->assertEquals( 401, $res['status'] );
+
+	}
+
+	/**
+	 * Test do_remote_install() error for no user.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_remote_install_no_user() {
+
+		$this->mockPostRequest( array(
+			'_llms_mailhawk_nonce' => wp_create_nonce( 'llms-mailhawk-install' ),
+		) );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
+
+		$this->assertArrayHasKey( 'message', $res );
+		$this->assertEquals( 'llms_mailhawk_install_unauthorized', $res['code'] );
+		$this->assertEquals( 403, $res['status'] );
+
+	}
+
+	/**
+	 * Test do_remote_install() error with plugins api.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_remote_install_plugins_api_error() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->mockPostRequest( array(
+			'_llms_mailhawk_nonce' => wp_create_nonce( 'llms-mailhawk-install' ),
+		) );
+
+		$handler = function( $ret, $action, $args ) {
+			return new WP_Error( 'plugins_api_failed', 'Error' );
+		};
+		add_filter( 'plugins_api', $handler, 10, 3 );
+		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
+		remove_filter( 'plugins_api', $handler, 10 );
+
+		$this->assertArrayHasKey( 'message', $res );
+		$this->assertEquals( 'plugins_api_failed', $res['code'] );
+		$this->assertEquals( 400, $res['status'] );
+
+	}
+
+	/**
+	 * Test do remote install success.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_do_remote_install_success() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->mockPostRequest( array(
+			'_llms_mailhawk_nonce' => wp_create_nonce( 'llms-mailhawk-install' ),
+		) );
+
+		// Install.
+		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
+		$this->assertEquals( array( 'partner_id', 'register_url', 'client_state', 'redirect_uri', ), array_keys( $res ) );
+		$this->assertEquals( 1, $res['partner_id'] );
+
+		// Already installed, activate.
+		$res = LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'do_remote_install' );
+		$this->assertEquals( array( 'partner_id', 'register_url', 'client_state', 'redirect_uri', ), array_keys( $res ) );
+		$this->assertEquals( 1, $res['partner_id'] );
+
+	}
+
+	/**
+	 * Test get_connect_setting()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_connect_setting() {
+
+		// Not connected.
+		$this->assertStringContains( 'id="llms-mailhawk-connect"', LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'get_connect_setting' ) );
+
+		// Connected and not suspended.
+		update_option( 'mailhawk_is_connected', 'yes' );
+		set_transient( 'mailhawk_is_suspended', 'no', 10 );
+		$this->assertStringContains( 'View settings', LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'get_connect_setting' ) );
+		$this->assertStringContains( 'manage your account', LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'get_connect_setting' ) );
+
+		// Connected and suspended.
+		set_transient( 'mailhawk_is_suspended', 'yes', 10 );
+		$this->assertStringContains( 'Email sending is currently disabled', LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'get_connect_setting' ) );
+
+	}
+
+	/**
+	 * Test should_output_inline() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_output_inline() {
+
+		// No user.
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'should_output_inline' ) );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Wrong screen.
+		set_current_screen( 'admin' );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'should_output_inline' ) );
+
+		// Mock screen.
+		set_current_screen( 'lifterlms_page_llms-settings' );
+
+		// Right screen, wrong tab.
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'should_output_inline' ) );
+
+		// Right screen, right tab, is connected.
+		update_option( 'mailhawk_is_connected', 'yes' );
+		$this->mockGetRequest( array( 'tab' => 'engagements' ) );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'should_output_inline' ) );
+
+		// Right screen, right tab, not connected.
+		update_option( 'mailhawk_is_connected', 'no' );
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->mailhawk, 'should_output_inline' ) );
+
+		set_current_screen( 'front' );
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-mailhawk.php
@@ -11,6 +11,22 @@
 class LLMS_Test_MailHawk extends LLMS_Unit_Test_Case {
 
 	/**
+	 * Setup before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		include_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-email-provider.php';
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-mailhawk.php';
+
+	}
+
+	/**
 	 * Setup the test case.
 	 *
 	 * @since [version]
@@ -20,7 +36,6 @@ class LLMS_Test_MailHawk extends LLMS_Unit_Test_Case {
 	public function setUp() {
 
 		parent::setUp();
-		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-mailhawk.php';
 		$this->mailhawk = new LLMS_MailHawk();
 
 	}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-sendwp.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-sendwp.php
@@ -13,16 +13,32 @@
 class LLMS_Test_SendWP extends LLMS_Unit_Test_Case {
 
 	/**
+	 * Setup before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		include_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-email-provider.php';
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-sendwp.php';
+
+	}
+
+	/**
 	 * Setup the test case.
 	 *
 	 * @since 3.36.1
+	 * @since [version] Include class file via `setUpBeforeClass()`.
 	 *
 	 * @return void
 	 */
 	public function setUp() {
 
 		parent::setUp();
-		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-sendwp.php';
 		$this->sendwp = new LLMS_SendWP();
 
 	}

--- a/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -9,7 +9,7 @@
  * @group settings_page_engagements
  *
  * @since 3.37.3
- * @version 3.37.3
+ * @since [version] Add tests for `get_settings_group_email_delivery()`.
  */
 class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 
@@ -70,6 +70,59 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 				'yes',
 			),
 		);
+
+	}
+
+	/**
+	 * Retrieve mock email provider settings used to test the get_settings_group_email_delivery() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	public function get_mock_email_provider_settings() {
+
+		return array(
+			array(
+				'id' => 'mock_email_provider_title',
+				'type' => 'subtitle',
+				'title' => 'Email sender',
+			),
+		);
+
+	}
+
+	/**
+	 * Return an array of mock settings and possible values.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_group_email_delivery_no_providers() {
+
+		$this->assertEquals( array(), LLMS_Unit_Test_Util::call_method( $this->page, 'get_settings_group_email_delivery' ) );
+
+	}
+
+	/**
+	 * Return an array of mock settings and possible values.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_group_email_delivery_with_providers() {
+
+		$this->assertEquals( array(), LLMS_Unit_Test_Util::call_method( $this->page, 'get_settings_group_email_delivery' ) );
+
+		add_filter( 'llms_email_delivery_services', array( $this, 'get_mock_email_provider_settings' ) );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->page, 'get_settings_group_email_delivery' );
+
+		$this->assertEquals( array( 'email_delivery', 'email_delivery_title', 'mock_email_provider_title', 'email_delivery_end' ), wp_list_pluck( $res, 'id' ) );
+
+		remove_filter( 'llms_email_delivery_services', array( $this, 'get_mock_email_provider' ) );
 
 	}
 


### PR DESCRIPTION
## Description

MailHawk is an email delivery service (like SendWP). 

Like the existing connector for SendWP, this connector performs a remote installation from the WP plugins repo to install SendWP and then trigger authorization redirect to MailHawk's oAuth provider.

After authorization users will be returned to the MailHawk settings area on the WP admin panel and LifterLMS is no longer involved.

View more info about the service https://mailhawk.io

+ Adds a MailHawk "connector" for easy install into the service
+ Makes minor changes to the SendWP integration
+ SendWP is automatically disabled on the provider's area when MailHawk is connected (and vice versa)

## How has this been tested?

Unit tests have been created to cover much of the new code introduced (probably not 100% coverage)

## Types of changes

New integration connector

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->


## Todos

+ [x] Update partner ID once it's provided to us
+ [ ] Update SendWP docs to reflect updated interface
+ [ ] Write MailHawk docs