### PR TITLE
Order status updated automatically using the hook for the enrollment …

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 3.0.0
- * @version 3.33.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,6 +15,9 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.0.0
  * @since 3.33.0 Added the logic to handle the Enrollment 'deleted' status on save.
+ * @since [version] In ` save_delete_enrollment()` removed order cancellation instruction, moved elsewhere as reaction to the enrollment deletion.
+ *                @see `LLMS_Controller_Orders->on_deleted_enrollment()` in `includes\controllers\class.llms.controller.orders.php`.
+ *                Also, add order note about the enrollment deletion only if it actually occurred.
  */
 class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 
@@ -133,6 +136,9 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 	 * Delete enrollment data based on posted values.
 	 *
 	 * @since 3.33.0
+	 * @since [version] Removed order cancellation instruction, moved elsewhere as reaction to the enrollment deletion.
+	 *                @see `LLMS_Controller_Orders->on_deleted_enrollment()` in `includes\controllers\class.llms.controller.orders.php`.
+	 *                Also, add order note about the enrollment deletion only if it actually occurred.
 	 *
 	 * @param int $post_id WP_Post ID of the order.
 	 * @return void
@@ -141,14 +147,16 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 
 		$order = llms_get_post( $post_id );
 
-		// Switch the order status to Cancelled: it will also unenroll the student setting the enrollment status to 'cancelled' as well
-		// @see `LLMS_Controller_Orders->error_order()`
-		$order->set_status( 'cancelled' );
+		/**
+		 * Completely remove any enrollment records related to the given product & order.
+		 * Also note that, by design, at this stage the student has already been unenrolled,
+		 * as the delete button is only available when the enrollment status is NOT 'enrolled'.
+		 */
+		if ( llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) ) ) {
 
-		// Completely remove any enrollment records related to the given product & order.
-		llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) );
+			$order->add_note( __( 'Student enrollment records have been deleted.', 'lifterlms' ), true );
 
-		$order->add_note( __( 'Student enrollment records have been deleted.', 'lifterlms' ), true );
+		}
 
 	}
 

--- a/includes/controllers/class.llms.controller.orders.php
+++ b/includes/controllers/class.llms.controller.orders.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.0.0
- * @version 3.36.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.34.4 Added filter `llms_order_can_be_confirmed`.
  * @since 3.34.5 Fixed logic error in `llms_order_can_be_confirmed` conditional.
  * @since 3.36.1 In `recurring_charge()`, made sure to process only proper LLMS_Orders of existing users.
