### PR TITLE
allow assets to be defined with an empty array signifying all defaults should be used

### DIFF
--- a/includes/class-llms-assets.php
+++ b/includes/class-llms-assets.php
@@ -280,7 +280,7 @@ class LLMS_Assets {
 		 */
 		$asset = apply_filters( "llms_get_{$type}_asset_before_prep", $asset, $handle, $this->package_id );
 
-		if ( $asset && is_array( $asset ) ) {
+		if ( false !== $asset && is_array( $asset ) ) {
 
 			$asset = wp_parse_args( $asset, $this->get_defaults( $type ) );
 

--- a/includes/class-llms-assets.php
+++ b/includes/class-llms-assets.php
@@ -15,7 +15,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.4.0
- * @version 4.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -241,6 +241,7 @@ class LLMS_Assets {
 	 * with default values from the `get_defaults()` method.
 	 *
 	 * @since 4.4.0
+	 * @since [version] Replace truthy check with an strict check against `false` to ensure assets defined with an empty array signifying all default values should be used.
 	 *
 	 * @param string $type   The asset type. Accepts either "script" or "style".
 	 * @param string $handle The asset handle.

--- a/tests/phpunit/unit-tests/class-llms-test-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-assets.php
@@ -216,7 +216,7 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test get() metho for an undefined asset.
+	 * Test get() method for an undefined asset.
 	 *
 	 * @since 4.4.0
 	 *
@@ -225,6 +225,34 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 	public function test_get_undefined() {
 
 		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'get', array( 'style', 'undefined-style' ) ) );
+
+	}
+
+	/**
+	 * Test get() method for an asset which is defined with an empty array signifying that all asset values should be defaults.
+	 *
+	 * @since [version]
+	 *
+	 * @see https://github.com/gocodebox/lifterlms/issues/1313
+	 *
+	 * @return version
+	 */
+	public function test_get_all_default_values() {
+
+		add_filter( 'llms_get_style_asset_before_prep', function( $asset, $handle ) {
+
+			if ( 'mock-style-with-all-defaults' === $handle ) {
+				$asset = array();
+			}
+
+			return $asset;
+
+		}, 10, 2 );
+
+		$asset = LLMS_Unit_Test_Util::call_method( $this->main, 'get', array( 'style', 'mock-style-with-all-defaults' ) );
+
+		$this->assertTrue( is_array( $asset ) );
+		$this->assertEquals( 'mock-style-with-all-defaults', $asset['handle'] );
 
 	}
 


### PR DESCRIPTION

## Description

Fixes #1313


## How has this been tested?

+ Manually
+ New & Existing unit tests

## Screenshots <!-- if applicable -->

## Types of changes

Fixes regression introduced in 4.4.0


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

