### PR TITLE
Explicitly set the number of points earned for a quiz question to zero except when the question is answered correctly

### DIFF
--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -672,9 +672,9 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 	/**
 	 * Record the attempt as started
 	 *
-	 * @return   obj             $this for chaining
-	 * @since    3.9.0
-	 * @version  3.9.0
+	 * @since 3.9.0
+	 *
+	 * @return LLMS_Quiz_Attempt Instance of the current quiz attempt object.
 	 */
 	public function start() {
 
@@ -687,9 +687,9 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 	/**
 	 * Retrieve the private data array
 	 *
-	 * @return   array
-	 * @since    3.9.0
-	 * @version  3.9.0
+	 * @since 3.9.0
+	 *
+	 * @return array
 	 */
 	public function to_array() {
 		return $this->data;

--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -411,7 +411,7 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 					$questions[ $inc[ $perm ] ] = $swap;
 				}
 			}
-		}// End if().
+		}
 
 		return $questions;
 
@@ -652,16 +652,17 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 	/**
 	 * Set the status of the attempt
 	 *
-	 * @param    string  $status   status value
-	 * @param    boolean $save     if true, immediately persists to database
-	 * @return   self
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 * @since [version] Use strict comparisons.
+	 *
+	 * @param string  $status Status value.
+	 * @param boolean $save   If `true`, immediately persists to database.
+	 * @return false|LLMS_Quiz_Attempt
 	 */
 	public function set_status( $status, $save = false ) {
 
 		$statuses = array_keys( llms_get_quiz_attempt_statuses() );
-		if ( ! in_array( $status, $statuses ) ) {
+		if ( ! in_array( $status, $statuses, true ) ) {
 			return false;
 		}
 		return $this->set( 'status', $status );

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-quiz-attempt.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-quiz-attempt.php
@@ -1,9 +1,13 @@
 <?php
 /**
- * Tests for the LLMS_Install Class
- * @group    quizzes
- * @since    3.9.0
- * @version  3.17.4
+ * Tests LLMS_Quiz_Attempt model.
+ *
+ * @group quizzes
+ * @group quiz_attempt
+ *
+ * @since 3.9.0
+ * @since 3.17.4 Unknown.
+ * @since [version] Add tests for the answer_question() method.
  */
 class LLMS_Test_Model_Quiz_Attempt extends LLMS_UnitTestCase {
 
@@ -27,6 +31,32 @@ class LLMS_Test_Model_Quiz_Attempt extends LLMS_UnitTestCase {
 		$attempt = LLMS_Quiz_Attempt::init( $qid, $lid, $uid );
 		$attempt->save();
 		return $attempt;
+
+	}
+
+	/**
+	 * Retrieve the first incorrect choice for a given question.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Question|WP_Post|int $question Question object, WP_Post object for a question post, or WP_Post ID of the question.
+	 * @return LLMS_Question_Choice
+	 */
+	private function get_incorrect_choice( $question ) {
+
+		$question = is_a( $question, 'LLMS_Question' ) ? $question : llms_get_post( $question );
+
+		foreach ( $question->get_choices() as $choice ) {
+
+			if ( $choice->is_correct() ) {
+				continue;
+			}
+
+			return array(
+				$choice->get( 'id' ),
+			);
+
+		}
 
 	}
 
@@ -63,7 +93,7 @@ class LLMS_Test_Model_Quiz_Attempt extends LLMS_UnitTestCase {
 
 			$answer_type = ( $current_question <= $to_answer_correctly );
 
-			// answer correctly until we don't have to anymore
+			// Answer correctly until we don't have to anymore.
 			foreach( $question->get_choices() as $key => $choice ) {
 				if ( $answer_type === $choice->is_correct() ) {
 					$attempt->answer_question( $question_id, array( $choice->get( 'id' ) ) );
@@ -81,7 +111,89 @@ class LLMS_Test_Model_Quiz_Attempt extends LLMS_UnitTestCase {
 
 	}
 
+	public function test_answer_question_correctly() {
 
+		$attempt   = $this->get_mock_attempt();
+		$questions = wp_list_pluck( $attempt->get_questions(), 'id' );
+		$question  = llms_get_post( $questions[0] );
+		$correct   = $question->get_correct_choice();
+
+		// Answer question.
+		$attempt = $attempt->answer_question( $questions[0], $correct );
+
+		$this->assertTrue( is_a( $attempt, 'LLMS_Quiz_Attempt' ) );
+
+		$res = $attempt->get_questions()[0];
+
+		$this->assertEquals( $res['points'], $res['earned'] );
+		$this->assertEquals( 'yes', $res['correct'] );
+		$this->assertEquals( $correct, $res['answer'] );
+
+
+		/**
+		 * Answer the question again to simulate a user going back to change their answer.
+		 *
+		 * @see https://github.com/gocodebox/lifterlms/issues/1211
+		 */
+		$incorrect = $this->get_incorrect_choice( $question );
+		$attempt->answer_question( $questions[0], $incorrect );
+
+		$res = $attempt->get_questions()[0];
+
+		$this->assertEquals( 0, $res['earned'] );
+		$this->assertEquals( 'no', $res['correct'] );
+		$this->assertEquals( $incorrect, $res['answer'] );
+
+	}
+
+	/**
+	 * Test answer_question() when supplying a correct answer
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_answer_question_incorrectly() {
+
+		$attempt   = $this->get_mock_attempt();
+		$questions = wp_list_pluck( $attempt->get_questions(), 'id' );
+		$question  = llms_get_post( $questions[0] );
+		$correct   = $question->get_correct_choice();
+
+		// Answer question.
+		$incorrect = $this->get_incorrect_choice( $question );
+		$attempt = $attempt->answer_question( $questions[0], $incorrect );
+
+		$res = $attempt->get_questions()[0];
+
+		$this->assertEquals( 0, $res['earned'] );
+		$this->assertEquals( 'no', $res['correct'] );
+		$this->assertEquals( $incorrect, $res['answer'] );
+
+		/**
+		 * Answer the question again to simulate a user going back to change their answer.
+		 *
+		 * @see https://github.com/gocodebox/lifterlms/issues/1211
+		 */
+		$attempt->answer_question( $questions[0], $correct );
+
+		$this->assertTrue( is_a( $attempt, 'LLMS_Quiz_Attempt' ) );
+
+		$res = $attempt->get_questions()[0];
+
+		$this->assertEquals( $res['points'], $res['earned'] );
+		$this->assertEquals( 'yes', $res['correct'] );
+		$this->assertEquals( $correct, $res['answer'] );
+
+	}
+
+	/**
+	 * Test answer_question() when supplying an incorrect answer
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function test_grading_with_floats() {
 
 		$attempt = $this->get_mock_attempt( 6 );


### PR DESCRIPTION
## Description

Fixes #1211 

The problem in the related issue is that the `answer_question()` method only sets the number of earned points if the answer is correct.

This works correctly when answering the question for the first time but when a question is initially correct and then answered again (incorrectly the second time) the question is wrong so the previously "earned" points are not revoked.

The incorrect behavior is then observed (as described in #1211)

This PR adjusts the logic of this method to ALWAYS set the number of earned points -- if correct, the number of available points are assigned as "earned" and otherwise "earned" is set to zero.

## How has this been tested?

New phpunit tests have been added to ensure that expected (working) functionality persists and that the undesired behavior in #1211 goes away.

I have run manual tests in various scenarios to recreate #1211 and also ensure "best case" scenarios continue to work as expected.

I've additionally tested this against LifterLMS Assignments with various auto-graded and manually graded question types.

## Screenshots <!-- if applicable -->

## Types of changes
+ Bug fix
+ Minor doc and CS fixes 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

