### PR TITLE
exclude 'protected' post types from wp 5.5. xml sitemap

### DIFF
--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS\Classes
  *
  * @since 1.0.0
- * @version 3.37.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,6 +26,7 @@ class LLMS_Post_Types {
 	 *
 	 * @since 1.0.0
 	 * @since 3.0.4 Unknown.
+	 * @since [version] Add filter to deregister protected post types.
 	 *
 	 * @return void
 	 */
@@ -35,6 +36,8 @@ class LLMS_Post_Types {
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
 		add_action( 'init', array( __CLASS__, 'register_post_statuses' ), 9 );
 		add_action( 'init', array( __CLASS__, 'register_taxonomies' ), 5 );
+
+		add_filter( 'wp_sitemaps_post_types', array( __CLASS__, 'deregister_sitemap_post_types' ) );
 
 		add_action( 'after_setup_theme', array( __CLASS__, 'add_thumbnail_support' ), 777 );
 
@@ -99,6 +102,27 @@ class LLMS_Post_Types {
 		}
 
 		add_image_size( 'llms_notification_icon', 64, 64, true );
+
+	}
+
+	/**
+	 * De-register protected post types from wp-sitemap.xml
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_Post_Type[] $post_types Array of post types.
+	 * @return WP_Post_Type[]
+	 */
+	public static function deregister_sitemap_post_types( $post_types ) {
+
+		unset(
+			$post_types['lesson'],
+			$post_types['llms_quiz'],
+			$post_types['llms_certificate'],
+			$post_types['llms_my_certificate']
+		);
+
+		return $post_types;
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-post-types.php
+++ b/tests/phpunit/unit-tests/class-llms-test-post-types.php
@@ -7,6 +7,28 @@
  */
 class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 
+	public function test_deregister_sitemap_post_types() {
+
+		$mock = array(
+			'post' => true,
+			'page' => true,
+			'course' => true,
+			'lesson' => true,
+			'llms_quiz' => true,
+			'llms_certificate' => true,
+			'llms_my_certificate' => true
+		);
+
+		$expect = array(
+			'post' => true,
+			'page' => true,
+			'course' => true,
+		);
+
+		$this->assertEquals( $expect, LLMS_Post_Types::deregister_sitemap_post_types( $mock ) );
+
+	}
+
 	public function test_register_post_taxonomies() {
 
 		LLMS_Post_Types::register_taxonomies();


### PR DESCRIPTION
## Description

Fixes #1281 

## How has this been tested?

Manually (use recreation steps)
Added new unit test for added method

## Screenshots <!-- if applicable -->

## Types of changes

5.5 compatibility fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

