### PR TITLE
Allow completion customization

### DIFF
--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -209,6 +209,46 @@ if ( ! function_exists( 'llms_filter_input' ) ) {
 	function llms_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = array() ) {
 		return filter_input( $type, $variable_name, $filter, $options );
 	}
+}
+
+/**
+ * Retrieve an array of post types which can be completed by students
+ *
+ * @since [version]
+ *
+ * @return string[]
+ */
+function llms_get_completable_post_types() {
+
+	/**
+	 * Filter the list of post types which can be completed by students.
+	 *
+	 * @since Unknown
+	 *
+	 * @param string[] $post_types WP_Post post type names.
+	 */
+	return apply_filters( 'llms_completable_post_types', array( 'course', 'section', 'lesson' ) );
+
+}
+
+/**
+ * Retrieve an array of taxonomies which can be completed by students
+ *
+ * @since [version]
+ *
+ * @return string[]
+ */
+function llms_get_completable_taxonomies() {
+
+	/**
+	 * Filter the list of taxonomies which can be completed by students.
+	 *
+	 * @since [version]
+	 *
+	 * @param string[] $taxonomies Taxonomy names.
+	 */
+	return apply_filters( 'llms_completable_taxonomies', array( 'course_track' ) );
+
 }
 
 /**

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1817,7 +1817,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 		 * Lessons have binary completion (complete or incomplete).
 		 *
 		 * Other objects are dependent on their children's statuses. These other object types
-		 * must check the combined progress of their children to see if it's complete / incomplete
+		 * must check the combined progress of their children to see if it's complete / incomplete.
 		 */
 		$complete = ( 'lesson' === $object_type ) ? ( 'complete' === $status ) : ( 100 == $this->get_progress( $object_id, $object_type, false ) );
 

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -24,6 +24,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.37.9 Added filters `llms_user_enrollment_allowed_post_types` & `llms_user_enrollment_status_allowed_post_types` which allow 3rd parties to enroll users into additional post types via core enrollment methods.
  * @since 4.0.0 Remove previously deprecated methods.
  * @since [version] The `$enrollment_trigger` parameter was added to the `'llms_user_enrollment_deleted'` action hook.