+ * @since [version] Added logic to set the order status to 'cancelled' when an enrollment linked to an order is deleted.
+ *               Also `llms_unenroll_on_error_order` fiter hook added.
  */
 class LLMS_Controller_Orders {
 
@@ -26,7 +28,8 @@ class LLMS_Controller_Orders {
 	 *
 	 * @since 3.0.0
 	 * @since 3.19.0 Updated.
-	 * @since 3.33.0 Added `before_delete_post` action to handle order deletion
+	 * @since 3.33.0 Added `before_delete_post` action to handle order deletion.
+	 * @since [version] Added `llms_user_enrollment_deleted` action to handle order status change on enrollment deletion.
 	 */
 	public function __construct() {
 
@@ -40,6 +43,9 @@ class LLMS_Controller_Orders {
 
 		// this action adds lifterlms specific action when an order is deleted, just before the WP post postmetas are removed.
 		add_action( 'before_delete_post', array( $this, 'on_delete_order' ) );
+
+		// this action is meant to do specific actions on orders when an enrollment, with an order as trigger, is deleted.
+		add_action( 'llms_user_enrollment_deleted', array( $this, 'on_user_enrollment_deleted' ), 10, 3 );
 
 		/**
 		 * Status Change Actions for Orders and Transactions
@@ -308,15 +314,33 @@ class LLMS_Controller_Orders {
 	}
 
 	/**
-	 * Called when an order's status changes to refunded, cancelled, expired, or failed
+	 * Called when an order's status changes to refunded, cancelled, expired, or failed.
 	 *
-	 * @param    obj $order  instance of an LLMS_Order
-	 * @return   void
+	 * @since 3.0.0
+	 * @since 3.10.0 Unknown.
+	 * @since [version] Added `llms_unenroll_on_error_order` filter hook.
+	 *
+	 * @param  LLMS_Order $order Instance of an LLMS_Order
+	 * @return void
 	 *
 	 * @since    3.0.0
 	 * @version  3.10.0
 	 */
 	public function error_order( $order ) {
+
+		$order->unschedule_recurring_payment();
+
+		/**
+		 * Determine if student should be unenrolled on order error.
+		 *
+		 * @since [version]
+		 *
+		 * @param bool       $unenroll_on_error_order True if the student should be unenrolled, false otherwise. Default true.
+		 * @param LLMS_Order $order                   Order object.
+		 */
+		if ( ! apply_filters( 'llms_unenroll_on_error_order', true, $order ) ) {
+			return;
+		}
 
 		switch ( current_filter() ) {
 
@@ -334,8 +358,6 @@ class LLMS_Controller_Orders {
 				break;
 
 		}
-
-		$order->unschedule_recurring_payment();
 
 		llms_unenroll_student( $order->get( 'user_id' ), $order->get( 'product_id' ), $status, 'order_' . $order->get( 'id' ) );
 
@@ -355,6 +377,34 @@ class LLMS_Controller_Orders {
 		$order = llms_get_post( $post_id );
 		if ( $order && is_a( $order, 'LLMS_Order' ) ) {
 			llms_delete_student_enrollment( $order->get( 'user_id' ), $order->get( 'product_id' ), 'order_' . $order->get( 'id' ) );
+		}
+
+	}
+
+	/**
+	 * Called when an user enrollment is deleted.
+	 * Will set the related order status to 'cancelled'.
+	 *
+	 * @since [version]
+	 *
+	 * @param int    $user_id    WP User ID.
+	 * @param int    $product_id WP Post ID of the course or membership.
+	 * @param string $trigger    The deleted enrollment trigger, or 'any' if no specific trigger.
+	 * @return void
+	 */
+	public function on_user_enrollment_deleted( $user_id, $product_id, $trigger ) {
+
+		$order_id = 'order_' === substr( $trigger, 0, 6 ) ? absint( substr( $trigger, 6 ) ) : false;
+		$order    = $order_id ? llms_get_post( $order_id ) : false;
+
+		if ( $order && is_a( $order, 'LLMS_Order' ) ) {
+
+			// No need to run an unenrollment as we're reacting to an enrollment deletion, user enrollments data already removed.
+			add_filter( 'llms_unenroll_on_error_order', '__return_false', 100 );
+			$order->set_status( 'cancelled' );
+			// Reset unenrollment's suspension.
+			remove_filter( 'llms_unenroll_on_error_order', '__return_false', 100 );
+
 		}
 
 	}

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 2.2.3
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,6 +23,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.36.2 Added logic to physically remove from the membership level and remove enrollments data on related products, when deleting a membership enrollment.
  * @since 3.37.9 Added filters `llms_user_enrollment_allowed_post_types` & `llms_user_enrollment_status_allowed_post_types` which allow 3rd parties to enroll users into additional post types via core enrollment methods.
  * @since 4.0.0 Remove previously deprecated methods.
+ * @since [version] The `$enrollment_trigger` parameter was added to the `'llms_user_enrollment_deleted'` action hook.
  */
 class LLMS_Student extends LLMS_Abstract_User_Data {
 
@@ -1687,8 +1688,9 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	 *
 	 * @since 3.33.0
 	 * @since 3.36.2 Added logic to physically remove from the membership level and remove enrollments data on related products.
+	 * @since [version] The `$enrollment_trigger` parameter was added to the `llms_user_enrollment_deleted` action hook.
 	 *
-	 * @see llms_delete_student_enrollment() calls this function without having to instantiate the LLMS_Student class first.
+	 * @see `llms_delete_student_enrollment()` calls this function without having to instantiate the LLMS_Student class first.
 	 *
 	 * @param int    $product_id WP Post ID of the course or membership.
 	 * @param string $trigger    Optional. Only delete the student's enrollment if the original enrollment trigger matches the submitted value.
@@ -1737,8 +1739,21 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 						$this->remove_membership_level( $product_id, '', true );
 				}
 
-				// trigger action
-				do_action( 'llms_user_enrollment_deleted', $this->get_id(), $product_id );
+				$enrollment_trigger = isset( $enrollment_trigger ) ? $enrollment_trigger : $this->get_enrollment_trigger( $product_id );
+				// no enrollment trigger exists b/c pre 3.0.0 enrollment, in this case fall back on the `$trigger` param.
+				$enrollment_trigger = $enrollment_trigger ? $enrollment_trigger : $trigger;
+
+				/**
+				 * Fires after an user enrollment has been deleted.
+				 *
+				 * @since 3.33.0
+				 * @since [version] The `$enrollment_trigger` parameter was added.
+				 *
+				 * @param int    $user_id             WP User ID.
+				 * @param int    $product_id          WP Post ID of the course or membership.
+				 * @param string $enrollment_trigger  The enrollment trigger.
+				 */
+				do_action( 'llms_user_enrollment_deleted', $this->get_id(), $product_id, $enrollment_trigger );
 
 				return true;
 

--- a/tests/phpunit/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-order-enrollment.php
+++ b/tests/phpunit/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-order-enrollment.php
@@ -28,7 +28,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 	}
 
 	/**
-	 * test the LLMS_Meta_Box_Order_Enrollment save method
+	 * test the LLMS_Meta_Box_Order_Enrollment save method.
 	 *
 	 * @since 3.33.0
 	 *
@@ -36,14 +36,14 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 	 */
 	public function test_save() {
 
-		// create a real order
+		// create a real order.
 		$order = $this->get_mock_order();
 
 		$order_id   = $order->get( 'id' );
 		$product_id = $order->get( 'product_id' );
 		$student_id = $order->get( 'user_id' );
 
-		// check enroll
+		// check enroll.
 		$this->setup_post( array(
 			'llms_update_enrollment_status'      => 'Update',
 			'llms_student_old_enrollment_status' => '',
@@ -53,7 +53,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 		$this->metabox->save( $order_id );
 		$this->assertTrue( llms_is_user_enrolled( $student_id, $product_id ) );
 
-		// check unenroll
+		// check unenroll.
 		$this->setup_post( array(
 			'llms_update_enrollment_status'      => 'Update',
 			'llms_student_old_enrollment_status' => 'enrolled',
@@ -63,7 +63,7 @@ class LLMS_Test_Meta_Box_Order_Enrollment extends LLMS_PostTypeMetaboxTestCase {
 		$this->metabox->save( $order_id );
 		$this->assertFalse( llms_is_user_enrolled( $student_id, $product_id ) );
 
-		// check enrollment deleted => no enrollment records + order status set to cancelled
+		// check enrollment deleted => no enrollment records + order status set to cancelled.
 		$this->setup_post( array(
 			'llms_delete_enrollment_status'      => 'Delete',
 			'llms_student_old_enrollment_status' => 'expired',

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -12,8 +12,9 @@
  * @since 3.36.1 When testing deleting/erroring orders make sure to schedule a recurring payment when setting an order as active so that,
  *               when subsequently we error/delete the order, checking the recurring payment is unscheduled makes sense.
  *               Also add tests on recurrint payments not processed when order or user deleted.
+ * @since [version] Added `test_on_user_enrollment_deleted()`.
  *
- * @version 3.36.1
+ * @version [version]
  */
 class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 
@@ -258,6 +259,59 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * test on user enrollment deleted.
+	 * The controller's `on_user_enrollment_deleted()` method is reponsible of changing the order status to `cancelled`
+	 * in reaction to the deletion of an enrollment with the same order as trigger.
+	 * @group whattino
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_on_user_enrollment_deleted() {
+
+		$order            = $this->get_mock_order();
+		$student_id       = $order->get( 'user_id' );
+		$order_product_id = $order->get( 'product_id' );
+		$order_id         = $order->get( 'id' );
+
+		// enroll the student.
+		$order->set( 'status', 'llms-active' );
+
+		$order_cancelled_actions = did_action( 'lifterlms_order_status_cancelled' );
+
+		$fake_order_id = $order_id + 999;
+
+		// delete user enrollment passing a fake order as trigger.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$fake_order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-active', llms_get_post( $order_id )->get( 'status' ) );
+
+		// delete user enrollment.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions + 1, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+		$order_cancelled_actions = did_action( 'lifterlms_order_status_cancelled' );
+
+		// check that trying to delete it again doesn't trigger the action again.
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+		// enroll the student again on the same course with a different trigger.
+		$student = llms_get_student( $student_id );
+		llms_enroll_student( $student_id, $order_product_id );
+
+		llms_delete_student_enrollment( $student_id, $order_product_id, "order_{$order_id}" );
+		$this->assertEquals( $order_cancelled_actions, did_action( 'lifterlms_order_status_cancelled' ) );
+		// check order status.
+		$this->assertEquals( 'llms-cancelled', llms_get_post( $order_id )->get( 'status' ) );
+
+	}
 
 	/**
 	 * Test expire access function


### PR DESCRIPTION
…deletion.

## Description
Removed logic to set the order status to 'cancelled' when deleting an enrollment from the order screen.
Added logic to automatically set the order status to 'cancelled' when an enrollment deletion with an order as trigger is deleted, from whatever place.

see https://github.com/gocodebox/lifterlms-rest/issues/95#issuecomment-535595441

## How has this been tested?
Manually, with already existing unit tests and new unit tests

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding Standards.

see #954 