### PR TITLE
Fix wrong next/previous lesson retrieved in presence of unpublished l…

### DIFF
--- a/includes/abstracts/llms.abstract.exportable.admin.table.php
+++ b/includes/abstracts/llms.abstract.exportable.admin.table.php
@@ -208,7 +208,7 @@ abstract class LLMS_Abstract_Exportable_Admin_Table {
 		/**
 		 * Customize the export file header columns.
 		 *
-		 * The dynamic portion of this hook ${this->id} refers to the ID of the table.
+		 * The dynamic portion of this hook `$this->id` refers to the ID of the table.
 		 *
 		 * @since 3.15.0
 		 *

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,9 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.29.0 Unknown.
  * @since 3.36.2 When getting the lesson's available date: add available number of days to the course start date only if there's a course start date.
  * @since 4.0.0 Remove deprecated methods.
+ * @since [version] Improve the query used to retrieve the previous/next so that we don't miss sibling lessons within the same section
+ *                  if the previous/next one(s) status is (are) not published. Make sure to always return `false` if no previous lesson is found.
+ *                  Use strict comparisions where needed.
  *
  * @property $audio_embed (string) Audio embed URL
  * @property $date_available (string/date) Date when lesson becomes available, applies when $drip_method is "date"
@@ -45,13 +48,13 @@ implements LLMS_Interface_Post_Audio
 
 		'order'                            => 'absint',
 
-		// drippable
+		// Drippable.
 		'days_before_available'            => 'absint',
 		'date_available'                   => 'text',
 		'drip_method'                      => 'text',
 		'time_available'                   => 'text',
 
-		// parent element
+		// Parent element.
 		'parent_course'                    => 'absint',
 		'parent_section'                   => 'absint',
 
@@ -64,47 +67,64 @@ implements LLMS_Interface_Post_Audio
 		'video_embed'                      => 'text',
 		'points'                           => 'absint',
 
-		// quizzes
+		// Quizzes.
 		'quiz'                             => 'absint',
 		'quiz_enabled'                     => 'yesno',
 
 	);
 
 	/**
-	 * Array of default property values
-	 * key => default value
+	 * Associative array of default property values
 	 *
-	 * @var  array
-	 * @since   3.24.0
-	 * @version 3.24.0
+	 * @since 3.24.0
+	 * @var array
 	 */
 	protected $property_defaults = array(
 		'points' => 1,
 	);
 
-	protected $db_post_type    = 'lesson';
+	/**
+	 * Name of the post type as stored in the database
+	 *
+	 * @since unknown
+	 * @var string
+	 */
+	protected $db_post_type = 'lesson';
+
+	/**
+	 * Post type name
+	 *
+	 * To use unprefixed post type names for filters and more.
+	 *
+	 * @since unknown
+	 * @var string
+	 */
 	protected $model_post_type = 'lesson';
 
 	/**
 	 * Attempt to get oEmbed for an audio provider
-	 * Falls back to the [audio] shortcode if the oEmbed fails
 	 *
-	 * @return   string
-	 * @since    1.0.0
-	 * @version  3.17.0
+	 * Falls back to the [audio] shortcode if the oEmbed fails.
+	 *
+	 * @since 1.0.0
+	 * @since 3.17.0 Unknown
+	 *
+	 * @return string
 	 */
 	public function get_audio() {
 		return $this->get_embed( 'audio' );
 	}
 
 	/**
-	 * Get the date a course became or will become available according to element drip settings.
+	 * Get the date a course became or will become available according to element drip settings
+	 *
 	 * If there are no drip settings, the published date of the element will be returned.
 	 *
 	 * @since 3.16.0
 	 * @since 3.36.2 Add available number of days to the course start date only if there's a course start date.
 	 *
-	 * @param  string $format Date format (passed to date_i18n()) (defaults to WP Core date + time formats)
+	 * @param string $format Optional. Date format (passed to date_i18n()). Default is empty string.
+	 *                       When not specified the WP Core date + time formats will be used.
 	 * @return string
 	 */
 	public function get_available_date( $format = '' ) {
@@ -117,12 +137,12 @@ implements LLMS_Interface_Post_Audio
 
 		$days = $this->get( 'days_before_available' ) * DAY_IN_SECONDS;
 
-		// default availability is the element's post date
+		// Default availability is the element's post date.
 		$available = $this->get_date( 'date', 'U' );
 
 		switch ( $drip_method ) {
 
-			// available on a specific date / time
+			// Available on a specific date / time.
 			case 'date':
 				$date = $this->get( 'date_available' );
 				$time = $this->get( 'time_available' );
@@ -135,7 +155,7 @@ implements LLMS_Interface_Post_Audio
 
 				break;
 
-			// available # of days after enrollment in course
+			// Available # of days after enrollment in course.
 			case 'enrollment':
 				$student = llms_get_student();
 				if ( $student ) {
@@ -156,7 +176,7 @@ implements LLMS_Interface_Post_Audio
 
 				break;
 
-			// available # of days after course start date
+			// Available # of days after course start date.
 			case 'start':
 				$course            = $this->get_course();
 				$course_start_date = $course ? $course->get_date( 'start_date', 'U' ) : '';
@@ -167,7 +187,7 @@ implements LLMS_Interface_Post_Audio
 
 				break;
 
-		}// End switch().
+		}
 
 		return date_i18n( $format, $available );
 
@@ -176,9 +196,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of LLMS_Course for the element's parent course
 	 *
-	 * @return   obj|null
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 *
+	 * @return LLMS_Course|null Returns `null` if the lesson is not attached to any courses.
 	 */
 	public function get_course() {
 
@@ -192,22 +212,21 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * An array of default arguments to pass to $this->create()
-	 * when creating a new post
+	 * An array of default arguments to pass to $this->create() when creating a new post
 	 *
-	 * @param    array $args   args of data to be passed to wp_insert_post
-	 * @return   array
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param array $args Optional. Args of data to be passed to `wp_insert_post()`. Default `null`.
+	 * @return array
 	 */
 	protected function get_creation_args( $args = null ) {
 
-		// allow nothing to be passed in
+		// Allow nothing to be passed in.
 		if ( empty( $args ) ) {
 			$args = array();
 		}
 
-		// backwards compat to original 3.0.0 format when just a title was passed in
+		// Backwards compat to original 3.0.0 format when just a title was passed in.
 		if ( is_string( $args ) ) {
 			$args = array(
 				'post_title' => $args,
@@ -228,6 +247,16 @@ implements LLMS_Interface_Post_Audio
 			)
 		);
 
+		/**
+		 * Filter the model creation args
+		 *
+		 * The dynamic portion of this hook, `$this->model_post_type`, refers to model post type.
+		 *
+		 * @since unknown
+		 *
+		 * @param array       $args   Args of data to be passed to `wp_insert_post()`.
+		 * @param LLMS_Lesson $lesson Instance of the LLMS_Lesson.
+		 */
 		return apply_filters( 'llms_' . $this->model_post_type . '_get_creation_args', $args, $this );
 
 	}
@@ -235,9 +264,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieves the lesson's order within its parent section
 	 *
+	 * @since 1.0.0
+	 * @since 3.0.0 Unknown.
+	 *
 	 * @return int
-	 * @since  1.0.0
-	 * @version  3.0.0
 	 */
 	public function get_order() {
 		return $this->get( 'order' );
@@ -246,9 +276,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get parent course id
 	 *
-	 * @return  int
-	 * @since   1.0.0
-	 * @version 3.0.0
+	 * @since 1.0.0
+	 * @since 3.0.0 Unknown.
+	 *
+	 * @return int
 	 */
 	public function get_parent_course() {
 		return absint( get_post_meta( $this->get( 'id' ), '_llms_parent_course', true ) );
@@ -257,9 +288,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get parent section id
 	 *
-	 * @return  int
-	 * @since   1.0.0
-	 * @version 3.0.0
+	 * @since 1.0.0
+	 * @since 3.0.0 Unknown.
+	 *
+	 * @return int
 	 */
 	public function get_parent_section() {
 		return absint( get_post_meta( $this->get( 'id' ), '_llms_parent_section', true ) );
@@ -268,9 +300,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get CSS classes to display on the course syllabus .llms-lesson-preview element
 	 *
-	 * @return   string
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return string
 	 */
 	public function get_preview_classes() {
 
@@ -292,9 +324,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get HTML of the icon to display in the .llms-lesson-preview element on the syllabus
 	 *
-	 * @return   string
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return string
 	 */
 	public function get_preview_icon_html() {
 
@@ -320,9 +352,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of LLMS_Course for the elements's parent section
 	 *
-	 * @return   obj|null
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 *
+	 * @return LLMS_Section|null Returns `null` it the lesson is not attached to any sections.
 	 */
 	public function get_section() {
 
@@ -336,11 +368,12 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * Retrieve an object for the assigned quiz (if a quiz is assigned )
+	 * Retrieve an object for the assigned quiz (if a quiz is assigned)
 	 *
-	 * @return   obj|false
-	 * @since    3.3.0
-	 * @version  3.16.0
+	 * @since 3.3.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @return LLMS_Quiz|false Returns `false` if the lesson has no existing quiz assigned.
 	 */
 	public function get_quiz() {
 		if ( $this->has_quiz() ) {
@@ -354,11 +387,13 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Attempt to get oEmbed for a video provider
-	 * Falls back to the [video] shortcode if the oEmbed fails
 	 *
-	 * @return   string
-	 * @since    1.0.0
-	 * @version  3.17.0
+	 * Falls back to the [video] shortcode if the oEmbed fails.
+	 *
+	 * @since 1.0.0
+	 * @since 3.17.0 Unknown.
+	 *
+	 * @return string
 	 */
 	public function get_video() {
 		return $this->get_embed( 'video' );
@@ -367,24 +402,26 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if lesson prereq is enabled and a prereq lesson is selected
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 * @since [version] Use strict comparison.
+	 *
+	 * @return boolean
 	 */
 	public function has_prerequisite() {
 
-		return ( 'yes' == $this->get( 'has_prerequisite' ) && $this->get( 'prerequisite' ) );
+		return ( 'yes' === $this->get( 'has_prerequisite' ) && $this->get( 'prerequisite' ) );
 
 	}
 
 	/**
 	 * Determine if the slug (post name) of a lesson has been modified
-	 * Ensures that lessons created via the builder with "New Lesson" as the title (default slug "new-lesson-{$num}")
-	 * have their slug renamed when the title is renamed for the first time
 	 *
-	 * @return   bool
-	 * @since    3.14.8
-	 * @version  3.14.8
+	 * Ensures that lessons created via the builder with "New Lesson" as the title (default slug "new-lesson-{$num}")
+	 * have their slug renamed when the title is renamed for the first time.
+	 *
+	 * @since 3.14.8
+	 *
+	 * @return bool
 	 */
 	public function has_modified_slug() {
 
@@ -396,9 +433,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a quiz is assigned to this lesson
 	 *
-	 * @return   boolean
-	 * @since    3.3.0
-	 * @version  3.29.0
+	 * @since 3.3.0
+	 * @since 3.29.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function has_quiz() {
 		return $this->get( 'quiz' ) ? true : false;
@@ -406,18 +444,19 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Determine if an element is available based on drip settings
-	 * If no settings, this will return true if the posts's published
-	 * date is in the past
 	 *
-	 * @return   boolean
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * If no settings, this will return true if the posts's published
+	 * date is in the past.
+	 *
+	 * @since 3.16.0
+	 *
+	 * @return boolean
 	 */
 	public function is_available() {
 
 		$drip_method = $this->get( 'drip_method' );
 
-		// drip is no enabled, so the element is available
+		// Drip is no enabled, so the element is available.
 		if ( ! $drip_method ) {
 			return true;
 		}
@@ -432,17 +471,19 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if the lesson has been completed by a specific user
 	 *
-	 * @param   int $user_id  WP_User ID of a student
-	 * @return  bool
-	 * @since   1.0.0
-	 * @version 3.0.0  refactored to utilize LLMS_Student->is_complete()
-	 *                 added $user_id param
+	 * @since 1.0.0
+	 * @since 3.0.0 Refactored to utilize LLMS_Student->is_complete().
+	 *              Added $user_id param.
+	 *
+	 * @param int $user_id Optional. WP_User ID of a student. Default `null`
+	 *                     If not provided, or a falsy is provided, will fall back on the current user id.
+	 * @return bool
 	 */
 	public function is_complete( $user_id = null ) {
 
 		$user_id = $user_id ? $user_id : get_current_user_id();
 
-		// incomplete b/c no user
+		// Incomplete b/c no user.
 		if ( ! $user_id ) {
 			return false;
 		}
@@ -457,9 +498,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a the lesson is marked as "free"
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return boolean
 	 */
 	public function is_free() {
 		return ( 'yes' === $this->get( 'free_lesson' ) );
@@ -468,9 +509,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if the lesson is an orphan
 	 *
-	 * @return   bool
-	 * @since    3.14.8
-	 * @version  3.14.8
+	 * @since 3.14.8
+	 * @since [version] Use `in_array()` with strict comparison to decide whether the parent course/section post status
+	 *                  is in a set of allowed statuses.
+	 * @return bool
 	 */
 	public function is_orphan() {
 
@@ -482,7 +524,7 @@ implements LLMS_Interface_Post_Audio
 
 			if ( ! $parent_id ) {
 				return true;
-			} elseif ( ! in_array( get_post_status( $parent_id ), $statuses ) ) {
+			} elseif ( ! in_array( get_post_status( $parent_id ), $statuses, true ) ) {
 				return true;
 			}
 		}
@@ -493,11 +535,13 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Determines if a quiz is enabled for the lesson
-	 * Lesson must have a quiz and the quiz must be enabled
 	 *
-	 * @return   bool
-	 * @since    3.16.0
-	 * @version  3.18.0
+	 * Lesson must have a quiz and the quiz must be enabled.
+	 *
+	 * @since 3.16.0
+	 * @since 3.18.0
+	 *
+	 * @return bool
 	 */
 	public function is_quiz_enabled() {
 		return ( $this->has_quiz() && llms_parse_bool( $this->get( 'quiz_enabled' ) ) && 'publish' === get_post_status( $this->get( 'quiz' ) ) );
@@ -505,12 +549,14 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Add data to the course model when converted to array
-	 * Called before data is sorted and returned by $this->jsonSerialize()
 	 *
-	 * @param    array $arr   data to be serialized
-	 * @return   array
-	 * @since    3.3.0
-	 * @version  3.16.0
+	 * Called before data is sorted and returned by $this->jsonSerialize().
+	 *
+	 * @since 3.3.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @param array $arr Data to be serialized.
+	 * @return array
 	 */
 	public function toArrayAfter( $arr ) {
 
@@ -526,13 +572,14 @@ implements LLMS_Interface_Post_Audio
 
 	}
 
-
-
-
-
-
-
-
+	/**
+	 * Update object data
+	 *
+	 * @since unknown.
+	 *
+	 * @param array $data Data to update as key=>val.
+	 * @return array
+	 */
 	public function update( $data ) {
 
 		$updated_values = array();
@@ -552,12 +599,38 @@ implements LLMS_Interface_Post_Audio
 
 	}
 
+	/**
+	 * Set lesson title
+	 *
+	 * @since unknown
+	 *
+	 * @param string $title The lesson title.
+	 * @return false|array False if the title couldn't be updated. An array of the type
+	 *                     array(
+	 *                         'id'    => lesson id,
+	 *                         'title' => the new title,
+	 *                     )
+	 *                     otherwise.
+	 */
 	public function set_title( $title ) {
 
 		return LLMS_Post_Handler::update_title( $this->id, $title );
 
 	}
 
+	/**
+	 * Set lesson's excerpt
+	 *
+	 * @since unknown
+	 *
+	 * @param string $excerpt The lesson excerpt.
+	 * @return false|array False if the title couldn't be updated. An array of the type
+	 *                     array(
+	 *                         'id'           => lesson id,
+	 *                         'post_excerpt' => the new excerpt,
+	 *                     )
+	 *                     otherwise.
+	 */
 	public function set_excerpt( $excerpt ) {
 
 		return LLMS_Post_Handler::update_excerpt( $this->id, $excerpt );
@@ -566,11 +639,14 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Set parent section
-	 * Set's parent section in database
 	 *
-	 * @param [int] $meta [id section post]
-	 * @return [mixed] $meta [if mta didn't exist returns the meta_id else t/f if update success]
-	 * Returns False if section id is already parent
+	 * Sets parent section in database.
+	 *
+	 * @since unknown
+	 *
+	 * @param int $section_id The WP Post ID of the section to be set as parent.
+	 * @return mixed $meta If meta didn't exist returns the meta_id else t/f if update success.
+	 *                     Returns `false` if the provided section id value was already set.
 	 */
 	public function set_parent_section( $section_id ) {
 
@@ -579,12 +655,15 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * Set parent section
-	 * Set's parent section in database
+	 * Set order
 	 *
-	 * @param [int] $meta [id section post]
-	 * @return [mixed] $meta [if mta didn't exist returns the meta_id else t/f if update success]
-	 * Returns False if section id is already parent
+	 * Sets lesson order within the parent sectionin database
+	 *
+	 * @since unknown
+	 *
+	 * @param int $order The new order
+	 * @return mixed $meta If meta didn't exist returns the meta_id else t/f if update success.
+	 *                     Returns `false` if the provided order value was already set.
 	 */
 	public function set_order( $order ) {
 
@@ -594,11 +673,14 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Set parent course
-	 * Set's parent course in database
 	 *
-	 * @param [int] $meta [id course post]
-	 * @return [mixed] $meta [if meta didn't exist returns the meta_id else t/f if update success]
-	 * Returns False if course id is already parent
+	 * Sets parent course in database
+	 *
+	 * @since unknown
+	 *
+	 * @param int $course_id The WP Post ID of the course to be set as parent.
+	 * @return mixed $meta If meta didn't exist returns the meta_id else t/f if update success.
+	 *                     Returns `false` if the course id value was already set.
 	 */
 	public function set_parent_course( $course_id ) {
 
@@ -609,7 +691,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the lesson prerequisite
 	 *
-	 * @return int [ID of the prerequisite post]
+	 * @since unknown
+	 *
+	 * @return int ID of the prerequisite post.
 	 */
 	public function get_prerequisite() {
 
@@ -621,6 +705,13 @@ implements LLMS_Interface_Post_Audio
 		}
 	}
 
+	/**
+	 * Get whether the lesson has a content set
+	 *
+	 * @since unknown
+	 *
+	 * @return boolean
+	 */
 	public function has_content() {
 		if ( ! empty( $this->post->post_content ) ) {
 			return true;
@@ -630,14 +721,21 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * Get Next lesson
-	 * Finds and returns next lesson id
+	 * Get next lesson ID
 	 *
-	 * @return   int [ID of next lesson]
-	 * @since    1.0.0
-	 * @version  3.24.0
+	 * @since 1.0.0
+	 * @since 3.24.0
+	 * @since [version] Improve the query so that we don't miss sibling lessons within the same section
+	 *                  if the next one(s) status is (are) not published.
+	 *                  Also clean up the code a little bit.
+	 *
+	 * @return false|int ID of the next lesson, if any, `false` otherwise.
 	 */
 	public function get_next_lesson() {
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:disable WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 
 		$parent_section   = $this->get_parent_section();
 		$current_position = $this->get_order();
@@ -648,6 +746,7 @@ implements LLMS_Interface_Post_Audio
 			'post_type'      => 'lesson',
 			'nopaging'       => true,
 			'post_status'    => 'publish',
+			'meta_key'       => '_llms_order',
 			'meta_query'     => array(
 				'relation' => 'AND',
 				array(
@@ -658,17 +757,16 @@ implements LLMS_Interface_Post_Audio
 				array(
 					'key'     => '_llms_order',
 					'value'   => $next_position,
-					'compare' => '=',
+					'compare' => '>=',
 				),
 			),
+			'orderby'        => 'meta_value_num',
+			'order'          => 'ASC',
 		);
 		$lessons = get_posts( $args );
 
-		// return the first one even if there for some crazy reason were more than one.
-		if ( $lessons ) {
-			return $lessons[0]->ID;
-		} else {
-			// See if there is another section after this section and get first lesson there
+		if ( empty( $lessons ) ) {
+			// See if there is another section after this section and get first lesson there.
 			$parent_course    = $this->get_parent_course();
 			$cursection       = new LLMS_Section( $this->get_parent_section() );
 			$current_position = $cursection->get_order();
@@ -699,38 +797,46 @@ implements LLMS_Interface_Post_Audio
 			if ( $sections ) {
 				$newsection = new LLMS_Section( $sections[0]->ID );
 				$lessons    = $newsection->get_lessons( 'posts' );
-				if ( $lessons ) {
-					return $lessons[0]->ID;
-				} else {
-					return false;
-				}
-			} else {
-				return false;
 			}
-		}// End if().
+		}
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:enable WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+
+		return empty( $lessons ) ? false : $lessons[0]->ID;
 	}
 
 	/**
-	 * Get previous lesson id
+	 * Get previous lesson ID
 	 *
-	 * @return   int [ID of previous lesson]
-	 * @since    1.0.0
-	 * @version  3.24.0
+	 * @since 1.0.0
+	 * @since 3.24.0 Unknown.
+	 * @since [version] Improve the query so that we don't miss sibling lessons within the same section
+	 *                  if the previous one(s) status is (are) not published.
+	 *                  Use strict comparisions where needed.
+	 *                  Make sure to always return `false` if no previous lesson is found.
+	 *
+	 * @return false|int ID of the previous lesson, if any, `false` otherwise.
 	 */
 	public function get_previous_lesson() {
+
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:disable WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 
 		$parent_section   = $this->get_parent_section();
 		$current_position = $this->get_order();
 
 		$previous_position = $current_position - 1;
 
-		if ( 0 != $previous_position ) {
+		if ( 0 !== (int) $previous_position ) { // `get_order()` returns an int, but it's filterable so let's be pedantic and cast it.
 
 			$args    = array(
 				'posts_per_page' => 1,
 				'post_type'      => 'lesson',
 				'nopaging'       => true,
 				'post_status'    => 'publish',
+				'meta_key'       => '_llms_order',
 				'meta_query'     => array(
 					'relation' => 'AND',
 					array(
@@ -741,26 +847,22 @@ implements LLMS_Interface_Post_Audio
 					array(
 						'key'     => '_llms_order',
 						'value'   => $previous_position,
-						'compare' => '=',
+						'compare' => '<=',
 					),
 				),
+				'orderby'        => 'meta_value_num',
+				'order'          => 'DESC',
 			);
 			$lessons = get_posts( $args );
 
-			// return the first one even if there for some crazy reason were more than one.
-			if ( $lessons ) {
-				return $lessons[0]->ID;
-			} else {
-				return false;
-			}
 		} else {
-			// See if there is a previous section
+			// See if there is a previous section.
 			$parent_course     = $this->get_parent_course();
 			$cursection        = new LLMS_Section( $this->get_parent_section() );
 			$current_position  = $cursection->get_order();
 			$previous_position = $current_position - 1;
 
-			if ( 0 != $previous_position ) {
+			if ( 0 !== (int) $previous_position ) { // `get_order()` returns an int, but it's filterable so let's be pedantic and cast it.
 				$args     = array(
 					'post_type'      => 'section',
 					'posts_per_page' => 500,
@@ -786,15 +888,17 @@ implements LLMS_Interface_Post_Audio
 				if ( $sections ) {
 					$newsection = new LLMS_Section( $sections[0]->ID );
 					$lessons    = $newsection->get_lessons( 'posts' );
-					if ( ! $lessons ) {
-						return false;
+					if ( $lessons ) {
+						$lessons = array( $lessons[ count( $lessons ) - 1 ] );
 					}
-					return $lessons[ count( $lessons ) - 1 ]->ID;
-				} else {
-					return false;
 				}
 			}
-		}// End if().
+		}
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		// phpcs:enable WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+
+		return empty( $lessons ) ? false : $lessons[0]->ID;
 	}
 
 }

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -855,7 +855,11 @@ implements LLMS_Interface_Post_Audio
 			);
 			$lessons = get_posts( $args );
 
-		} else {
+		}
+
+		// Either this lesson is the first lesson of its section or any previous section's lesson are not published.
+		if ( 0 === (int) $previous_position || ( isset( $lessons ) && empty( $lessons ) ) ) { // `get_order()` returns an int, but it's filterable so let's be pedantic and cast it.
+
 			// See if there is a previous section.
 			$parent_course     = $this->get_parent_course();
 			$cursection        = new LLMS_Section( $this->get_parent_section() );

--- a/templates/course/lesson-preview.php
+++ b/templates/course/lesson-preview.php
@@ -2,10 +2,13 @@
 /**
  * Template for a lesson preview element
  *
- * @author      LifterLMS
- * @package     LifterLMS/Templates
- * @since       1.0.0
- * @version     3.19.2
+ * @author LifterLMS
+ * @package LifterLMS/Templates
+ *
+ * @since 1.0.0
+ * @since 3.19.2 Unknown.
+ * @since [version] Use the passed `$order` param if available, in favor of retrieving the lesson's order post meta.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 
@@ -27,7 +30,7 @@ $data_msg     = $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_htm
 			<?php endif; ?>
 
 			<aside class="llms-extra">
-				<span class="llms-lesson-counter"><?php printf( _x( '%1$d of %2$d', 'lesson order within section', 'lifterlms' ), $lesson->get_order(), $total_lessons ); ?></span>
+				<span class="llms-lesson-counter"><?php printf( _x( '%1$d of %2$d', 'lesson order within section', 'lifterlms' ), isset( $order ) ? $order : $lesson->get_order(), $total_lessons ); ?></span>
 				<?php echo $lesson->get_preview_icon_html(); ?>
 			</aside>
 

--- a/templates/course/syllabus.php
+++ b/templates/course/syllabus.php
@@ -2,10 +2,13 @@
 /**
  * Template for the Course Syllabus Displayed on individual course pages
  *
- * @author      LifterLMS
- * @package     LifterLMS/Templates
- * @since       1.0.0
- * @version     3.24.0
+ * @author LifterLMS
+ * @package LifterLMS/Templates
+ *
+ * @since 1.0.0
+ * @since 3.24.0 Unknown.
+ * @since [version] Pass the progressive lesson order value to the lesson-prewiew template.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 global $post;
@@ -25,6 +28,8 @@ $sections = $course->get_sections();
 
 		<?php foreach ( $sections as $section ) : ?>
 
+			<?php $lesson_order = 0; ?>
+
 			<?php if ( apply_filters( 'llms_display_outline_section_titles', true ) ) : ?>
 				<h3 class="llms-h3 llms-section-title"><?php echo get_the_title( $section->get( 'id' ) ); ?></h3>
 			<?php endif; ?>
@@ -40,6 +45,7 @@ $sections = $course->get_sections();
 						array(
 							'lesson'        => $lesson,
 							'total_lessons' => count( $lessons ),
+							'order'         => ++$lesson_order,
 						)
 					);
 					?>

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -1,27 +1,31 @@
 <?php
 /**
  * Tests for LifterLMS Lesson Model
- * @group     post_models
- * @group     lessons
  *
- * @since  3.14.8
+ * @group post_models
+ * @group lessons
+ *
+ * @since 3.14.8
  * @since 3.29.0 Unknown.
  * @since 3.36.2 Added tests on lesson's availability with drip method set as 3 days after
  *               the course start date and empty course start date.
  *               Also added `$date_delta` property to be used to test dates against current time.
- * @version 3.36.2
+ * @since [version] Added tests on next/previous lessons retrieval.
+ * @version [version]
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
-	 * class name for the model being tested by the class
-	 * @var  string
+	 * Class name for the model being tested by the class
+	 *
+	 * @var string
 	 */
 	protected $class_name = 'LLMS_Lesson';
 
 	/**
-	 * db post type of the model being tested
-	 * @var  string
+	 * Db post type of the model being tested
+	 *
+	 * @var string
 	 */
 	protected $post_type = 'lesson';
 
@@ -31,66 +35,72 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 * @var integer
 	 */
 	private $date_delta = 60;
+
 	/**
 	 * Get properties, used by test_getters_setters
-	 * This should match, exactly, the object's $properties array
-	 * @return   array
-	 * @since    3.14.8
-	 * @version  3.16.11
+	 *
+	 * This should match, exactly, the object's $properties array.
+	 *
+	 * @since 3.14.8
+	 * @since 3.16.11 Unknown.
+	 * @return array
 	 */
 	protected function get_properties() {
 		return array(
 
-			'order' => 'absint',
+			'order'                 => 'absint',
 
-			// drippable
+			// Drippable.
 			'days_before_available' => 'absint',
-			'date_available' => 'text',
-			'drip_method' => 'text',
-			'time_available' => 'text',
+			'date_available'        => 'text',
+			'drip_method'           => 'text',
+			'time_available'        => 'text',
 
-			// parent element
-			'parent_course' => 'absint',
-			'parent_section' => 'absint',
+			// Parent element.
+			'parent_course'         => 'absint',
+			'parent_section'        => 'absint',
 
-			'audio_embed' => 'text',
-			'free_lesson' => 'yesno',
-			'has_prerequisite' => 'yesno',
-			'prerequisite' => 'absint',
+			'audio_embed'           => 'text',
+			'free_lesson'           => 'yesno',
+			'has_prerequisite'      => 'yesno',
+			'prerequisite'          => 'absint',
 			'require_passing_grade' => 'yesno',
-			'video_embed' => 'text',
+			'video_embed'           => 'text',
 
-			// quizzes
-			'quiz' => 'absint',
-			'quiz_enabled' => 'yesno',
+			// Quizzes.
+			'quiz'                  => 'absint',
+			'quiz_enabled'          => 'yesno',
 
 		);
 	}
 
 	/**
 	 * Get data to fill a create post with
-	 * This is used by test_getters_setters
-	 * @return   array
-	 * @since    3.14.8
-	 * @version  3.16.11
+	 *
+	 * This is used by test_getters_setters.
+	 *
+	 * @since 3.14.8
+	 * @since 3.16.11 Unknown.
+	 *
+	 * @return array
 	 */
 	protected function get_data() {
 		return array(
-			'audio_embed' => 'http://example.tld/audio_embed',
-			'date_available' => '11/21/2018',
+			'audio_embed'           => 'http://example.tld/audio_embed',
+			'date_available'        => '11/21/2018',
 			'days_before_available' => '24',
-			'drip_method' => 'date',
-			'free_lesson' => 'no',
-			'has_prerequisite' => 'yes',
-			'order' => 1,
-			'parent_course' => 85,
-			'parent_section' => 32,
-			'prerequisite' => 344,
-			'quiz' => 123,
-			'quiz_enabled' => 'yes',
+			'drip_method'           => 'date',
+			'free_lesson'           => 'no',
+			'has_prerequisite'      => 'yes',
+			'order'                 => 1,
+			'parent_course'         => 85,
+			'parent_section'        => 32,
+			'prerequisite'          => 344,
+			'quiz'                  => 123,
+			'quiz_enabled'          => 'yes',
 			'require_passing_grade' => 'yes',
-			'time_available' => '12:34 PM',
-			'video_embed' => 'http://example.tld/video_embed',
+			'time_available'        => '12:34 PM',
+			'video_embed'           => 'http://example.tld/video_embed',
 		);
 	}
 
@@ -120,14 +130,14 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$format = 'Y-m-d';
 
 		$course_id = $this->generate_mock_courses( 1, 1, 2, 0 )[0];
-		$course = llms_get_post( $course_id );
-		$lesson = $course->get_lessons()[0];
+		$course    = llms_get_post( $course_id );
+		$lesson    = $course->get_lessons()[0];
 		$lesson_id = $lesson->get( 'id' );
-		$student = $this->get_mock_student();
+		$student   = $this->get_mock_student();
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
-		// no drip settings, lesson is currently available.
+		// No drip settings, lesson is currently available.
 		$this->assertEquals( current_time( $format ), $lesson->get_available_date( $format ) );
 
 		$lesson->set( 'drip_method', 'date' );
@@ -157,7 +167,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$lesson->set( 'days_before_available', '3' );
 		$this->assertEquals( $student->get_completion_date( $prereq_id, 'U' ) + ( DAY_IN_SECONDS * 3 ), $lesson->get_available_date( 'U' ) );
 
-		// check lesson immediately available if set to be available after 3 days ofter a course start date which is empty.
+		// Check lesson immediately available if set to be available after 3 days ofter a course start date which is empty.
 		$lesson->set( 'drip_method', 'start' );
 		$lesson->set( 'days_before_available', '3' );
 		$course->set( 'start_date', '' );
@@ -165,15 +175,22 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test get course
+	 *
+	 * @since unknown
+	 *
+	 * @return void
+	 */
 	public function test_get_course() {
 
 		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
 		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
 
-		// returns a course when everything's okay.
+		// Returns a course when everything's okay.
 		$this->assertTrue( is_a( $lesson->get_course(), 'LLMS_Course' ) );
 
-		// course trashed / doesn't exist, returns null.
+		// Course trashed / doesn't exist, returns null.
 		wp_delete_post( $course->get( 'id' ), true );
 		$this->assertNull( $lesson->get_course() );
 
@@ -181,9 +198,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test Audio and Video Embeds
-	 * @return   void
-	 * @since    3.14.8
-	 * @version  3.14.8
+	 *
+	 * @since 3.14.8
+	 *
+	 * @return void
 	 */
 	public function test_get_embeds() {
 
@@ -192,7 +210,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 		$lesson = new LLMS_Lesson( 'new', 'Lesson With Embeds' );
 
-		// empty string when none set
+		// Empty string when none set.
 		$this->assertEmpty( $lesson->get_audio() );
 		$this->assertEmpty( $lesson->get_video() );
 
@@ -202,15 +220,15 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$audio_embed = $lesson->get_audio();
 		$video_embed = $lesson->get_video();
 
-		// string
+		// String.
 		$this->assertTrue( is_string( $audio_embed ) );
 		$this->assertTrue( is_string( $video_embed ) );
 
-		// should be an iframe for valid embeds
+		// Should be an iframe for valid embeds.
 		$this->assertEquals( 0, strpos( $audio_embed, '<iframe' ) );
 		$this->assertEquals( 0, strpos( $video_embed, '<iframe' ) );
 
-		// fallbacks should be a link to the URL
+		// Fallbacks should be a link to the URL.
 		$lesson->set( 'audio_embed', 'http://lifterlms.com/not/embeddable' );
 		$lesson->set( 'video_embed', 'http://lifterlms.com/not/embeddable' );
 		$this->assertEquals( 0, strpos( $audio_embed, '<a' ) );
@@ -218,15 +236,22 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test getting parent section
+	 *
+	 * @since unknown
+	 *
+	 * @return void
+	 */
 	public function test_get_section() {
 
 		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
 		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
 
-		// returns a course when everything's okay
+		// Returns a course when everything's okay.
 		$this->assertTrue( is_a( $lesson->get_section(), 'LLMS_Section' ) );
 
-		// section trashed / doesn't exist, returns null
+		// Section trashed / doesn't exist, returns null.
 		wp_delete_post( $lesson->get( 'parent_section' ), true );
 		$this->assertNull( $lesson->get_section() );
 
@@ -234,23 +259,24 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	/**
 	 * Test has_modified_slug function
-	 * @return   void
-	 * @since    3.14.8
-	 * @version  3.14.8
+	 *
+	 * @since 3.14.8
+	 *
+	 * @return void
 	 */
 	public function test_has_modified_slug() {
 
 		$lesson = new LLMS_Lesson( 'new', 'New Lesson' );
 
-		// default unmodified slug
+		// Default unmodified slug.
 		$this->assertFalse( $lesson->has_modified_slug() );
 
-		// default unmodified slug with a unique int at the end
+		// Default unmodified slug with a unique int at the end.
 		$lesson->set( 'name', 'new-lesson-123' );
 
 		$this->assertFalse( $lesson->has_modified_slug() );
 
-		// renamed slug
+		// Renamed slug.
 		$lesson->set( 'name', 'modified-slug' );
 
 		$this->assertTrue( $lesson->has_modified_slug() );
@@ -260,9 +286,9 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Test the has_quiz() method
 	 *
-	 * @return  void
-	 * @since   3.29.0
-	 * @version 3.29.0
+	 * @since 3.29.0
+	 *
+	 * @return void
 	 */
 	public function test_has_quiz() {
 
@@ -274,36 +300,43 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test the is_available() method
+	 *
+	 * @since unknown
+	 *
+	 * @return void
+	 */
 	public function test_is_available() {
 
 		$course_id = $this->generate_mock_courses( 1, 1, 2, 0 )[0];
-		$course = llms_get_post( $course_id );
-		$lesson = $course->get_lessons()[0];
+		$course    = llms_get_post( $course_id );
+		$lesson    = $course->get_lessons()[0];
 		$lesson_id = $lesson->get( 'id' );
-		$student = $this->get_mock_student();
+		$student   = $this->get_mock_student();
 		wp_set_current_user( $student->get_id() );
 		$student->enroll( $course_id );
 
-		// no drip settings, lesson is currently available
+		// No drip settings, lesson is currently available.
 		$this->assertTrue( $lesson->is_available() );
 
-		// date in past so the lesson is available
+		// Date in past so the lesson is available.
 		$lesson = llms_get_post( $lesson_id );
 		$lesson->set( 'drip_method', 'date' );
 		$lesson->set( 'date_available', '12/12/2012' );
 		$lesson->set( 'time_available', '12:12 AM' );
 		$this->assertTrue( $lesson->is_available() );
 
-		// date in future so lesson not available
+		// Date in future so lesson not available.
 		$lesson->set( 'date_available', date( 'm/d/Y', current_time( 'timestamp' ) + DAY_IN_SECONDS ) );
 		$this->assertFalse( $lesson->is_available() );
 
-		// available 3 days after enrollment
+		// Available 3 days after enrollment.
 		$lesson->set( 'drip_method', 'enrollment' );
 		$lesson->set( 'days_before_available', '3' );
 		$this->assertFalse( $lesson->is_available() );
 
-		// now available
+		// Now available.
 		llms_mock_current_time( '+4 days' );
 		$this->assertTrue( $lesson->is_available() );
 
@@ -311,10 +344,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$lesson->set( 'drip_method', 'start' );
 		$course->set( 'start_date', date( 'm/d/Y', current_time( 'timestamp' ) + DAY_IN_SECONDS ) );
 
-		// not available until 3 days after course start date
+		// Not available until 3 days after course start date.
 		$this->assertFalse( $lesson->is_available() );
 
-		// now available
+		// Now available.
 		llms_mock_current_time( '+4 days' );
 		$this->assertTrue( $lesson->is_available() );
 		llms_reset_current_time();
@@ -322,7 +355,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$prereq_id = $lesson_id;
 		$student->mark_complete( $lesson_id, 'lesson' );
 
-		// second lesson not available until 3 days after lesson 1 is complete
+		// Second lesson not available until 3 days after lesson 1 is complete.
 		$lesson = $course->get_lessons()[1];
 
 		$lesson->set( 'has_prerequisite', 'yes' );
@@ -339,81 +372,182 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * test the is_orphan function
-	 * @return   [type]
-	 * @since    3.14.8
-	 * @version  3.14.8
+	 * Test the is_orphan() method
+	 *
+	 * @since 3.14.8
+	 *
+	 * @return void
 	 */
 	public function test_is_orphan() {
 
-		$course = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 0, 0 )[0] );
 		$section = llms_get_post( $course->get_sections( 'ids' )[0] );
-		$lesson = llms_get_post( $course->get_lessons( 'ids' )[0] );
+		$lesson  = llms_get_post( $course->get_lessons( 'ids' )[0] );
 
-		// not an orphan
+		// Not an orphan.
 		$this->assertFalse( $lesson->is_orphan() );
 
- 		$test_statuses = get_post_stati( array( '_builtin' => true ) );
+		$test_statuses = get_post_stati( array( '_builtin' => true ) );
 		foreach ( array_keys( $test_statuses ) as $status ) {
 
-			$assert = in_array( $status, array( 'publish', 'future', 'draft', 'pending', 'private', 'auto-draft' ) ) ? 'assertFalse' : 'assertTrue';
+			$assert = in_array( $status, array( 'publish', 'future', 'draft', 'pending', 'private', 'auto-draft' ), true ) ? 'assertFalse' : 'assertTrue';
 
-			// check parent course
-			wp_update_post( array(
-				'ID' => $course->get( 'id' ),
-				'post_status' => $status,
-			) );
+			// Check parent course.
+			wp_update_post(
+				array(
+					'ID'          => $course->get( 'id' ),
+					'post_status' => $status,
+				)
+			);
 			$this->$assert( $lesson->is_orphan() );
-			wp_update_post( array(
-				'ID' => $course->get( 'id' ),
-				'post_status' => 'publish',
-			) );
+			wp_update_post(
+				array(
+					'ID'          => $course->get( 'id' ),
+					'post_status' => 'publish',
+				)
+			);
 
-			// check parent section
-			wp_update_post( array(
-				'ID' => $section->get( 'id' ),
-				'post_status' => $status,
-			) );
+			// Check parent section.
+			wp_update_post(
+				array(
+					'ID'          => $section->get( 'id' ),
+					'post_status' => $status,
+				)
+			);
 			$this->$assert( $lesson->is_orphan() );
-			wp_update_post( array(
-				'ID' => $section->get( 'id' ),
-				'post_status' => 'publish',
-			) );
+			wp_update_post(
+				array(
+					'ID'          => $section->get( 'id' ),
+					'post_status' => 'publish',
+				)
+			);
 
 		}
 
-		// parent course doesn't exist
+		// Parent course doesn't exist.
 		$lesson->set( 'parent_course', 123456789 );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_course', $course->get( 'id' ) );
 
-		// parent section doesn't exist
+		// Parent section doesn't exist.
 		$lesson->set( 'parent_section', 123456789 );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_section', $section->get( 'id' ) );
 
-		// parent course isn't set
+		// Parent course isn't set.
 		$lesson->set( 'parent_course', '' );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_course', $course->get( 'id' ) );
 
-		// parent section isn't set
+		// Parent section isn't set.
 		$lesson->set( 'parent_section', '' );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_section', $section->get( 'id' ) );
 
-		// metakey for parent course doesn't exist
+		// Metakey for parent course doesn't exist.
 		delete_post_meta( $lesson->get( 'id' ), '_llms_parent_course' );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_course', $course->get( 'id' ) );
 
-		// metakey for parent section doesn't exist
+		// Metakey for parent section doesn't exist.
 		delete_post_meta( $lesson->get( 'id' ), '_llms_parent_section' );
 		$this->assertTrue( $lesson->is_orphan() );
 		$lesson->set( 'parent_section', $section->get( 'id' ) );
 
-		// not an orphan
+		// Not an orphan.
 		$this->assertFalse( $lesson->is_orphan() );
+
+	}
+
+	/**
+	 * Test next lesson
+	 *
+	 * @since [version]
+	 */
+	public function test_next_lesson() {
+
+		// Generate a course with 2 sections and 3 lessons for each of them.
+		$course_id   = $this->generate_mock_courses( 1, 2, 3, 0 )[0];
+		$section_ids = llms_get_post( $course_id )->get_sections( 'ids' );
+		$section_one = llms_get_post( $section_ids[0] );
+		$section_two = llms_get_post( $section_ids[1] );
+
+		$sec_lessons = array(
+			$section_one->get_lessons( 'ids' ),
+			$section_two->get_lessons( 'ids' ),
+		);
+
+		// Test next lesson of s1 l2 is s1 l3.
+		$this->assertEquals( $sec_lessons[0][2], llms_get_post( $sec_lessons[0][1] )->get_next_lesson() );
+
+		// Test next lesson of s1 l3 is s2 l1.
+		$this->assertEquals( $sec_lessons[1][0], llms_get_post( $sec_lessons[0][2] )->get_next_lesson() );
+
+		// Swap s1 l2 and s1 l3 orders.
+		llms_get_post( $sec_lessons[0][1] )->set( 'order', 3 );
+		llms_get_post( $sec_lessons[0][2] )->set( 'order', 2 );
+
+		// Test next lesson of s1 l1 is the original s1 l3.
+		$this->assertEquals( $sec_lessons[0][2], llms_get_post( $sec_lessons[0][0] )->get_next_lesson() );
+		// "Persist" the new order in our sec_lessons array.
+		list( $sec_lessons[0][2], $sec_lessons[0][1] ) = array( $sec_lessons[0][1], $sec_lessons[0][2] );
+
+		// Test s2 l3 has no next lesson.
+		$this->assertFalse( llms_get_post( $sec_lessons[1][2] )->get_next_lesson() );
+
+		// Unpublish s1 l2, test next lesson of s1 l1 is s1 l3.
+		llms_get_post( $sec_lessons[0][1] )->set( 'status', 'draft' );
+		$this->assertEquals( $sec_lessons[0][2], llms_get_post( $sec_lessons[0][0] )->get_next_lesson() );
+
+		// Unpublish s2 l3, test next lesson of s2 l2 is false.
+		llms_get_post( $sec_lessons[1][2] )->set( 'status', 'draft' );
+		$this->assertFalse( llms_get_post( $sec_lessons[1][1] )->get_next_lesson() );
+	}
+
+
+	/**
+	 * Test previous lesson
+	 *
+	 * @since [version]
+	 */
+	public function test_previous_lesson() {
+
+		// Generate a course with 2 sections and 3 lessons for each of them.
+		$course_id   = $this->generate_mock_courses( 1, 2, 3, 0 )[0];
+		$section_ids = llms_get_post( $course_id )->get_sections( 'ids' );
+		$section_one = llms_get_post( $section_ids[0] );
+		$section_two = llms_get_post( $section_ids[1] );
+
+		$sec_lessons = array(
+			$section_one->get_lessons( 'ids' ),
+			$section_two->get_lessons( 'ids' ),
+		);
+
+		// Test previous lesson of s1 l3 is s1 l2.
+		$this->assertEquals( $sec_lessons[0][1], llms_get_post( $sec_lessons[0][2] )->get_previous_lesson() );
+
+		// Test previous lesson of s2 l1 is s1 l3.
+		$this->assertEquals( $sec_lessons[0][2], llms_get_post( $sec_lessons[1][0] )->get_previous_lesson() );
+
+		// Swap s1 l1 and s1 l2 orders.
+		llms_get_post( $sec_lessons[0][0] )->set( 'order', 2 );
+		llms_get_post( $sec_lessons[0][1] )->set( 'order', 1 );
+
+		// Test previous lesson of s1 l3 is the original s1 l1.
+		$this->assertEquals( $sec_lessons[0][0], llms_get_post( $sec_lessons[0][2] )->get_previous_lesson() );
+		// "Persist" the new order in our sec_lessons array.
+		list( $sec_lessons[0][0], $sec_lessons[0][1] ) = array( $sec_lessons[0][1], $sec_lessons[0][0] );
+
+		// Test s1 l1 has no previous lesson.
+		$this->assertFalse( llms_get_post( $sec_lessons[0][0] )->get_previous_lesson() );
+
+		// Unpublish s2 l2, test previous lesson of s2 l3 is s2 l1.
+		llms_get_post( $sec_lessons[1][1] )->set( 'status', 'draft' );
+		$this->assertEquals( $sec_lessons[1][0], llms_get_post( $sec_lessons[1][2] )->get_previous_lesson() );
+
+		// Unpublish s1 l1, test next lesson of s1 l2 is false.
+		llms_get_post( $sec_lessons[0][0] )->set( 'status', 'draft' );
+		$this->assertFalse( llms_get_post( $sec_lessons[0][1] )->get_previous_lesson() );
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -545,7 +545,11 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		llms_get_post( $sec_lessons[1][1] )->set( 'status', 'draft' );
 		$this->assertEquals( $sec_lessons[1][0], llms_get_post( $sec_lessons[1][2] )->get_previous_lesson() );
 
-		// Unpublish s1 l1, test next lesson of s1 l2 is false.
+		// Unpublish s2 l1, test previous lesson of s2 l2 is s1 l3.
+		llms_get_post( $sec_lessons[1][0] )->set( 'status', 'draft' );
+		$this->assertEquals( $sec_lessons[0][2], llms_get_post( $sec_lessons[1][1] )->get_previous_lesson() );
+
+		// Unpublish s1 l1, test previous lesson of s1 l2 is false.
 		llms_get_post( $sec_lessons[0][0] )->set( 'status', 'draft' );
 		$this->assertFalse( llms_get_post( $sec_lessons[0][1] )->get_previous_lesson() );
 


### PR DESCRIPTION
…essons

## Description
Fixes #1294 

Also fixed cs.

Running new tests I realized that `get_previous_lesson()` on the first lesson of a course returned NULL (actually no return), so I took this occasion to ensure it always returns false if no previous lesson is found, plus I slightly cleaned that method + his twin `get_nex_lesson()`.

## How has this been tested?
Old and new ad-hoc tests, plus some manual :P 

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

