### PR TITLE
Add $type prop declarations for LLMS_Abstract_Database_Store child classes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -128,6 +128,64 @@
     ],
     "packages-dev": [
         {
+            "name": "composer/xdebug-handler",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "reference": "fa2aaf99e2087f013a14f7432c1cd2dd7d8f1f51",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0",
+                "psr/log": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || 6.5 - 8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-04T11:16:35+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "dev-master",
             "source": {
@@ -307,32 +365,39 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.5.2",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239"
+                "reference": "c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
-                "reference": "9daf26d0368d4a12bed1cacae1a9f3a6f0adf239",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38",
+                "reference": "c64472f8e76ca858c79ad9a4cf1e2734b3f8cc38",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.7",
-                "symfony/config": "^2.3.0|^3|^4",
-                "symfony/dependency-injection": "^2.3.0|^3|^4",
-                "symfony/filesystem": "^2.3.0|^3|^4"
+                "symfony/config": "^2.3.0|^3|^4|^5",
+                "symfony/dependency-injection": "^2.3.0|^3|^4|^5",
+                "symfony/filesystem": "^2.3.0|^3|^4|^5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8|^5.7",
+                "easy-doc/easy-doc": "0.0.0 || ^1.2.3",
+                "gregwar/rst": "^1.0",
+                "phpunit/phpunit": "^4.8.35|^5.7",
                 "squizlabs/php_codesniffer": "^2.0.0"
             },
             "bin": [
                 "src/bin/pdepend"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PDepend\\": "src/main/php/PDepend"
@@ -343,7 +408,13 @@
                 "BSD-3-Clause"
             ],
             "description": "Official version of pdepend to be handled with Composer",
-            "time": "2017-12-13T13:21:38+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/pdepend/pdepend",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-20T10:53:13+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -449,16 +520,16 @@
         },
         {
             "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.0",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5"
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5",
-                "reference": "06cc8d2c2ed62a70f52963dbdf5eaa1ec0fe34c5",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
                 "shasum": ""
             },
             "require": {
@@ -503,20 +574,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-08-28T15:29:06+00:00"
+            "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.1.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936"
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
-                "reference": "b1bb79a7cab1fb856b56f1b5cf110b6e52d8e936",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
                 "shasum": ""
             },
             "require": {
@@ -555,7 +626,7 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-08-28T15:58:19+00:00"
+            "time": "2019-11-04T15:17:54+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
@@ -761,24 +832,26 @@
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.7.0",
+            "version": "2.8.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "a05a999c644f4bc9a204846017db7bb7809fbe4c"
+                "reference": "685550627f3727f96eabb98e0aaaf1cbf9b0b224"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/a05a999c644f4bc9a204846017db7bb7809fbe4c",
-                "reference": "a05a999c644f4bc9a204846017db7bb7809fbe4c",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/685550627f3727f96eabb98e0aaaf1cbf9b0b224",
+                "reference": "685550627f3727f96eabb98e0aaaf1cbf9b0b224",
                 "shasum": ""
             },
             "require": {
+                "composer/xdebug-handler": "^1.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.5",
+                "pdepend/pdepend": "^2.7.1",
                 "php": ">=5.3.9"
             },
             "require-dev": {
+                "easy-doc/easy-doc": "0.0.0 || ^1.3.2",
                 "gregwar/rst": "^1.0",
                 "mikey179/vfsstream": "^1.6.4",
                 "phpunit/phpunit": "^4.8.36 || ^5.7.27",
@@ -825,7 +898,13 @@
                 "phpmd",
                 "pmd"
             ],
-            "time": "2019-07-30T21:13:32+00:00"
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpmd/phpmd",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-29T00:08:01+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -1289,12 +1368,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "014d250daebff39eba15ba990eeb2a140798e77c"
+                "reference": "fc1bc363ecf887921e3897c7b1dad3587ae154eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/014d250daebff39eba15ba990eeb2a140798e77c",
-                "reference": "014d250daebff39eba15ba990eeb2a140798e77c",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/fc1bc363ecf887921e3897c7b1dad3587ae154eb",
+                "reference": "fc1bc363ecf887921e3897c7b1dad3587ae154eb",
                 "shasum": ""
             },
             "require": {
@@ -1330,7 +1409,54 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2018-12-29T15:36:03+00:00"
+            "time": "2019-10-04T14:07:35+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "reference": "0f73288fd15629204f9d42b7055f72dacbe811fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2020-03-23T09:12:05+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1897,12 +2023,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "bb50f790f17a431f8cf294274081a723bf376878"
+                "reference": "e3eecbb8b0ac88472c5c21723b995ac3269f2fbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/bb50f790f17a431f8cf294274081a723bf376878",
-                "reference": "bb50f790f17a431f8cf294274081a723bf376878",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e3eecbb8b0ac88472c5c21723b995ac3269f2fbd",
+                "reference": "e3eecbb8b0ac88472c5c21723b995ac3269f2fbd",
                 "shasum": ""
             },
             "require": {
@@ -1940,36 +2066,38 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-14T22:43:20+00:00"
+            "time": "2020-07-20T23:06:10+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "4.4.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4430cd5d92f78bfe190ca54af93e0d1564b17e8f"
+                "reference": "3448649b5e61ddfb1e4a1c7fc2983b365ff622c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4430cd5d92f78bfe190ca54af93e0d1564b17e8f",
-                "reference": "4430cd5d92f78bfe190ca54af93e0d1564b17e8f",
+                "url": "https://api.github.com/repos/symfony/config/zipball/3448649b5e61ddfb1e4a1c7fc2983b365ff622c1",
+                "reference": "3448649b5e61ddfb1e4a1c7fc2983b365ff622c1",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
-                "symfony/filesystem": "^3.4|^4.0|^5.0",
-                "symfony/polyfill-ctype": "~1.8"
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/filesystem": "^4.4|^5.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-php80": "^1.15"
             },
             "conflict": {
-                "symfony/finder": "<3.4"
+                "symfony/finder": "<4.4"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^3.4|^4.0|^5.0",
-                "symfony/finder": "^3.4|^4.0|^5.0",
-                "symfony/messenger": "^4.1|^5.0",
-                "symfony/service-contracts": "^1.1",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/finder": "^4.4|^5.0",
+                "symfony/messenger": "^4.4|^5.0",
+                "symfony/service-contracts": "^1.1|^2",
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/yaml": "To use the yaml reference dumper"
@@ -1977,7 +2105,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -2004,41 +2132,57 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T09:00:56+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-15T10:59:44+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "4.4.x-dev",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "85113f15002fa057a68554dd3d1e0b48e4e7bd51"
+                "reference": "d79c7bb11a0cb91593c4b45b19610504d52c2b99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/85113f15002fa057a68554dd3d1e0b48e4e7bd51",
-                "reference": "85113f15002fa057a68554dd3d1e0b48e4e7bd51",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/d79c7bb11a0cb91593c4b45b19610504d52c2b99",
+                "reference": "d79c7bb11a0cb91593c4b45b19610504d52c2b99",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.2.5",
                 "psr/container": "^1.0",
-                "symfony/service-contracts": "^1.1.6"
+                "symfony/deprecation-contracts": "^2.1",
+                "symfony/polyfill-php80": "^1.15",
+                "symfony/service-contracts": "^1.1.6|^2"
             },
             "conflict": {
-                "symfony/config": "<4.3",
-                "symfony/finder": "<3.4",
-                "symfony/proxy-manager-bridge": "<3.4",
-                "symfony/yaml": "<3.4"
+                "symfony/config": "<5.1",
+                "symfony/finder": "<4.4",
+                "symfony/proxy-manager-bridge": "<4.4",
+                "symfony/yaml": "<4.4"
             },
             "provide": {
                 "psr/container-implementation": "1.0",
                 "symfony/service-implementation": "1.0"
             },
             "require-dev": {
-                "symfony/config": "^4.3|^5.0",
-                "symfony/expression-language": "^3.4|^4.0|^5.0",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/config": "^5.1",
+                "symfony/expression-language": "^4.4|^5.0",
+                "symfony/yaml": "^4.4|^5.0"
             },
             "suggest": {
                 "symfony/config": "",
@@ -2050,7 +2194,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -2077,30 +2221,108 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-26T16:27:46+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-15T10:59:44+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "4.4.x-dev",
+            "name": "symfony/deprecation-contracts",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "a7b5a7f8e6805cfe0e183960acdf69e90b764494"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/a7b5a7f8e6805cfe0e183960acdf69e90b764494",
-                "reference": "a7b5a7f8e6805cfe0e183960acdf69e90b764494",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5e20b83385a77593259c9f8beb2c43cd03b2ac14",
+                "reference": "5e20b83385a77593259c9f8beb2c43cd03b2ac14",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-06T08:49:21+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "e7550993849f986f01a9161b302d4aed8d4aab0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e7550993849f986f01a9161b302d4aed8d4aab0a",
+                "reference": "e7550993849f986f01a9161b302d4aed8d4aab0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.4-dev"
+                    "dev-master": "5.2-dev"
                 }
             },
             "autoload": {
@@ -2127,7 +2349,21 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-08-21T15:14:41+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-30T20:38:10+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2135,12 +2371,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/550ebaac289296ce228a706d0867afc34687e3f4",
-                "reference": "550ebaac289296ce228a706d0867afc34687e3f4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -2152,7 +2388,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.12-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -2185,7 +2425,101 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2019-08-06T08:03:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -2193,16 +2527,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3"
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
-                "reference": "ea7263d6b6d5f798b56a45a5b8d686725f2719a3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3",
+                "php": ">=7.2.5",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -2211,7 +2545,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -2243,7 +2581,21 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2019-08-20T14:44:19+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-06T13:23:11+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2338,16 +2690,16 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a"
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/f90e8692ce97b693633db7ab20bfa78d930f536a",
-                "reference": "f90e8692ce97b693633db7ab20bfa78d930f536a",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
+                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
                 "shasum": ""
             },
             "require": {
@@ -2355,12 +2707,13 @@
                 "squizlabs/php_codesniffer": "^3.3.1"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
                 "phpcompatibility/php-compatibility": "^9.0",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2379,7 +2732,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-11-11T12:34:03+00:00"
+            "time": "2020-05-13T23:57:56+00:00"
         }
     ],
     "aliases": [],

