### PR TITLE
Upcoming payment reminder

### DIFF
--- a/includes/controllers/class.llms.controller.orders.php
+++ b/includes/controllers/class.llms.controller.orders.php
@@ -332,6 +332,8 @@ class LLMS_Controller_Orders {
 
 		$order->unschedule_recurring_payment();
 
+		$order->unschedule_upcoming_payment_reminder();
+
 		/**
 		 * Determine if student should be unenrolled on order error.
 		 *
@@ -444,6 +446,7 @@ class LLMS_Controller_Orders {
 		llms_unenroll_student( $order->get( 'user_id' ), $order->get( 'product_id' ), $status, 'order_' . $order->get( 'id' ) );
 		$order->add_note( $note );
 		$order->unschedule_recurring_payment();
+		$order->unschedule_upcoming_payment_reminder();
 
 		if ( $new_order_status ) {
 			$order->set_status( $new_order_status );
@@ -465,6 +468,7 @@ class LLMS_Controller_Orders {
 		$order->set( 'date_access_expires', $date );
 
 		$order->unschedule_recurring_payment();
+		$order->unschedule_upcoming_payment_reminder();
 		$order->maybe_schedule_expiration();
 
 	}

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -1401,6 +1401,9 @@ class LLMS_Order extends LLMS_Post_Model {
 			// Unschedule the next action (does nothing if no action scheduled).
 			$this->unschedule_recurring_payment();
 
+			// Unschedule upcoming payment reminder (does nothing if no action scheduled).
+			$this->unschedule_upcoming_payment_reminder();
+
 			// Convert our date to UTC before passing to the scheduler.
 			$date = get_gmt_from_date( $date, 'U' );
 
@@ -1419,6 +1422,9 @@ class LLMS_Order extends LLMS_Post_Model {
 
 				// unschedule the next action (does nothing if no action scheduled)
 				$this->unschedule_recurring_payment();
+
+				// Unschedule upcoming payment reminder (does nothing if no action scheduled).
+				$this->unschedule_upcoming_payment_reminder();
 
 				// add a note that the plan has completed
 				$this->add_note( __( 'Order payment plan completed.', 'lifterlms' ) );
@@ -1664,6 +1670,21 @@ class LLMS_Order extends LLMS_Post_Model {
 
 		if ( as_next_scheduled_action( 'llms_charge_recurring_payment', $this->get_action_args() ) ) {
 			as_unschedule_action( 'llms_charge_recurring_payment', $this->get_action_args() );
+		}
+
+	}
+
+	/**
+	 * Cancels a scheduled upcoming payment reminder notification
+	 *
+	 * Does nothing if no payments are scheduled
+	 *
+	 * @return void
+	 */
+	public function unschedule_upcoming_payment_reminder() {
+
+		if ( as_next_scheduled_action( 'llms_send_upcoming_payment_reminder_notification', $this->get_action_args() ) ) {
+			as_unschedule_action( 'llms_send_upcoming_payment_reminder_notification', $this->get_action_args() );
 		}
 
 	}

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -785,6 +785,20 @@ class LLMS_Order extends LLMS_Post_Model {
 		}
 
 		/**
+		 * Retrieve the date to remind user before actual payment
+		 *
+		 * @return string
+		 */
+		public function get_upcoming_payment_reminder_date()
+		{
+			
+			$next_payment_date = $this->get_next_payment_due_date();
+			
+			return date_i18n( 'Y-m-d H:i:s', strtotime('-1 day', strtotime($next_payment_date) ) );
+
+		}
+
+		/**
 		 * Filter the next payment due date.
 		 *
 		 * A timestamp should always be returned as the conversion to the requested format
@@ -1394,6 +1408,8 @@ class LLMS_Order extends LLMS_Post_Model {
 		}
 
 		$date = $this->get_next_payment_due_date();
+
+		$reminder_date = $this->get_upcoming_payment_reminder_date();
 
 		// Unschedule and reschedule.
 		if ( $date && ! is_wp_error( $date ) ) {

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -351,6 +351,7 @@ class LLMS_Notifications {
 			'section_complete',
 			'student_welcome',
 			'subscription_cancelled',
+			'upcoming_payment_reminder',
 		);
 
 		foreach ( $triggers as $name ) {

--- a/includes/notifications/controllers/class.llms.notification.controller.upcoming.payment.reminder.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.upcoming.payment.reminder.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Notification Controller: Upcoming Payment Reminder
+ *
+ * @package LifterLMS/Notifications/Controllers/Classes
+ *
+ * @since 3.10.0
+ * @version 3.10.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification Controller: Upcoming Payment Reminder
+ *
+ * @since 3.10.0
+ */
+class LLMS_Notification_Controller_Upcoming_Payment_Reminder extends LLMS_Notification_Controller_Payment_Retry {
+
+	/**
+	 * Trigger Identifier
+	 *
+	 * @var  [type]
+	 */
+	public $id = 'upcoming_payment_reminder';
+
+	/**
+	 * Action hooks used to trigger sending of the notification
+	 *
+	 * @var  array
+	 */
+	protected $action_hooks = array(
+		'llms_send_upcoming_payment_reminder_notification',
+	);
+
+	/**
+	 * Callback function called when a payment retry is scheduled
+	 *
+	 * @param    int $order   Instance of an LLMS_Order
+	 * @return   void
+	 * @since    3.10.0
+	 * @version  3.10.0
+	 */
+	public function action_callback( $order = null ) {
+
+		$order = llms_get_post($order);
+
+		$this->user_id = $order->get( 'user_id' );
+		$this->post_id = $order->get( 'id' );
+
+		$this->send();
+
+	}
+
+	/**
+	 * Get the translatable title for the notification
+	 * used on settings screens
+	 *
+	 * @return   string
+	 */
+	public function get_title() {
+		return __( 'Upcoming Payment Reminder', 'lifterlms' );
+	}
+
+}
+
+return LLMS_Notification_Controller_Upcoming_Payment_Reminder::instance();

--- a/includes/notifications/views/class.llms.notification.view.upcoming.payment.reminder.php
+++ b/includes/notifications/views/class.llms.notification.view.upcoming.payment.reminder.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Notification View: Upcoming Payment Reminder
+ *
+ * @package LifterLMS/Notifications/Views/Classes
+ *
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification View: Payment Retry
+ *
+ * @since 3.10.0
+ */
+class LLMS_Notification_View_Upcoming_Payment_Reminder extends LLMS_Abstract_Notification_View {
+
+	/**
+	 * Settings for basic notifications
+	 *
+	 * @var  array
+	 */
+	protected $basic_options = array(
+		/**
+		 * Time in milliseconds to show a notification
+		 * before automatically dismissing it
+		 */
+		'auto_dismiss' => 10000,
+		/**
+		 * Enables manual dismissal of notifications
+		 */
+		'dismissible'  => true,
+	);
+
+
+	/**
+	 * Notification Trigger ID
+	 *
+	 * @var  [type]
+	 */
+	public $trigger_id = 'upcoming_payment_reminder';
+
+	/**
+	 * Setup body content for output
+	 *
+	 * @return   string
+	 */
+	protected function set_body() {
+
+		if ( 'email' === $this->notification->get( 'type' ) ) {
+			return $this->set_body_email();
+		}
+		return $this->set_body_basic();
+
+	}
+
+	/**
+	 * Setup default notification body for basic notifications
+	 */
+	private function set_body_basic() {
+		return esc_html__( 'You will be charged for your subscription tomorrow.', 'lifterlms' );
+	}
+
+	/**
+	 * Setup default notification body for email notifications
+	 */
+	private function set_body_email() {
+		$mailer = LLMS()->mailer();
+
+		$table_style = sprintf(
+			'border-collapse:collapse;color:%1$s;font-family:%2$s;font-size:%3$s;Margin-bottom:15px;text-align:left;width:100%%;',
+			$mailer->get_css( 'font-color', false ),
+			$mailer->get_css( 'font-family', false ),
+			$mailer->get_css( 'font-size', false )
+		);
+		$tr_style    = 'color:inherit;font-family:inherit;font-size:inherit;';
+		$td_style    = sprintf( 'border-bottom:1px solid %s;color:inherit;font-family:inherit;font-size:inherit;padding:10px;', $mailer->get_css( 'divider-color', false ) );
+
+		$rows = array(
+			'NEXT_PAYMENT_DATE'  => __( 'Upcoming Payment Reminder', 'lifterlms' ),
+			'PRODUCT_TITLE_LINK' => '{{PRODUCT_TYPE}}',
+			'PLAN_TITLE'         => __( 'Plan', 'lifterlms' ),
+			'PAYMENT_AMOUNT'     => __( 'Amount', 'lifterlms' ),
+		);
+
+		ob_start();
+		?><p><?php printf( __( 'Hello %s,', 'lifterlms' ), '{{CUSTOMER_NAME}}' ); ?></p>
+		<p><?php printf( __( 'You will be charged for your subscription to %1$s tomorrow on %2$s.', 'lifterlms' ), '{{PRODUCT_TITLE}}', '{{NEXT_PAYMENT_DATE}}' ); ?></p>
+		<p><?php printf( __( 'You can unsubscribe on %1$sorder\'s page%2$s.', 'lifterlms' ), '<a href="{{ORDER_URL}}">', '</a>' ); ?></p>
+		<h4><?php printf( __( 'Order #%s', 'lifterlms' ), '{{ORDER_ID}}' ); ?></h4>
+		<table style="<?php echo $table_style; ?>">
+		<?php foreach ( $rows as $code => $name ) : ?>
+			<tr style="<?php echo $tr_style; ?>">
+				<th style="<?php echo $td_style; ?>width:33.3333%;"><?php echo $name; ?></th>
+				<td style="<?php echo $td_style; ?>">{{<?php echo $code; ?>}}</td>
+			</tr>
+		<?php endforeach; ?>
+		</table>
+		<p><a href="{{ORDER_URL}}"><?php _e( 'Update Payment Method', 'lifterlms' ); ?></a></p>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Setup footer content for output
+	 *
+	 * @return   string
+	 * @since    3.10.0
+	 * @version  3.10.0
+	 */
+	protected function set_footer() {
+		$url = $this->set_merge_data( '{{ORDER_URL}}' );
+		return '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Update Payment Method', 'lifterlms' ) . '</a>';
+	}
+
+	/**
+	 * Setup notification icon for output
+	 *
+	 * @return   string
+	 * @since    3.10.0
+	 * @version  3.10.0
+	 */
+	protected function set_icon() {
+		return $this->get_icon_default( 'warning' );
+	}
+
+	/**
+	 * Setup merge codes that can be used with the notification
+	 *
+	 * @return   array
+	 * @since    3.10.0
+	 * @version  3.10.0
+	 */
+	protected function set_merge_codes() {
+		return array(
+			'{{CUSTOMER_ADDRESS}}'   => __( 'Customer Address', 'lifterlms' ),
+			'{{CUSTOMER_NAME}}'      => __( 'Customer Name', 'lifterlms' ),
+			'{{CUSTOMER_PHONE}}'     => __( 'Customer Phone', 'lifterlms' ),
+			'{{NEXT_PAYMENT_DATE}}'  => __( 'Next Payment Date', 'lifterlms' ),
+			'{{ORDER_ID}}'           => __( 'Order ID', 'lifterlms' ),
+			'{{ORDER_URL}}'          => __( 'Order URL', 'lifterlms' ),
+			'{{PAYMENT_AMOUNT}}'     => __( 'Payment Amount', 'lifterlms' ),
+			'{{PLAN_TITLE}}'         => __( 'Plan Title', 'lifterlms' ),
+			'{{PRODUCT_TITLE}}'      => __( 'Product Title', 'lifterlms' ),
+			'{{PRODUCT_TYPE}}'       => __( 'Product Type', 'lifterlms' ),
+			'{{PRODUCT_TITLE_LINK}}' => __( 'Product Title (Link)', 'lifterlms' ),
+		);
+	}
+
+	/**
+	 * Replace merge codes with actual values
+	 *
+	 * @param    string $code  the merge code to ge merged data for
+	 * @return   string
+	 * @since    3.10.0
+	 * @version  3.10.0
+	 */
+	protected function set_merge_data( $code ) {
+
+		$order = $this->post;
+
+		switch ( $code ) {
+
+			case '{{CUSTOMER_ADDRESS}}':
+				$code = '';
+				if ( isset( $order->billing_address_1 ) ) {
+					$code .= $order->get( 'billing_address_1' );
+					if ( isset( $order->billing_address_2 ) ) {
+						$code .= ' ';
+						$code .= $order->get( 'billing_address_2' );
+					}
+					$code .= ', ';
+					$code .= $order->get( 'billing_city' );
+					$code .= $order->get( 'billing_state' );
+					$code .= ', ';
+					$code .= $order->get( 'billing_zip' );
+					$code .= ', ';
+					$code .= llms_get_country_name( $order->get( 'billing_country' ) );
+				}
+				break;
+
+			case '{{CUSTOMER_NAME}}':
+				$code = $order->get_customer_name();
+				break;
+
+			case '{{CUSTOMER_PHONE}}':
+				$code = $order->get( 'billing_phone' );
+				break;
+
+			case '{{NEXT_PAYMENT_DATE}}':
+				$code = $order->get_date( 'date_next_payment', get_option( 'date_format' ) . ' ' . get_option( 'time_format' ) );
+				break;
+
+			case '{{ORDER_ID}}':
+				$code = $order->get( 'id' );
+				break;
+
+			case '{{ORDER_URL}}':
+				$code = esc_url( $order->get_view_link() );
+				break;
+
+			case '{{PAYMENT_AMOUNT}}':
+				$code = $order->get_price( 'total' );
+				break;
+
+			case '{{PLAN_TITLE}}':
+				$code = $order->get( 'plan_title' );
+				break;
+
+			case '{{PRODUCT_TITLE}}':
+				$code = $order->get( 'product_title' );
+				break;
+
+			case '{{PRODUCT_TITLE_LINK}}':
+				$permalink = esc_url( get_permalink( $order->get( 'product_id' ) ) );
+				if ( $permalink ) {
+					$title = $this->set_merge_data( '{{PRODUCT_TITLE}}' );
+					$code  = '<a href="' . $permalink . '">' . $title . '</a>';
+				}
+				break;
+
+			case '{{PRODUCT_TYPE}}':
+				$obj = $order->get_product();
+				if ( is_a( $obj, 'WP_Post' ) ) {
+					$code = _x( 'Item', 'generic product type description', 'lifterlms' );
+				} else {
+					$code = $obj->get_post_type_label( 'singular_name' );
+				}
+				break;
+
+		}// End switch().
+
+		return $code;
+
+	}
+
+	/**
+	 * Setup notification subject for output
+	 *
+	 * @return   string
+	 */
+	protected function set_subject() {
+		return sprintf( __( 'You will be charged for your subscription to %1$s tomorrow on %2$s', 'lifterlms' ), '{{PRODUCT_TITLE}}', '{{NEXT_PAYMENT_DATE}}' );
+	}
+
+	/**
+	 * Setup notification title for output
+	 *
+	 * @return   string
+	 */
+	protected function set_title() {
+		if ( 'email' === $this->notification->get( 'type' ) ) {
+			return sprintf( __( 'You will be charged for your subscription tomorrow. Order #%s', 'lifterlms' ), '{{ORDER_ID}}' );
+		}
+		return sprintf( __( 'You will be charged for your subscription to %s', 'lifterlms' ), '{{PRODUCT_TITLE}}' );
+	}
+
+}


### PR DESCRIPTION
## Description
I added a notification about the upcoming recurrent payment. Notification is scheduled on 1 day before payment due date.

## How has this been tested?
I ve done only manual testing. I created several orders with recurrent payments, than looked for scheduled actions and their dates: actual payment and notification the day before. Than i ran this scheduled actions by hand and watched as they reappeared. Than i tested order due date change and order cancelation.

## Types of changes
- New notification controller + view
- Added code for scheduling and unscheduling notification invocation in order model next to code for scheduling and unscheduling or recurrent payments

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

