### PR TITLE
Made sure to exit after redirecting on attempt deletion.

### DIFF
--- a/includes/controllers/class.llms.controller.admin.quiz.attempts.php
+++ b/includes/controllers/class.llms.controller.admin.quiz.attempts.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.16.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +33,7 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 	 * @since 3.16.0
 	 * @since 3.16.9 Unknown.
 	 * @since 3.35.0 Sanitize `$_POST` data.
+	 * @since [version] Made sure to exit after redirecting on attempt deletion.
 	 *
 	 * @return void
 	 */
@@ -63,6 +64,7 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 				);
 				$attempt->delete();
 				wp_safe_redirect( $url );
+				exit();
 			} elseif ( 'llms_attempt_grade' === $action && ( isset( $_POST['remarks'] ) || isset( $_POST['points'] ) ) ) {
 				$this->save_grade( $attempt );
 			}
@@ -76,6 +78,7 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 	 * @since 3.16.0
 	 * @since 3.30.3 Strip slashes on remarks.
 	 * @since 3.35.0 Sanitize `$_POST` data.
+	 * @since [version] Use strict type comparisons where needed.
 	 *
 	 * @param LLMS_Quiz_Attempt $attempt Quiz attempt instance.
 	 * @return void
@@ -112,7 +115,7 @@ class LLMS_Controller_Admin_Quiz_Attempts {
 		$attempt->calculate_grade()->save();
 
 		// If all questions were graded the grade will have been calculated and we can trigger completion actions.
-		if ( in_array( $attempt->get( 'status' ), array( 'fail', 'pass' ) ) ) {
+		if ( in_array( $attempt->get( 'status' ), array( 'fail', 'pass' ), true ) ) {
 			$attempt->do_completion_actions();
 		}
 


### PR DESCRIPTION
## Description
Fixes #1342 

The strict type comparison added when using `in_array()` to compare the `$attempt` post status to a list of strings was done without additional casts because the `LLMS_Post_Model::get()` method returns a string, since it uses `sanitize_text_field()` for `'text'` based properties.

## How has this been tested?
manually

## Screenshots
n/a

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

