### PR TITLE
Refactor asset enqueue/registration logic for reporting/analytics related scripts

### DIFF
--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -299,7 +299,7 @@ class LLMS_Admin_Assets {
 
 			$current_tab = llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING );
 
-			wp_register_script( 'llms-google-charts', LLMS_PLUGIN_URL . 'assets/js/vendor/gcharts-loader.min.js', array(), '2019-09-04' );
+			wp_register_script( 'llms-google-charts', LLMS_PLUGIN_URL . 'assets/js/vendor/gcharts-loader.min.js', array(), '2019-09-04', false );
 			wp_register_script( 'llms-analytics', LLMS_PLUGIN_URL . 'assets/js/llms-analytics' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-admin-scripts', 'llms-google-charts' ), LLMS()->version, true );
 
 			// Settings "general" tab where we have analytics widgets.
@@ -314,9 +314,7 @@ class LLMS_Admin_Assets {
 				} elseif ( 'quizzes' === $current_tab && 'attempts' === llms_filter_input( INPUT_GET, 'stab', FILTER_SANITIZE_STRING ) ) {
 					wp_enqueue_script( 'llms-quiz-attempt-review', LLMS_PLUGIN_URL . 'assets/js/llms-quiz-attempt-review' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS()->version, true );
 				}
-
 			}
