### PR TITLE
Remove unwanted parameter in call to `calculate_grade()`

### DIFF
--- a/includes/class-llms-grades.php
+++ b/includes/class-llms-grades.php
@@ -234,7 +234,7 @@ class LLMS_Grades {
 		// Grade not found in cache or we're not using the cache.
 		if ( false === $grade ) {
 
-			$grade = $this->calculate_grade( $post, $student, $use_cache );
+			$grade = $this->calculate_grade( $post, $student );
 
 			// Store in the cache.
 			wp_cache_set(


### PR DESCRIPTION
## Description
Remove `$use_cache` parameter in `calculate_grade()` call because that method does not accept that parameter.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