+ *              Added new filter to allow customization of object completion data.
  */
 class LLMS_Student extends LLMS_Abstract_User_Data {
 
@@ -1767,83 +1768,115 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 
 	/**
 	 * Update the completion status of a track, course, section, or lesson for the current student
-	 * Cascades up to parents and clears progress caches for parents
-	 * Triggers actions for completion/incompletion
-	 * Inserts / updates necessary user postmeta data
 	 *
-	 * @param    string $status       new status to update to [complete|incomplete]
-	 * @param    int    $object_id    WP Post ID of the lesson, section, course, or track
-	 * @param    string $object_type  object type [lesson|section|course|course_track]
-	 * @param    string $trigger      String describing the reason for marking complete
-	 * @return   boolean
-	 * @since    3.17.0
-	 * @version  3.17.0
+	 * Cascades up to parents and clears progress caches for parents.
+	 *
+	 * Triggers actions for completion/incompletion.
+	 *
+	 * Inserts / updates necessary user postmeta data.
+	 *
+	 * @since 3.17.0
+	 * @since [version] Use filterable functions to determine if the object is completable.
+	 *                Added filter to allow customization of object parent data.
+	 *
+	 * @param string $status      New status to update to, either "complete" or "incomplete".
+	 * @param int    $object_id   WP_Post ID of the object.
+	 * @param string $object_type The type of object. A lesson, section, course, or course_track.
+	 * @param string $trigger     String describing the reason for the status change.
+	 * @return boolean
 	 */
 	private function update_completion_status( $status, $object_id, $object_type, $trigger = 'unspecified' ) {
 
-		/**
-		 * Before hook
-		 *
-		 * @action  before_llms_mark_complete
-		 * @action  before_llms_mark_incomplete
-		 */
-		do_action( 'before_llms_mark_' . $status, $this->get_id(), $object_id, $object_type, $trigger );
+		$student_id = $this->get_id();
 
-		// can only be marked incomplete in the following post types
-		if ( in_array( $object_type, apply_filters( 'llms_completable_post_types', array( 'course', 'lesson', 'section' ) ) ) ) {
+		/**
+		 * Fires before a student's object completion status is updated.
+		 *
+		 * The dynamic portion of this hook, `$status`, refers to the new completion status of the object,
+		 * either "complete" or "incomplete"
+		 *
+		 * @since Unknown
+		 *
+		 * @param int    $student_id  WP_User ID of the student.
+		 * @param int    $object_id   WP_Post ID of the object.
+		 * @param string $object_type The type of object. A lesson, section, course, or course_track.
+		 * @param string $trigger     String describing the reason for the status change.
+		 */
+		do_action( "before_llms_mark_{$status}", $student_id, $object_id, $object_type, $trigger );
+
+		// Retrieve an instance of the objec we're acting on.
+		if ( in_array( $object_type, llms_get_completable_post_types(), true ) ) {
 			$object = llms_get_post( $object_id );
-		} elseif ( 'course_track' === $object_type ) {
-			$object = get_term( $object_id, 'course_track' );
+		} elseif ( in_array( $object_type, llms_get_completable_taxonomies(), true ) ) {
+			$object = get_term( $object_id, $object_type );
 		} else {
 			return false;
 		}
 
-		// parent(s) to cascade up and check for incompletion
-		// lessons -> section -> course -> track(s)
-		$parent_ids  = array();
-		$parent_type = false;
-
-		// lessons are complete / incomplete automatically
-		// other object types are dependent on their children's statuses
-		// so the other object types need to check progress manually (bypassing cache) to see if it's complete / incomplete
+		/**
+		 * Lessons have binary completion (complete or incomplete).
+		 *
+		 * Other objects are dependent on their children's statuses. These other object types
+		 * must check the combined progress of their children to see if it's complete / incomplete
+		 */
 		$complete = ( 'lesson' === $object_type ) ? ( 'complete' === $status ) : ( 100 == $this->get_progress( $object_id, $object_type, false ) );
 
-		// get the immediate parent so we can cascade up and maybe mark the parent as incomplete as well
+		// Get parent information.
+		$parent_data = array(
+			'ids'  => array(),
+			'type' => false,
+		);
+
+		// Get the immediate parent so we can cascade up and maybe update the parent's status.
 		switch ( $object_type ) {
 
 			case 'lesson':
-				$parent_ids  = array( $object->get( 'parent_section' ) );
-				$parent_type = 'section';
+				$parent_data['ids']  = array( $object->get( 'parent_section' ) );
+				$parent_data['type'] = 'section';
 				break;
 
 			case 'section':
-				$parent_ids  = array( $object->get( 'parent_course' ) );
-				$parent_type = 'course';
+				$parent_data['ids']  = array( $object->get( 'parent_course' ) );
+				$parent_data['type'] = 'course';
 				break;
 
 			case 'course':
-				$parent_ids  = wp_list_pluck( $object->get_tracks(), 'term_id' );
-				$parent_type = 'course_track';
+				$parent_data['ids']  = wp_list_pluck( $object->get_tracks(), 'term_id' );
+				$parent_data['type'] = 'course_track';
 				break;
 
 		}
 
-		// reset the cached progress for any objects with children
+		/**
+		 * Filter the parent data used to cascade object completion up to an object's parent(s).
+		 *
+		 * @since [version]
+		 *
+		 * @param array  $parent_data {
+		 *     Array of the object's parent information.
+		 *
+		 *     @type int[]  $ids  Object ids for the parent object(s).
+		 *     @type string $type Object type (course, course_track, etc...).
+		 * }
+		 * @param object $object      The object. An `LLMS_Course`, for example.
+		 * @param int    $ojbect_id   The object's ID.
+		 * @param string $object_type The object's type.
+		 */
+		$parent_data = apply_filters( 'llms_mark_complete_parent_data', $parent_data, $object, $object_id, $object_type );
+
+		// Reset the cached progress for any objects with children.
 		if ( 'lesson' !== $object_type ) {
 			$this->set( sprintf( '%1$s_%2$d_progress', $object_type, $object_id ), '' );
 		}
 
-		// reset cache for all parents
-		if ( $parent_ids && $parent_type ) {
-
-			foreach ( $parent_ids as $pid ) {
-
-				$this->set( sprintf( '%1$s_%2$d_progress', $parent_type, $pid ), '' );
-
+		// Reset cache for all parents.
+		if ( $parent_data['ids'] && $parent_data['type'] ) {
+			foreach ( $parent_data['ids'] as $pid ) {
+				$this->set( sprintf( '%1$s_%2$d_progress', $parent_data['type'], $pid ), '' );
 			}
 		}
 
-		// determine if an update should be made
+		// Determine if an update should be made.
 		$update = ( 'complete' === $status && $complete ) || ( 'incomplete' === $status && ! $complete );
 
 		if ( $update ) {
@@ -1856,41 +1889,60 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			}
 
 			/**
-			 * Generic hook
+			 * Hook that fires when a student's completion status is updated for any object.
 			 *
-			 * @action  llms_mark_complete
-			 * @action  llms_mark_incomplete
+			 * The dynamic portion of this hook, `$status`, refers to the new completion status of the object,
+			 * either "complete" or "incomplete"
+			 *
+			 * @since Unknown
+			 *
+			 * @param int    $student_id  WP_User ID of the student.
+			 * @param int    $object_id   WP_Post ID of the object.
+			 * @param string $object_type The type of object. A lesson, section, course, or course_track.
+			 * @param string $trigger     String describing the reason for the status change.
 			 */
-			do_action( 'llms_mark_' . $status, $this->get_id(), $object_id, $object_type, $trigger );
+			do_action( "llms_mark_{$status}", $student_id, $object_id, $object_type, $trigger );
 
 			/**
-			 * Specific hook
-			 * Also backwards compatible
+			 * Hook that fires when a student's completion status is updated for a specific object type.
 			 *
-			 * @action  lifterlms_{$object_type}_completed
-			 * @action  lifterlms_{$object_type}_incompleted
+			 * The dynamic portion of this hook, `$object_type` refers to the WP_Post post_type of the object
+			 * which the student's completion status is being updated for.
+			 *
+			 * The dynamic portion of this hook, `$status`, refers to the new completion status of the object,
+			 * either "complete" or "incomplete"
+			 *
+			 * @since Unknown
+			 *
+			 * @param int $student_id WP_User ID of the student.
+			 * @param int $object_id  WP_Post ID of the object.
 			 */
-			do_action( 'lifterlms_' . $object_type . '_' . $status . 'd', $this->get_id(), $object_id );
+			do_action( "lifterlms_{$object_type}_{$status}", $student_id, $object_id );
 
-			// cascade up for parents
-			if ( $parent_ids && $parent_type ) {
-
-				foreach ( $parent_ids as $pid ) {
-
-					$this->update_completion_status( $status, $pid, $parent_type, $trigger );
-
+			// Cascade up for parents.
+			if ( $parent_data['ids'] && $parent_data['type'] ) {
+				foreach ( $parent_data['ids'] as $pid ) {
+					$this->update_completion_status( $status, $pid, $parent_data['type'], $trigger );
 				}
 			}
 
 			/**
-			 * Generic after hook
+			 * Hook that fires after a student's completion status for an object and it's parents have
+			 * been updated.
 			 *
-			 * @action  after_llms_mark_complete
-			 * @action  after_llms_mark_incomplete
+			 * The dynamic portion of this hook, `$status`, refers to the new completion status of the object,
+			 * either "complete" or "incomplete"
+			 *
+			 * @since Unknown
+			 *
+			 * @param int    $student_id  WP_User ID of the student.
+			 * @param int    $object_id   WP_Post ID of the object.
+			 * @param string $object_type The type of object. A lesson, section, course, or course_track.
+			 * @param string $trigger     String describing the reason for the status change.
 			 */
-			do_action( 'after_llms_mark_' . $status, $this->get_id(), $object_id, $object_type, $trigger );
+			do_action( "after_llms_mark_{$status}", $student_id, $object_id, $object_type, $trigger );
 
-		}// End if().
+		}
 
 		return $update;
 

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1917,7 +1917,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			 * @param int $student_id WP_User ID of the student.
 			 * @param int $object_id  WP_Post ID of the object.
 			 */
-			do_action( "lifterlms_{$object_type}_{$status}", $student_id, $object_id );
+			do_action( "lifterlms_{$object_type}_{$status}d", $student_id, $object_id );
 
 			// Cascade up for parents.
 			if ( $parent_data['ids'] && $parent_data['type'] ) {

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -10,7 +10,7 @@
  * @since 3.36.1 Use exception from lifterlms-tests lib.
  * @since 3.37.12 Fix errors thrown due to usage of `llms_section` instead of `section`.
  * @since 3.37.14 When testing `llms_get_post_parent_course()` added tests on other LLMS post types which are not instance of `LLMS_Post_Model`.
- * @version 3.37.14
+ * @since [version] Add tests for llms_get_completable_post_types() & llms_get_completable_taxonomies().
  */
 class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
@@ -72,6 +72,29 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 		$this->assertEquals( $expect, llms_assoc_array_insert( $array, 'another', 'new_key', 'item' ) );
 
 	}
+
+	/**
+	 * Test llms_get_completable_post_types()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_completable_post_types() {
+		$this->assertEquals( array( 'course', 'section', 'lesson' ), llms_get_completable_post_types() );
+	}
+
+	/**
+	 * Test llms_get_completable_taxonomies()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_completable_taxonomies() {
+		$this->assertEquals( array( 'course_track' ), llms_get_completable_taxonomies() );
+	}
+
 
 	/**
 	 * Test llms_get_core_supported_themes()


### PR DESCRIPTION
## Description

The goal of this PR is to make it possible for a 3rd party to use the LifterLMS "progress" system (marking post/taxonomy objects as complete/incomplete) using our internal API and some hooks and filters.

This PR expands the extensibility of the API with a new filter and "DRYs" some functionality by using functions for determining whether or not an object is completeable (instead of having the filters hardcoded into the method).

In a forthcoming PR we will use these functions in the REST API to extend these functionality to the `/students/{id}/progress` endpoint.

## How has this been tested?

+ Existing unit tests
+ Manually tested mark complete / incomplete buttons on a test site

## Types of changes
+ Non-breaking

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

