### PR TITLE
Escape `{` character in SQL queries.

### DIFF
--- a/includes/integrations/class.llms.integration.bbpress.php
+++ b/includes/integrations/class.llms.integration.bbpress.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Integrations/Classes
  *
  * @since 3.0.0
- * @version 3.38.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.37.11 Don't update saved forum values during course quick edits.
  * @since 3.38.1 When looking for forum course restrictions make sure to run a more generic query
  *               so that it matches forum ids whether they've been save as integers or strings.
+ * @since [version] Added MySQL 8.0 compatibility.
  */
 class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 
@@ -243,8 +244,8 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 	 * Check if a forum is restricted to a course(s)
 	 *
 	 * @since 3.12.0
-	 * @since 3.38.1 Make the query more generic so that it matches forum ids whether they've been saved
-	 *               as integers or strings.
+	 * @since 3.38.1 Make the query more generic so that it matches forum ids whether they've been saved as integers or strings.
+	 * @since [version] Escape `{` character in SQL query to add MySQL 8.0 support.
 	 *
 	 * @param int $forum_id WP_Post ID of the forum.
 	 * @return int[]
@@ -260,7 +261,7 @@ class LLMS_Integration_BBPress extends LLMS_Abstract_Integration {
 			 WHERE metas.meta_key = '_llms_bbp_forum_ids'
 			   AND metas.meta_value REGEXP %s
 			   AND posts.post_status = 'publish';",
-				'a:[0-9][0-9]*:{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . sprintf( '%d', absint( $forum_id ) ) . '"?;)'
+				'a:[0-9][0-9]*:\{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . sprintf( '%d', absint( $forum_id ) ) . '"?;)'
 			)
 		);
 

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.0.0
- * @version 3.38.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.32.0 Added `get_student_count()` method.
  * @since 3.36.3 Added `get_categories()`, `get_tags()` and `toArrayAfter()` methods.
  * @since 3.38.1 Added methods for retrieving posts associated with the membership.
+ * @since [version] Added MySQL 8.0 compatibility.
  *
  * @property $auto_enroll (array) Array of course IDs users will be autoenrolled in upon successful enrollment in this membership
  * @property $instructors (array) Course instructor user information
@@ -344,6 +345,7 @@ implements LLMS_Interface_Post_Instructors, LLMS_Interface_Post_Sales_Page {
 	 * Performs a WPDB query to retrieve posts associated with the membership
 	 *
 	 * @since 3.38.1
+	 * @since [version] Escape `{` character in SQL query to add MySQL 8.0 support.
 	 *
 	 * @see LLMS_Membesrhip::get_associated_posts()
 	 *
@@ -382,7 +384,7 @@ implements LLMS_Interface_Post_Instructors, LLMS_Interface_Post_Sales_Page {
 					$enabled_key,
 					$enabled_value,
 					$list_key,
-					'a:[0-9][0-9]*:{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . $this->get( 'id' ) . '"?;)'
+					'a:[0-9][0-9]*:\{(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?[0-9][0-9]*"?;)*(i:[0-9][0-9]*;(i|s:[0-9][0-9]*):"?' . $this->get( 'id' ) . '"?;)'
 				)
 			);
 


### PR DESCRIPTION
## Description

Fixes #1178 

## How has this been tested?

Existing unit tests pass in the following environments:
PHP 7.4 and MySQL 8.0.19
PHP 7.4 and MariaDB 10.4.12

MariaDB 10.4 should work equivalently to MySQL (native) 5.6 and 5.7 (according to https://mariadb.com/kb/en/mariadb-vs-mysql-compatibility/#replication-compatibility)

Travis tests run on MySQL 5.7 so assuming passing CI tests we'll have full coverage that the change doesn't break in supported versions

## Types of changes

Non-breaking bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

