### PR TITLE
Return the author's display name as the default instructor's name 

### DIFF
--- a/includes/models/model.llms.post.instructors.php
+++ b/includes/models/model.llms.post.instructors.php
@@ -93,10 +93,12 @@ class LLMS_Post_Instructors {
 
 		// if empty, respond with the course author in an array
 		if ( ! $instructors ) {
+			$author = get_userdata( $this->post->get( 'author' ) );
 			$instructors = array(
 				wp_parse_args(
 					array(
-						'id' => $this->post->get( 'author' ),
+						'id' 	=> $this->post->get( 'author' ),
+						'name' 	=> $author ? $author->display_name : '',
 					),
 					llms_get_instructors_defaults()
 				),

--- a/includes/models/model.llms.post.instructors.php
+++ b/includes/models/model.llms.post.instructors.php
@@ -93,12 +93,12 @@ class LLMS_Post_Instructors {
 
 		// if empty, respond with the course author in an array
 		if ( ! $instructors ) {
-			$author = get_userdata( $this->post->get( 'author' ) );
+			$author      = get_userdata( $this->post->get( 'author' ) );
 			$instructors = array(
 				wp_parse_args(
 					array(
-						'id' 	=> $this->post->get( 'author' ),
-						'name' 	=> $author ? $author->display_name : '',
+						'id'   => $this->post->get( 'author' ),
+						'name' => $author ? $author->display_name : '',
 					),
 					llms_get_instructors_defaults()
 				),

--- a/tests/unit-tests/class-llms-test-post-instructors.php
+++ b/tests/unit-tests/class-llms-test-post-instructors.php
@@ -90,6 +90,8 @@ class LLMS_Test_Post_Instructors extends LLMS_UnitTestCase {
 			$post->set_instructors();
 			$expect = $defaults;
 			$expect['id'] = $user_ids[1];
+			$author = get_userdata( $user_ids[1] );
+			$expect['name'] = $author->display_name;
 			$this->assertEquals( array( $expect ), $post->get_instructors() );
 
 		}


### PR DESCRIPTION
## Description
The get_instructors() method of the LLMS_Post_Instructors() is not returning the same result when there is no instructors set and it fallback to the post author.

When instructors are set, the method return for each instructor an array with the following indexes: label, visibility, id and name.

However, when there is no instructors set, the array of the instructor only contain 3 indexes: label, visibility and id. 

The objective of this merge is to return the name as well for this case.

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests 
The code needs a modification in the automated tests (see in the commit)
- [x] My code follows the LifterLMS Coding Standards.