### PR TITLE
use numeric comparisons for the order meta query

### DIFF
--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 4.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -725,9 +725,8 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 1.0.0
 	 * @since 3.24.0
-	 * @since 4.4.0 Improve the query so that we don't miss sibling lessons within the same section
-	 *                  if the next one(s) status is (are) not published.
-	 *                  Also clean up the code a little bit.
+	 * @since 4.4.0 Improve query so that unpublished siblings do not break expected results.
+	 * @since [version] Use a numeric comparison for the next position meta query.
 	 *
 	 * @return false|int ID of the next lesson, if any, `false` otherwise.
 	 */
@@ -758,6 +757,7 @@ implements LLMS_Interface_Post_Audio
 					'key'     => '_llms_order',
 					'value'   => $next_position,
 					'compare' => '>=',
+					'type'    => 'numeric',
 				),
 			),
 			'orderby'        => 'meta_value_num',
@@ -811,10 +811,10 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 1.0.0
 	 * @since 3.24.0 Unknown.
-	 * @since 4.4.0 Improve the query so that we don't miss sibling lessons within the same section
-	 *                  if the previous one(s) status is (are) not published.
-	 *                  Use strict comparisions where needed.
-	 *                  Make sure to always return `false` if no previous lesson is found.
+	 * @since 4.4.0 Improve query so that unpublished siblings do not break expected results.
+	 *              Use strict comparisions where needed.
+	 *              Make sure to always return `false` if no previous lesson is found.
+	 *              @since [version] Use a numeric comparison for the previous position meta query.
 	 *
 	 * @return false|int ID of the previous lesson, if any, `false` otherwise.
 	 */
@@ -848,6 +848,7 @@ implements LLMS_Interface_Post_Audio
 						'key'     => '_llms_order',
 						'value'   => $previous_position,
 						'compare' => '<=',
+						'type'    => 'numeric',
 					),
 				),
 				'orderby'        => 'meta_value_num',

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -11,7 +11,7 @@
  *               the course start date and empty course start date.
  *               Also added `$date_delta` property to be used to test dates against current time.
  * @since 4.4.0 Added tests on next/previous lessons retrieval.
- * @version 4.4.0
+ * @since [version] Add additional navigation testing scenarios.
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
@@ -464,7 +464,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 *
 	 * @since 4.4.0
 	 */
-	public function test_next_lesson() {
+	public function test_get_next_lesson() {
 
 		// Generate a course with 2 sections and 3 lessons for each of them.
 		$course_id   = $this->generate_mock_courses( 1, 2, 3, 0 )[0];
@@ -510,7 +510,7 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 *
 	 * @since 4.4.0
 	 */
-	public function test_previous_lesson() {
+	public function test_get_previous_lesson() {
 
 		// Generate a course with 2 sections and 3 lessons for each of them.
 		$course_id   = $this->generate_mock_courses( 1, 2, 3, 0 )[0];
@@ -552,6 +552,40 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		// Unpublish s1 l1, test previous lesson of s1 l2 is false.
 		llms_get_post( $sec_lessons[0][0] )->set( 'status', 'draft' );
 		$this->assertFalse( llms_get_post( $sec_lessons[0][1] )->get_previous_lesson() );
+
+	}
+
+	/**
+	 * Test navigation with sections that have more than 10 lessons
+	 *
+	 * This scenario exposes an issue that causes string comparisons to fail, the lesson order will be returned
+	 * incorrectly.
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms/issues/1316
+	 *
+	 * @return void
+	 */
+	public function test_navigation_large_sections() {
+
+		$course  = $this->factory->course->create_and_get( array( 'sections' => 2, 'lessons' => 10, 'quizzes' => 0 ) );
+		$lessons = $course->get_lessons();
+
+		$i = 0;
+		while ( $i < count( $lessons ) ) {
+
+			$lesson = $lessons[ $i ];
+
+			$next = 19 === $i ? false : $lessons[ $i + 1 ]->get( 'id' );
+			$prev = 0 === $i ? false : $lessons[ $i - 1 ]->get( 'id' );
+
+			$this->assertEquals( $next, $lesson->get_next_lesson(), $i );
+			$this->assertEquals( $prev, $lesson->get_previous_lesson(), $i );
+
+			++$i;
+
+		}
 
 	}
 


### PR DESCRIPTION
## Description

Fixes #1316 

## How has this been tested?

+ Manually
+ New unit tests

## Screenshots <!-- if applicable -->

## Types of changes

Regression fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