-
 		}
 
 	}

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -108,6 +108,7 @@ class LLMS_Admin_Assets {
 	 * @since 3.22.0 Unknown.
 	 * @since 3.35.0 Explicitly set asset versions.
 	 * @since 3.35.1 Don't reference external scripts & styles.
+	 * @since [version] Move logic for reporting/analytics scripts to `maybe_enqueue_reporting()`.
 	 *
 	 * @return   void
 	 */
@@ -203,42 +204,7 @@ class LLMS_Admin_Assets {
 				wp_enqueue_script( 'llms-select2' );
 			}
 
-			if ( 'lifterlms_page_llms-reporting' === $screen->base || 'lifterlms_page_llms-settings' === $screen->base ) {
-
-				wp_register_script( 'llms-google-charts', LLMS_PLUGIN_URL . 'assets/js/vendor/gcharts-loader.min.js', array(), '2019-09-04' );
-				wp_register_script( 'llms-analytics', LLMS_PLUGIN_URL . 'assets/js/llms-analytics' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-admin-scripts', 'llms-google-charts' ), LLMS()->version, true );
-
-				if ( 'lifterlms_page_llms-settings' === $screen->base ) {
-
-					wp_enqueue_script( 'llms-analytics' );
-					wp_enqueue_script( 'llms-metaboxes' );
-
-				} elseif ( isset( $_GET['tab'] ) ) {
-
-					switch ( $_GET['tab'] ) {
-						case 'enrollments':
-						case 'sales':
-							wp_enqueue_script( 'llms-select2' );
-							wp_enqueue_script( 'llms-analytics' );
-							wp_enqueue_script( 'llms-metaboxes' );
-
-							break;
-
-						case 'students':
-							if ( isset( $_GET['stab'] ) && 'courses' === $_GET['stab'] ) {
-								wp_enqueue_script( 'llms-metaboxes' );
-							}
-							break;
-
-						case 'quizzes':
-							if ( isset( $_GET['stab'] ) && 'attempts' === $_GET['stab'] ) {
-								wp_enqueue_script( 'llms-quiz-attempt-review', LLMS_PLUGIN_URL . 'assets/js/llms-quiz-attempt-review' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS()->version, true );
-							}
-							break;
-
-					}
-				}
-			}
+			$this->maybe_enqueue_reporting( $screen );
 
 			wp_enqueue_script( 'top-modal' );
 
@@ -316,6 +282,42 @@ class LLMS_Admin_Assets {
 
 		echo '<script type="text/javascript">window.LLMS = window.LLMS || {};</script>';
 		echo '<script type="text/javascript">window.LLMS.l10n = window.LLMS.l10n || {}; window.LLMS.l10n.strings = ' . LLMS_L10n::get_js_strings( true ) . ';</script>';
+
+	}
+
+	/**
+	 * Register and enqueue scripts used on and related-to reporting and analytics
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_Sreen $screen Screen object from WP `get_current_screen()`.
+	 * @return void
+	 */
+	protected function maybe_enqueue_reporting( $screen ) {
+
+		if ( in_array( $screen->base, array( 'lifterlms_page_llms-reporting', 'lifterlms_page_llms-settings' ), true ) ) {
+
+			$current_tab = llms_filter_input( INPUT_GET, 'tab', FILTER_SANITIZE_STRING );
+
+			wp_register_script( 'llms-google-charts', LLMS_PLUGIN_URL . 'assets/js/vendor/gcharts-loader.min.js', array(), '2019-09-04' );
+			wp_register_script( 'llms-analytics', LLMS_PLUGIN_URL . 'assets/js/llms-analytics' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-admin-scripts', 'llms-google-charts' ), LLMS()->version, true );
+
+			// Settings "general" tab where we have analytics widgets.
+			if ( 'lifterlms_page_llms-settings' === $screen->base && ( is_null( $current_tab ) || 'general' === $current_tab ) ) {
+
+				wp_enqueue_script( 'llms-analytics' );
+
+			} elseif ( 'lifterlms_page_llms-reporting' === $screen->base ) {
+
+				if ( in_array( $current_tab, array( 'enrollments', 'sales' ), true ) ) {
+					wp_enqueue_script( 'llms-analytics' );
+				} elseif ( 'quizzes' === $current_tab && 'attempts' === llms_filter_input( INPUT_GET, 'stab', FILTER_SANITIZE_STRING ) ) {
+					wp_enqueue_script( 'llms-quiz-attempt-review', LLMS_PLUGIN_URL . 'assets/js/llms-quiz-attempt-review' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS()->version, true );
+				}
+
+			}
+
+		}
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Test Admin Assets Class
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group admin_assets
+ * @group assets
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
+
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = new LLMS_Admin_Assets();
+
+	}
+
+	/**
+	 * Tear down test case
+	 *
+	 * Dequeue & Dereqister all assets that may have been enqueued during tests.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+
+		/**
+		 * List of asset handles that may have been enqueued or registered during the test
+		 *
+		 * We do not care if they actually were registered or enqueued, we'll remove them
+		 * anyway since the functions will fail silently for assets that were not
+		 * previously enqueued or registered.
+		 */
+		$handles = array(
+			'llms-google-charts',
+			'llms-analytics'
+		);
+
+		foreach ( $handles as $handle ) {
+			wp_dequeue_script( $handle );
+			wp_deregister_script( $handle );
+		}
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on a screen where it shouldn't be registered.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_wrong_screen() {
+
+		$screen = (object) array( 'base' => 'fake' );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetNotRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetNotRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-google-charts' );
+		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the general settings page where analytics are required for the data widgets
+	 *
+	 * This test tests the default "assumed" tab when there's no `tab` set in the $_GET array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_general_settings_assumed() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-settings' );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetIsEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the general settings page where analytics are required for the data widgets
+	 *
+	 * This test is the same as test_maybe_enqueue_reporting_general_settings_assumed() except this one explicitly
+	 * tests for the presence of the `tab=general` in the $_GET array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_general_settings_explicit() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-settings' );
+		$this->mockGetRequest( array( 'tab' => 'general' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetIsEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on settings tabs other than general, scripts will be registered but not enqueued.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_other_tabs() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-settings' );
+		$this->mockGetRequest( array( 'tab' => 'fake' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on reporting screens where the scripts aren't needed.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_invalid_reporting_screens() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-reporting' );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the enrollments reporting screen
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_enrollments_reporting_screens() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-reporting' );
+		$this->mockGetRequest( array( 'tab' => 'enrollments' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetIsEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the sales reporting screen
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_sales_reporting_screens() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-reporting' );
+		$this->mockGetRequest( array( 'tab' => 'sales' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetIsEnqueued( 'script', 'llms-analytics' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the main quizzes reporting screen
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_quiz_main_reporting_screens() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-reporting' );
+		$this->mockGetRequest( array( 'tab' => 'quizzes' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
+		$this->assertAssetNotEnqueued( 'script', 'llms-quiz-attempt-review' );
+
+	}
+
+	/**
+	 * Test maybe_enqueue_reporting() on the quiz attempts reporting screen
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_enqueue_reporting_quiz_attempts_reporting_screens() {
+
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-reporting' );
+		$this->mockGetRequest( array( 'tab' => 'quizzes', 'stab' => 'attempts' ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
+
+		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+
+		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
+		$this->assertAssetIsEnqueued( 'script', 'llms-quiz-attempt-review' );
+
+	}
+
+
+}


### PR DESCRIPTION
## Description

Fixes #1288 

## How has this been tested?

+ Manually tested affected screens to ensure intended functionality remains (scripts are enqueued where they should)
+ Manually tested to ensure the reported issue goes away
+ Previously failing e2e tests no longer fail as a result of the fixed JSON error
+ Added new unit tests for new asset enqueue/registration method

## Types of changes

+ Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

