### PR TITLE
Doc updates

### DIFF
--- a/includes/abstracts/abstract.llms.admin.table.php
+++ b/includes/abstracts/abstract.llms.admin.table.php
@@ -708,7 +708,7 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 	/**
 	 * Get a CSS class list (as a string) for each TR
 	 *
-	 * @param    mixed $data  object / array of data that the function can use to extract the data
+	 * @param    mixed $row  object / array of data that the function can use to extract the data
 	 * @return   string
 	 * @since    3.24.0
 	 * @version  3.24.0
@@ -801,7 +801,7 @@ abstract class LLMS_Admin_Table extends LLMS_Abstract_Exportable_Admin_Table {
 	/**
 	 * Get the HTML for a WP User Link
 	 *
-	 * @param    int    $post_id  WP User ID
+	 * @param    int    $user_id  WP User ID
 	 * @param    string $text     Optional text to display within the anchor, if none supplied $user_id if used
 	 * @return   string
 	 * @since    3.17.2

--- a/includes/achievements/class.llms.achievement.user.php
+++ b/includes/achievements/class.llms.achievement.user.php
@@ -167,7 +167,7 @@ class LLMS_Achievement_User extends LLMS_Achievement {
 	/**
 	 * Creates new instance of WP_User and calls parent method create
 	 *
-	 * @param  int $person_id [id of user]
+	 * @param  int $user_id [id of user]
 	 * @param  int $id [id of post]
 	 * @param  int $lesson_id [id of associated lesson]
 	 *

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -846,9 +846,12 @@ class LLMS_Admin_Settings {
 	/**
 	 * Get a setting from the settings API.
 	 *
-	 * @param mixed $option
+	 * @since Unknown
+	 * @since 3.7.5 Unknown
+	 *
+	 * @param string $option_name Option name.
+	 * @param mixed  $default     Optional default value.
 	 * @return string
-	 * @version  3.7.5
 	 */
 	public static function get_option( $option_name, $default = '' ) {
 		// Array value.

--- a/includes/admin/class.llms.admin.user.custom.fields.php
+++ b/includes/admin/class.llms.admin.user.custom.fields.php
@@ -62,9 +62,9 @@ class LLMS_Admin_User_Custom_Fields {
 	 * @since 3.13.0 Unknown.
 	 * @since 3.37.15 Correctly pass `$user` to `$this->save()`.
 	 *
-	 * @param obj     &$errors Instance of WP_Error, passed by reference.
-	 * @param bool    $update  `true` if updating a profile, `false` if a new user.
-	 * @param WP_User $user    Instance of WP_User for the user being updated.
+	 * @param obj     $errors Instance of WP_Error, passed by reference.
+	 * @param bool    $update `true` if updating a profile, `false` if a new user.
+	 * @param WP_User $user   Instance of WP_User for the user being updated.
 	 * @return void
 	 */
 	public function add_errors( &$errors, $update, $user ) {

--- a/includes/admin/post-types/tables/class.llms.table.student.management.php
+++ b/includes/admin/post-types/tables/class.llms.table.student.management.php
@@ -92,9 +92,9 @@ class LLMS_Table_StudentManagement extends LLMS_Admin_Table {
 	 * @since 3.33.0 Added action button to delete a cancelled enrollment.
 	 * @since 3.33.0 Added icon popover tooltip via llms tooltip data attribute api.
 	 *
-	 * @param string $key The column id / key.
-	 * @param int    $user_id WP User ID.
-	 * @return  mixed
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student Student object.
+	 * @return mixed
 	 */
 	public function get_data( $key, $student ) {
 

--- a/includes/admin/reporting/tables/llms.table.achievements.php
+++ b/includes/admin/reporting/tables/llms.table.achievements.php
@@ -35,7 +35,7 @@ class LLMS_Table_Achievements extends LLMS_Admin_Table {
 	/**
 	 * Get HTML for buttons in the actions cell of the table
 	 *
-	 * @param    int $certificate_id  WP Post ID of the llms_my_certificate
+	 * @param    int $achievement_id WP Post ID of the achievement post.
 	 * @return   void
 	 * @since    3.18.0
 	 * @version  3.18.0

--- a/includes/admin/reporting/tables/llms.table.course.students.php
+++ b/includes/admin/reporting/tables/llms.table.course.students.php
@@ -95,11 +95,12 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 	/**
 	 * Retrieve data for the columns
 	 *
-	 * @param    string $key        the column id / key
-	 * @param    int    $user_id    WP User ID
-	 * @return   mixed
-	 * @since    3.15.0
-	 * @version  3.17.2
+	 * @since 3.15.0
+	 * @since 3.17.2 Unknown.
+	 *
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student Student object.
+	 * @return mixed
 	 */
 	public function get_data( $key, $student ) {
 

--- a/includes/admin/reporting/tables/llms.table.membership.students.php
+++ b/includes/admin/reporting/tables/llms.table.membership.students.php
@@ -115,8 +115,8 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 	 *
 	 * @since 3.32.0
 	 *
-	 * @param string $key     The column id / key.
-	 * @param int    $user_id WP User ID.
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student Student object.
 	 * @return mixed
 	 */
 	public function get_data( $key, $student ) {

--- a/includes/admin/settings/tables/class.llms.table.notification.settings.php
+++ b/includes/admin/settings/tables/class.llms.table.notification.settings.php
@@ -37,11 +37,11 @@ class LLMS_Table_NotificationSettings extends LLMS_Admin_Table {
 	/**
 	 * Retrieve data for the columns
 	 *
-	 * @param    string $key        the column id / key
-	 * @param    int    $user_id    WP User ID
-	 * @return   mixed
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $key  The column id / key.
+	 * @param array  $data Table data array.
+	 * @return mixed
 	 */
 	public function get_data( $key, $data ) {
 

--- a/includes/class-llms-grades.php
+++ b/includes/class-llms-grades.php
@@ -71,25 +71,25 @@ class LLMS_Grades {
 		$grade  = null;
 		$grades = array();
 
-		// loop through all the children and compile the overall grade & points data
+		// Loop through all the children and compile the overall grade & points data.
 		foreach ( $children as $child_id ) {
 
 			$child = llms_get_post( $child_id );
 			$grade = $this->get_grade( $child_id, $student, false );
 
-			// non numeric grade (null) hasn't been taken yet or no gradable elements exist on the child
+			// Non numeric grade (null) hasn't been taken yet or no gradable elements exist on the child.
 			if ( ! is_numeric( $grade ) ) {
 				continue;
 			}
 
 			$points = $child->get( 'points' );
 
-			// if no points assigned to the child, the grade doesn't count towards the overall grade
+			// If no points assigned to the child, the grade doesn't count towards the overall grade.
 			if ( ! $points ) {
 				continue;
 			}
 
-			// add the grade & points for further processing after we have all the data
+			// Add the grade & points for further processing after we have all the data.
 			$grades[] = array(
 				'grade'  => $grade,
 				'points' => $points,
@@ -97,20 +97,20 @@ class LLMS_Grades {
 
 		}
 
-		// if we have at least one grade
+		// If we have at least one grade.
 		if ( count( $grades ) ) {
 
-			// get the total available points for all children with a numeric grade & a points value
+			// Get the total available points for all children with a numeric grade & a points value.
 			$total_points = array_sum( wp_list_pluck( $grades, 'points' ) );
 
-			// if we don't have any points this element can't have an overall grade
+			// If we don't have any points this element can't have an overall grade.
 			if ( $total_points ) {
 
-				// sum up the adjusted grade
+				// Sum up the adjusted grade.
 				$grade = 0;
 				foreach ( $grades as $data ) {
-					// calculate the adjusted the grade
-					// grade multiplied by available points over total points
+					// Calculate the adjusted the grade.
+					// Grade multiplied by available points over total points.
 					$grade += $data['grade'] * ( $data['points'] / $total_points );
 				}
 			}
@@ -175,13 +175,13 @@ class LLMS_Grades {
 
 				break;
 
-			// 3rd party / custom element grading
+			// 3rd party / custom element grading.
 			default:
 				$grade = apply_filters( 'llms_calculate_' . $post_type . '_grade', $grade, $post, $student );
 
 		}
 
-		// round numeric results
+		// Round numeric results.
 		if ( is_numeric( $grade ) ) {
 			$grade = $this->round( $grade );
 		}
@@ -231,12 +231,12 @@ class LLMS_Grades {
 
 		$grade = $use_cache ? $this->get_grade_from_cache( $post, $student ) : false;
 
-		// grade not found in cache or we're not using the cache
+		// Grade not found in cache or we're not using the cache.
 		if ( false === $grade ) {
 
 			$grade = $this->calculate_grade( $post, $student, $use_cache );
 
-			// store in the cache
+			// Store in the cache.
 			wp_cache_set(
 				sprintf( '%d_grade', $post->get( 'id' ) ),
 				$grade,

--- a/includes/class.llms.achievement.php
+++ b/includes/class.llms.achievement.php
@@ -100,7 +100,7 @@ class LLMS_Achievement {
 
 	public function __construct() {
 
-		// Settings TODO Refactor: theses can come from the achievement post now
+		// Settings TODO Refactor: theses can come from the achievement post now.
 		$this->enabled = get_option( 'enabled' );
 
 		$this->find    = array( '{blogname}', '{site_title}' );

--- a/includes/class.llms.achievements.php
+++ b/includes/class.llms.achievements.php
@@ -123,10 +123,11 @@ class LLMS_Achievements {
 
 	/**
 	 * Award an achievement to a user
-	 * Calls trigger method passing arguments
+	 *
+	 * Calls trigger method passing arguments.
 	 *
 	 * @param  int $person_id        [ID of the current user]
-	 * @param  int $achievement      [Achievement template post ID]
+	 * @param  int $achievement_id   [Achievement template post ID]
 	 * @param  int $related_post_id  Post ID of the related engagement (eg lesson id)
 	 * @return void
 	 * @since    ??

--- a/includes/class.llms.ajax.php
+++ b/includes/class.llms.ajax.php
@@ -82,13 +82,16 @@ class LLMS_AJAX {
 
 	/**
 	 * Handles the AJAX request for my plugin.
+	 *
+	 * @since Unknown
+	 *
+	 * @return void
 	 */
 	public static function handle() {
 
-		// Make sure we are getting a valid AJAX request
+		// Make sure we are getting a valid AJAX request.
 		check_ajax_referer( self::NONCE );
 
-		// $request = self::scrub_request( $_REQUEST );
 		$request = $_REQUEST;
 
 		$response = call_user_func( 'LLMS_AJAX_Handler::' . $request['action'], $request );
@@ -161,17 +164,6 @@ class LLMS_AJAX {
 		);
 	}
 
-	/*
-							 /$$ /$$ /$$                           /$$
-							| $$| $$| $$                          | $$
-		  /$$$$$$$  /$$$$$$ | $$| $$| $$$$$$$   /$$$$$$   /$$$$$$$| $$   /$$  /$$$$$$$
-		 /$$_____/ |____  $$| $$| $$| $$__  $$ |____  $$ /$$_____/| $$  /$$/ /$$_____/
-		| $$        /$$$$$$$| $$| $$| $$  \ $$  /$$$$$$$| $$      | $$$$$$/ |  $$$$$$
-		| $$       /$$__  $$| $$| $$| $$  | $$ /$$__  $$| $$      | $$_  $$  \____  $$
-		|  $$$$$$$|  $$$$$$$| $$| $$| $$$$$$$/|  $$$$$$$|  $$$$$$$| $$ \  $$ /$$$$$$$/
-		 \_______/ \_______/|__/|__/|_______/  \_______/ \_______/|__/  \__/|_______/
-	*/
-
 	/**
 	 * Check if a voucher is a duplicate.
 	 *
@@ -215,7 +207,7 @@ class LLMS_AJAX {
 	 */
 	public function query_quiz_questions() {
 
-		// grab the search term if it exists
+		// Grab the search term if it exists.
 		$term = array_key_exists( 'term', $_REQUEST ) ? llms_filter_input( INPUT_POST, 'term', FILTER_SANITIZE_STRING ) : '';
 
 		$page = array_key_exists( 'page', $_REQUEST ) ? llms_filter_input( INPUT_POST, 'page', FILTER_SANITIZE_NUMBER_INT ) : 0;

--- a/includes/class.llms.background.updater.php
+++ b/includes/class.llms.background.updater.php
@@ -97,12 +97,12 @@ class LLMS_Background_Updater extends WP_Background_Process {
 	 */
 	public function get_progress() {
 
-		// if the queue is empty we've already finished
+		// If the queue is empty we've already finished.
 		if ( $this->is_queue_empty() ) {
 			return 0;
 		}
 
-		// get the progress
+		// Get the progress.
 		$batch     = $this->get_batch();
 		$total     = max( array_keys( $batch->data ) ) + 1;
 		$remaining = count( $batch->data );

--- a/includes/class.llms.certificate.php
+++ b/includes/class.llms.certificate.php
@@ -110,7 +110,7 @@ class LLMS_Certificate {
 	 */
 	public function __construct() {
 
-		// Settings TODO Refactor: theses can come from the email post now
+		// Settings TODO Refactor: theses can come from the email post now.
 		$this->email_type = 'html';
 
 		$this->find    = array( '{blogname}', '{site_title}' );

--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -337,7 +337,7 @@ class LLMS_Data {
 		if ( absint( $id ) ) {
 			return sprintf( '%1$s (#%2$d) [%3$s]', get_the_title( $id ), $id, get_permalink( $id ) );
 		}
-		return 'Not Set'; // Don't translate this or you won't be able to read it smartypants....
+		return 'Not Set'; // Don't translate this or you won't be able to read it smartypants.
 	}
 
 	/**

--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -21,8 +21,8 @@ class LLMS_Data {
 	/**
 	 * Get the data data
 	 *
-	 * @param    string $dataset  dataset to retrieve data for [tracker|system_report]
-	 * @param    string $format   data return format (unused for unrecalled reasons)
+	 * @param string $dataset Dataset to retrieve data for [tracker|system_report].
+	 * @param string $format  Data return format (unused for unrecalled reasons).
 	 * @return   array
 	 * @since    3.0.0
 	 * @version  3.17.0
@@ -31,47 +31,47 @@ class LLMS_Data {
 
 		$data = array();
 
-		// add admin email for tracker requests
+		// Add admin email for tracker requests.
 		if ( 'tracker' === $dataset ) {
 			$data['email'] = apply_filters( 'llms_get_data_admin_email', get_option( 'admin_email' ) );
 		}
 
-		// general data
+		// General data.
 		$data['url'] = home_url();
 
-		// wp info
+		// Wp info.
 		$data['wordpress'] = self::get_wp_data();
 
-		// llms settings
+		// Llms settings.
 		$data['settings'] = self::get_llms_settings();
 
-		// gateways
+		// Gateways.
 		$data['gateways'] = self::get_gateway_data();
 
-		// server info
+		// Server info.
 		$data['server'] = self::get_server_data();
 
-		// browser / os
+		// Browser / os.
 		$data['browser'] = self::get_browser_data();
 
-		// theme info
+		// Theme info.
 		$data['theme'] = self::get_theme_data();
 
-		// plugin info
+		// Plugin info.
 		$data['plugins'] = self::get_plugin_data();
 
 		if ( 'tracker' === $dataset ) {
 
-			// published content type counts
+			// Published content type counts.
 			$data['post_counts'] = self::get_post_type_counts();
 
-			// user data
+			// User data.
 			$data['user_counts'] = self::get_user_counts();
 
-			// count student engagements
+			// Count student engagements.
 			$data['engagement_counts'] = self::get_engagement_counts();
 
-			// order data
+			// Order data.
 			$data['order_counts'] = self::get_order_counts();
 
 		}
@@ -130,28 +130,28 @@ class LLMS_Data {
 	 * Retrieve metadata from a file.
 	 * Copied from WCs get_file_version which is based on WP Core's get_file_data function.
 	 *
-	 * @param    string $file   Path to the file
+	 * @param string $file  Path to the file.
 	 * @return   string
 	 * @since    3.11.2
 	 * @version  3.11.2
 	 */
 	private static function get_file_version( $file ) {
 
-		// Avoid notices if file does not exist
+		// Avoid notices if file does not exist.
 		if ( ! file_exists( $file ) ) {
 			return '';
 		}
 
-		// We don't need to write to the file, so just open for reading.
+		// We don't need to write to the file, so just open for reading..
 		$fp = fopen( $file, 'r' );
 
-		// Pull only the first 8kiB of the file in.
+		// Pull only the first 8kiB of the file in..
 		$file_data = fread( $fp, 8192 );
 
-		// PHP will close file handle, but we are good citizens.
+		// PHP will close file handle, but we are good citizens..
 		fclose( $fp );
 
-		// Make sure we catch CR-only line endings.
+		// Make sure we catch CR-only line endings..
 		$file_data = str_replace( "\r", "\n", $file_data );
 		$version   = '';
 
@@ -207,7 +207,7 @@ class LLMS_Data {
 
 		foreach ( $integrations->integrations() as $obj ) {
 
-			// @todo upgrade this when integration abstract is finished
+			// @todo Upgrade this when integration abstract is finished.
 			if ( method_exists( $obj, 'is_available' ) ) {
 
 				$data[ $obj->title ] = $obj->is_available() ? 'Yes' : 'No';
@@ -327,7 +327,7 @@ class LLMS_Data {
 	 * Get an option that should return a page ID
 	 * and return the page name and ID as a formatted string
 	 *
-	 * @param    string $option  option name in the wp_options table
+	 * @param string $option Option name in the wp_options table.
 	 * @return   string
 	 * @since    3.0.0
 	 * @version  3.0.0
@@ -337,7 +337,7 @@ class LLMS_Data {
 		if ( absint( $id ) ) {
 			return sprintf( '%1$s (#%2$d) [%3$s]', get_the_title( $id ), $id, get_permalink( $id ) );
 		}
-		return 'Not Set'; // don't translate this or you won't be able to read it smartypants...
+		return 'Not Set'; // Don't translate this or you won't be able to read it smartypants....
 	}
 
 	/**
@@ -349,7 +349,7 @@ class LLMS_Data {
 	 */
 	private static function get_plugin_data() {
 
-		// ensure we have our plugin function
+		// Ensure we have our plugin function.
 		if ( ! function_exists( 'get_plugins' ) ) {
 			include ABSPATH . '/wp-admin/includes/plugin.php';
 		}
@@ -502,17 +502,15 @@ class LLMS_Data {
 	 */
 	private static function get_theme_data() {
 
-		$data = array();
-		// @codingStandardsIgnoreStart
-		$theme_data = wp_get_theme();
-		$data['name'] = $theme_data->get( 'Name' );
-		$data['version'] = $theme_data->get( 'Version' );
-		$data['themeuri'] = $theme_data->get( 'ThemeURI' );
-		$data['authoruri'] = $theme_data->get( 'AuthorURI' );
-		$data['template'] = $theme_data->get( 'Template' );
-		$data['child_theme'] = is_child_theme() ? 'Yes' : 'No';
+		$data                 = array();
+		$theme_data           = wp_get_theme();
+		$data['name']         = $theme_data->get( 'Name' );
+		$data['version']      = $theme_data->get( 'Version' );
+		$data['themeuri']     = $theme_data->get( 'ThemeURI' );
+		$data['authoruri']    = $theme_data->get( 'AuthorURI' );
+		$data['template']     = $theme_data->get( 'Template' );
+		$data['child_theme']  = is_child_theme() ? 'Yes' : 'No';
 		$data['llms_support'] = ( ! current_theme_supports( 'lifterlms' ) ) ? 'No' : 'Yes';
-		// @codingStandardsIgnoreEnd
 
 		return $data;
 

--- a/includes/class.llms.date.php
+++ b/includes/class.llms.date.php
@@ -179,7 +179,7 @@ class LLMS_Date {
 		$minutes_string = '';
 		$seconds_string = '';
 
-		// determine hours vs hour in string
+		// Determine hours vs hour in string.
 		if ( ! empty( $hours ) ) {
 			if ( $hours > 1 ) {
 				$hour_desc = __( 'hours', 'lifterlms' );
@@ -201,7 +201,7 @@ class LLMS_Date {
 			}
 		}
 
-		// determine minutes vs minute in string
+		// Determine minutes vs minute in string.
 		if ( ! empty( $minutes ) ) {
 			if ( $minutes > 1 ) {
 				$minute_desc = __( 'minutes', 'lifterlms' );

--- a/includes/class.llms.emails.php
+++ b/includes/class.llms.emails.php
@@ -58,14 +58,14 @@ class LLMS_Emails {
 	 */
 	private function __construct() {
 
-		// template functions
+		// Template functions.
 		LLMS()->include_template_functions();
 
-		// email base class
+		// Email base class.
 		require_once 'emails/class.llms.email.php';
 		$this->emails['generic'] = 'LLMS_Email';
 
-		// Include email child classes
+		// Include email child classes.
 		require_once 'emails/class.llms.email.engagement.php';
 		$this->emails['engagement'] = 'LLMS_Email_Engagement';
 
@@ -169,12 +169,12 @@ class LLMS_Emails {
 
 		$emails = $this->get_emails();
 
-		// if we have an email matching the ID, return an instance of that email class
+		// If we have an email matching the ID, return an instance of that email class.
 		if ( isset( $emails[ $id ] ) ) {
 			return new $emails[ $id ]( $args );
 		}
 
-		// otherwise return a generic email and set the ID to be the requested ID
+		// Otherwise return a generic email and set the ID to be the requested ID.
 		/** @var LLMS_Email $generic */
 		$generic = new $emails['generic']( $args );
 		$generic->set_id( $id );

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -38,11 +38,11 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 		$this->admin_title          = __( 'Manual', 'lifterlms' );
 		$this->title                = __( 'Manual', 'lifterlms' );
 		$this->description          = __( 'Pay manually via check', 'lifterlms' );
-		$this->payment_instructions = ''; // fields
+		$this->payment_instructions = ''; // Fields.
 
 		$this->supports = array(
 			'checkout_fields'    => false,
-			'refunds'            => false, // manual refunds are available always for all gateways and are not handled by this class
+			'refunds'            => false, // Manual refunds are available always for all gateways and are not handled by this class.
 			'single_payments'    => true,
 			'recurring_payments' => true,
 			'test_mode'          => false,
@@ -164,19 +164,19 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 	 */
 	public function handle_pending_order( $order, $plan, $person, $coupon = false ) {
 
-		// no payment (free orders)
+		// No payment (free orders).
 		if ( floatval( 0 ) === $order->get_initial_price( array(), 'float' ) ) {
 
-			// free access plans do not generate receipts
+			// Free access plans do not generate receipts.
 			if ( $plan->is_free() ) {
 
 				$order->set( 'status', 'llms-completed' );
 
-				// free trial, reduced to free via coupon, etc...
-				// we do want to record a transaction and then generate a receipt
+				// Free trial, reduced to free via coupon, etc....
+				// We do want to record a transaction and then generate a receipt.
 			} else {
 
-				// record a $0.00 transaction to ensure a receipt is sent
+				// Record a $0.00 transaction to ensure a receipt is sent.
 				$order->record_transaction(
 					array(
 						'amount'             => floatval( 0 ),
@@ -192,7 +192,7 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 
 			$this->complete_transaction( $order );
 
-			// payment due
+			// Payment due.
 		} else {
 
 			/**
@@ -200,12 +200,12 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 			 */
 			do_action( 'llms_manual_payment_due', $order, $this );
 
-			// show the user payment instructions for the order
+			// Show the user payment instructions for the order.
 			do_action( 'lifterlms_handle_pending_order_complete', $order );
 			wp_redirect( $order->get_view_link() );
 			exit;
 
-		}// End if().
+		}
 
 	}
 
@@ -220,10 +220,10 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 	 */
 	public function handle_recurring_transaction( $order ) {
 
-		// switch to order on hold if it's a paid order
+		// Switch to order on hold if it's a paid order.
 		if ( $order->get_price( 'total', array(), 'float' ) > 0 ) {
 
-			// update status
+			// Update status.
 			$order->set_status( 'on-hold' );
 
 			/**

--- a/includes/class.llms.generator.php
+++ b/includes/class.llms.generator.php
@@ -605,6 +605,7 @@ class LLMS_Generator {
 	 * @since 3.30.2 Added hooks.
 	 *
 	 * @param array $raw       Raw question data.
+	 * @param obj   $manager   Question manager instance.
 	 * @param int   $author_id Optional author ID to use as a fallback if no raw author data supplied for the lesson.
 	 * @return int The WP_Post ID of the generated question.
 	 */

--- a/includes/class.llms.l10n.php
+++ b/includes/class.llms.l10n.php
@@ -38,14 +38,14 @@ class LLMS_L10n {
 
 		$strings = array();
 
-		// add strings that should only be translated on the admin panel
+		// Add strings that should only be translated on the admin panel.
 		if ( is_admin() ) {
 
 			$strings = apply_filters( 'lifterlms_js_l10n_admin', $strings );
 
 		}
 
-		// allow filtering so extensions don't have to implement their own l10n functions
+		// Allow filtering so extensions don't have to implement their own l10n functions.
 		$strings = apply_filters( 'lifterlms_js_l10n', $strings );
 
 		if ( true === $json ) {

--- a/includes/class.llms.lesson.handler.php
+++ b/includes/class.llms.lesson.handler.php
@@ -31,7 +31,7 @@ class LLMS_Lesson_Handler {
 
 			foreach ( $lessons as $key => $value ) {
 
-				// get parent course if assigned
+				// Get parent course if assigned.
 				$parent_course = get_post_meta( $value->ID, '_llms_parent_course', true );
 
 				if ( $parent_course ) {
@@ -51,20 +51,20 @@ class LLMS_Lesson_Handler {
 
 	public static function assign_to_course( $course_id, $section_id, $lesson_id, $duplicate = true, $reset_order = true ) {
 
-		// Get position of next lesson
+		// Get position of next lesson.
 		$section      = new LLMS_Section( $section_id );
 		$lesson_order = $section->get_next_available_lesson_order();
 
-		// first determine if lesson is associated with a course
-		// we need to know this because if it is already associated then we duplicate it and assign the dupe
+		// First determine if lesson is associated with a course.
+		// We need to know this because if it is already associated then we duplicate it and assign the dupe.
 		$parent_course  = get_post_meta( $lesson_id, '_llms_parent_course', true );
 		$parent_section = get_post_meta( $lesson_id, '_llms_parent_section', true );
 
-		// parent course exists, lets dupe this baby!
+		// Parent course exists, lets dupe this baby!.
 		if ( $parent_course && true == $duplicate ) {
 			$lesson_id = self::duplicate_lesson( $course_id, $section_id, $lesson_id );
 		} else {
-			// add parent section and course to new lesson
+			// Add parent section and course to new lesson.
 			update_post_meta( $lesson_id, '_llms_parent_section', $section_id );
 			update_post_meta( $lesson_id, '_llms_parent_course', $course_id );
 
@@ -84,14 +84,14 @@ class LLMS_Lesson_Handler {
 			return false;
 		}
 
-		// duplicate the lesson
+		// Duplicate the lesson.
 		$new_lesson_id = self::duplicate( $lesson_id );
 
 		if ( ! $new_lesson_id ) {
 			return false;
 		}
 
-		// add parent section and course to new lesson
+		// Add parent section and course to new lesson.
 		update_post_meta( $new_lesson_id, '_llms_parent_section', $section_id );
 		update_post_meta( $new_lesson_id, '_llms_parent_course', $course_id );
 
@@ -101,20 +101,20 @@ class LLMS_Lesson_Handler {
 
 	public static function duplicate( $post_id ) {
 
-		// make sure we have a post id and it returns a post
+		// Make sure we have a post id and it returns a post.
 		if ( ! isset( $post_id ) ) {
 			return false;
 		}
 
 		$post_obj = get_post( $post_id );
-		// last check...
+		// Last check.
 		if ( ! isset( $post_obj ) || null == $post_obj ) {
 			return false;
 		}
 
-		// no going back now...
+		// No going back now.
 
-		// create duplicate post
+		// Create duplicate post.
 		$args = array(
 			'comment_status' => $post_obj->comment_status,
 			'ping_status'    => $post_obj->ping_status,
@@ -131,12 +131,12 @@ class LLMS_Lesson_Handler {
 			'post_password'  => $post_obj->post_password,
 		);
 
-		// create the duplicate post
+		// Create the duplicate post.
 		$new_post_id = wp_insert_post( $args );
 
 		if ( $new_post_id ) {
 
-			// get all current post terms and set them to the new post
+			// Get all current post terms and set them to the new post.
 			$taxonomies = get_object_taxonomies( $post_obj->post_type );
 			foreach ( $taxonomies as $taxonomy ) {
 				$post_terms = wp_get_object_terms(
@@ -149,7 +149,7 @@ class LLMS_Lesson_Handler {
 				wp_set_object_terms( $new_post_id, $post_terms, $taxonomy, false );
 			}
 
-			// duplicate meta
+			// Duplicate meta.
 			$insert_meta = self::duplicate_meta( $post_id, $new_post_id );
 
 		}
@@ -164,7 +164,7 @@ class LLMS_Lesson_Handler {
 		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
-		// duplicate all post meta
+		// Duplicate all post meta.
 		$post_meta_infos = $wpdb->get_results( "SELECT meta_key, meta_value FROM $wpdb->postmeta WHERE post_id=$post_id" );
 
 		if ( count( $post_meta_infos ) != 0 ) {
@@ -173,7 +173,7 @@ class LLMS_Lesson_Handler {
 
 			foreach ( $post_meta_infos as $meta_info ) {
 
-				// do not copy the following meta values
+				// Do not copy the following meta values.
 				if ( '_llms_parent_section' === $meta_info->meta_key ) {
 					$meta_info->meta_value = '';
 				}
@@ -203,4 +203,4 @@ class LLMS_Lesson_Handler {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
-} //end LLMS_POST_Handler
+}

--- a/includes/class.llms.payment.gateways.php
+++ b/includes/class.llms.payment.gateways.php
@@ -26,7 +26,7 @@ class LLMS_Payment_Gateways {
 	public $payment_gateways = array();
 
 	/**
-	 * private instance of class
+	 * Private instance of class
 	 *
 	 * @var null
 	 */
@@ -50,7 +50,7 @@ class LLMS_Payment_Gateways {
 	/**
 	 * Constructor
 	 *
-	 * @version  3.0.0
+	 * @version 3.0.0
 	 */
 	public function __construct() {
 
@@ -64,7 +64,7 @@ class LLMS_Payment_Gateways {
 
 			$order = absint( $load_gateway->get_display_order() );
 
-			// if the order already exists create a new order for it
+			// If the order already exists create a new order for it.
 			if ( isset( $this->payment_gateways[ $order ] ) ) {
 
 				$order = max( array_keys( $this->payment_gateways ) ) + 1;

--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -85,10 +85,10 @@ class LLMS_Person_Handler {
 
 		$uid = get_current_user_id();
 
-		// setup all the fields to load
+		// Setup all the fields to load.
 		$fields = array();
 
-		// this isn't needed if we're on an account screen or
+		// This isn't needed if we're on an account screen or.
 		if ( 'account' !== $screen && ( 'checkout' !== $screen || ! $uid ) ) {
 			$fields[] = array(
 				'columns'     => 12,
@@ -100,8 +100,8 @@ class LLMS_Person_Handler {
 			);
 		}
 
-		// on the checkout screen, if we already have a user we can remove these fields:
-		// username, email, email confirm, password, password confirm, password meter
+		// On the checkout screen, if we already have a user we can remove these fields:.
+		// Username, email, email confirm, password, password confirm, password meter.
 		if ( 'checkout' !== $screen || ! $uid ) {
 			$email_con = get_option( 'lifterlms_user_info_field_email_confirmation_' . $screen . '_visibility' );
 			$fields[]  = array(
@@ -125,7 +125,7 @@ class LLMS_Person_Handler {
 				);
 			}
 
-			// account screen has password updates at the bottom
+			// Account screen has password updates at the bottom.
 			if ( 'account' !== $screen ) {
 				$fields = self::get_password_fields( $screen, $fields );
 			}
@@ -205,7 +205,7 @@ class LLMS_Person_Handler {
 				'required'    => ( 'required' === $address ) ? true : false,
 				'type'        => 'select',
 			);
-		}// End if().
+		}
 
 		$phone = get_option( 'lifterlms_user_info_field_phone_' . $screen . '_visibility' );
 		if ( 'hidden' !== $phone ) {
@@ -243,14 +243,14 @@ class LLMS_Person_Handler {
 
 		}
 
-		// add account password fields
+		// Add account password fields.
 		if ( 'account' === $screen ) {
 			$fields = self::get_password_fields( $screen, $fields );
 		}
 
 		$fields = apply_filters( 'lifterlms_get_person_fields', $fields, $screen );
 
-		// populate fields with data, if we have any
+		// Populate fields with data, if we have any.
 		if ( $data ) {
 			$fields = self::fill_fields( $fields, $data );
 		}
@@ -569,12 +569,12 @@ class LLMS_Person_Handler {
 				'ID' => $data['user_id'],
 			);
 
-			// email address if set
+			// Email address if set.
 			if ( isset( $data['email_address'] ) ) {
 				$insert_data['user_email'] = $data['email_address'];
 			}
 
-			// update password if both are set
+			// Update password if both are set.
 			if ( isset( $data['password'] ) && isset( $data['password_confirm'] ) ) {
 				$insert_data['user_pass'] = $data['password'];
 			}
@@ -591,7 +591,7 @@ class LLMS_Person_Handler {
 
 			return new WP_Error( 'invalid', __( 'Invalid action', 'lifterlms' ) );
 
-		}// End if().
+		}
 
 		foreach ( $extra_data as $field ) {
 			if ( isset( $data[ $field ] ) ) {
@@ -599,18 +599,18 @@ class LLMS_Person_Handler {
 			}
 		}
 
-		// attempt to insert the data
+		// Attempt to insert the data.
 		$person_id = $insert_func( apply_filters( 'lifterlms_user_' . $action . '_insert_user', $insert_data, $data, $action ) );
 
-		// return the error object if registration fails
+		// Return the error object if registration fails.
 		if ( is_wp_error( $person_id ) ) {
 			return apply_filters( 'lifterlms_user_' . $action . '_failure', $person_id, $data, $action );
 		}
 
-		// add user ip address
+		// Add user ip address.
 		$data[ self::$meta_prefix . 'ip_address' ] = llms_get_ip_address();
 
-		// metas
+		// Metas.
 		$possible_metas = apply_filters(
 			'llms_person_insert_data_possible_metas',
 			array(
@@ -631,13 +631,13 @@ class LLMS_Person_Handler {
 			}
 		}
 
-		// record all meta values
+		// Record all meta values.
 		$metas = apply_filters( 'lifterlms_user_' . $action . '_insert_user_meta', $insert_metas, $data, $action );
 		foreach ( $metas as $key => $val ) {
 			$meta_func( $person_id, $key, $val );
 		}
 
-		// if agree to terms data is present, record the agreement date
+		// If agree to terms data is present, record the agreement date.
 		if ( isset( $data[ self::$meta_prefix . 'agree_to_terms' ] ) && 'yes' === $data[ self::$meta_prefix . 'agree_to_terms' ] ) {
 
 			$meta_func( $person_id, self::$meta_prefix . 'agree_to_terms', current_time( 'mysql' ) );
@@ -660,10 +660,10 @@ class LLMS_Person_Handler {
 
 		do_action( 'lifterlms_before_user_login', $data );
 
-		// validate the fields & allow custom validation to occur.
+		// Validate the fields & allow custom validation to occur..
 		$valid = self::validate_fields( apply_filters( 'lifterlms_user_login_data', $data ), 'login' );
 
-		// if errors found, return them.
+		// If errors found, return them..
 		if ( is_wp_error( $valid ) ) {
 			return apply_filters( 'lifterlms_user_login_errors', $valid, $data, false );
 		}
@@ -673,7 +673,7 @@ class LLMS_Person_Handler {
 
 		$err = new WP_Error( 'login-error', __( 'Could not find an account with the supplied email address and password combination.', 'lifterlms' ) );
 
-		// get the username from the email address
+		// Get the username from the email address.
 		if ( llms_parse_bool( get_option( 'lifterlms_registration_generate_username' ) ) && apply_filters( 'lifterlms_get_username_from_email', true ) ) {
 
 			$user = get_user_by( 'email', wp_unslash( $data['llms_login'] ) );
@@ -731,15 +731,15 @@ class LLMS_Person_Handler {
 
 		do_action( 'lifterlms_before_user_registration', $data, $screen );
 
-		// generate a username if we're supposed to generate a username
+		// Generate a username if we're supposed to generate a username.
 		if ( llms_parse_bool( get_option( 'lifterlms_registration_generate_username' ) ) && ! empty( $data['email_address'] ) ) {
 			$data['user_login'] = self::generate_username( $data['email_address'] );
 		}
 
-		// validate the fields & allow custom validation to occur
+		// Validate the fields & allow custom validation to occur.
 		$valid = apply_filters( 'lifterlms_user_registration_data', self::validate_fields( $data, $screen ), $data, $screen );
 
-		// if errors found, return them
+		// If errors found, return them.
 		if ( is_wp_error( $valid ) ) {
 
 			return apply_filters( 'lifterlms_user_registration_errors', $valid, $data, $screen );
@@ -748,24 +748,24 @@ class LLMS_Person_Handler {
 
 			do_action( 'lifterlms_user_registration_after_validation', $data, $screen );
 
-			// create the user and update all metadata
-			$person_id = self::insert_data( $data, 'registration' ); // even during checkout we want to call this registration
+			// Create the user and update all metadata.
+			$person_id = self::insert_data( $data, 'registration' ); // Even during checkout we want to call this registration.
 
-			// return the error object if registration fails
+			// Return the error object if registration fails.
 			if ( is_wp_error( $person_id ) ) {
-				return $person_id; // this is filtered already
+				return $person_id; // This is filtered already.
 			}
 
-			// signon
+			// Signon.
 			if ( $signon ) {
 				llms_set_person_auth_cookie( $person_id, false );
 			}
 
-			// fire actions
+			// Fire actions.
 			do_action( 'lifterlms_created_person', $person_id, $data, $screen );
 			do_action( 'lifterlms_user_registered', $person_id, $data, $screen );
 
-			// return the ID
+			// Return the ID.
 			return $person_id;
 
 		}
@@ -826,22 +826,22 @@ class LLMS_Person_Handler {
 
 		do_action( 'lifterlms_before_user_update', $data, $screen );
 
-		// user_id will automatically be the current user if non provided
+		// User_id will automatically be the current user if non provided.
 		if ( empty( $data['user_id'] ) ) {
 			$data['user_id'] = get_current_user_id();
 		}
 
-		// if no user id available, return an error
+		// If no user id available, return an error.
 		if ( ! $data['user_id'] ) {
 			$e = new WP_Error();
 			$e->add( 'user_id', __( 'No user ID specified.', 'lifterlms' ), 'missing-user-id' );
 			return $e;
 		}
 
-		// validate the fields & allow custom validation to occur
+		// Validate the fields & allow custom validation to occur.
 		$valid = apply_filters( 'lifterlms_user_update_data', self::validate_fields( $data, $screen ), $data, $screen );
 
-		// if errors found, return them
+		// If errors found, return them.
 		if ( is_wp_error( $valid ) ) {
 
 			return apply_filters( 'lifterlms_user_update_errors', $valid, $data, $screen );
@@ -850,12 +850,12 @@ class LLMS_Person_Handler {
 
 			do_action( 'lifterlms_user_update_after_validation', $data, $screen );
 
-			// create the user and update all metadata
+			// Create the user and update all metadata.
 			$person_id = self::insert_data( $data, 'update' );
 
-			// return the error object if registration fails
+			// Return the error object if registration fails.
 			if ( is_wp_error( $person_id ) ) {
-				return $person_id; // this is filtered already
+				return $person_id; // This is filtered already.
 			}
 
 			do_action( 'lifterlms_user_updated', $person_id, $data, $screen );
@@ -905,8 +905,8 @@ class LLMS_Person_Handler {
 
 			$fields = self::get_available_fields( $screen );
 
-			// if no current password submitted with an account update
-			// we can remove password fields so we don't get false validations
+			// If no current password submitted with an account update.
+			// We can remove password fields so we don't get false validations.
 			if ( 'account' === $screen && empty( $data['current_password'] ) ) {
 				unset( $data['current_password'], $data['password'], $data['password_confirm'] );
 				foreach ( $fields as $key => $field ) {
@@ -929,7 +929,7 @@ class LLMS_Person_Handler {
 			$field_type = isset( $field['type'] ) ? $field['type'] : '';
 			$val        = isset( $data[ $name ] ) ? self::sanitize_field( $data[ $name ], $field_type ) : '';
 
-			// ensure required fields are submitted
+			// Ensure required fields are submitted.
 			if ( isset( $field['required'] ) && $field['required'] && empty( $val ) ) {
 
 				$e->add( $field['id'], sprintf( __( '%s is a required field', 'lifterlms' ), $label ), 'required' );
@@ -937,12 +937,12 @@ class LLMS_Person_Handler {
 
 			}
 
-			// check email field for uniqueness
+			// Check email field for uniqueness.
 			if ( 'email_address' === $name ) {
 
 				$skip_email = false;
 
-				// only run this check when we're trying to change the email address for an account update
+				// Only run this check when we're trying to change the email address for an account update.
 				if ( 'account' === $screen ) {
 					$user = wp_get_current_user();
 					if ( self::sanitize_field( $data['email_address'], 'email' ) === $user->user_email ) {
@@ -955,7 +955,7 @@ class LLMS_Person_Handler {
 				}
 			} elseif ( 'user_login' === $name ) {
 
-				// blacklist usernames for security purposes
+				// Blacklist usernames for security purposes.
 				$banned_usernames = apply_filters( 'llms_usernames_blacklist', array( 'admin', 'test', 'administrator', 'password', 'testing' ) );
 
 				if ( in_array( $val, $banned_usernames ) || ! validate_username( $val ) ) {
@@ -981,12 +981,12 @@ class LLMS_Person_Handler {
 				}
 			}
 
-			// scrub and check field data types
+			// Scrub and check field data types.
 			if ( isset( $field['type'] ) ) {
 
 				switch ( $field['type'] ) {
 
-					// ensure it's a selectable option
+					// Ensure it's a selectable option.
 					case 'select':
 					case 'radio':
 						if ( ! in_array( $val, array_keys( $field['options'] ) ) ) {
@@ -994,12 +994,7 @@ class LLMS_Person_Handler {
 						}
 						break;
 
-					// case 'password':
-					// case 'text':
-					// case 'textarea':
-					// break;
-
-					// make sure the value is numeric
+					// Make sure the value is numeric.
 					case 'number':
 						if ( ! is_numeric( $val ) ) {
 							$e->add( $field['id'], sprintf( __( '%s must be numeric', 'lifterlms' ), $label ), 'invalid' );
@@ -1007,7 +1002,7 @@ class LLMS_Person_Handler {
 						}
 						break;
 
-					// validate the email address
+					// Validate the email address.
 					case 'email':
 						if ( ! is_email( $val ) ) {
 							$e->add( $field['id'], sprintf( __( '%s must be a valid email address', 'lifterlms' ), $label ), 'invalid' );
@@ -1015,16 +1010,16 @@ class LLMS_Person_Handler {
 						break;
 
 				}
-			}// End if().
+			}
 
-			// store this fields label so it can be used in a match error later if necessary
+			// Store this fields label so it can be used in a match error later if necessary.
 			if ( ! empty( $field['matched'] ) ) {
 
 				$matched_values[ $field['matched'] ] = $label;
 
 			}
 
-			// match matchy fields
+			// Match matchy fields.
 			if ( ! empty( $field['match'] ) ) {
 
 				$match = isset( $data[ $field['match'] ] ) ? self::sanitize_field( $data[ $field['match'] ], $field_type ) : false;
@@ -1034,9 +1029,9 @@ class LLMS_Person_Handler {
 
 				}
 			}
-		}// End foreach().
+		}
 
-		// return errors if we have errors
+		// Return errors if we have errors.
 		if ( $e->get_error_messages() ) {
 			return $e;
 		}

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -250,7 +250,7 @@ class LLMS_Post_Types {
 				'publish_posts'          => sprintf( 'publish_%s', $plural ),
 
 				'delete_post'            => sprintf( 'delete_%s', $singular ),
-				'delete_posts'           => sprintf( 'delete_%s', $plural ), // this is the core bug issue here
+				'delete_posts'           => sprintf( 'delete_%s', $plural ), // Dhis is the core bug issue here.
 				'delete_private_posts'   => sprintf( 'delete_private_%s', $plural ),
 				'delete_published_posts' => sprintf( 'delete_published_%s', $plural ),
 				'delete_others_posts'    => sprintf( 'delete_others_%s', $plural ),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -250,7 +250,7 @@ class LLMS_Post_Types {
 				'publish_posts'          => sprintf( 'publish_%s', $plural ),
 
 				'delete_post'            => sprintf( 'delete_%s', $singular ),
-				'delete_posts'           => sprintf( 'delete_%s', $plural ), // Dhis is the core bug issue here.
+				'delete_posts'           => sprintf( 'delete_%s', $plural ), // This is the core bug issue here.
 				'delete_private_posts'   => sprintf( 'delete_private_%s', $plural ),
 				'delete_published_posts' => sprintf( 'delete_published_%s', $plural ),
 				'delete_others_posts'    => sprintf( 'delete_others_%s', $plural ),

--- a/includes/class.llms.post.handler.php
+++ b/includes/class.llms.post.handler.php
@@ -32,7 +32,7 @@ class LLMS_Post_Handler {
 			$title = 'Section 1';
 		}
 
-		// create section post
+		// Create section post.
 		$post_data = apply_filters(
 			'lifterlms_new_post',
 			array(
@@ -46,9 +46,9 @@ class LLMS_Post_Handler {
 
 		$post_id = wp_insert_post( $post_data, true );
 
-		// check for error in update
+		// Check for error in update.
 		if ( is_wp_error( $post_id ) ) {
-			// for now just log the error and set $post_id to 0 (false)
+			// For now just log the error and set $post_id to 0 (false).
 			llms_log( $post_id->get_error_message() );
 			$post_id = 0;
 		}
@@ -64,7 +64,7 @@ class LLMS_Post_Handler {
 			'post_title' => $title,
 		);
 
-		// Update the post into the database
+		// Update the post into the database.
 		$updated_post_id = wp_update_post( $post_data );
 
 		if ( $updated_post_id ) {
@@ -83,7 +83,7 @@ class LLMS_Post_Handler {
 			'post_excerpt' => $excerpt,
 		);
 
-		// Update the post into the database
+		// Update the post into the database.
 		$updated_post_id = wp_update_post( $post_data );
 
 		if ( $updated_post_id ) {
@@ -104,13 +104,13 @@ class LLMS_Post_Handler {
 	 */
 	public static function create_section( $course_id, $title = '' ) {
 
-		// no course id? no new section!
+		// No course id? no new section!.
 		if ( ! isset( $course_id ) ) {
 			return;
 		}
 
-		// set the section_order variable
-		// get the count of sections in the course and add 1
+		// Set the section_order variable.
+		// Get the count of sections in the course and add 1.
 		$course        = new LLMS_Course( $course_id );
 		$sections      = $course->get_sections( 'posts' );
 		$section_order = count( $sections ) + 1;
@@ -119,7 +119,7 @@ class LLMS_Post_Handler {
 
 		$post_id = self::create( 'section', $title );
 
-		// if post created set parent course and order to order determined above
+		// If post created set parent course and order to order determined above.
 		if ( $post_id ) {
 			update_post_meta( $post_id, '_llms_order', $section_order );
 
@@ -131,22 +131,26 @@ class LLMS_Post_Handler {
 	}
 
 	/**
-	 * Creates a new Lesson
+	 * Create lesson
 	 *
-	 * @param  [int]  $course_id [the parent course id]
-	 * @param  string $title    [optional: a title for the lesson]
-	 * @param  string $excerpt  [optional: a desc for the lesson]
-	 * @return [int]            [post id of lesson]
+	 * @since Unknown
+	 * @deprecated [version]
+	 *
+	 * @param int    $course_id  WP_Post ID of the course.
+	 * @param int    $section_id WP_Post ID of the lesson's parent section.
+	 * @param string $title   Optional lesson title.
+	 * @param string $excerpt Option excerpt.
+	 * @return int WP_Post ID of the created lesson.
 	 */
 	public static function create_lesson( $course_id, $section_id, $title = '', $excerpt = '' ) {
 
-		// no course id or section id? no new lesson!
+		// No course id or section id? no new lesson!.
 		if ( ! isset( $course_id ) || ! isset( $course_id ) ) {
 			return;
 		}
 
-		// set the lesson_order variable
-		// get the count of lessons in the section
+		// Set the lesson_order variable.
+		// Get the count of lessons in the section.
 		$section      = new LLMS_Section( $section_id );
 		$lesson_order = $section->get_next_available_lesson_order();
 
@@ -154,7 +158,7 @@ class LLMS_Post_Handler {
 
 		$post_id = self::create( 'lesson', $title, $excerpt );
 
-		// if post created set parent section, parent course and order determined above
+		// If post created set parent section, parent course and order determined above.
 		if ( $post_id ) {
 			update_post_meta( $post_id, '_llms_order', $lesson_order );
 
@@ -201,7 +205,7 @@ class LLMS_Post_Handler {
 
 			foreach ( $lessons as $key => $value ) {
 
-				// get parent course if assigned
+				// Get parent course if assigned.
 				$parent_course = get_post_meta( $value->ID, '_llms_parent_course', true );
 
 				if ( $parent_course ) {

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -50,7 +50,7 @@ class LLMS_Post_Relationships {
 
 		'llms_quiz'  => array(
 			array(
-				'action'    => 'delete', // delete = force delete; trash = move to trash
+				'action'    => 'delete', // Delete = force delete; trash = move to trash.
 				'meta_key'  => '_llms_parent_id', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'post_type' => 'llms_question',
 			),

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -91,7 +91,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	 */
 	protected function parse_args() {
 
-		// sanitize post & user ids
+		// Sanitize post & user ids.
 		foreach ( array( 'post_id', 'user_id' ) as $key ) {
 
 			$this->arguments[ $key ] = $this->sanitize_id_array( $this->arguments[ $key ] );
@@ -166,13 +166,13 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 					$this->arguments['query'][] = $all_events[ $type ];
 				}
 			}
-		}// End if().
+		}
 
 		if ( $this->arguments['query'] ) {
 
 			foreach ( $this->arguments['query'] as $i => &$query ) {
 
-				// ensure that each query has a compare operator
+				// Ensure that each query has a compare operator.
 				$query = wp_parse_args(
 					$query,
 					array(
@@ -287,7 +287,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 
 			$sql .= ' )';
 
-		}// End if().
+		}
 
 		return apply_filters( $this->get_filter( 'where' ), $sql, $this );
 

--- a/includes/class.llms.question.manager.php
+++ b/includes/class.llms.question.manager.php
@@ -74,7 +74,6 @@ class LLMS_Question_Manager {
 		if ( 'llms_quiz' === $this->get_parent_type() ) {
 			return $this->parent;
 		}
-		// Llms_question.
 		return $this->parent->get_quiz();
 
 	}

--- a/includes/class.llms.question.manager.php
+++ b/includes/class.llms.question.manager.php
@@ -74,7 +74,7 @@ class LLMS_Question_Manager {
 		if ( 'llms_quiz' === $this->get_parent_type() ) {
 			return $this->parent;
 		}
-		// llms_question
+		// Llms_question.
 		return $this->parent->get_quiz();
 
 	}
@@ -89,7 +89,7 @@ class LLMS_Question_Manager {
 	 */
 	public function create_question( $data = array() ) {
 
-		// ensure the question belongs to this quiz
+		// Ensure the question belongs to this quiz.
 		$data['parent_id'] = $this->get_parent()->get( 'id' );
 
 		$question = new LLMS_Question( 'new', $data );
@@ -117,12 +117,12 @@ class LLMS_Question_Manager {
 			return false;
 		}
 
-		// error
+		// Error.
 		if ( ! wp_delete_post( $id, true ) ) {
 			return false;
 		}
 
-		// deleted
+		// Deleted.
 		return true;
 
 	}
@@ -139,14 +139,14 @@ class LLMS_Question_Manager {
 
 		$question = llms_get_post( $id );
 
-		// not valid question, return false
+		// Not valid question, return false.
 		if ( empty( $question ) || ! is_a( $question, 'LLMS_Question' ) ) {
 			return false;
 		}
 
 		$parent_id = $question->get( 'parent_id' );
 
-		// when parent id is set, only retrieve questions attached to this parent
+		// When parent id is set, only retrieve questions attached to this parent.
 		if ( $parent_id && $parent_id !== $this->get_parent()->get( 'id' ) ) {
 
 			if ( 'llms_question' === $this->get_parent_type() && $this->get_quiz()->get( 'id' ) === $question->get_quiz()->get( 'id' ) ) {
@@ -156,7 +156,7 @@ class LLMS_Question_Manager {
 			return false;
 		}
 
-		// success
+		// Success.
 		return $question;
 
 	}
@@ -214,21 +214,21 @@ class LLMS_Question_Manager {
 	 */
 	public function update_question( $data = array() ) {
 
-		// if there's no ID, we'll add a new question
+		// If there's no ID, we'll add a new question.
 		if ( ! isset( $data['id'] ) ) {
 			return $this->create_question( $data );
 		}
 
-		// get the question
+		// Get the question.
 		$question = $this->get_question( $data['id'] );
 		if ( ! $question ) {
 			return false;
 		}
 
-		// update all submitted data
+		// Update all submitted data.
 		foreach ( $data as $key => $val ) {
 
-			// merge image data into the array
+			// Merge image data into the array.
 			if ( 'image' === $key ) {
 				$val = array_merge(
 					array(
@@ -244,7 +244,7 @@ class LLMS_Question_Manager {
 			$question->set( $key, $val );
 		}
 
-		// return question ID
+		// Return question ID.
 		return $question->get( 'id' );
 
 	}

--- a/includes/class.llms.review.php
+++ b/includes/class.llms.review.php
@@ -140,7 +140,7 @@ class LLMS_Reviews {
 				</div>
 				<?php
 			}
-		}// End if().
+		}
 	}
 
 	/**
@@ -155,7 +155,7 @@ class LLMS_Reviews {
 
 		$post = array(
 			'post_content' => llms_filter_input( INPUT_POST, 'review_text', FILTER_SANITIZE_STRING ), // The full text of the post.
-			'post_name'    => llms_filter_input( INPUT_POST, 'review_title', FILTER_SANITIZE_STRING ), // The name (slug) for your post
+			'post_name'    => llms_filter_input( INPUT_POST, 'review_title', FILTER_SANITIZE_STRING ), // The name (slug) for your post.
 			'post_title'   => llms_filter_input( INPUT_POST, 'review_title', FILTER_SANITIZE_STRING ), // The title of your post.
 			'post_status'  => 'publish',
 			'post_type'    => 'llms_review',

--- a/includes/class.llms.roles.php
+++ b/includes/class.llms.roles.php
@@ -126,7 +126,7 @@ class LLMS_Roles {
 
 		$caps = array();
 
-		// students get nothing
+		// Students get nothing.
 		if ( 'student' !== $role ) {
 
 			$post_types = array(
@@ -140,7 +140,7 @@ class LLMS_Roles {
 
 				$post_caps = LLMS_Post_Types::get_post_type_caps( $names );
 
-				// filter the caps down for these roles
+				// Filter the caps down for these roles.
 				if ( in_array( $role, array( 'instructor', 'instructors_assistant' ) ) ) {
 
 					$allowed = array(
@@ -170,7 +170,7 @@ class LLMS_Roles {
 
 				$caps[ $post_type ] = array_fill_keys( array_values( $post_caps ), true );
 
-			}// End foreach().
+			}
 
 			$taxes = array(
 				'course_cat'        => 'course_cat',
@@ -184,7 +184,7 @@ class LLMS_Roles {
 
 				$tax_caps = LLMS_Post_Types::get_tax_caps( $names );
 
-				// filter the caps down for these roles
+				// Filter the caps down for these roles.
 				if ( in_array( $role, array( 'instructor', 'instructors_assistant' ) ) ) {
 
 					$allowed = array(
@@ -202,7 +202,7 @@ class LLMS_Roles {
 				$caps[ $tax ] = array_fill_keys( array_values( $tax_caps ), true );
 
 			}
-		}// End if().
+		}
 
 		return apply_filters( 'llms_get_' . $role . '_post_type_caps', $caps );
 
@@ -235,9 +235,12 @@ class LLMS_Roles {
 					'read'          => true,
 					'upload_files'  => true,
 
-					// see WP Core issue(s)
-					// https://core.trac.wordpress.org/ticket/22895
-					// https://core.trac.wordpress.org/ticket/16808
+					/**
+					 * See WP Core issue(s)
+					 *
+					 * @link https://core.trac.wordpress.org/ticket/22895
+					 * @link https://core.trac.wordpress.org/ticket/16808
+					 */
 					'edit_posts'    => true,
 				);
 
@@ -248,9 +251,12 @@ class LLMS_Roles {
 					'read'         => true,
 					'upload_files' => true,
 
-					// see WP Core issue(s)
-					// https://core.trac.wordpress.org/ticket/22895
-					// https://core.trac.wordpress.org/ticket/16808
+					/**
+					 * See WP Core issue(s)
+					 *
+					 * @link https://core.trac.wordpress.org/ticket/22895
+					 * @link https://core.trac.wordpress.org/ticket/16808
+					 */
 					'edit_posts'   => true,
 				);
 
@@ -297,7 +303,7 @@ class LLMS_Roles {
 			default:
 				$add = array();
 
-		}// End switch().
+		}
 
 		return apply_filters( 'llms_get_' . $role . '_wp_caps', array_merge( $add, $caps ) );
 
@@ -341,8 +347,6 @@ class LLMS_Roles {
 			return;
 		}
 
-		// self::remove_roles(); // @todo remove, this is here for dev reasons only
-
 		$roles                  = self::get_roles();
 		$roles['administrator'] = __( 'Administrator', 'lifterlms' );
 
@@ -377,12 +381,12 @@ class LLMS_Roles {
 
 		$wp_roles = wp_roles();
 
-		// delete all our custom roles
+		// Delete all our custom roles.
 		foreach ( array_keys( self::get_roles() ) as $role ) {
 			$wp_roles->remove_role( $role );
 		}
 
-		// remove custom caps from the WP core admin role
+		// Remove custom caps from the WP core admin role.
 		self::update_caps( $wp_roles->get_role( 'administrator' ), 'remove' );
 
 	}

--- a/includes/class.llms.sidebars.php
+++ b/includes/class.llms.sidebars.php
@@ -24,13 +24,13 @@ class LLMS_Sidebars {
 	 */
 	public static function init() {
 
-		// replaces sidebars with course & lesson sidebars
+		// Replaces sidebars with course & lesson sidebars.
 		add_filter( 'sidebars_widgets', array( __CLASS__, 'replace_default_sidebars' ) );
 
-		// registers llms core sidebars
+		// Registers llms core sidebars.
 		add_action( 'widgets_init', array( __CLASS__, 'register_sidebars' ), 5 );
 
-		// custom actions for genesis
+		// Custom actions for genesis.
 		add_action( 'genesis_init', array( __CLASS__, 'genesis_support' ) );
 
 	}
@@ -115,16 +115,16 @@ class LLMS_Sidebars {
 	 */
 	public static function genesis_support() {
 
-		// remove default registration in favor of genesis registration methods
+		// Remove default registration in favor of genesis registration methods.
 		remove_action( 'widgets_init', array( __CLASS__, 'register_sidebars' ), 5 );
 
-		// add genesis registration method
+		// Add genesis registration method.
 		add_action( 'widgets_init', array( __CLASS__, 'genesis_register_sidebars' ), 5 );
 
-		// replace primary genesis sidebar with our course / lesson sidebar
+		// Replace primary genesis sidebar with our course / lesson sidebar.
 		add_action( 'genesis_before_sidebar_widget_area', array( __CLASS__, 'genesis_do_sidebar' ) );
 
-		// genesis uses it's own reg method so we can send an empty array of settings
+		// Genesis uses it's own reg method so we can send an empty array of settings.
 		add_filter( 'llms_sidebar_settings', '__return_empty_array' );
 
 	}

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -80,7 +80,7 @@ class LLMS_Site {
 
 		$url = get_option( 'llms_site_url' );
 
-		// remove the lock string before returning it
+		// Remove the lock string before returning it.
 		$url = str_replace( self::$lock_string, '', $url );
 
 		$url = set_url_scheme( $url );

--- a/includes/class.llms.student.dashboard.php
+++ b/includes/class.llms.student.dashboard.php
@@ -82,9 +82,9 @@ class LLMS_Student_Dashboard {
 	 */
 	private static function get_courses( $limit = 10, $skip = 0 ) {
 
-		// get sorting option
+		// Get sorting option.
 		$option = get_option( 'lifterlms_myaccount_courses_in_progress_sorting', 'date,DESC' );
-		// parse to order & orderby
+		// Parse to order & orderby.
 		$option  = explode( ',', $option );
 		$orderby = ! empty( $option[0] ) ? $option[0] : 'date';
 		$order   = ! empty( $option[1] ) ? $option[1] : 'DESC';
@@ -114,7 +114,7 @@ class LLMS_Student_Dashboard {
 
 		global $wp;
 
-		// set default tab
+		// Set default tab.
 		$current_tab = apply_filters( 'llms_student_dashboard_default_tab', 'dashboard' );
 
 		$tabs = self::get_tabs();
@@ -314,11 +314,7 @@ class LLMS_Student_Dashboard {
 	}
 
 	public function modify_rewrite_rules_order( $rules ) {
-
-		// var_dump( $rules );
-
 		return $rules;
-
 	}
 
 	/**
@@ -354,7 +350,7 @@ class LLMS_Student_Dashboard {
 
 			$order = new LLMS_Order( $wp->query_vars['orders'] );
 
-			// ensure people can't locate other peoples orders by dropping numbers into the url bar
+			// Ensure people can't locate other peoples orders by dropping numbers into the url bar.
 			if ( get_current_user_id() !== $order->get( 'user_id' ) ) {
 				$order        = false;
 				$transactions = array();

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -97,30 +97,30 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		$statuses = $this->arguments['statuses'];
 
-		// allow strings to be submitted when only requesting one status
+		// Allow strings to be submitted when only requesting one status.
 		if ( is_string( $statuses ) ) {
 			$statuses = array( $statuses );
 		}
 
-		// ensure only valid statuses are used
+		// Ensure only valid statuses are used.
 		$statuses = array_intersect( $statuses, array_keys( llms_get_enrollment_statuses() ) );
 
-		// no statuses should return original default
+		// No statuses should return original default.
 		if ( ! $statuses ) {
 			$statuses = array_keys( llms_get_enrollment_statuses() );
 		}
 
 		$this->arguments['statuses'] = $statuses;
 
-		// allow numeric strings & ints to be passed instead of an array
+		// Allow numeric strings & ints to be passed instead of an array.
 		$post_ids = $this->arguments['post_id'];
 		if ( ! is_array( $post_ids ) && is_numeric( $post_ids ) && $post_ids > 0 ) {
 			$post_ids = array( $post_ids );
 		}
 
 		foreach ( $post_ids as $key => &$id ) {
-			$id = absint( $id ); // verify we have ints
-			if ( $id <= 0 ) { // remove anything negative or 0
+			$id = absint( $id ); // Verify we have ints.
+			if ( $id <= 0 ) { // Remove anything negative or 0.
 				unset( $post_ids[ $key ] );
 			}
 		}
@@ -179,7 +179,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 */
 	private function requires_field( $field ) {
 
-		// get the fields we're sorting by to see if we need to select them for the sorting
+		// Get the fields we're sorting by to see if we need to select them for the sorting.
 		$sort_fields = array_keys( $this->get( 'sort' ) );
 
 		if ( in_array( $field, $sort_fields ) ) {
@@ -238,7 +238,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			'overall_grade'    => "JOIN {$wpdb->usermeta} AS m_o_g ON u.ID = m_o_g.user_id AND m_o_g.meta_key = 'llms_overall_grade'",
 		);
 
-		// add the fields to the array of fields to select
+		// Add the fields to the array of fields to select.
 		foreach ( $fields as $key => $statment ) {
 			if ( $this->requires_field( $key ) ) {
 				$joins[] = $statment;
@@ -296,13 +296,13 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		$selects = array();
 
-		// always select the ID
+		// Always select the ID.
 		$selects[] = 'u.ID as id';
 
-		// always add the subqueries for enrollment status
+		// Always add the subqueries for enrollment status.
 		$selects[] = "( {$this->sql_subquery( 'meta_value' )} ) AS status";
 
-		// all the possible fields
+		// All the possible fields.
 		$fields = array(
 			'date'             => "( {$this->sql_subquery( 'updated_date' )} ) AS `date`",
 			'last_name'        => 'm_last.meta_value AS last_name',
@@ -313,7 +313,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			'overall_grade'    => 'CAST( m_o_g.meta_value AS decimal( 5, 2 ) ) AS overall_grade',
 		);
 
-		// add the fields to the array of fields to select
+		// Add the fields to the array of fields to select.
 		foreach ( $fields as $key => $statment ) {
 			if ( $this->requires_field( $key ) ) {
 				$selects[] = $statment;

--- a/includes/class.llms.track.php
+++ b/includes/class.llms.track.php
@@ -64,12 +64,11 @@ class LLMS_Track {
 	 */
 	public function get_courses() {
 
-		// no posts in the term, return an empty array
+		// No posts in the term, return an empty array.
 		if ( 0 === $this->term->count ) {
 			return array();
 		}
 
-		// get posts
 		$q = new WP_Query(
 			array(
 				'post_status'    => 'publish',
@@ -86,7 +85,6 @@ class LLMS_Track {
 			)
 		);
 
-		// return posts
 		if ( $q->have_posts() ) {
 			return $q->posts;
 		} else {

--- a/includes/class.llms.tracker.php
+++ b/includes/class.llms.tracker.php
@@ -55,28 +55,27 @@ class LLMS_Tracker {
 	 */
 	public static function send_data( $force = false ) {
 
-		// don't trigger during AJAX Requests
+		// Don't trigger during AJAX Requests.
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
 		}
 
-		// allow forcing of the send despite the interval
+		// Allow forcing of the send despite the interval.
 		if ( ! $force && ! apply_filters( 'llms_tracker_force_send', false ) ) {
 
-			// only send data once a week
+			// Only send data once a week.
 			$last_send = self::get_last_send_time();
 			if ( $last_send && $last_send > apply_filters( 'llms_tracker_send_interval', strtotime( '-1 week' ) ) ) {
 				return;
 			}
 		}
 
-		// record a last send time
+		// Record a last send time.
 		update_option( 'llms_tracker_last_send_time', time() );
 
 		$r = wp_remote_post(
 			self::API_URL,
 			array(
-				// 'sslverify'   => false,
 				'body'        => array(
 					'data' => json_encode( LLMS_Data::get_data( 'tracker' ) ),
 				),

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -82,7 +82,7 @@ class LLMS_User_Permissions {
 	 *
 	 * @param bool[]   $allcaps Array of key/value pairs where keys represent a capability name and boolean values
 	 *                          represent whether the user has that capability.
-	 * @param string[] $caps    Required primitive capabilities for the requested capability.
+	 * @param string[] $cap     Required primitive capabilities for the requested capability.
 	 * @param array    $args {
 	 *     Arguments that accompany the requested capability check.
 	 *

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -198,7 +198,7 @@ class LLMS_View_Manager {
 			return 'self';
 		}
 
-		// Ensure it's a valid view
+		// Ensure it's a valid view.
 		$views = $this->get_views();
 		if ( ! isset( $views[ $_GET['llms-view-as'] ] ) ) {
 			return 'self';
@@ -350,7 +350,7 @@ class LLMS_View_Manager {
 	 */
 	public function scripts() {
 
-		// If it's self we don't need anything fancy going on here
+		// If it's self we don't need anything fancy going on here.
 		if ( 'self' === $this->get_view() ) {
 			return;
 		}

--- a/includes/class.llms.voucher.php
+++ b/includes/class.llms.voucher.php
@@ -337,7 +337,7 @@ class LLMS_Voucher {
 
 				do_action( 'llms_voucher_used', $voucher->id, $user_id, $voucher->code );
 
-				// se voucher code.
+				// Use voucher code.
 				$data = array(
 					'user_id' => $user_id,
 					'code_id' => $voucher->id,

--- a/includes/class.llms.voucher.php
+++ b/includes/class.llms.voucher.php
@@ -337,7 +337,7 @@ class LLMS_Voucher {
 
 				do_action( 'llms_voucher_used', $voucher->id, $user_id, $voucher->code );
 
-				// use voucher code
+				// se voucher code.
 				$data = array(
 					'user_id' => $user_id,
 					'code_id' => $voucher->id,

--- a/includes/controllers/class.llms.controller.achievements.php
+++ b/includes/controllers/class.llms.controller.achievements.php
@@ -21,14 +21,12 @@ class LLMS_Controller_Achievements {
 	/**
 	 * Constructor
 	 *
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
-
 		add_action( 'init', array( $this, 'maybe_handle_reporting_actions' ) );
-
 	}
 
 	/**
@@ -54,10 +52,10 @@ class LLMS_Controller_Achievements {
 	/**
 	 * Delete a cert
 	 *
-	 * @param    int $cert_id  WP Post ID of the llms_my_certificate
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 *
+	 * @param int $cert_id WP Post ID of the llms_my_certificate.
+	 * @return void
 	 */
 	private function delete( $cert_id ) {
 

--- a/includes/controllers/class.llms.controller.admin.quiz.attempts.php
+++ b/includes/controllers/class.llms.controller.admin.quiz.attempts.php
@@ -105,13 +105,13 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 			}
 		}
 
-		// update the attempt with new questions
+		// Update the attempt with new questions.
 		$attempt->set_questions( $questions, true );
 
-		// attempt to calculate the grade
+		// Attempt to calculate the grade.
 		$attempt->calculate_grade()->save();
 
-		// if all questions were graded the grade will have been calculated and we can trigger completion actions
+		// If all questions were graded the grade will have been calculated and we can trigger completion actions.
 		if ( in_array( $attempt->get( 'status' ), array( 'fail', 'pass' ) ) ) {
 			$attempt->do_completion_actions();
 		}

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -55,7 +55,7 @@ class LLMS_Controller_Certificates {
 			$auth = llms_filter_input( INPUT_GET, '_llms_cert_auth', FILTER_SANITIZE_STRING );
 
 			global $wpdb;
-			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_llms_auth_nonce' AND meta_value = %s", $auth ) ); // db call ok; no-cache ok
+			$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = '_llms_auth_nonce' AND meta_value = %s", $auth ) ); // db call ok; no-cache ok.
 			if ( $post_id && 'llms_certificate' === get_post_type( $post_id ) ) {
 				$post_type_args['publicly_queryable'] = true;
 			}
@@ -155,7 +155,7 @@ class LLMS_Controller_Certificates {
 
 		$filepath = LLMS()->certificates()->get_export( $cert_id );
 		if ( is_wp_error( $filepath ) ) {
-			// @todo need to handle errors differently on admin panel
+			// @todo Need to handle errors differently on admin panel.
 			return llms_add_notice( $filepath->get_error_message(), 'error' );
 		}
 
@@ -165,7 +165,7 @@ class LLMS_Controller_Certificates {
 
 		readfile( $filepath );
 
-		// delete file after download
+		// Delete file after download.
 		ignore_user_abort( true );
 		wp_delete_file( $filepath );
 		exit;

--- a/includes/controllers/class.llms.controller.lesson.progression.php
+++ b/includes/controllers/class.llms.controller.lesson.progression.php
@@ -5,21 +5,25 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.17.1
- * @version  3.29.0
+ * @version 3.29.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Controller_Lesson_Progression class.
+ * LLMS_Controller_Lesson_Progression class
+ *
+ * @since 3.17.1
  */
 class LLMS_Controller_Lesson_Progression {
 
 	/**
 	 * Constructor
 	 *
-	 * @since    3.17.1
-	 * @version  3.29.0
+	 * @since 3.17.1
+	 * @since 3.29.0 Unknown
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -38,10 +42,10 @@ class LLMS_Controller_Lesson_Progression {
 	/**
 	 * Retrieve a lesson ID from form data for the mark complete / incomplete forms
 	 *
-	 * @param   string $action form action, either "complete" or "incomplete".
-	 * @return  int|null  NULL when either required post fields are missing or if the lesson_id is non-numeric, int (lesson id) on success
-	 * @since   3.29.0
-	 * @version 3.29.0
+	 * @since 3.29.0
+	 *
+	 * @param tring $action Form action, either "complete" or "incomplete".
+	 * @return int|null Returns `null` when either required post fields are missing or if the lesson_id is non-numeric, int (lesson id) on success.
 	 */
 	private function get_lesson_id_from_form_data( $action ) {
 
@@ -52,7 +56,7 @@ class LLMS_Controller_Lesson_Progression {
 		$submitted = llms_filter_input( INPUT_POST, 'mark_' . $action );
 		$lesson_id = llms_filter_input( INPUT_POST, 'mark-' . $action );
 
-		// required fields.
+		// Required fields.
 		if ( is_null( $submitted ) || is_null( $lesson_id ) ) {
 			return null;
 		}
@@ -74,9 +78,9 @@ class LLMS_Controller_Lesson_Progression {
 	/**
 	 * Handle form submission from the Student -> Courses -> Course table where admins can toggle completion of lessons for a student.
 	 *
-	 * @return  void
-	 * @since   3.29.0
-	 * @version 3.29.0
+	 * @since 3.29.0
+	 *
+	 * @return void
 	 */
 	public function handle_admin_managment_forms() {
 
@@ -105,13 +109,15 @@ class LLMS_Controller_Lesson_Progression {
 
 	/**
 	 * Mark Lesson as complete
-	 * Complete Lesson form post
-	 * Marks lesson as complete and returns completion message to user
-	 * Autoadvances to next lesson if completion is successful
 	 *
-	 * @return   void
-	 * @since    3.17.1
-	 * @version  3.29.0
+	 * + Complete Lesson form post.
+	 * + Marks lesson as complete and returns completion message to user.
+	 * + Autoadvances to next lesson if completion is successful.
+	 *
+	 * @since 3.17.1
+	 * @since 3.29.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function handle_complete_form() {
 
@@ -139,12 +145,14 @@ class LLMS_Controller_Lesson_Progression {
 
 	/**
 	 * Mark Lesson as incomplete
-	 * Incomplete Lesson form post
-	 * Marks lesson as incomplete and returns incompletion message to user
 	 *
-	 * @return   void
-	 * @since    3.17.1
-	 * @version  3.29.0
+	 * + Incomplete Lesson form post.
+	 * + Marks lesson as incomplete and returns incompletion message to user.
+	 *
+	 * @since 3.17.1
+	 * @since 3.29.0 Unknown.
+	 *
+	 * @return void
 	 */
 	public function handle_incomplete_form() {
 
@@ -165,13 +173,14 @@ class LLMS_Controller_Lesson_Progression {
 	/**
 	 * Handle completion of lesson via `llms_trigger_lesson_completion` action
 	 *
-	 * @param    int    $user_id    User ID
-	 * @param    int    $lesson_id  Lesson ID
-	 * @param    string $trigger    Optional trigger description string
-	 * @param    array  $args       Optional arguments
-	 * @return   void
-	 * @since    3.17.1
-	 * @version  3.29.0
+	 * @since 3.17.1
+	 * @since 3.29.0 Unknown.
+	 *
+	 * @param int    $user_id   User ID.
+	 * @param int    $lesson_id Lesson ID.
+	 * @param string $trigger   Optional trigger description string.
+	 * @param array  $args      Optional arguments.
+	 * @return void
 	 */
 	public function mark_complete( $user_id, $lesson_id, $trigger = '', $args = array() ) {
 
@@ -186,12 +195,12 @@ class LLMS_Controller_Lesson_Progression {
 	/**
 	 * Trigger lesson completion when a quiz is completed
 	 *
-	 * @param    int $student_id  WP User ID
-	 * @param    int $quiz_id     WP Post ID of the quiz
-	 * @param    obj $attempt     Instance of the LLMS_Quiz_Attempt
-	 * @return   void
-	 * @since    3.17.1
-	 * @version  3.17.1
+	 * @since 3.17.1
+	 *
+	 * @param int $student_id WP User ID.
+	 * @param int $quiz_id    WP Post ID of the quiz.
+	 * @param obj $attempt    Instance of the LLMS_Quiz_Attempt.
+	 * @return void
 	 */
 	public function quiz_complete( $student_id, $quiz_id, $attempt ) {
 
@@ -210,19 +219,18 @@ class LLMS_Controller_Lesson_Progression {
 	/**
 	 * Before a lesson is marked as complete, check if all the lesson's quiz requirements are met
 	 *
-	 * @filter   llms_allow_lesson_completion
-	 * @param    bool   $allow_completion  whether or not to allow completion (true by default, false if something else has already prevented)
-	 * @param    int    $user_id           WP User ID of the student completing the lesson
-	 * @param    int    $lesson_id         WP Post ID of the lesson to be completed
-	 * @param    string $trigger           text string to record the reason why the lesson is being completed
-	 * @param    array  $args              optional additional arguments from the triggering function
-	 * @return   bool
-	 * @since    3.17.1
-	 * @version  3.17.1
+	 * @since 3.17.1
+	 *
+	 * @param bool   $allow_completion Whether or not to allow completion (true by default, false if something else has already prevented).
+	 * @param int    $user_id          WP User ID of the student completing the lesson.
+	 * @param int    $lesson_id        WP Post ID of the lesson to be completed.
+	 * @param string $trigger          Text string to record the reason why the lesson is being completed.
+	 * @param array  $args             Optional additional arguments from the triggering function.
+	 * @return bool
 	 */
 	public function quiz_maybe_prevent_lesson_completion( $allow_completion, $user_id, $lesson_id, $trigger, $args ) {
 
-		// if allow completion is already false, we don't need to run any quiz checks
+		// If allow completion is already false, we don't need to run any quiz checks.
 		if ( ! $allow_completion ) {
 			return $allow_completion;
 		}
@@ -230,10 +238,10 @@ class LLMS_Controller_Lesson_Progression {
 		$lesson           = llms_get_post( $lesson_id );
 		$passing_required = llms_parse_bool( $lesson->get( 'require_passing_grade' ) );
 
-		// if the lesson is being completed by a quiz
+		// If the lesson is being completed by a quiz.
 		if ( 0 === strpos( $trigger, 'quiz_' ) ) {
 
-			// passing is required AND the attempt was a failure
+			// Passing is required AND the attempt was a failure.
 			if ( $passing_required && ! $args['attempt']->is_passing() ) {
 				$allow_completion = false;
 			}
@@ -243,12 +251,12 @@ class LLMS_Controller_Lesson_Progression {
 			$student = llms_get_student( $user_id );
 			$attempt = $student->quizzes()->get_best_attempt( $quiz_id );
 
-			// passing is not required but there's not attempts yet
-			// at least one attempt (passing or otherwise) is required!
+			// Passing is not required but there's not attempts yet.
+			// At least one attempt (passing or otherwise) is required!.
 			if ( ! $passing_required && ! $attempt ) {
 				$allow_completion = false;
 
-				// passing is required and there's no attempts or the best attempt is not passing
+				// Passing is required and there's no attempts or the best attempt is not passing.
 			} elseif ( $passing_required && ( ! $attempt || ! $attempt->is_passing() ) ) {
 				$allow_completion = false;
 			}

--- a/includes/controllers/class.llms.controller.quizzes.php
+++ b/includes/controllers/class.llms.controller.quizzes.php
@@ -66,18 +66,18 @@ class LLMS_Controller_Quizzes {
 	 * Handle form submission of the "take quiz" button attached to lessons with quizzes
 	 *
 	 * @since 1.0.0
-	 * @since 3.9.0 Unkown.
+	 * @since 3.9.0 Unknown.
 	 *
 	 * @return void
 	 */
 	public function take_quiz() {
 
-		// invalid nonce or the form wasn't submitted
+		// Invalid nonce or the form wasn't submitted.
 		if ( ! llms_verify_nonce( '_llms_take_quiz_nonce', 'take_quiz', 'POST' ) ) {
 			return;
 		}
 
-		// check required fields
+		// Check required fields.
 		if ( ! isset( $_POST['quiz_id'] ) || ! isset( $_POST['associated_lesson'] ) ) {
 			return llms_add_notice( __( 'Could not proceed to the quiz because required information was missing.', 'lifterlms' ), 'error' );
 		}
@@ -91,7 +91,7 @@ class LLMS_Controller_Quizzes {
 			return llms_add_notice( $exception->getMessage(), 'error' );
 		}
 
-		// redirect user to quiz page
+		// Redirect user to quiz page.
 		$redirect = add_query_arg(
 			array(
 				'attempt_key' => $attempt->get_key(),

--- a/includes/emails/class.llms.email.php
+++ b/includes/emails/class.llms.email.php
@@ -313,7 +313,7 @@ class LLMS_Email {
 		$temp = null;
 
 		// Override the $post global with the email post content (if it exists)..
-		// This fixes Elementor / WC conflict outlined at https://github.com/gocodebox/lifterlms/issues/730..
+		// This fixes Elementor / WC conflict outlined at https://github.com/gocodebox/lifterlms/issues/730.
 		if ( isset( $this->email_post ) ) {
 			$temp = $post;
 			$post = $this->email_post;

--- a/includes/emails/class.llms.email.php
+++ b/includes/emails/class.llms.email.php
@@ -312,7 +312,7 @@ class LLMS_Email {
 		global $post;
 		$temp = null;
 
-		// Override the $post global with the email post content (if it exists)..
+		// Override the $post global with the email post content (if it exists).
 		// This fixes Elementor / WC conflict outlined at https://github.com/gocodebox/lifterlms/issues/730.
 		if ( isset( $this->email_post ) ) {
 			$temp = $post;
@@ -330,7 +330,7 @@ class LLMS_Email {
 
 		$html = apply_filters( 'llms_email_content_get_content_html', ob_get_clean(), $this );
 
-		// Restore the default $post global..
+		// Restore the default $post global.
 		if ( $temp ) {
 			$post = $temp;
 		}

--- a/includes/emails/class.llms.email.php
+++ b/includes/emails/class.llms.email.php
@@ -187,7 +187,7 @@ class LLMS_Email {
 	 */
 	public function add_recipient( $address, $type = 'to', $name = '' ) {
 
-		// if an ID was supplied, get the information from the student object
+		// If an ID was supplied, get the information from the student object.
 		if ( is_numeric( $address ) ) {
 			$student = llms_get_student( $address );
 			if ( ! $student ) {
@@ -197,12 +197,12 @@ class LLMS_Email {
 			$name    = $student->get_name();
 		}
 
-		// ensure address is a valid email
+		// Ensure address is a valid email.
 		if ( ! filter_var( $address, FILTER_VALIDATE_EMAIL ) ) {
 			return false;
 		}
 
-		// if a name is supplied format the name & address
+		// If a name is supplied format the name & address.
 		if ( $name ) {
 			$address = sprintf( '%1$s <%2$s>', $name, $address );
 		}
@@ -312,8 +312,8 @@ class LLMS_Email {
 		global $post;
 		$temp = null;
 
-		// Override the $post global with the email post content (if it exists).
-		// This fixes Elementor / WC conflict outlined at https://github.com/gocodebox/lifterlms/issues/730.
+		// Override the $post global with the email post content (if it exists)..
+		// This fixes Elementor / WC conflict outlined at https://github.com/gocodebox/lifterlms/issues/730..
 		if ( isset( $this->email_post ) ) {
 			$temp = $post;
 			$post = $this->email_post;
@@ -330,7 +330,7 @@ class LLMS_Email {
 
 		$html = apply_filters( 'llms_email_content_get_content_html', ob_get_clean(), $this );
 
-		// Restore the default $post global.
+		// Restore the default $post global..
 		if ( $temp ) {
 			$post = $temp;
 		}
@@ -472,7 +472,7 @@ class LLMS_Email {
 	/**
 	 * set the subject for the email
 	 *
-	 * @param    string $content_type text string to use for the email subject.
+	 * @param    string $subject Text string to use for the email subject.
 	 * @return   $this
 	 * @since    3.8.0
 	 * @version  3.24.0

--- a/includes/functions/llms-functions-options.php
+++ b/includes/functions/llms-functions-options.php
@@ -12,12 +12,15 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Retrieve a "secure" option.
+ *
  * Checks environment variables and then constant definitions
  *
- * @param   string $name Name of the variable.
- * @return  mixed
- * @since   3.29.0
- * @version 3.29.0
+ * @since 3.29.0
+ *
+ * @param string $secure_name Name of the option variable / constant.
+ * @param mixed  $default     Optional default value used as a fallback.
+ * @param string $db_name     Optional option name to fallback on if no constant or environment var is found.
+ * @return mixed
  */
 function llms_get_secure_option( $secure_name, $default = false, $db_name = '' ) {
 

--- a/includes/functions/llms.functions.course.php
+++ b/includes/functions/llms.functions.course.php
@@ -4,7 +4,7 @@
  *
  * @package LifterLMS/Functions
  *
- * @since unknown
+ * @since Unknown
  * @version 3.37.13
  */
 
@@ -37,7 +37,7 @@ function get_course( $the_course = false, $args = array() ) {
  * @since Unknown
  * @since 3.37.13 Use `LLMS_Lesson` in favor of the deprecated `LLMS_Course_Factory::get_lesson()` method.
  *
- * @param WP_Post|int|false $the_product Lesson post object or id. If `false` uses the global `$post` object.
+ * @param WP_Post|int|false $the_lesson Lesson post object or id. If `false` uses the global `$post` object.
  * @param array             $args        Arguments to pass to the LLMS_Lesson Constructor.
  * @return LLMS_Product
  */

--- a/includes/functions/llms.functions.person.php
+++ b/includes/functions/llms.functions.person.php
@@ -305,7 +305,7 @@ function llms_register_user( $data = array(), $screen = 'registration', $signon 
  * @since  3.0.0 Use `wp_set_current_user()` rather than overriding the global manually.
  * @since  3.36.0 Pass the `$remember` param to `wp_set_auth_cookie()`
  *
- * @param  int  $person_id WP_User ID.
+ * @param  int  $user_id  WP_User ID.
  * @param  bool $remember Whether to remember the user.
  * @return void
  */

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -149,7 +149,7 @@ function llms_cleanup_tmp() {
 
 	foreach ( glob( LLMS_TMP_DIR . '*' ) as $file ) {
 
-		// Dont cleanup index and .htaccess.
+		// Don't cleanup index and .htaccess.
 		if ( in_array( basename( $file ), $exclude ) ) {
 			continue;
 		}
@@ -646,7 +646,7 @@ function llms_form_field( $field = array(), $echo = true ) {
 	 */
 	$field = apply_filters( 'llms_form_field_args', $field );
 
-	// Setup the field value (if one exists)..
+	// Setup the field value (if one exists).
 	if ( '' !== $field['value'] ) {
 		$field['value'] = $field['value'];
 	} elseif ( '' !== $field['default'] ) {
@@ -654,7 +654,7 @@ function llms_form_field( $field = array(), $echo = true ) {
 	}
 	$value_attr = ( '' !== $field['value'] ) ? ' value="' . esc_attr( $field['value'] ) . '"' : '';
 
-	// Use id as the name if name isn't specified..
+	// Use id as the name if name isn't specified.
 	$field['name'] = ( '' === $field['name'] ) ? $field['id'] : $field['name'];
 
 	/**
@@ -666,35 +666,35 @@ function llms_form_field( $field = array(), $echo = true ) {
 
 	$field['placeholder'] = wp_strip_all_tags( $field['placeholder'] );
 
-	// Add inline css if set..
+	// Add inline css if set.
 	$field['style'] = ( $field['style'] ) ? ' style="' . $field['style'] . '"' : '';
 
-	// Add space to classes..
+	// Add space to classes.
 	$field['wrapper_classes'] = ( $field['wrapper_classes'] ) ? ' ' . $field['wrapper_classes'] : '';
 	$field['classes']         = ( $field['classes'] ) ? ' ' . $field['classes'] : '';
 
-	// Add column information to the wrapper..
+	// Add column information to the wrapper.
 	$field['wrapper_classes'] .= ' llms-cols-' . $field['columns'];
 	$field['wrapper_classes'] .= ( $field['last_column'] ) ? ' llms-cols-last' : '';
 
 	$desc = $field['description'] ? '<span class="llms-description">' . $field['description'] . '</span>' : '';
 
-	// Required attributes and content..
+	// Required attributes and content.
 	$required_char = apply_filters( 'lifterlms_form_field_required_character', '*', $field );
 	$required_span = $field['required'] ? ' <span class="llms-required">' . $required_char . '</span>' : '';
 	$required_attr = $field['required'] ? ' required="required"' : '';
 
-	// Setup the label..
+	// Setup the label.
 	$label = $field['label'] ? '<label for="' . $field['id'] . '">' . $field['label'] . $required_span . '</label>' : '';
 
-	// Disabled field..
+	// Disabled field.
 	$disabled_attr = ( $field['disabled'] ) ? ' disabled="disabled"' : '';
 
-	// Min & Max values..
+	// Min & Max values.
 	$min_attr = ( $field['min_length'] ) ? ' minlength="' . $field['min_length'] . '"' : '';
 	$max_attr = ( $field['max_length'] ) ? ' maxlength="' . $field['max_length'] . '"' : '';
 
-	// Setup the return value..
+	// Setup the return value.
 	$html = '<div class="llms-form-field type-' . $field['type'] . $field['wrapper_classes'] . '">';
 
 	if ( 'hidden' !== $field['type'] && 'checkbox' !== $field['type'] && 'radio' !== $field['type'] ) {

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -149,7 +149,7 @@ function llms_cleanup_tmp() {
 
 	foreach ( glob( LLMS_TMP_DIR . '*' ) as $file ) {
 
-		// dont cleanup index and .htaccess
+		// Dont cleanup index and .htaccess.
 		if ( in_array( basename( $file ), $exclude ) ) {
 			continue;
 		}
@@ -268,18 +268,18 @@ function llms_get_core_supported_themes() {
  * @version  3.24.0
  */
 function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
-	// If not numeric then convert timestamps
+	// If not numeric then convert timestamps.
 	if ( ! is_numeric( $time1 ) ) {
 		$time1 = strtotime( $time1 );
 	}
 	if ( ! is_numeric( $time2 ) ) {
 		$time2 = strtotime( $time2 );
 	}
-	// If time1 > time2 then swap the 2 values
+	// If time1 > time2 then swap the 2 values.
 	if ( $time1 > $time2 ) {
 		list( $time1, $time2 ) = array( $time2, $time1 );
 	}
-	// Set up intervals and diffs arrays
+	// Set up intervals and diffs arrays.
 	$intervals     = array( 'year', 'month', 'day', 'hour', 'minute', 'second' );
 	$l18n_singular = array(
 		'year'   => __( 'year', 'lifterlms' ),
@@ -299,14 +299,14 @@ function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
 	);
 	$diffs         = array();
 	foreach ( $intervals as $interval ) {
-		// Create temp time from time1 and interval
+		// Create temp time from time1 and interval.
 		$ttime = strtotime( '+1 ' . $interval, $time1 );
-		// Set initial values
+		// Set initial values.
 		$add    = 1;
 		$looped = 0;
-		// Loop until temp time is smaller than time2
+		// Loop until temp time is smaller than time2.
 		while ( $time2 >= $ttime ) {
-			// Create new temp time from time1 and interval
+			// Create new temp time from time1 and interval.
 			$add++;
 			$ttime = strtotime( '+' . $add . ' ' . $interval, $time1 );
 			$looped++;
@@ -317,23 +317,23 @@ function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
 	$count = 0;
 	$times = array();
 	foreach ( $diffs as $interval => $value ) {
-		// Break if we have needed precision
+		// Break if we have needed precision.
 		if ( $count >= $precision ) {
 			break;
 		}
-		// Add value and interval if value is bigger than 0
+		// Add value and interval if value is bigger than 0.
 		if ( $value > 0 ) {
 			if ( 1 != $value ) {
 				$text = $l18n_plural[ $interval ];
 			} else {
 				$text = $l18n_singular[ $interval ];
 			}
-			// Add value and interval to times array
+			// Add value and interval to times array.
 			$times[] = $value . ' ' . $text;
 			$count++;
 		}
 	}
-	// Return string with times
+	// Return string with times.
 	return implode( ', ', $times );
 }
 
@@ -381,7 +381,7 @@ function llms_get_engagement_triggers() {
 			'course_enrollment'      => __( 'Student enrolls in a course', 'lifterlms' ),
 			'course_purchased'       => __( 'Student purchases a course', 'lifterlms' ),
 			'course_completed'       => __( 'Student completes a course', 'lifterlms' ),
-			// 'days_since_login' => __( 'Days since user last logged in', 'lifterlms' ), // @todo
+			// 'days_since_login' => __( 'Days since user last logged in', 'lifterlms' ), // @todo.
 			'lesson_completed'       => __( 'Student completes a lesson', 'lifterlms' ),
 			'quiz_completed'         => __( 'Student completes a quiz', 'lifterlms' ),
 			'quiz_passed'            => __( 'Student passes a quiz', 'lifterlms' ),
@@ -646,7 +646,7 @@ function llms_form_field( $field = array(), $echo = true ) {
 	 */
 	$field = apply_filters( 'llms_form_field_args', $field );
 
-	// Setup the field value (if one exists).
+	// Setup the field value (if one exists)..
 	if ( '' !== $field['value'] ) {
 		$field['value'] = $field['value'];
 	} elseif ( '' !== $field['default'] ) {
@@ -654,7 +654,7 @@ function llms_form_field( $field = array(), $echo = true ) {
 	}
 	$value_attr = ( '' !== $field['value'] ) ? ' value="' . esc_attr( $field['value'] ) . '"' : '';
 
-	// Use id as the name if name isn't specified.
+	// Use id as the name if name isn't specified..
 	$field['name'] = ( '' === $field['name'] ) ? $field['id'] : $field['name'];
 
 	/**
@@ -666,35 +666,35 @@ function llms_form_field( $field = array(), $echo = true ) {
 
 	$field['placeholder'] = wp_strip_all_tags( $field['placeholder'] );
 
-	// Add inline css if set.
+	// Add inline css if set..
 	$field['style'] = ( $field['style'] ) ? ' style="' . $field['style'] . '"' : '';
 
-	// Add space to classes.
+	// Add space to classes..
 	$field['wrapper_classes'] = ( $field['wrapper_classes'] ) ? ' ' . $field['wrapper_classes'] : '';
 	$field['classes']         = ( $field['classes'] ) ? ' ' . $field['classes'] : '';
 
-	// Add column information to the wrapper.
+	// Add column information to the wrapper..
 	$field['wrapper_classes'] .= ' llms-cols-' . $field['columns'];
 	$field['wrapper_classes'] .= ( $field['last_column'] ) ? ' llms-cols-last' : '';
 
 	$desc = $field['description'] ? '<span class="llms-description">' . $field['description'] . '</span>' : '';
 
-	// Required attributes and content.
+	// Required attributes and content..
 	$required_char = apply_filters( 'lifterlms_form_field_required_character', '*', $field );
 	$required_span = $field['required'] ? ' <span class="llms-required">' . $required_char . '</span>' : '';
 	$required_attr = $field['required'] ? ' required="required"' : '';
 
-	// Setup the label.
+	// Setup the label..
 	$label = $field['label'] ? '<label for="' . $field['id'] . '">' . $field['label'] . $required_span . '</label>' : '';
 
-	// Disabled field.
+	// Disabled field..
 	$disabled_attr = ( $field['disabled'] ) ? ' disabled="disabled"' : '';
 
-	// Min & Max values.
+	// Min & Max values..
 	$min_attr = ( $field['min_length'] ) ? ' minlength="' . $field['min_length'] . '"' : '';
 	$max_attr = ( $field['max_length'] ) ? ' maxlength="' . $field['max_length'] . '"' : '';
 
-	// Setup the return value.
+	// Setup the return value..
 	$html = '<div class="llms-form-field type-' . $field['type'] . $field['wrapper_classes'] . '">';
 
 	if ( 'hidden' !== $field['type'] && 'checkbox' !== $field['type'] && 'radio' !== $field['type'] ) {
@@ -795,7 +795,7 @@ function llms_get_enrollment_statuses() {
  */
 function llms_get_enrollment_status_name( $status ) {
 
-	$status   = strtolower( $status ); // backwards compatibility
+	$status   = strtolower( $status ); // Backwards compatibility.
 	$statuses = llms_get_enrollment_statuses();
 	if ( is_array( $statuses ) && isset( $statuses[ $status ] ) ) {
 		$status = $statuses[ $status ];
@@ -816,21 +816,21 @@ function llms_get_ip_address() {
 
 	$ip = '';
 
-	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Look below you.
-	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Look below you.
+	// Phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Look below you..
+	// Phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Look below you..
 
 	if ( isset( $_SERVER['HTTP_X_REAL_IP'] ) ) {
 		$ip = $_SERVER['HTTP_X_REAL_IP'];
 	} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
-		// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2
-		// Make sure we always only send through the first IP in the list which should always be the client IP.
+		// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2.
+		// Make sure we always only send through the first IP in the list which should always be the client IP..
 		$ip = trim( current( explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) );
 	} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 		$ip = $_SERVER['REMOTE_ADDR'];
 	}
 
-	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+	// Phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized.
+	// Phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash.
 
 	$ip = sanitize_text_field( wp_unslash( $ip ) );
 

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -816,21 +816,21 @@ function llms_get_ip_address() {
 
 	$ip = '';
 
-	// Phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Look below you..
-	// Phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Look below you..
+	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Look below you.
+	// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- Look below you.
 
 	if ( isset( $_SERVER['HTTP_X_REAL_IP'] ) ) {
 		$ip = $_SERVER['HTTP_X_REAL_IP'];
 	} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
 		// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2.
-		// Make sure we always only send through the first IP in the list which should always be the client IP..
+		// Make sure we always only send through the first IP in the list which should always be the client IP.
 		$ip = trim( current( explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) );
 	} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 		$ip = $_SERVER['REMOTE_ADDR'];
 	}
 
-	// Phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized.
-	// Phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash.
+	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 
 	$ip = sanitize_text_field( wp_unslash( $ip ) );
 

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -79,12 +79,12 @@ if ( ! function_exists( 'llms_email_header' ) ) {
 function llms_template_redirect() {
 	global $wp_query, $wp;
 
-	// When default permalinks are enabled, redirect shop page to post type archive url
+	// When default permalinks are enabled, redirect shop page to post type archive url.
 	if ( ! empty( $_GET['page_id'] ) && get_option( 'permalink_structure' ) == '' && llms_get_page_id( 'shop' ) == $_GET['page_id'] ) {
 		wp_safe_redirect( get_post_type_archive_link( 'course' ) );
 		exit;
 	}
-	// When default permalinks are enabled, redirect memberships page to post type archive url
+	// When default permalinks are enabled, redirect memberships page to post type archive url.
 	if ( ! empty( $_GET['page_id'] ) && get_option( 'permalink_structure' ) == '' && llms_get_page_id( 'memberships' ) == $_GET['page_id'] ) {
 		wp_safe_redirect( get_post_type_archive_link( 'llms_membership' ) );
 		exit;
@@ -609,7 +609,7 @@ if ( ! function_exists( 'lifterlms_page_title' ) ) {
 		}
 
 	}
-}// End if().
+}// End if()..
 
 /**
  * Outputs the html for a progress bar
@@ -732,7 +732,7 @@ if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 		}
 
 	}
-}// End if().
+}// End if()..
 
 
 
@@ -1129,14 +1129,14 @@ function llms_post_classes( $classes, $class = array(), $post_id = '' ) {
 
 	$post_type = get_post_type( $post_id );
 
-	// add enrolled classes
+	// Add enrolled classes.
 	if ( 'lesson' === $post_type || 'course' === $post_type || 'llms_membership' === $post_type ) {
 
 		$classes[] = llms_is_user_enrolled( get_current_user_id(), $post_id ) ? 'is-enrolled' : 'not-enrolled';
 
 	}
 
-	// add completion classes
+	// Add completion classes.
 	if ( 'lesson' === $post_type || 'course' === $post_type ) {
 
 		if ( get_current_user_id() ) {

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -609,7 +609,7 @@ if ( ! function_exists( 'lifterlms_page_title' ) ) {
 		}
 
 	}
-}// End if()..
+}
 
 /**
  * Outputs the html for a progress bar
@@ -732,7 +732,7 @@ if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 		}
 
 	}
-}// End if()..
+}
 
 
 

--- a/includes/models/model.llms.add-on.php
+++ b/includes/models/model.llms.add-on.php
@@ -207,7 +207,7 @@ class LLMS_Add_On {
 	/**
 	 * Translate strings
 	 *
-	 * @param    string $status  untranslated string / key
+	 * @param    string $string Untranslated string / key.
 	 * @return   string
 	 * @since    3.22.0
 	 * @version  3.22.0

--- a/includes/models/model.llms.instructor.php
+++ b/includes/models/model.llms.instructor.php
@@ -26,7 +26,7 @@ class LLMS_Instructor extends LLMS_Abstract_User_Data {
 	/**
 	 * Add a parent instructor to an assistant instructor
 	 *
-	 * @param    mixed $parent_id  WP User ID of the parent instructor or array of User IDs to add multiple
+	 * @param    mixed $parent_ids WP User ID of the parent instructor or array of User IDs to add multiple
 	 * @return   boolean
 	 * @since    3.13.0
 	 * @version  3.14.4

--- a/includes/models/model.llms.question.php
+++ b/includes/models/model.llms.question.php
@@ -200,8 +200,8 @@ class LLMS_Question extends LLMS_Post_Model {
 	 *
 	 * @since 3.38.2
 	 *
-	 * @param string  $keyThe property key.
-	 * @param boolean $rawOptional. Whether or not we need to get the raw value. Default false.
+	 * @param string  $key The property key.
+	 * @param boolean $raw Optional. Whether or not we need to get the raw value. Default false.
 	 * @return mixed
 	 */
 	public function get( $key, $raw = false ) {
@@ -223,7 +223,7 @@ class LLMS_Question extends LLMS_Post_Model {
 	 * @since 3.16.0
 	 * @since 4.4.0 Use strict comparison.
 	 *
-	 * @param string $id  Choice ID.
+	 * @param string $id Choice ID.
 	 * @return obj|false
 	 */
 	public function get_choice( $id ) {

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1397,7 +1397,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	 *
 	 * @see     llms_is_user_enrolled()
 	 *
-	 * @param   int|array $product_id  WP Post ID of a Course, Section, Lesson, or Membership or array of multiple IDs.
+	 * @param   int|array $product_ids WP Post ID of a Course, Section, Lesson, or Membership or array of multiple IDs.
 	 * @param   string    $relation    Comparator for enrollment check.
 	 *                                     All = user must be enrolled in all $product_ids.
 	 *                                     Any = user must be enrolled in at least one of the $product_ids.

--- a/includes/models/model.llms.student.quizzes.php
+++ b/includes/models/model.llms.student.quizzes.php
@@ -156,14 +156,14 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 			$allowed = $quiz->get( 'allowed_attempts' );
 			$used    = $this->count_attempts_by_quiz( $quiz->get( 'id' ) );
 
-			// ensure undefined, null, '', etc.. show as an int
+			// Ensure undefined, null, '', etc.. show as an int.
 			if ( ! $allowed ) {
 				$allowed = 0;
 			}
 
 			$remaining = ( $allowed - $used );
 
-			// don't show negative attempts
+			// Don't show negative attempts.
 			$ret = max( 0, $remaining );
 
 		}
@@ -253,8 +253,8 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	/**
 	 * Get the last completed attempt for a given quiz or quiz/lesson combination
 	 *
-	 * @param    int $quiz    WP Post ID of a Quiz
-	 * @param    int $lesson  WP Post ID of a Lesson
+	 * @param    int $quiz_id    WP Post ID of a Quiz.
+	 * @param    int $deprecated Deprecated.
 	 * @return   false|obj
 	 * @since    3.9.0
 	 * @version  3.16.0

--- a/includes/notifications/controllers/class.llms.notification.controller.student.welcome.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.student.welcome.php
@@ -58,7 +58,7 @@ class LLMS_Notification_Controller_Student_Welcome extends LLMS_Abstract_Notific
 	 *
 	 * @since 3.8.0
 	 *
-	 * @param int $transaction Instance of a LLMS_Transaction
+	 * @param int $user_id WP_User ID.
 	 * @return void
 	 */
 	public function action_callback( $user_id = null ) {

--- a/includes/privacy/class-llms-privacy-erasers.php
+++ b/includes/privacy/class-llms-privacy-erasers.php
@@ -142,7 +142,7 @@ class LLMS_Privacy_Erasers extends LLMS_Privacy {
 
 		if ( $deleted ) {
 
-			/* Translators: %d = number of notifications */
+			// Translators: %d = number of notifications.
 			$messages[] = sprintf( __( 'Removed %d notifications.', 'lifterlms' ), $deleted );
 
 		}
@@ -162,7 +162,7 @@ class LLMS_Privacy_Erasers extends LLMS_Privacy {
 	 */
 	private static function erase_order_data( $order ) {
 
-		// cancel recurring orders
+		// Cancel recurring orders.
 		if ( $order->is_recurring() && in_array( $order->get( 'status' ), array( 'llms-on-hold', 'llms-active', 'llms-pending-cancel' ) ) ) {
 			$order->set_status( 'cancelled' );
 			$order->add_note( __( 'Order cancelled during personal data erasure.', 'lifterlms' ) );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -87,16 +87,6 @@
 		<exclude-pattern>templates/**/*.php</exclude-pattern>
 	</rule>
 
-	<!--
-		@todo The following rule set is disabled for the following files/directories
-			  We are in the process of gradually fixing these in bulk.
-			  See https://github.com/gocodebox/lifterlms/issues/946
-	-->
-	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
-		<exclude-pattern>templates/*.php</exclude-pattern>
-		<exclude-pattern>templates/**/*.php</exclude-pattern>
-	</rule>
-
 	<rule ref="WordPress.WP.I18n">
 		<!-- @todo: Fix all of these -->
 		<exclude name="WordPress.WP.I18n.MissingTranslatorsComment" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -38,7 +38,6 @@
 		<exclude name="Squiz.Commenting.FunctionComment.MissingParamName" />
 		<exclude name="Squiz.Commenting.VariableComment.Missing" />
 
-		<exclude name="Squiz.Commenting.FunctionComment.ParamNameNoMatch" />
 		<exclude name="Squiz.Commenting.FunctionComment.InvalidReturnVoid" />
 
 		<!-- @todo: Update these to use a prefix, see https://github.com/WordPress/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -93,11 +93,6 @@
 			  See https://github.com/gocodebox/lifterlms/issues/946
 	-->
 	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
-		<exclude-pattern>includes/*.php</exclude-pattern>
-
-		<!-- <include-pattern>includes/achievements/*.php</include-pattern> -->
-		<include-pattern>includes/admin/*.php</include-pattern>
-
 		<exclude-pattern>templates/*.php</exclude-pattern>
 		<exclude-pattern>templates/**/*.php</exclude-pattern>
 	</rule>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -15,7 +15,7 @@
     <!-- Exclude deprecated/legacy files -->
     <exclude-pattern>includes/functions/llms-functions-deprecated.php</exclude-pattern>
 
-	<!-- Don't throw errors for this 3rd party library file -->
+	<!-- Don't throw errors for this 3rd party library -->
 	<rule ref="WordPress.DB.PreparedSQL.InterpolatedNotPrepared">
 		<exclude-pattern>includes/libraries/wp-background-processing/wp-background-process.php</exclude-pattern>
 	</rule>
@@ -84,6 +84,57 @@
 
 		<exclude-pattern>templates/*.php</exclude-pattern>
 		<exclude-pattern>templates/**/*.php</exclude-pattern>
+	</rule>
+
+	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
+		<!-- Permanently excluded library files -->
+		<exclude-pattern>includes/libraries/wp-background-processing/*.php</exclude-pattern>
+
+		<!-- To be fixed -->
+		<exclude-pattern>includes/certificates/class.llms.certificate.user.php</exclude-pattern>
+		<exclude-pattern>includes/emails/class.llms.email.engagement.php</exclude-pattern>
+		<exclude-pattern>includes/forms/controllers/class.llms.controller.login.php</exclude-pattern>
+		<exclude-pattern>includes/forms/controllers/class.llms.controller.registration.php</exclude-pattern>
+		<exclude-pattern>includes/forms/frontend/class.llms.frontend.forms.php</exclude-pattern>
+		<exclude-pattern>includes/forms/frontend/class.llms.frontend.password.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms-functions-access-plans.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.certificate.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.currency.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.log.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.notice.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.order.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.person.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.privacy.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.quiz.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.template.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.templates.achievements.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.templates.certificates.php</exclude-pattern>
+		<exclude-pattern>includes/functions/llms.functions.templates.privacy.php</exclude-pattern>
+		<exclude-pattern>includes/functions/updates/llms-functions-updates-300.php</exclude-pattern>
+		<exclude-pattern>includes/functions/updates/llms-functions-updates-303.php</exclude-pattern>
+		<exclude-pattern>includes/functions/updates/llms-functions-updates-3160.php</exclude-pattern>
+		<exclude-pattern>includes/functions/updates/llms-functions-updates-343.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.access.plan.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.coupon.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.course.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.instructor.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.notification.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.order.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.question.choice.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.quiz.attempt.question.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.section.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.student.php</exclude-pattern>
+		<exclude-pattern>includes/models/model.llms.transaction.php</exclude-pattern>
+		<exclude-pattern>includes/notifications/class.llms.notifications.query.php</exclude-pattern>
+		<exclude-pattern>includes/privacy/class-llms-privacy-exporters.php</exclude-pattern>
+		<exclude-pattern>includes/privacy/class-llms-privacy.php</exclude-pattern>
+		<exclude-pattern>includes/processors/class.llms.processor.course.data.php</exclude-pattern>
+		<exclude-pattern>includes/processors/class.llms.processor.membership.bulk.enroll.php</exclude-pattern>
+		<exclude-pattern>includes/processors/class.llms.processor.table.to.csv.php</exclude-pattern>
+		<exclude-pattern>includes/processors/class.llms.processors.php</exclude-pattern>
+		<exclude-pattern>includes/shortcodes/class.llms.shortcode.course.outline.php</exclude-pattern>
+		<exclude-pattern>includes/shortcodes/class.llms.shortcode.hide.content.php</exclude-pattern>
+		<exclude-pattern>includes/widgets/class.llms.widget.course.syllabus.php</exclude-pattern>
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -95,8 +95,7 @@
 	<rule ref="Squiz.Commenting.InlineComment.InvalidEndChar">
 		<exclude-pattern>includes/*.php</exclude-pattern>
 
-		<include-pattern>includes/abstracts/*.php</include-pattern>
-		<include-pattern>includes/achievements/*.php</include-pattern>
+		<!-- <include-pattern>includes/achievements/*.php</include-pattern> -->
 		<include-pattern>includes/admin/*.php</include-pattern>
 
 		<exclude-pattern>templates/*.php</exclude-pattern>

--- a/templates/admin/post-types/order-transactions.php
+++ b/templates/admin/post-types/order-transactions.php
@@ -14,7 +14,7 @@ if ( ! is_admin() ) {
 	exit;
 }
 
-// create a "step" attribute for price fields according to LLMS settings
+// Create a "step" attribute for price fields according to LLMS settings.
 $price_step = number_format( 0.01, get_lifterlms_decimals(), get_lifterlms_decimal_separator(), get_lifterlms_thousand_separator() );
 
 ?>

--- a/templates/admin/reporting/tabs/quizzes/overview.php
+++ b/templates/admin/reporting/tabs/quizzes/overview.php
@@ -6,7 +6,7 @@
  *
  * @since 3.16.0
  * @since 3.35.0 Access `$_GET` data via `llms_filter_input()`.
- * @version  3.16.0
+ * @version 3.35.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -104,10 +104,6 @@ $now         = current_time( 'timestamp' );
 		<h3><i class="fa fa-bolt" aria-hidden="true"></i> <?php _e( 'Recent events', 'lifterlms' ); ?></h3>
 
 		<em><?php _e( 'Quiz events coming soon...', 'lifterlms' ); ?></em>
-
-		<?php // foreach ( $data->recent_events() as $event ) : ?>
-			<?php // LLMS_Admin_Reporting::output_event( $event, 'quiz' ); ?>
-		<?php // endforeach; ?>
 
 	</aside>
 

--- a/templates/content-single-course-before.php
+++ b/templates/content-single-course-before.php
@@ -2,20 +2,21 @@
 /**
  * The Template for displaying all single courses.
  *
- * @author      codeBOX
- * @package     lifterLMS/Templates
+ * @package LifterLMS/Templates
+ *
+ * @since Unknown
+ * @version Unknown
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * @todo move these notices somewhere else
- * @var  LLMS_Course
+ * @todo Move these notices somewhere else.
  */
 $course = new LLMS_Course( get_the_ID() );
 
 if ( 'yes' === $course->get( 'time_period' ) ) {
-	// if the start date hasn't passed yet
+	// If the start date hasn't passed yet.
 	if ( ! $course->has_date_passed( 'start_date' ) ) {
 
 		llms_add_notice( $course->get( 'course_opens_message' ), 'notice' );

--- a/templates/loop/featured-image.php
+++ b/templates/loop/featured-image.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 
 global $post;
 
-// short circuit if the featured video tile option is enabled for a course
+// Short circuit if the featured video tile option is enabled for a course.
 if ( 'course' === $post->post_type ) {
 	$course = llms_get_post( $post );
 	if ( 'yes' === $course->get( 'tile_featured_video' ) && $course->get( 'video_embed' ) ) {

--- a/templates/quiz/results.php
+++ b/templates/quiz/results.php
@@ -50,8 +50,6 @@ if ( ! $attempt && ! $attempts ) {
 		/**
 		 * Action fired prior to the output of LifterLMS Quiz Results HTML
 		 *
-		 * Hook description.
-		 *
 		 * @since Unknown
 		 *
 		 * @param LLMS_Quiz_Attempt $attempt Attempt object.

--- a/templates/quiz/results.php
+++ b/templates/quiz/results.php
@@ -8,7 +8,7 @@
  * @since 3.35.0 Access `$_GET` data via `llms_filter_input()`.
  * @version 3.35.0
  *
- * @arg  $attempt  (obj)  LLMS_Quiz_Attempt instance
+ * @property LLMS_Quiz_Attempt $attempt Attempt object.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,6 +46,16 @@ if ( ! $attempt && ! $attempts ) {
 		 *
 		 * @hooked lifterlms_template_quiz_attempt_results - 10
 		 */
+
+		/**
+		 * Action fired prior to the output of LifterLMS Quiz Results HTML
+		 *
+		 * Hook description.
+		 *
+		 * @since Unknown
+		 *
+		 * @param LLMS_Quiz_Attempt $attempt Attempt object.
+		 */
 		do_action( 'llms_single_quiz_attempt_results', $attempt );
 	?>
 
@@ -56,7 +66,7 @@ if ( ! $attempt && ! $attempts ) {
 				<option value="">-- <?php _e( 'Select an Attempt', 'lifterlms' ); ?> --</option>
 				<?php foreach ( $attempts as $attempt ) : ?>
 					<option value="<?php echo esc_url( $attempt->get_permalink() ); ?>">
-						<?php // translators: 1: attempt number; 2: grade percentage; 3: pass/fail text ?>
+						<?php // Translators: %1$d = Attempt number; %2$s = Grade percentage; %3$s = Pass/fail text. ?>
 						<?php printf( __( 'Attempt #%1$d - %2$s (%3$s)', 'lifterlms' ), $attempt->get( 'attempt' ), round( $attempt->get( 'grade' ), 2 ) . '%', $attempt->l10n( 'status' ) ); ?>
 					</option>
 				<?php endforeach; ?>


### PR DESCRIPTION
Per #946 

+ Fixes quite a few violations of `Squiz.Commenting.InlineComment.InvalidEndChar`. Remaining files have been excluded for this rule in phpcs.xml so that we can avoid accidental violations in new (and already fixed) files.
+ Fixes all remaining violations of `Squiz.Commenting.FunctionComment.ParamNameNoMatch`
+ Other misc doc violation fixes