### PR TITLE
Fix core script double registration

### DIFF
--- a/assets/js/app/llms-ajax.js
+++ b/assets/js/app/llms-ajax.js
@@ -58,9 +58,14 @@ LLMS.Ajax = {
 
 	/**
 	 * Initialize Ajax methods
-	 * loads class methods
+	 *
+	 * @since Unknown
+	 * @since [version] Update ajax nonce source.
+	 *
+	 * @param {Object} obj Options object.
+	 * @return {Object}
 	 */
-	init: function(obj) {
+	init: function( obj ) {
 
 		// if obj is not of type object or null return false;
 		if ( obj === null || typeof obj !== 'object' ) {
@@ -76,7 +81,7 @@ LLMS.Ajax = {
 		obj.async    = 'async'		in obj ? obj.async : this.async;
 
 		// add nonce to data object
-		obj.data._ajax_nonce = wp_ajax_data.nonce;
+		obj.data._ajax_nonce = window.llms.ajax_nonce || wp_ajax_data.nonce;
 
 		// add post id to data object
 		var $R           = LLMS.Rest,

--- a/assets/js/app/llms-ajax.js
+++ b/assets/js/app/llms-ajax.js
@@ -67,7 +67,7 @@ LLMS.Ajax = {
 	 */
 	init: function( obj ) {
 
-		// if obj is not of type object or null return false;
+		// If obj is not of type object or null return false.
 		if ( obj === null || typeof obj !== 'object' ) {
 			return false;
 		}
@@ -80,10 +80,10 @@ LLMS.Ajax = {
 		obj.dataType = 'dataType'	in obj ? obj.dataType : this.dataType;
 		obj.async    = 'async'		in obj ? obj.async : this.async;
 
-		// add nonce to data object
+		// Add nonce to data object.
 		obj.data._ajax_nonce = window.llms.ajax_nonce || wp_ajax_data.nonce;
 
-		// add post id to data object
+		// Add post id to data object.
 		var $R           = LLMS.Rest,
 		query_vars       = $R.get_query_vars();
 		obj.data.post_id = 'post' in query_vars ? query_vars.post : null;

--- a/assets/js/builder/Views/PostSearch.js
+++ b/assets/js/builder/Views/PostSearch.js
@@ -1,8 +1,8 @@
 /**
  * Post Popover Search content View
  *
- * @since    3.16.0
- * @version  3.17.0
+ * @since 3.16.0
+ * @version [version]
  */
 define( [], function() {
 
@@ -59,11 +59,14 @@ define( [], function() {
 
 		/**
 		 * Render the section
+		 *
 		 * Initializes a new collection and views for all lessons in the section
 		 *
-		 * @return   void
-		 * @since    3.16.0
-		 * @version  3.16.12
+		 * @since 3.16.0
+		 * @since 3.16.12 Unknown
+		 * @since [version] Update ajax nonce source.
+		 *
+		 * @return void
 		 */
 		render: function() {
 			var self = this;
@@ -82,15 +85,12 @@ define( [], function() {
 								post_type: self.post_type,
 								term: params.term,
 								page: params.page,
-								_ajax_nonce: wp_ajax_data.nonce,
+								_ajax_nonce: window.llms.ajax_nonce,
 							};
 						},
-						// error: function( xhr, status, error ) {
-						// console.log( status, error );
-						// },
 					},
 					dropdownParent: $( '.wrap.lifterlms.llms-builder' ),
-					// don't escape html from render_result
+					// Don't escape html from render_result.
 					escapeMarkup: function( markup ) {
 						return markup;
 					},

--- a/assets/js/builder/Views/PostSearch.js
+++ b/assets/js/builder/Views/PostSearch.js
@@ -60,10 +60,10 @@ define( [], function() {
 		/**
 		 * Render the section
 		 *
-		 * Initializes a new collection and views for all lessons in the section
+		 * Initializes a new collection and views for all lessons in the section.
 		 *
 		 * @since 3.16.0
-		 * @since 3.16.12 Unknown
+		 * @since 3.16.12 Unknown.
 		 * @since [version] Update ajax nonce source.
 		 *
 		 * @return void

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -2,7 +2,7 @@
  * LifterLMS Admin Panel Javascript
  *
  * @since Unknown
- * @version 3.40.0
+ * @version [version]
  *
  * @param obj $ Traditional jQuery reference.
  * @return void
@@ -60,6 +60,7 @@
 	 * @since 3.19.4
 	 * @since 3.32.0 Added ability to fetch posts based on their post status.
 	 * @since 3.37.2 Added ability to fetch posts (llms posts) filtered by their instructor id.
+	 * @since [version] Update ajax nonce source.
 	 *
 	 * @param obj options Options passed to Select2.
 	 *                    Each default option will pulled from the elements data-attributes.
@@ -106,7 +107,7 @@
 						instructor_id : options.instructor_id,
 						post_statuses: options.post_statuses,
 						term: params.term,
-						_ajax_nonce: wp_ajax_data.nonce
+						_ajax_nonce: window.llms.ajax_nonce,
 					};
 				},
 				processResults: function( data, params ) {
@@ -163,11 +164,13 @@
 
 	/**
 	 * Simple jQuery plugin to transform select elements into Select2-powered elements to query for Students via AJAX
-	 * @param    obj   options  options passed to Select2
-	 *                          each default option will pulled from the elements data-attributes
-	 * @return   void
-	 * @since    ??
-	 * @version  3.17.5
+	 *
+	 * @since Unknown
+	 * @since 3.17.5 Unknown.
+	 * @since [version] Update ajax nonce source.
+	 *
+	 * @param obj options Options passed to Select2. Each default option will pulled from the elements data-attributes.
+	 * @return void
 	 */
 	$.fn.llmsStudentsSelect2 = function( options ) {
 
@@ -200,7 +203,7 @@
 				url: window.ajaxurl,
 				data: function( params ) {
 					return {
-						_ajax_nonce: wp_ajax_data.nonce,
+						_ajax_nonce: window.llms.ajax_nonce,
 						action: 'query_students',
 						page: params.page,
 						not_enrolled_in: params.not_enrolled_in || options.not_enrolled_in,

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -169,7 +169,7 @@
 	 * @since 3.17.5 Unknown.
 	 * @since [version] Update ajax nonce source.
 	 *
-	 * @param obj options Options passed to Select2. Each default option will pulled from the elements data-attributes.
+	 * @param obj options Options passed to Select2. Each default option will be pulled from the elements data-attributes.
 	 * @return void
 	 */
 	$.fn.llmsStudentsSelect2 = function( options ) {

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -256,7 +256,7 @@ class LLMS_Admin_Assets {
 	 * Initialize the "llms" object for other scripts to hook into
 	 *
 	 * @since 1.0.0
-	 * @since 3.7.5 Unknown
+	 * @since 3.7.5 Unknown.
 	 * @since [version] Add `ajax_nonce`.
 	 *
 	 * @return void

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -109,6 +109,7 @@ class LLMS_Admin_Assets {
 	 * @since 3.35.0 Explicitly set asset versions.
 	 * @since 3.35.1 Don't reference external scripts & styles.
 	 * @since [version] Move logic for reporting/analytics scripts to `maybe_enqueue_reporting()`.
+	 *              Enqueue the main `llms` script.
 	 *
 	 * @return   void
 	 */
@@ -147,6 +148,8 @@ class LLMS_Admin_Assets {
 		}
 
 		if ( $this->is_llms_page() ) {
+
+			LLMS_Assets::enqueue_script( 'llms' );
 
 			wp_enqueue_script( 'jquery-ui-datepicker' );
 			wp_enqueue_script( 'jquery-ui-sortable' );
@@ -252,9 +255,11 @@ class LLMS_Admin_Assets {
 	/**
 	 * Initialize the "llms" object for other scripts to hook into
 	 *
+	 * @since 1.0.0
+	 * @since 3.7.5 Unknown
+	 * @since [version] Add `ajax_nonce`.
+	 *
 	 * @return void
-	 * @since    1.0.0
-	 * @version  3.7.5
 	 */
 	public function admin_print_scripts() {
 
@@ -275,6 +280,7 @@ class LLMS_Admin_Assets {
 		echo '
 			<script type="text/javascript">
 				window.llms = window.llms || {};
+				window.llms.ajax_nonce = "' . wp_create_nonce( LLMS_AJAX::NONCE ) . '";
 				window.llms.admin_url = "' . admin_url() . '";
 				window.llms.post = ' . json_encode( $postdata ) . ';
 			</script>

--- a/includes/class.llms.ajax.php
+++ b/includes/class.llms.ajax.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -59,18 +59,24 @@ class LLMS_AJAX {
 
 	/**
 	 * Register the AJAX handler class with all the appropriate WordPress hooks.
+	 *
+	 * @since Unknown
+	 * @since [version] Move `register_script()` to script enqueue hook in favor of `wp_loaded`.
+	 *
+	 * @return void
 	 */
 	public function register() {
 
 		$handler = 'LLMS_AJAX';
-
 		$methods = get_class_methods( 'LLMS_AJAX_Handler' );
 
 		foreach ( $methods as $method ) {
 			add_action( 'wp_ajax_' . $method, array( $handler, 'handle' ) );
 			add_action( 'wp_ajax_nopriv_' . $method, array( $handler, 'handle' ) );
-			add_action( 'wp_loaded', array( $this, 'register_script' ) );
 		}
+
+		$action = is_admin() ? 'admin_enqueue_scripts' : 'wp_enqueue_scripts';
+		add_action( $action, array( $this, 'register_script' ), 20 );
 
 	}
 
@@ -116,26 +122,22 @@ class LLMS_AJAX {
 	 *
 	 * @since 1.0.0
 	 * @since 3.35.0 Sanitize data & declare script versions.
+	 * @since [version] Don't register the `llms` script.
+	 * @deprecated [version] Retrieve ajax nonce via `window.llms.ajax-nonce` in favor of `wp_ajax_data.nonce`.
 	 *
-	 * @return  void
+	 * @return void
 	 */
 	public function register_script() {
 
-		// script will only register once
-		wp_register_script( 'llms', LLMS_PLUGIN_URL . '/assets/js/llms' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 		wp_localize_script( 'llms', 'wp_ajax_data', $this->get_ajax_data() );
-
-		$script = ! empty( $_SERVER['SCRIPT_NAME'] ) ? sanitize_text_field( wp_unslash( $_SERVER['SCRIPT_NAME'] ) ) : false;
-		// ensure this doesn't load on the wp-login.php screen
-		if ( false === stripos( $script, strrchr( wp_login_url(), '/' ) ) ) {
-			wp_enqueue_script( 'llms' );
-		}
 
 	}
 
 	/**
 	 * Get the AJAX data
-	 * Currently only retrieves the nonce until we can figure out how to get the post id too
+	 *
+	 * @since Unknown
+	 * @deprecated [version] Retrieve ajax nonce via `window.llms.ajax-nonce` in favor of `wp_ajax_data.nonce`.
 	 *
 	 * @return array
 	 */

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -122,6 +122,7 @@ class LLMS_Frontend_Assets {
 	 * @since 1.0.0
 	 * @since 3.18.0 Unknown.
 	 * @since 3.35.0 Explicitly define asset versions.
+	 * @since [version] Enqueue the main `lifterlms-styles` stylesheet using `LLMS_Assets::enqueue_style()`.
 	 *
 	 * @return void
 	 */
@@ -133,9 +134,7 @@ class LLMS_Frontend_Assets {
 
 		wp_enqueue_style( 'webui-popover', LLMS_PLUGIN_URL . 'assets/vendor/webui-popover/jquery.webui-popover' . LLMS_ASSETS_SUFFIX . '.css', array(), '1.2.15' );
 
-		wp_enqueue_style( 'lifterlms-styles', LLMS_PLUGIN_URL . 'assets/css/lifterlms' . LLMS_ASSETS_SUFFIX . '.css', array(), LLMS()->version );
-		wp_style_add_data( 'lifterlms-styles', 'rtl', 'replace' );
-		wp_style_add_data( 'lifterlms-styles', 'suffix', LLMS_ASSETS_SUFFIX );
+		LLMS_Assets::enqueue_style( 'lifterlms-styles' );
 
 		if ( 'llms_my_certificate' === $post_type || 'llms_certificate' === $post_type ) {
 			wp_enqueue_style( 'certificates', LLMS_PLUGIN_URL . 'assets/css/certificates' . LLMS_ASSETS_SUFFIX . '.css', array(), LLMS()->version );
@@ -157,6 +156,8 @@ class LLMS_Frontend_Assets {
 	 * @since 3.35.0 Explicitly define asset versions.
 	 * @since 3.36.0 Localize tracking with client-side settings.
 	 * @since 4.0.0 Remove dependencies "collapse" and "transition".
+	 * @since [version] Enqueue the main `llms` script using `LLMS_Assets::enqueue_script()`.
+	 *              Add Add `window.llms.ajax_nonce` data to replace `wp_ajax_data.nonce`.
 	 *
 	 * @return void
 	 */
@@ -173,9 +174,7 @@ class LLMS_Frontend_Assets {
 			wp_enqueue_script( 'llms-jquery-matchheight' );
 		}
 
-		// @todo  this is currently being double registered and enqueued by LLMS_Ajax.
-		wp_register_script( 'llms', LLMS_PLUGIN_URL . 'assets/js/llms' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
-		wp_enqueue_script( 'llms' );
+		LLMS_Assets::enqueue_script( 'llms' );
 
 		wp_register_script( 'llms-notifications', LLMS_PLUGIN_URL . 'assets/js/llms-notifications' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 		if ( get_current_user_id() ) {
@@ -204,6 +203,10 @@ class LLMS_Frontend_Assets {
 		self::enqueue_inline_script(
 			'llms-ajaxurl',
 			'window.llms = window.llms || {};window.llms.ajaxurl = "' . admin_url( 'admin-ajax.php', $ssl ) . '";'
+		);
+		self::enqueue_inline_script(
+			'llms-ajax-nonce',
+			'window.llms = window.llms || {};window.llms.ajax_nonce = "' . wp_create_nonce( LLMS_AJAX::NONCE ) . '";'
 		);
 		self::enqueue_inline_script(
 			'llms-tracking-settings',


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description

+ Fixes #1274 
+ Fixes #1285 

## How has this been tested?

+ Manual tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Optimizations
+ Bug fix
+ Deprecates global js variable `window.wp_ajax_data.nonce` in favor of `window.llms.ajax_nonce`. The original seems too dangerous and ripe for a plugin/core conflict.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

