### PR TITLE
Doc: Fix includes/shortcodes/* packages

### DIFF
--- a/includes/shortcodes/class.llms.bbp.shortcode.course.forums.list.php
+++ b/includes/shortcodes/class.llms.bbp.shortcode.course.forums.list.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_bbp_course_forums]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.12.0
  * @version 3.12.1

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -4,7 +4,7 @@
  *
  * Controls functionality associated with shortcode [llms_checkout].
  *
- * @package LifterLMS/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 1.0.0
  * @version 3.36.3

--- a/includes/shortcodes/class.llms.shortcode.course.author.php
+++ b/includes/shortcodes/class.llms.shortcode.course.author.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_author]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.11.1

--- a/includes/shortcodes/class.llms.shortcode.course.continue.button.php
+++ b/includes/shortcodes/class.llms.shortcode.course.continue.button.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_continue_button]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.11.1
  * @version 3.11.1

--- a/includes/shortcodes/class.llms.shortcode.course.continue.php
+++ b/includes/shortcodes/class.llms.shortcode.course.continue.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_continue]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.6.0

--- a/includes/shortcodes/class.llms.shortcode.course.meta.info.php
+++ b/includes/shortcodes/class.llms.shortcode.course.meta.info.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_meta_info]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.6.0

--- a/includes/shortcodes/class.llms.shortcode.course.outline.php
+++ b/includes/shortcodes/class.llms.shortcode.course.outline.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_outline]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.5.1
  * @version 3.19.2

--- a/includes/shortcodes/class.llms.shortcode.course.prerequisites.php
+++ b/includes/shortcodes/class.llms.shortcode.course.prerequisites.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_prerequisites]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.6.0

--- a/includes/shortcodes/class.llms.shortcode.course.reviews.php
+++ b/includes/shortcodes/class.llms.shortcode.course.reviews.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_reviews]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.6.0

--- a/includes/shortcodes/class.llms.shortcode.course.syllabus.php
+++ b/includes/shortcodes/class.llms.shortcode.course.syllabus.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_course_syllabus]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.6.0
  * @version 3.6.0

--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_courses]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.14.0
  * @version 3.31.0

--- a/includes/shortcodes/class.llms.shortcode.hide.content.php
+++ b/includes/shortcodes/class.llms.shortcode.hide.content.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_hide_content]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.5.1
  * @version 3.24.1

--- a/includes/shortcodes/class.llms.shortcode.lesson.mark.complete.php
+++ b/includes/shortcodes/class.llms.shortcode.lesson.mark.complete.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_lesson_mark_complete]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.11.1
  * @version 3.11.1

--- a/includes/shortcodes/class.llms.shortcode.membership.link.php
+++ b/includes/shortcodes/class.llms.shortcode.membership.link.php
@@ -2,11 +2,11 @@
 /**
  * LifterLMS Membership Link Shortcode
  *
- * Output an anchor link for a membership
+ * Output an anchor link for a membership.
  *
  * [lifterlms_membership_link]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.0.0
  * @version 3.4.3

--- a/includes/shortcodes/class.llms.shortcode.my.account.php
+++ b/includes/shortcodes/class.llms.shortcode.my.account.php
@@ -4,7 +4,7 @@
  *
  * Shortcode: [lifterlms_my_account].
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 1.0.0
  * @version 4.0.0

--- a/includes/shortcodes/class.llms.shortcode.my.achievements.php
+++ b/includes/shortcodes/class.llms.shortcode.my.achievements.php
@@ -4,7 +4,7 @@
  *
  * [lifterlms_my_achievements]
  *
- * @package LifterLMS/Classes/Shortcodes
+ * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.14.1
  * @version 3.14.1


### PR DESCRIPTION
## Description
Fix includes/shortcodes/* packages in the file header, from  `LifterLMS/Classes/Shortcodes` to `LifterLMS/Shortcodes/Classes`

## How has this been tested?
n/a

## Screenshots <!-- if applicable -->

## Types of changes
Docs changes 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

