### PR TITLE
Remove usage of deprecated jQuery.on( 'ready', ... )

### DIFF
--- a/assets/js/app/llms-achievements.js
+++ b/assets/js/app/llms-achievements.js
@@ -18,9 +18,10 @@ LLMS.Achievements = {
 	 */
 	init: function() {
 
-		var self = this;
-
 		if ( $( '.llms-achievement' ) ) {
+
+			var self = this;
+
 			$( function() {
 				self.bind();
 				self.maybe_open();

--- a/assets/js/app/llms-achievements.js
+++ b/assets/js/app/llms-achievements.js
@@ -3,8 +3,8 @@
  *
  * @package LifterLMS/Scripts
  *
- * @since    3.14.0
- * @version  3.14.0
+ * @since 3.14.0
+ * @version [version]
  */
 
 LLMS.Achievements = {
@@ -12,9 +12,9 @@ LLMS.Achievements = {
 	/**
 	 * Init
 	 *
-	 * @return   void
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return void
 	 */
 	init: function() {
 
@@ -32,9 +32,9 @@ LLMS.Achievements = {
 	/**
 	 * Bind DOM events
 	 *
-	 * @return   void
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return void
 	 */
 	bind: function() {
 
@@ -65,10 +65,10 @@ LLMS.Achievements = {
 	/**
 	 * Creates modal a modal for an achievement
 	 *
-	 * @param    obj   $el  jQuery selector for the modal card
-	 * @return   void
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @param obj $el The jQuery selector for the modal card.
+	 * @return void
 	 */
 	create_modal: function( $el ) {
 
@@ -108,9 +108,9 @@ LLMS.Achievements = {
 	/**
 	 * On page load, opens a modal if the URL contains an achievement in the location hash
 	 *
-	 * @return   void
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return void
 	 */
 	maybe_open: function() {
 

--- a/assets/js/app/llms-achievements.js
+++ b/assets/js/app/llms-achievements.js
@@ -21,7 +21,7 @@ LLMS.Achievements = {
 		var self = this;
 
 		if ( $( '.llms-achievement' ) ) {
-			$( document ).on( 'ready', function() {
+			$( function() {
 				self.bind();
 				self.maybe_open();
 			} );

--- a/assets/js/llms-metabox-achievement.js
+++ b/assets/js/llms-metabox-achievement.js
@@ -1,6 +1,7 @@
-jQuery( document ).ready(function($){
+( function( $ ) {
 
-	$( '.achievement_image_button' ).click(function(e) {
+	// Open Media Manager modal.
+	$( '.achievement_image_button' ).click( function( e ) {
 
 		// Create Media Manager On Click to allow multiple on one Page
 		var achievement_uploader;
@@ -41,12 +42,6 @@ jQuery( document ).ready(function($){
 
 	});
 
-});
-/*
-* Media Manager 3.5
-* @version 1.70
-*/
-jQuery( document ).ready(function($){
 	// Remove Image and replace with default and Erase Image ID for achievement
 	$( '.llms_achievement_clear_image_button' ).click(function(e) {
 		e.preventDefault();
@@ -58,4 +53,4 @@ jQuery( document ).ready(function($){
 		$( achievement_img_src ).attr( 'src', achievement_default_img_src );
 	});
 
-});
+} )( jQuery );


### PR DESCRIPTION
## Description

Fixes #1268 

## How has this been tested?

Manual tests of affected screens (student dashboard)

## Screenshots <!-- if applicable -->

## Types of changes

Removes usage of deprecated jQuery syntax



## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