--- a/includes/abstracts/llms.abstract.database.store.php
+++ b/includes/abstracts/llms.abstract.database.store.php
@@ -24,31 +24,48 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * The Database ID of the record
 	 *
-	 * @var  null
+	 * @var int
 	 */
 	protected $id = null;
 
 	/**
 	 * Object properties
 	 *
-	 * @var  array
+	 * @var array
 	 */
 	private $data = array();
 
+	/**
+	 * Column name of the record's "created" date
+	 *
+	 * This can be set to an empty string if the extending
+	 * class does not utilize or require created date storage.
+	 *
+	 * @var string
+	 */
 	protected $date_created = 'created';
+
+	/**
+	 * Column name of the record's "updated" date
+	 *
+	 * This can be set to an empty string if the extending
+	 * class does not utilize or require updated date storage.
+	 *
+	 * @var string
+	 */
 	protected $date_updated = 'updated';
 
 	/**
 	 * Array of table column name => format
 	 *
-	 * @var  array
+	 * @var array
 	 */
 	protected $columns = array();
 
 	/**
 	 * Primary Key column name => format
 	 *
-	 * @var  array
+	 * @var array
 	 */
 	protected $primary_key = array(
 		'id' => '%d',
@@ -57,37 +74,41 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Database Table Name
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $table = '';
 
 	/**
 	 * Database Table Prefix
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $table_prefix = 'lifterlms_';
 
 	/**
 	 * The record type
-	 * Used for filters/actions
-	 * Should be defined by extending classes
 	 *
-	 * @var  string
+	 * Used for filters/actions.
+	 *
+	 * Should be defined by extending classes.
+	 *
+	 * @var string
 	 */
 	protected $type = '';
 
 	/**
 	 * Constructor
 	 *
-	 * @since    3.14.0
-	 * @version  3.21.0
+	 * @since 3.14.0
+	 * @since 3.21.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
 		if ( ! $this->id ) {
 
-			// if created dates supported, add current time to the data on construction
+			// If created dates supported, add current time to the data on construction.
 			if ( $this->date_created ) {
 				$this->set( $this->date_created, llms_current_time( 'mysql' ), false );
 			}
@@ -102,23 +123,22 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Get object data
 	 *
-	 * @param    string $key  key to retrieve
-	 * @return   mixed
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @param string $key Key to retrieve.
+	 * @return mixed
 	 */
 	public function __get( $key ) {
-
 		return $this->data[ $key ];
-
 	}
 
 	/**
 	 * Determine if the item exists in the database
 	 *
-	 * @return   boolean
-	 * @since    3.14.7
-	 * @version  3.15.0
+	 * @since 3.14.7
+	 * @since 3.15.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function exists() {
 
@@ -127,6 +147,7 @@ abstract class LLMS_Abstract_Database_Store {
 		}
 
 		return false;
+
 	}
 
 	/**
@@ -136,9 +157,9 @@ abstract class LLMS_Abstract_Database_Store {
 	 * @since 3.16.0 Unknown.
 	 * @since 3.36.0 Prevent undefined index error when attempting to retrieve an unset value from an unsaved object.
 	 *
-	 * @param    string  $key    key to retrieve
-	 * @param    boolean $cache  if true, save data to to the object for future gets
-	 * @return   mixed
+	 * @param string  $key   Key to retrieve.
+	 * @param boolean $cache If true, save data to to the object for future gets.
+	 * @return mixed
 	 */
 	public function get( $key, $cache = true ) {
 
@@ -157,27 +178,26 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Set object data
 	 *
-	 * @param    string $key  column name
-	 * @param    mixed  $val  column value
-	 * @return   void
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @param string $key Column name.
+	 * @param mixed  $val Column value.
+	 * @return void
 	 */
 	public function __set( $key, $val ) {
-
 		$this->data[ $key ] = $val;
-
 	}
 
 	/**
 	 * General setter
 	 *
-	 * @param    string  $key   column name
-	 * @param    mixed   $val   column value
-	 * @param    boolean $save  if true, immediately persists to database
-	 * @return   self
-	 * @since    3.14.0
-	 * @version  3.21.0
+	 * @since 3.14.0
+	 * @since 3.21.0 Unknown.
+	 *
+	 * @param string  $key  Column name.
+	 * @param mixed   $val  Column value.
+	 * @param boolean $save If true, immediately persists to database.
+	 * @return LLMS_Abstract_Database_Store Instance of the current object, useful for chaining.
 	 */
 	public function set( $key, $val, $save = false ) {
 
@@ -186,14 +206,14 @@ abstract class LLMS_Abstract_Database_Store {
 			$update = array(
 				$key => $val,
 			);
-			// if update date supported, add an updated date
+			// If update date supported, add an updated date.
 			if ( $this->date_updated ) {
 				$update[ $this->date_updated ] = llms_current_time( 'mysql' );
 			}
 			$this->update( $update );
 		}
 
-		return $this; // allow chaining like $this->set( $key, $val )->save();
+		return $this;
 
 	}
 
@@ -204,7 +224,7 @@ abstract class LLMS_Abstract_Database_Store {
 	 * @since 3.33.0 Return self for chaining instead of void.
 	 *
 	 * @param array $data key => val
-	 * @return self
+	 * @return LLMS_Abstract_Database_Store Instance of the current object, useful for chaining.
 	 */
 	public function setup( $data ) {
 
@@ -212,16 +232,17 @@ abstract class LLMS_Abstract_Database_Store {
 			$this->set( $key, $val, false );
 		}
 
-		return $this; // allow chaining like $this->setup( $data )->save();
+		return $this;
 
 	}
 
 	/**
 	 * Create the item in the database
 	 *
-	 * @return   int|false
-	 * @since    3.14.0
-	 * @version  3.24.0
+	 * @since 3.14.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @return int|false Record ID on success, false on error or when there's nothing to save.
 	 */
 	private function create() {
 
@@ -231,7 +252,7 @@ abstract class LLMS_Abstract_Database_Store {
 
 		global $wpdb;
 		$format = array_map( array( $this, 'get_column_format' ), array_keys( $this->data ) );
-		$res    = $wpdb->insert( $this->get_table(), $this->data, $format );
+		$res    = $wpdb->insert( $this->get_table(), $this->data, $format ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		if ( 1 === $res ) {
 			$this->id = $wpdb->insert_id;
 			do_action( 'llms_' . $this->type . '_created', $this->id, $this );
@@ -244,9 +265,10 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Delete the object from the database
 	 *
-	 * @return   boolean     true on success, false otherwise
-	 * @since    3.14.0
-	 * @version  3.24.0
+	 * @since 3.14.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @return boolean `true` on success, `false` otherwise.
 	 */
 	public function delete() {
 
@@ -257,7 +279,7 @@ abstract class LLMS_Abstract_Database_Store {
 		$id = $this->id;
 		global $wpdb;
 		$where = array_combine( array_keys( $this->primary_key ), array( $this->id ) );
-		$res   = $wpdb->delete( $this->get_table(), $where, array_values( $this->primary_key ) );
+		$res   = $wpdb->delete( $this->get_table(), $where, array_values( $this->primary_key ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		if ( $res ) {
 			$this->id   = null;
 			$this->data = array();
@@ -271,10 +293,10 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Read object data from the database
 	 *
-	 * @param    array|string $keys   key name (or array of keys) to retrieve from the database
-	 * @return   array|false           key=>val array of data or false when record not found
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @param string[]|string $keys Key name (or array of keys) to retrieve from the database.
+	 * @return array|false Returns a key=>val array of data or `false` when record not found.
 	 */
 	private function read( $keys ) {
 
@@ -282,7 +304,7 @@ abstract class LLMS_Abstract_Database_Store {
 		if ( is_array( $keys ) ) {
 			$keys = implode( ', ', $keys );
 		}
-		$res = $wpdb->get_row(
+		$res = $wpdb->get_row( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$wpdb->prepare( "SELECT {$keys} FROM {$this->get_table()} WHERE {$this->get_primary_key()} = %d", $this->id ), // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- This query is safe.
 			ARRAY_A
 		);
@@ -293,17 +315,18 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Update object data in the database
 	 *
-	 * @param    array $data  data to update as key=>val
-	 * @return   bool
-	 * @since    3.14.0
-	 * @version  3.24.0
+	 * @since 3.14.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param array $data Data to update as key=>val.
+	 * @return boolean
 	 */
 	private function update( $data ) {
 
 		global $wpdb;
 		$format = array_map( array( $this, 'get_column_format' ), array_keys( $data ) );
 		$where  = array_combine( array_keys( $this->primary_key ), array( $this->id ) );
-		$res    = $wpdb->update( $this->get_table(), $data, $where, $format, array_values( $this->primary_key ) );
+		$res    = $wpdb->update( $this->get_table(), $data, $where, $format, array_values( $this->primary_key ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 		if ( $res ) {
 			do_action( 'llms_' . $this->type . '_updated', $this->id, $this );
 			return true;
@@ -317,7 +340,7 @@ abstract class LLMS_Abstract_Database_Store {
 	 *
 	 * @since 3.14.0
 	 *
-	 * @return obj
+	 * @return LLMS_Abstract_Database_Store Instance of the current object, useful for chaining.
 	 */
 	protected function hydrate() {
 
@@ -328,32 +351,30 @@ abstract class LLMS_Abstract_Database_Store {
 			}
 		}
 
-		return $this; // allow chaining
+		return $this;
 
 	}
 
 	/**
 	 * Save object to the database
-	 * Creates is it doesn't already exist, updates if it does
 	 *
-	 * @return   boolean
-	 * @since    3.14.0
-	 * @version  3.24.0
+	 * Creates it if doesn't already exist, updates if it does.
+	 *
+	 * @since 3.14.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function save() {
 
 		if ( ! $this->id ) {
-
 			$id = $this->create();
 			if ( $id ) {
 				return true;
 			}
 			return false;
-
 		} else {
-
 			return $this->update( $this->data );
-
 		}
 
 	}
@@ -361,10 +382,10 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Retrieve the format for a column
 	 *
-	 * @param    string $key  column name
-	 * @return   string
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @param string $key Column name.
+	 * @return string
 	 */
 	private function get_column_format( $key ) {
 
@@ -378,23 +399,21 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Retrieve the primary key column name
 	 *
-	 * @return   string
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return string
 	 */
 	protected function get_primary_key() {
-
 		$primary_key = array_keys( $this->primary_key );
 		return preg_replace( '/[^a-zA-Z0-9_]/', '', $primary_key[0] );
-
 	}
 
 	/**
 	 * Get the ID of the object
 	 *
-	 * @return   int
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return int
 	 */
 	public function get_id() {
 		return $this->id;
@@ -403,9 +422,9 @@ abstract class LLMS_Abstract_Database_Store {
 	/**
 	 * Get the table Name
 	 *
-	 * @return   string
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return string
 	 */
 	private function get_table() {
 

--- a/includes/abstracts/llms.abstract.database.store.php
+++ b/includes/abstracts/llms.abstract.database.store.php
@@ -18,8 +18,8 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.34.0 to_array() method returns value of the primary key instead of the format.
  * @since 3.36.0 Prevent undefined index error when attempting to retrieve an unset value from an unsaved object.
  *               Hydrate before returning an array via the `to_array()` method.
- * @since [version]  Add deprecated hook calls to preserve backwards compatibility for extending classes which have no `$type` property declaration.
- *                 Updated the `$type` property to have a default placeholder value.
+ * @since [version] Add deprecated hook calls to preserve backwards compatibility for extending classes which have no `$type` property declaration.
+ *              Updated the `$type` property to have a default placeholder value.
  */
 abstract class LLMS_Abstract_Database_Store {
 
@@ -263,7 +263,7 @@ abstract class LLMS_Abstract_Database_Store {
 			/**
 			 * Fires when a new database record is created.
 			 *
-			 * The dynamic portion of this hook, `$type`, refers to the record type.
+			 * The dynamic portion of this hook, `$this->type`, refers to the record type.
 			 *
 			 * @since Unknown.
 			 *
@@ -313,7 +313,7 @@ abstract class LLMS_Abstract_Database_Store {
 			/**
 			 * Fires when a new database record is created.
 			 *
-			 * The dynamic portion of this hook, `$type`, refers to the record type.
+			 * The dynamic portion of this hook, `$this->type`, refers to the record type.
 			 *
 			 * @since Unknown.
 			 *
@@ -380,7 +380,7 @@ abstract class LLMS_Abstract_Database_Store {
 			/**
 			 * Fires when a new database record is updated.
 			 *
-			 * The dynamic portion of this hook, `$type`, refers to the record type.
+			 * The dynamic portion of this hook, `$this->type`, refers to the record type.
 			 *
 			 * @since Unknown.
 			 *
@@ -409,7 +409,7 @@ abstract class LLMS_Abstract_Database_Store {
 	 *
 	 * @since 3.14.0
 	 *
-	 * @return LLMS_Abstract_Database_Store Instance of the current object, useful for chaining.
+	 * @return LLMS_Abstract_Database_Store instance of the current object, useful for chaining.
 	 */
 	protected function hydrate() {
 

--- a/includes/abstracts/llms.abstract.database.store.php
+++ b/includes/abstracts/llms.abstract.database.store.php
@@ -279,7 +279,7 @@ abstract class LLMS_Abstract_Database_Store {
 			 *
 			 * @link https://github.com/gocodebox/lifterlms/issues/1248
 			 */
-			do_action_deprecated( "llms__created", $this->id, $this );
+			do_action_deprecated( 'llms__created', $this->id, $this );
 
 			return $this->id;
 		}
@@ -329,7 +329,7 @@ abstract class LLMS_Abstract_Database_Store {
 			 *
 			 * @link https://github.com/gocodebox/lifterlms/issues/1248
 			 */
-			do_action_deprecated( "llms__deleted", $id, $this );
+			do_action_deprecated( 'llms__deleted', $id, $this );
 
 			return true;
 		}
@@ -396,7 +396,7 @@ abstract class LLMS_Abstract_Database_Store {
 			 *
 			 * @link https://github.com/gocodebox/lifterlms/issues/1248
 			 */
-			do_action_deprecated( "llms__updated", $this->id, $this );
+			do_action_deprecated( 'llms__updated', $this->id, $this );
 
 			return true;
 		}

--- a/includes/models/class-llms-event.php
+++ b/includes/models/class-llms-event.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LifterLMS Event Model
  *
  * @since 3.36.0
+ * @since [version] Added record `$type` property definition.
  */
 class LLMS_Event extends LLMS_Abstract_Database_Store {
 
@@ -52,6 +53,13 @@ class LLMS_Event extends LLMS_Abstract_Database_Store {
 	 * @var  string
 	 */
 	protected $table = 'events';
+
+	/**
+	 * The record type
+	 *
+	 * @var string
+	 */
+	protected $type = 'event';
 
 	/**
 	 * Constructor

--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Quiz_Attempt model class
  *
  * @since 3.9.0
- * @since 3.9.2  Added `calculate_point_weight()`, `get_question_order()`, `is_passing()` methods.
+ * @since 3.9.2 Added `calculate_point_weight()`, `get_question_order()`, `is_passing()` methods.
  * @since 3.16.0 Unknown.
  * @since 3.16.7 Unknown.
  * @since 3.17.1 Unknown.
@@ -22,12 +22,12 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.24.0 Unknown.
  * @since 3.26.3 Unknown.
  * @since 3.29.0 Unknown.
- * @since 4.0.0  Remove reliance on deprecated method `LLMS_Quiz::get_passing_percent()` & remove deprecated class method `get_status()`.
- *               Fix issue encountered when answering a question incorrectly after initially answering it correctly.
- * @since 4.2.0  Use strict type comparisons where possible.
- *               In the `l10n()` method, made sure the status key exists to avoid trying to access to array's undefined index.
- *               Added the public method `get_siblings()`.
- * @since [version]  Added `$type` property declaration.
+ * @since 4.0.0 Remove reliance on deprecated method `LLMS_Quiz::get_passing_percent()` & remove deprecated class method `get_status()`.
+ *              Fix issue encountered when answering a question incorrectly after initially answering it correctly.
+ * @since 4.2.0 Use strict type comparisons where possible.
+ *              In the `l10n()` method, made sure the status key exists to avoid trying to access to array's undefined index.
+ *              Added the public method `get_siblings()`.
+ * @since [version] Added `$type` property declaration.
  */
 class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 

--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.9.0
- * @version 4.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Quiz_Attempt model class
  *
  * @since 3.9.0
- * @since 3.9.2 Added `calculate_point_weight()`, `get_question_order()`, `is_passing()` methods.
+ * @since 3.9.2  Added `calculate_point_weight()`, `get_question_order()`, `is_passing()` methods.
  * @since 3.16.0 Unknown.
  * @since 3.16.7 Unknown.
  * @since 3.17.1 Unknown.
@@ -22,11 +22,13 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.24.0 Unknown.
  * @since 3.26.3 Unknown.
  * @since 3.29.0 Unknown.
- * @since 4.0.0 Remove reliance on deprecated method `LLMS_Quiz::get_passing_percent()` & remove deprecated class method `get_status()`.
- *              Fix issue encountered when answering a question incorrectly after initially answering it correctly.
- * @since 4.2.0 Use strict type comparisons where possible.
- *              In the `l10n()` method, made sure the status key exists to avoid trying to access to array's undefined index.
- *              Added the public method `get_siblings()`.
+ * @since 4.0.0  Remove reliance on deprecated method `LLMS_Quiz::get_passing_percent()` & remove deprecated class method `get_status()`.
+ *               Fix issue encountered when answering a question incorrectly after initially answering it correctly.
+ * @since 4.2.0  Use strict type comparisons where possible.
+ *               In the `l10n()` method, made sure the status key exists to avoid trying to access to array's undefined index.
+ *               Added the public method `get_siblings()`.
+ * @since [version]  Added `$type` property declaration.
+ *
  */
 class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 
@@ -57,6 +59,13 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 	 * @var string
 	 */
 	protected $table = 'quiz_attempts';
+
+	/**
+	 * The record type
+	 *
+	 * @var string
+	 */
+	protected $type = 'quiz_attempt';
 
 	/**
 	 * Constructor

--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -28,7 +28,6 @@ defined( 'ABSPATH' ) || exit;
  *               In the `l10n()` method, made sure the status key exists to avoid trying to access to array's undefined index.
  *               Added the public method `get_siblings()`.
  * @since [version]  Added `$type` property declaration.
- *
  */
 class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 

--- a/includes/models/model.llms.user.postmeta.php
+++ b/includes/models/model.llms.user.postmeta.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.15.0
- * @version 3.15.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,6 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_User_Postmeta model class
  *
  * @since 3.15.0
+ * @since [version] Added `$type` propertly declaration.
  */
 class LLMS_User_Postmeta extends LLMS_Abstract_Database_Store {
 
@@ -48,6 +49,13 @@ class LLMS_User_Postmeta extends LLMS_Abstract_Database_Store {
 	 * @var  string
 	 */
 	protected $table = 'user_postmeta';
+
+	/**
+	 * The record type
+	 *
+	 * @var string
+	 */
+	protected $type = 'user_postmeta';
 
 	/**
 	 * Constructor

--- a/tests/phpunit/unit-tests/models/class-llms-test-event.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-event.php
@@ -8,7 +8,7 @@
  * @group events
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @since [version] Add assertions to test against hooks and deprecated hooks.
  */
 class LLMS_Test_Event extends LLMS_Unit_Test_Case {
 
@@ -37,13 +37,16 @@ class LLMS_Test_Event extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test creation.
+	 * Test CRUD.
 	 *
 	 * @since 3.36.0
+	 * @since [version] Add update & deletion & added assertions against expected hooks.
 	 *
 	 * @return void
 	 */
-	public function test_create() {
+	public function test_crud() {
+
+		$actions = did_action( 'llms_event_created' );
 
 		$expected_time = current_time( 'timestamp' ) - DAY_IN_SECONDS;
 		llms_tests_mock_current_time( $expected_time );
@@ -56,19 +59,40 @@ class LLMS_Test_Event extends LLMS_Unit_Test_Case {
 			'event_action' => 'load',
 		);
 
+		// Create.
 		$event = new LLMS_Event();
 		$event->setUp( $args );
 		$this->assertTrue( $event->save() );
-		$this->assertTrue( is_numeric( $event->get( 'id' ) ) );
+		$id = $event->get( 'id' );
+		$this->assertTrue( is_numeric( $id ) );
 
 		llms_tests_reset_current_time();
 
-		$event = new LLMS_Event( $event->get( 'id' ) );
+		$event = new LLMS_Event( $id );
 
 		$this->assertEquals( $expected_time, strtotime( $event->get( 'date' ) ) );
 		foreach( $args as $key => $expected ) {
 			$this->assertEquals( $expected, $event->get( $key ) );
 		}
+
+		$this->assertEquals( ++$actions, did_action( 'llms_event_created' ) );
+		$this->assertEquals( 0, did_action( 'llms___created' ) );
+
+		// Update.
+		$actions = did_action( 'llms_event_updated' );
+		$event->set( 'actor_id', 2, true );
+
+		$this->assertEquals( ++$actions, did_action( 'llms_event_updated' ) );
+		$this->assertEquals( 0, did_action( 'llms__updated' ) );
+
+		$event = new LLMS_Event( $id );
+		$this->assertEquals( 2, $event->get( 'actor_id' ) );
+
+		// Delete.
+		$actions = did_action( 'llms_event_deleted' );
+		$this->assertTrue( $event->delete() );
+		$this->assertEquals( ++$actions, did_action( 'llms_event_deleted' ) );
+		$this->assertEquals( 0, did_action( 'llms__deleted' ) );
 
 	}
 


### PR DESCRIPTION
## Description

Fixes #1248 

## How has this been tested?

+ New unit tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Bugfix
+ Adds `do_action_deprecated()` calls to preserve backwards compatibility for hooks that would be lost by adding type declarations.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

