### PR TITLE
Removes "duplicate" logic from `llms_deprecated_function()` in favor of core method

### DIFF
--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -115,47 +115,24 @@ if ( ! function_exists( 'llms_content' ) ) {
 /**
  * Provide deprecation warnings
  *
- * Very similar to https://developer.wordpress.org/reference/functions/_deprecated_function/
+ * This function uses WP core's `_deprecated_function()`, logging to the LifterLMS log file
+ * located at `wp-content/updloads/llms-logs/llms-{$hash}.log` instead of `wp-content/debug.log`.
  *
- * @param   string $function    name of the deprecated class or function
- * @param   string $version     version deprecation occurred
- * @param   string $replacement function to use in it's place (optional)
- * @return  void
- * @since   2.6.0
- * @version 3.6.0
+ * @since 2.6.0
+ * @since 3.6.0 Unknown.
+ * @since [version] Uses WP `_deprecated_function()` instead of duplicating it's logic.
+ *
+ * @param string $function    Name of the deprecated function.
+ * @param string $version     LifterLMS version that deprecated the function.
+ * @param string $replacement Replacement function.
+ * @return void
  */
 function llms_deprecated_function( $function, $version, $replacement = null ) {
 
-	// only warn if debug is enabled
-	if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
-		return;
-	}
-
-	if ( function_exists( '__' ) ) {
-
-		if ( ! is_null( $replacement ) ) {
-			$string = sprintf( __( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', 'lifterlms' ), $function, $version, $replacement );
-		} else {
-			$string = sprintf( __( '%1$s is <strong>deprecated</strong> since version %2$s!', 'lifterlms' ), $function, $version );
-		}
-	} else {
-
-		if ( ! is_null( $replacement ) ) {
-			$string = sprintf( '%1$s is <strong>deprecated</strong> since version %2$s! Use %3$s instead.', $function, $version, $replacement );
-		} else {
-			$string = sprintf( '%1$s is <strong>deprecated</strong> since version %2$s!', $function, $version );
-		}
-	}
-
-	// warn on screen
-	if ( defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG_DISPLAY ) {
-		echo '<br>' . $string . '<br>';
-	}
-
-	// log to the error logger
-	if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-		llms_log( $string );
-	}
+	$init_log_path = ini_get( 'error_log' );
+	ini_set( 'error_log', llms_get_log_path( 'llms' ) );
+	_deprecated_function( $function, $version, $replacement );
+	ini_set( 'error_log', $init_log_path );
 
 }
 

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 4.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -129,10 +129,7 @@ if ( ! function_exists( 'llms_content' ) ) {
  */
 function llms_deprecated_function( $function, $version, $replacement = null ) {
 
-	$init_log_path = ini_get( 'error_log' );
-	ini_set( 'error_log', llms_get_log_path( 'llms' ) );
 	_deprecated_function( $function, $version, $replacement );
-	ini_set( 'error_log', $init_log_path );
 
 }
 

--- a/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
@@ -1,30 +1,36 @@
 <?php
 /**
  * LLMS Frontend Assets Tests
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group assets
+ * @group frontend_assets
+ *
+ * @since [version]
  */
-
 class LLMS_Test_Frontend_Assets extends LLMS_UnitTestCase {
 
 	/**
 	 * Test inline script management functions
-	 * @return   void
-	 * @since    3.4.1
-	 * @version  3.4.1
+	 *
+	 * @since 3.4.1
+	 *
+	 * @expectedDeprecated LLMS_Frontend_Assets::enqueue_inline_script()
+	 * @expectedDeprecated LLMS_Frontend_Assets::is_inline_enqueued()
+	 *
+	 * @return void
 	 */
 	public function test_inline_scripts() {
 
-		// new script should return true
+		// New script should return true.
 		$this->assertTrue( LLMS_Frontend_Assets::enqueue_inline_script( 'test-id', 'alert("hello");', 'footer', 25 ) );
 
-		// script should be enqueued
+		// Script should be enqueued.
 		$this->assertTrue( LLMS_Frontend_Assets::is_inline_script_enqueued( 'test-id' ) );
 
-		// duplicate should assert false
-		$this->assertFalse( LLMS_Frontend_Assets::enqueue_inline_script( 'test-id', 'alert("hello");', 'footer', 25 ) );
-
-		// fake script not enqueued
+		// Fake script not enqueued.
 		$this->assertFalse( LLMS_Frontend_Assets::is_inline_script_enqueued( 'fake-id' ) );
 
 	}
-
 }

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -74,6 +74,54 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * [test_llms_deprecated_function description]
+	 *
+	 * @since [version]
+	 *
+	 * @expectedDeprecated DEPRECATED
+	 *
+	 * @return [type] [description]
+	 */
+	public function test_llms_deprecated_function() {
+
+		// Hold the initial log path so we can test that it's properly restored.
+		$init_log_path = ini_get( 'error_log' );
+
+		// Add an action where we'll test that all our deprecation data is properly passed.
+		add_action( 'deprecated_function_run', array( $this, 'deprecated_function_run_assertions' ), 10, 3 );
+
+		llms_deprecated_function( 'DEPRECATED', '999.999.999', 'REPLACEMENT' );
+
+		remove_action( 'deprecated_function_run', array( $this, 'deprecated_function_run_assertions' ) );
+
+		// The initial log handler should be restored.
+		$this->assertEquals( ini_get( 'error_log' ), $init_log_path );
+
+	}
+
+	/**
+	 * Callback method used to test `llms_deprecated_function()`.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $function    Deprecated function name.
+	 * @param string $replacement Deprecated function replacement.
+	 * @param string $version     Deprecated version number.
+	 * @return void
+	 */
+	public function deprecated_function_run_assertions( $function, $replacement, $version ) {
+
+		// Our deprecation data should be passed to the core.
+		$this->assertEquals( 'DEPRECATED', $function );
+		$this->assertEquals( 'REPLACEMENT', $replacement );
+		$this->assertEquals( '999.999.999', $version );
+
+		// The log file should be temporarily set to the llms log file.
+		$this->assertEquals( llms_get_log_path( 'llms' ), ini_get( 'error_log' ) );
+
+	}
+
+	/**
 	 * Test llms_get_completable_post_types()
 	 *
 	 * @since 4.2.0

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -2,6 +2,8 @@
 /**
  * Tests for LifterLMS Core Functions
  *
+ * @package LifterLMS/Tests/Functions
+ *
  * @group functions
  * @group functions_core
  *
@@ -11,6 +13,7 @@
  * @since 3.37.12 Fix errors thrown due to usage of `llms_section` instead of `section`.
  * @since 3.37.14 When testing `llms_get_post_parent_course()` added tests on other LLMS post types which are not instance of `LLMS_Post_Model`.
  * @since 4.2.0 Add tests for llms_get_completable_post_types() & llms_get_completable_taxonomies().
+ * @since [version] Add tests for `llms_deprecated_function()`
  */
 class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
@@ -74,18 +77,15 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * [test_llms_deprecated_function description]
+	 * Test llms_deprecated_function()
 	 *
 	 * @since [version]
 	 *
 	 * @expectedDeprecated DEPRECATED
 	 *
-	 * @return [type] [description]
+	 * @return void
 	 */
 	public function test_llms_deprecated_function() {
-
-		// Hold the initial log path so we can test that it's properly restored.
-		$init_log_path = ini_get( 'error_log' );
 
 		// Add an action where we'll test that all our deprecation data is properly passed.
 		add_action( 'deprecated_function_run', array( $this, 'deprecated_function_run_assertions' ), 10, 3 );
@@ -93,9 +93,6 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 		llms_deprecated_function( 'DEPRECATED', '999.999.999', 'REPLACEMENT' );
 
 		remove_action( 'deprecated_function_run', array( $this, 'deprecated_function_run_assertions' ) );
-
-		// The initial log handler should be restored.
-		$this->assertEquals( ini_get( 'error_log' ), $init_log_path );
 
 	}
 
@@ -115,9 +112,6 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 		$this->assertEquals( 'DEPRECATED', $function );
 		$this->assertEquals( 'REPLACEMENT', $replacement );
 		$this->assertEquals( '999.999.999', $version );
-
-		// The log file should be temporarily set to the llms log file.
-		$this->assertEquals( llms_get_log_path( 'llms' ), ini_get( 'error_log' ) );
 
 	}
 


### PR DESCRIPTION

## Description

The `llms_deprecated_function()` method originally copied the logic of the WP core method `_deprecated_function()`. This function is prefixed with an underscore and __previously__ came with a note that it was for internal use only. This language has been removed (I don't know when) but it looks like it's "acceptable" for plugins to use this function now.

As a citation, WC uses the function: https://github.com/woocommerce/woocommerce/blob/0699022a46c4750e0b2574de9fccc85795e8e332/includes/wc-deprecated-functions.php#L54

Our function has always logged to the `llms-$hash.log` file in favor of the wp debug.log file. In order to maintain this behavior, this update uses `ini_get()` and `ini_set()` to log to our log file when a deprecated function call is made.

I do not see any downside to this change but the behavior *does change* slightly. Previously no error was triggered by our deprecated functions and now an error *will* be triggered. There is some "danger" in this change but assuming we don't trigger any deprecated functions with our own code we should be okay. Prior to release we should ensure that no add-ons are creating any deprecated warning or logs.

The main motivation for this PR is to make it possible to use the `@expectedDeprecated` annotation provided by the WP Core's phpunit testing lib. This will allow us to leave tests for deprecated functions intact instead of removing them.

## How has this been tested?

+ Manually tested
+ Added new unit tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Developer improvement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

