### PR TITLE
Adds RTL support for the Javascript Popovers in the course builder

### DIFF
--- a/assets/js/builder/Views/Popover.js
+++ b/assets/js/builder/Views/Popover.js
@@ -1,13 +1,18 @@
 /**
- * Single Quiz View
+ * Popover View
  *
- * @since    3.16.0
- * @version  3.16.0
+ * @since 3.16.0
+ * @version [version]
  */
 define( [], function() {
 
 	return Backbone.View.extend( {
 
+		/**
+		 * Default Properties
+		 *
+		 * @type {Object}
+		 */
 		defaults: {
 			placement: 'auto',
 			// container: document.body,
@@ -26,16 +31,17 @@ define( [], function() {
 		/**
 		 * Wrapper Tag name
 		 *
-		 * @type  {String}
+		 * @type {String}
 		 */
 		tagName: 'div',
 
 		/**
 		 * Initialization callback func (renders the element on screen)
 		 *
-		 * @return   void
-		 * @since    3.14.1
-		 * @version  3.14.1
+		 * @since 3.14.1
+		 * @since [version] Add RTL support for popovers.
+		 *
+		 * @return void
 		 */
 		initialize: function( data ) {
 
@@ -44,6 +50,18 @@ define( [], function() {
 			}
 
 			this.args = _.defaults( data.args, this.defaults );
+
+			// Reverse directions for RTL sites.
+			if ( $( 'body' ).hasClass( 'rtl' ) ) {
+
+				if ( -1 !== this.args.placement.indexOf( 'left' ) ) {
+					this.args.placement = this.args.placement.replace( 'left', 'right' );
+				} else if ( -1 !== this.args.placement.indexOf( 'right' ) ) {
+					this.args.placement = this.args.placement.replace( 'right', 'left' );
+				}
+
+			}
+
 			this.render();
 
 		},
@@ -51,9 +69,9 @@ define( [], function() {
 		/**
 		 * Compiles the template and renders the view
 		 *
-		 * @return   self (for chaining)
-		 * @since    3.16.0
-		 * @version  3.16.0
+		 * @since 3.16.0
+		 *
+		 * @return {Object} Instance of the Backbone.view.
 		 */
 		render: function() {
 
@@ -65,9 +83,10 @@ define( [], function() {
 		/**
 		 * Hide the popover
 		 *
-		 * @return   self (for chaining)
-		 * @since    3.16.0
-		 * @version  3.16.12
+		 * @since 3.16.0
+		 * @since 3.16.12 Unknown.
+		 *
+		 * @return {Object} Instance of the Backbone.view.
 		 */
 		hide: function() {
 
@@ -79,9 +98,10 @@ define( [], function() {
 		/**
 		 * Show the popover
 		 *
-		 * @return   self (for chaining)
-		 * @since    3.16.0
-		 * @version  3.16.12
+		 * @since 3.16.0
+		 * @since 3.16.12 Unknown.
+		 *
+		 * @return {Object} Instance of the Backbone.view.
 		 */
 		show: function() {
 


### PR DESCRIPTION
## Description

Fixes https://github.com/gocodebox/lifterlms-advanced-quizzes/issues/11

The issue was reported in an add-on repository, but the offending code is actually in the core codebase.

This PR adds logic to switch "left" to "right" and "right" to "left" when either "left" or "right" is used for the `placement` parameter of the popover view parameters.

This also takes into account multi-directional placements, for example "top-right" will become "top-left" on an RTL site.

## How has this been tested?

Manually with both LTR and RTL sites.

## Screenshots <!-- if applicable -->

## Types of changes

bugfix

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/master/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/master/docs/documentation-standards.md -->

