### PR TITLE
Remove product global

### DIFF
--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -25,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
  *                Deprecated `LLMS_PlayNice::wc_is_account_page()`.
  * @since 3.37.18 Resolve Divi/WC conflict encountered using the frontend pagebuilder on courses and memberships.
  * @since 4.0.0 Removed previously deprecated method `LLMS_PlayNice::wc_is_account_page()`.
+ *              Remove Divi Frontend Builder WC conflict code.
  */
 class LLMS_PlayNice {
 
@@ -62,6 +63,7 @@ class LLMS_PlayNice {
 	 * @since 3.31.0
 	 * @since 3.37.17 Changed the way we handle endpoints conflict, using a different WC filter hook.
 	 * @since 3.37.18 Add fix for Divi Frontend-Builder WC conflict.
+	 * @since 4.0.0 Remove Divi Frontend Builder WC conflict code.
 	 *
 	 * @return void
 	 */
@@ -71,10 +73,6 @@ class LLMS_PlayNice {
 
 		if ( $wc_exists ) {
 			add_filter( 'woocommerce_account_endpoint_page_not_found', array( $this, 'wc_account_endpoint_page_not_found' ) );
-		}
-
-		if ( $wc_exists && 'divi' === strtolower( get_template() ) ) {
-			add_action( 'et_fb_enqueue_assets', array( $this, 'divi_fb_wc_product_tabs_before' ), 1 );
 		}
 
 	}
@@ -96,39 +94,6 @@ class LLMS_PlayNice {
 		}
 
 		return $tabs;
-
-	}
-
-	/**
-	 * Temporarily remove global LLMS_Product data when the Divi Frontend Page builder is loading.
-	 *
-	 * Resolves an issue encountered when running Divi, WooCommerce, and LifterLMS which
-	 * prevents the frontend builder from loading on courses and memberships because LifterLMS
-	 * (stupidly?) and WC both use the global `$product` variable to store data about our respective
-	 * products and Divi assumes (understandably?) that `$product` is always a `WC_Product` causing
-	 * fatal errors.
-	 *
-	 * @since 3.37.18
-	 *
-	 * @link https://github.com/gocodebox/lifterlms/issues/1079
-	 *
-	 * @return void
-	 */
-	public function divi_fb_wc_product_tabs_before() {
-
-		global $product;
-		if ( isset( $_GET['et_fb'] ) && isset( $product ) && is_a( $product, 'LLMS_Product' ) ) {
-
-			// Store the product temporarily.
-			$this->temp_vars['product'] = $product;
-
-			// Unset it.
-			unset( $GLOBALS['product'] );
-
-			// Restore it when Divi's done with the var.
-			add_filter( 'woocommerce_product_tabs', array( $this, 'divi_fb_wc_product_tabs_after' ), 999 );
-
-		}
 
 	}
 

--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -78,26 +78,6 @@ class LLMS_PlayNice {
 	}
 
 	/**
-	 * After Divi processes WC metabox tabs restore our global variables (just in case).
-	 *
-	 * @since 3.37.18
-	 *
-	 * @link https://github.com/gocodebox/lifterlms/issues/1079
-	 *
-	 * @param array[] $tabs Array of WC product metabox tabs.
-	 * @return array[]
-	 */
-	public function divi_fb_wc_product_tabs_after( $tabs ) {
-
-		if ( ! empty( $this->temp_vars['product'] ) ) {
-			$GLOBALS['product'] = $this->temp_vars['product'];
-		}
-
-		return $tabs;
-
-	}
-
-	/**
 	 * Allow our dashboard endpoints sharing a query var with WC to function
 	 *
 	 * Inform WC that it should not force a 404 because we're on a valid endpoint.

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -461,34 +461,6 @@ function llms_setup_course_data( $post ) {
 add_action( 'the_post', 'llms_setup_course_data' );
 
 /**
- * When the_post is called, put course data into a global.
- *
- * @param mixed $post
- * @return LLMS_Course
- */
-function llms_setup_product_data( $post ) {
-
-	if ( ! is_admin() ) {
-
-		if ( 'course' == $post->post_type || 'llms_membership' == $post->post_type ) {
-			unset( $GLOBALS['product'] );
-
-			if ( is_int( $post ) ) {
-				$post = get_post( $post ); }
-
-			if ( empty( $post->post_type ) ) {
-				return; }
-
-				$GLOBALS['product'] = llms_get_product( $post );
-
-				return $GLOBALS['product'];
-		}
-	}
-
-}
-add_action( 'the_post', 'llms_setup_product_data' );
-
-/**
  * When the_post is called, put lesson data into a global.
  *
  * @param mixed $post
@@ -499,7 +471,6 @@ function llms_setup_lesson_data( $post ) {
 
 		if ( 'lesson' == $post->post_type ) {
 			unset( $GLOBALS['lesson'] );
-			// unset( $GLOBALS['course'] );
 
 			if ( is_int( $post ) ) {
 				$post = get_post( $post ); }
@@ -516,7 +487,6 @@ function llms_setup_lesson_data( $post ) {
 			$GLOBALS['lesson'] = get_lesson( $post );
 
 			llms_setup_course_data( $parent_course );
-			// $GLOBALS['course'] = get_course( $parent_course );
 
 			return $GLOBALS['lesson'];
 		}

--- a/templates/membership/full-description.php
+++ b/templates/membership/full-description.php
@@ -5,12 +5,12 @@
  * @package LifterLMS/Templates
  *
  * @since Unknown
- * @version Unknown
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
-global $post, $product;
+global $post;
 
 ?>
 <div class="llms-full-description">


### PR DESCRIPTION
## Description

Removes usage of the `$GLOBALS['product']` variable as well as (useless) functions that call it.

Also removes Divi/WC compatibility code designed to prevent Divi frontend builder conflicts encountered when using LifterLMS/WC/Divi together.

## How has this been tested?

Manual tests

## Screenshots <!-- if applicable -->

## Types of changes

Breaking changes:

+ removes function `llms_setup_product_data()`
+ removes method: `LLMS_PlayNice::divi_fb_wc_product_tabs_after()`
+ removes method: `LLMS_PlayNice::divi_fb_wc_product_tabs_before()`

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

