### PR TITLE
Load theme support classes during `after_setup_theme`

### DIFF
--- a/includes/theme-support/class-llms-theme-support.php
+++ b/includes/theme-support/class-llms-theme-support.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/ThemeSupport/Classes
  *
  * @since 3.37.0
- * @version 3.37.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,23 +21,23 @@ class LLMS_Theme_Support {
 	 * Constructor
 	 *
 	 * @since 3.37.0
+	 * @since [version] Load includes during `after_setup_theme` instead of `plugins_loaded`.
 	 *
 	 * @return void
 	 */
 	public function __construct() {
-
-		$this->includes();
-
+		add_action( 'after_setup_theme', array( $this, 'includes' ) );
 	}
 
 	/**
 	 * Conditionally require additional theme support classes.
 	 *
 	 * @since 3.37.0
+	 * @since [version] Method access changed to `public`.
 	 *
 	 * @return void
 	 */
-	protected function includes() {
+	public function includes() {
 
 		switch ( get_template() ) {
 

--- a/tests/phpunit/unit-tests/theme-support/class-llms-test-theme-support.php
+++ b/tests/phpunit/unit-tests/theme-support/class-llms-test-theme-support.php
@@ -7,7 +7,6 @@
  * @group theme_support
  *
  * @since 3.37.0
- * @version 3.37.0
  */
 class LLMS_Test_Theme_Support extends LLMS_Unit_Test_Case {
 
@@ -44,6 +43,7 @@ class LLMS_Test_Theme_Support extends LLMS_Unit_Test_Case {
 	 * Test theme support classes are loaded based on the current theme template.
 	 *
 	 * @since 3.37.0
+	 * @since [version] Update theme support class instantiation.
 	 *
 	 * @return void
 	 */
@@ -51,7 +51,8 @@ class LLMS_Test_Theme_Support extends LLMS_Unit_Test_Case {
 
 		foreach ( $this->supported as $template => $class ) {
 			update_option( 'template', $template );
-			new LLMS_Theme_Support();
+			$support = new LLMS_Theme_Support();
+			$support->includes();
 			$this->assertTrue( class_exists( $class ) );
 		}
 

--- a/tests/phpunit/unit-tests/theme-support/class-llms-test-twenty-twenty.php
+++ b/tests/phpunit/unit-tests/theme-support/class-llms-test-twenty-twenty.php
@@ -7,7 +7,6 @@
  * @group theme_support
  *
  * @since 3.37.0
- * @version 3.37.0
  */
 class LLMS_Test_Twenty_Twenty extends LLMS_Unit_Test_Case {
 
@@ -15,6 +14,7 @@ class LLMS_Test_Twenty_Twenty extends LLMS_Unit_Test_Case {
 	 * Setup the test case.
 	 *
 	 * @since 3.37.0
+	 * @since [version] Update theme support class instantiation.
 	 *
 	 * @return void
 	 */
@@ -22,7 +22,8 @@ class LLMS_Test_Twenty_Twenty extends LLMS_Unit_Test_Case {
 
 		parent::setUp();
 		update_option( 'template', 'twentytwenty' );
-		new LLMS_Theme_Support();
+		$support = new LLMS_Theme_Support();
+		$support->includes();
 
 	}
 


### PR DESCRIPTION
## Description

Fixes #1251 

This delays loading of the theme-support classes until `after_setup_theme`. Previously the classes were included during `plugins_loaded`.

This change seems to have no negative impact on the existing functionality of the theme support classes but fixes #1251 

This bug occurs because the WP Customizer filters `get_template()` during the initialization of a preview: https://github.com/WordPress/WordPress/blob/5950e1504250b4f92d20c30befa494741892db26/wp-includes/class-wp-customize-manager.php#L676

Before this PR we check the template during `plugins_loaded` which happens before this customizer check

## How has this been tested?

+ Manual tests against supported themes to ensure theme support features continue working
+ Unit tests continue working for twentytwenty, although some tests needed to be updated to continue working after this change

## Screenshots <!-- if applicable -->

## Types of changes

+ bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

