### PR TITLE
Fix unhandled error when scraping a certificate to export producing a fatal

### DIFF
--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 3.38.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.37.3 Refactored `get_export_html()` method.
  *               Added an action `llms_certificate_generate_export` to allow modification of certificate exports before being stored on the server.
  * @since 3.38.1 Use `LLMS_Mime_Type_Extractor::from_file_path()` when retrieving the certificate's imgs mime types during html export.
+ * @since [version] When generating the certificate the to export, if `$this->scrape_certificate()` generates a WP_Error early return it to avoid fatals.
  */
 class LLMS_Certificates {
 
@@ -96,8 +97,9 @@ class LLMS_Certificates {
 	 *
 	 * @since 3.18.0
 	 * @since 3.37.3 Added action `llms_certificate_generate_export`.
+	 * @since [version] Introduce `llms_certificate_error` WP_Error code.
 	 *
-	 * @param string $filepath Full path for the created file.
+	 * @param string $filepath       Full path for the created file.
 	 * @param int    $certificate_id WP_Post ID of the earned certificate.
 	 * @return mixed WP_Error or full path to the generated export.
 	 */
@@ -112,19 +114,19 @@ class LLMS_Certificates {
 		/**
 		 * Run actions prior to certificate export generation.
 		 *
-		 * @param string $filepath Full path where the created file will be stored. Passed as a reference.
-		 * @param string $html Certificate HTML. Passed as a reference.
-		 * @param int $certificate_id WP_Post ID of the earned certificate.
+		 * @param string $filepath       Full path where the created file will be stored. Passed as a reference.
+		 * @param string $html           Certificate HTML. Passed as a reference.
+		 * @param int    $certificate_id WP_Post ID of the earned certificate.
 		 */
 		do_action_ref_array( 'llms_certificate_generate_export', array( &$filepath, &$html, $certificate_id ) );
 
 		$file = fopen( $filepath, 'w' );
 		if ( false === $file ) {
-			return new WP_Error( __( 'Unable to open export file (HTML certificate) for writing.', 'lifterlms' ) );
+			return new WP_Error( 'llms_certificate_error', __( 'Unable to open export file (HTML certificate) for writing.', 'lifterlms' ) );
 		}
 
 		if ( false === fwrite( $file, $html ) ) {
-			return new WP_Error( __( 'Unable to write to export file (HTML certificate).', 'lifterlms' ) );
+			return new WP_Error( 'llms_certificate_error', __( 'Unable to write to export file (HTML certificate).', 'lifterlms' ) );
 		}
 
 		fclose( $file );
@@ -139,7 +141,7 @@ class LLMS_Certificates {
 	 * @since 3.18.0
 	 *
 	 * @param int  $certificate_id WP Post ID of the earned certificate.
-	 * @param bool $use_cache If true will check for existence of a cached version of the file first.
+	 * @param bool $use_cache      If true will check for existence of a cached version of the file first.
 	 * @return mixed WP_Error or full path to the generated export.
 	 */
 	public function get_export( $certificate_id, $use_cache = false ) {
@@ -175,6 +177,7 @@ class LLMS_Certificates {
 	 * @since 3.18.0
 	 * @since 3.24.3 Unknown.
 	 * @since 3.37.3 Refactored method into multiple functions.
+	 * @since [version] If `$this->scrape_certificate()` generates a `WP_Error` early return it.
 	 *
 	 * @param int $certificate_id WP_Post ID of the earned certificate.
 	 * @return string
@@ -183,6 +186,10 @@ class LLMS_Certificates {
 
 		// Retrieve the raw HTML of the page.
 		$html = $this->scrape_certificate( $certificate_id );
+
+		if ( is_wp_error( $html ) ) {
+			return $html;
+		}
 
 		// If DOMDocument exists, modify the DOM before exporting.
 		if ( class_exists( 'DOMDocument' ) ) {
@@ -194,8 +201,8 @@ class LLMS_Certificates {
 		 *
 		 * @since  3.18.0
 		 *
-		 * @param string $html HTML to be exported.
-		 * @param int $certificate_id WP_Post ID of the earned certificate.
+		 * @param string $html           HTML to be exported.
+		 * @param int    $certificate_id WP_Post ID of the earned certificate.
 		 */
 		return apply_filters( 'llms_get_certificate_export_html', $html, $certificate_id );
 
@@ -342,8 +349,8 @@ class LLMS_Certificates {
 		 *
 		 * @since 3.18.0
 		 *
-		 * @param string $url Certificate permalink with a one-time use authorization token appended as a query string variable.
-		 * @param int $certificate_id WP_Post ID of the earned certificate (an "llms_my_certificate" post).
+		 * @param string $url            Certificate permalink with a one-time use authorization token appended as a query string variable.
+		 * @param int    $certificate_id WP_Post ID of the earned certificate (an "llms_my_certificate" post).
 		 */
 		$url = apply_filters(
 			'llms_get_certificate_export_html_url',

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -180,7 +180,7 @@ class LLMS_Certificates {
 	 * @since [version] If `$this->scrape_certificate()` generates a `WP_Error` early return it.
 	 *
 	 * @param int $certificate_id WP_Post ID of the earned certificate.
-	 * @return string
+	 * @return WP_Error|string HTML of the certificate on success, otherwise an error object.
 	 */
 	private function get_export_html( $certificate_id ) {
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.18.0
- * @version 3.37.4
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.35.0 Sanitize `$_POST` data.
  * @since 3.37.4 Modify `llms_certificate` post type registration to allow certificate templates to be exported.
  *               When exporting a certificate template, use the `post_author` for the certificate's WP User ID.
+ * @since [version] Properly use an `error` notice to display a WP_Error when trying to download a certificate.
  */
 class LLMS_Controller_Certificates {
 
@@ -146,6 +147,7 @@ class LLMS_Controller_Certificates {
 	 * on the View Certificate front end & on reporting backend for admins.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Properly use an `error` notice to display a WP_Error.
 	 *
 	 * @return void
 	 */
@@ -154,7 +156,7 @@ class LLMS_Controller_Certificates {
 		$filepath = LLMS()->certificates()->get_export( $cert_id );
 		if ( is_wp_error( $filepath ) ) {
 			// @todo need to handle errors differently on admin panel
-			return llms_add_notice( $filepath->get_error_message() );
+			return llms_add_notice( $filepath->get_error_message(), 'error' );
 		}
 
 		header( 'Content-Description: File Transfer' );


### PR DESCRIPTION
## Description

Fixes #1275 

## How has this been tested?
manually with reproduction steps in #1275

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

