### PR TITLE
(WIP) Split large log files

### DIFF
--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -155,7 +155,7 @@ class LLMS_Install {
 				 *
 				 * @param string $recurrence Cron job recurrence interval. Must be valid interval as retrieved from `wp_get_schedules()`. Default is "daily".
 				 */
-				'hook' => 'llms_backup_logs',
+				'hook'     => 'llms_backup_logs',
 				'interval' => apply_filters( 'llms_backup_logs_interval', 'daily' ),
 			),
 			array(
@@ -168,11 +168,11 @@ class LLMS_Install {
 				 *
 				 * @param string $recurrence Cron job recurrence interval. Must be valid interval as retrieved from `wp_get_schedules()`. Default is "daily".
 				 */
-				'hook' => 'llms_cleanup_tmp',
+				'hook'     => 'llms_cleanup_tmp',
 				'interval' => apply_filters( 'llms_cleanup_tmp_interval', 'daily' ),
 			),
 			array(
-				'hook' => 'llms_send_tracking_data',
+				'hook'     => 'llms_send_tracking_data',
 				/**
 				 * Filter the recurrence interval at which tracking data is gathered and sent.
 				 *
@@ -185,7 +185,7 @@ class LLMS_Install {
 				'interval' => apply_filters( 'llms_tracker_schedule_interval', 'daily' ),
 			),
 			array(
-				'hook' => 'llms_delete_expired_session_data',
+				'hook'     => 'llms_delete_expired_session_data',
 				/**
 				 * Filter the recurrence interval at which expired session are removed from the database.
 				 *
@@ -195,7 +195,7 @@ class LLMS_Install {
 				 *
 				 * @param string $recurrence Cron job recurrence interval. Must be valid interval as retrieved from `wp_get_schedules()`. Default is "hourly".
 				 */
-				'interval' =>  apply_filters( 'llms_delete_expired_session_data_recurrence', 'hourly' ),
+				'interval' => apply_filters( 'llms_delete_expired_session_data_recurrence', 'hourly' ),
 			),
 		);
 

--- a/includes/functions/llms.functions.log.php
+++ b/includes/functions/llms.functions.log.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.0.0
- * @version 3.0.0
+ * @version 3.75
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -13,10 +13,10 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Retrieve the full path to the log file for a given log handle
  *
- * @param    string $handle  log handle
- * @return   string
- * @since    3.0.0
- * @version  3.0.0
+ * @since 3.0.0
+ *
+ * @param string $handle Log handle.
+ * @return string
  */
 function llms_get_log_path( $handle ) {
 
@@ -27,31 +27,53 @@ function llms_get_log_path( $handle ) {
 /**
  * Log arbitrary messages to a log file
  *
- * @param    mixed  $message   data to log
- * @param    string $handle    allow creation of multiple log files by handle
- * @return   boolean
- * @since    1.0.0
- * @version  3.7.5
+ * @since 1.0.0
+ * @since 3.7.5 Unknown.
+ *
+ * @param mixed  $message Data to log.
+ * @param string $handle  Allow creation of multiple log files by handle.
+ * @return boolean
  */
 function llms_log( $message, $handle = 'llms' ) {
 
-	$r = false;
+	$ret = false;
 
 	$fh = fopen( llms_get_log_path( $handle ), 'a' );
-	// open the file (creates it if it doesn't already exist)
+
+	// Open the file (creates it if it doesn't already exist).
 	if ( $fh ) {
 
-		// print array or objects with print_r
+		// Print array or objects with `print_r`.
 		if ( is_array( $message ) || is_object( $message ) ) {
 			$message = print_r( $message, true );
 		}
 
-		$r = fwrite( $fh, date_i18n( 'm-d-Y @ H:i:s -' ) . ' ' . $message . "\n" );
+		$ret = fwrite( $fh, gmdate( 'Y-m-d H:i:s' ) . ' - ' . $message . "\n" );
 
 		fclose( $fh );
 
 	}
 
-	return $r;
+	return $ret ? true : false;
+
+}
+
+function llms_split_log( $handle ) {
+
+	$file = llms_get_log_path( $handle );
+	$size = file_exists( $file ) ? filesize( $file ) : 0;
+
+	$maxsize = absint( apply_filters( 'llms_log_max_filesize', 5 ) ) * 1000 * 1000;
+
+	if ( $size >= $maxsize ) {
+
+		$copy = str_replace( '.log', sprintf( '-%d.log', time() ), $file );
+		copy( $file, $copy );
+		unlink( $file );
+
+		return $copy;
+ 	}
+
+ 	return false;
 
 }

--- a/includes/functions/llms.functions.log.php
+++ b/includes/functions/llms.functions.log.php
@@ -11,54 +11,6 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Retrieve the full path to the log file for a given log handle
- *
- * @since 3.0.0
- *
- * @param string $handle Log handle.
- * @return string
- */
-function llms_get_log_path( $handle ) {
-
-	return trailingslashit( LLMS_LOG_DIR ) . $handle . '-' . sanitize_file_name( wp_hash( $handle ) ) . '.log';
-
-}
-
-/**
- * Log arbitrary messages to a log file
- *
- * @since 1.0.0
- * @since 3.7.5 Unknown.
- *
- * @param mixed  $message Data to log.
- * @param string $handle  Allow creation of multiple log files by handle.
- * @return boolean
- */
-function llms_log( $message, $handle = 'llms' ) {
-
-	$ret = false;
-
-	$fh = fopen( llms_get_log_path( $handle ), 'a' );
-
-	// Open the file (creates it if it doesn't already exist).
-	if ( $fh ) {
-
-		// Print array or objects with `print_r`.
-		if ( is_array( $message ) || is_object( $message ) ) {
-			$message = print_r( $message, true );
-		}
-
-		$ret = fwrite( $fh, gmdate( 'Y-m-d H:i:s' ) . ' - ' . $message . "\n" );
-
-		fclose( $fh );
-
-	}
-
-	return $ret ? true : false;
-
-}
-
-/**
  * Copy a log file that is greater than or equal to the max allowed log file size
  *
  * If the log file's size is larger than the maximum allowed log file size (5MB) it will rename the log, adding
@@ -68,6 +20,8 @@ function llms_log( $message, $handle = 'llms' ) {
  * too large which could cause performance issues during reads and writes.
  *
  * @since [version]
+ *
+ * @see llms_backup_logs()
  *
  * @param string $handle Log file handle.
  * @return null|boolean|string Returns `null` if the log file is not larger than the max size, `false` if an error is encountered,
@@ -140,7 +94,7 @@ function llms_backup_log( $handle ) {
  *
  * @since [version]
  *
- * @see llms_backup_logs()
+ * @see llms_backup_log()
  *
  * @return void
  */
@@ -154,5 +108,55 @@ function llms_backup_logs() {
 			llms_backup_log( $parts[0] );
 		}
 	}
+
+}
+add_action( 'llms_backup_logs', 'llms_backup_logs' );
+
+
+/**
+ * Retrieve the full path to the log file for a given log handle
+ *
+ * @since 3.0.0
+ *
+ * @param string $handle Log handle.
+ * @return string
+ */
+function llms_get_log_path( $handle ) {
+
+	return trailingslashit( LLMS_LOG_DIR ) . $handle . '-' . sanitize_file_name( wp_hash( $handle ) ) . '.log';
+
+}
+
+/**
+ * Log arbitrary messages to a log file
+ *
+ * @since 1.0.0
+ * @since 3.7.5 Unknown.
+ *
+ * @param mixed  $message Data to log.
+ * @param string $handle  Allow creation of multiple log files by handle.
+ * @return boolean
+ */
+function llms_log( $message, $handle = 'llms' ) {
+
+	$ret = false;
+
+	$fh = fopen( llms_get_log_path( $handle ), 'a' );
+
+	// Open the file (creates it if it doesn't already exist).
+	if ( $fh ) {
+
+		// Print array or objects with `print_r`.
+		if ( is_array( $message ) || is_object( $message ) ) {
+			$message = print_r( $message, true );
+		}
+
+		$ret = fwrite( $fh, gmdate( 'Y-m-d H:i:s' ) . ' - ' . $message . "\n" );
+
+		fclose( $fh );
+
+	}
+
+	return $ret ? true : false;
 
 }

--- a/includes/functions/llms.functions.log.php
+++ b/includes/functions/llms.functions.log.php
@@ -72,8 +72,8 @@ function llms_split_log( $handle ) {
 		unlink( $file );
 
 		return $copy;
- 	}
+	}
 
- 	return false;
+	return false;
 
 }

--- a/includes/functions/llms.functions.log.php
+++ b/includes/functions/llms.functions.log.php
@@ -105,7 +105,7 @@ function llms_backup_logs() {
 		// Get the handle from the file path.
 		$parts = explode( '-', basename( $file, '.log' ) );
 		if ( $parts ) {
-			llms_backup_log( $parts[0] );
+			llms_backup_log( implode( '-', array_slice( $parts, 0, -1 ) ) );
 		}
 	}
 

--- a/includes/functions/llms.functions.log.php
+++ b/includes/functions/llms.functions.log.php
@@ -123,7 +123,6 @@ function llms_backup_log( $handle ) {
 
 			return $copy;
 		}
-
 	}
 
 	return null;
@@ -154,7 +153,6 @@ function llms_backup_logs() {
 		if ( $parts ) {
 			llms_backup_log( $parts[0] );
 		}
-
 	}
 
 }

--- a/tests/phpunit/unit-tests/class-llms-test-install.php
+++ b/tests/phpunit/unit-tests/class-llms-test-install.php
@@ -9,6 +9,7 @@
  * @since 3.3.1
  * @since 3.37.8 Fix directory path to uninstall.php
  * @since 4.0.0 Test creation of all tables; fix caching issue when testing full install; add new cron test.
+ * @since [version] Test log backup cron.
  */
 class LLMS_Test_Install extends LLMS_UnitTestCase {
 
@@ -40,6 +41,7 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 	 * @since 3.3.1
 	 * @since 3.28.0 Unknown.
 	 * @since 4.0.0 Test session cleanup cron.
+	 * @since [version] Test log backup cron.
 	 *
 	 * @return void
 	 */
@@ -47,6 +49,7 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 		$crons = array(
 			'llms_cleanup_tmp',
+			'llms_backup_logs',
 			'llms_send_tracking_data',
 			'llms_delete_expired_session_data',
 		);

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Test Logging Functions
+ *
+ * @package LifterLMS/Tests/Functions
+ *
+ * @group functions
+ * @group functions_logs
+ *
+ * @since [version]
+ */
+class LLMS_Test_Functions_Logs extends LLMS_UnitTestCase {
+
+	/**
+	 * Test llms_get_log_path()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_log_path() {
+
+		$handle = 'testhandle';
+		$expected_hash = wp_hash( $handle );
+
+		$expected_file = sprintf( '%1$s-%2$s.log', $handle, $expected_hash );
+
+		$path = llms_get_log_path( $handle );
+
+		$this->assertEquals( $expected_file, basename( $path ) );
+		$this->assertEquals( untrailingslashit( LLMS_LOG_DIR ), dirname( $path ) );
+
+		$this->assertEquals( LLMS_LOG_DIR . $expected_file, $path );
+
+	}
+
+	/**
+	 * Test llms_log() when logging a string
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_log_string() {
+
+		$this->assertTrue( llms_log( 'Test message', 'teststringlog' ) );
+
+		$logs = explode( ' - ', file_get_contents( llms_get_log_path( 'teststringlog' ) ) );
+
+		$this->assertTrue( date_create( $logs[0] ) instanceof DateTime );
+
+		$this->assertEquals( "Test message\n", $logs[1] );
+
+	}
+
+	/**
+	 * Test llms_log() when logging an array
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_log_array() {
+
+		$this->assertTrue( llms_log( array( 'Test message' ), 'testarrlog' ) );
+
+		$logs = explode( ' - ', file_get_contents( llms_get_log_path( 'testarrlog' ) ) );
+
+		$this->assertTrue( date_create( $logs[0] ) instanceof DateTime );
+
+		$this->assertEquals( "Array
+(
+    [0] => Test message
+)
+
+", $logs[1] );
+
+	}
+
+	/**
+	 * Test llms_log() when logging an object
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_log_object() {
+
+		$this->assertTrue( llms_log( (object) array( 'Test' => 1 ), 'testobjlog' ) );
+
+		$logs = explode( ' - ', file_get_contents( llms_get_log_path( 'testobjlog' ) ) );
+
+		$this->assertTrue( date_create( $logs[0] ) instanceof DateTime );
+
+		$this->assertEquals( "stdClass Object
+(
+    [Test] => 1
+)
+
+", $logs[1] );
+
+	}
+
+	/**
+	 * Test llms_split_log
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_split_log() {
+
+		// Reduce the max filesize to 1MB to make testing easier.
+		$handler = function( $max ) {
+			return 1;
+		};
+		add_filter( 'llms_log_max_filesize', $handler );
+
+		$handle = 'logtosplit';
+		$file   = llms_get_log_path( $handle );
+
+		// File doesn't exist, no need to split.
+		$this->assertFalse( llms_split_log( $handle ) );
+
+		llms_log( str_repeat( '01', 999 ), $handle );
+
+		// File does exist but doesn't need to be split yet.
+		$this->assertFalse( llms_split_log( $handle ) );
+
+		clearstatcache( true, $file );
+
+		// Create a file that exceeds 1MB.
+		$i = 0;
+		while ( $i <= 501 ) {
+			llms_log( str_repeat( '01', 999 ), $handle );
+			++$i;
+		}
+
+		// Get the contents of the original to compare later.
+		$original = file_get_contents( $file );
+
+		// Split the file.
+		$copy = llms_split_log( $handle );
+
+		// We made a copy.
+		$this->assertTrue( false !== $copy );
+
+		// Return should be different than than the original.
+		$this->assertNotEquals( $copy, $file );
+
+		// Copy exists.
+		$this->assertTrue( file_exists( $copy ) );
+
+		// Original has been removed.
+		$this->assertFalse( file_exists( $file ) );
+
+		// Compare copy contents to the original.
+		$this->assertEquals( $original, file_get_contents( $copy ) );
+
+		// Remove small max size.
+		remove_filter( 'llms_log_max_filesize', $handler );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
@@ -240,7 +240,7 @@ class LLMS_Test_Functions_Logs extends LLMS_UnitTestCase {
 
 		llms_backup_logs();
 
-		$this->assertEquals( $actions + 2, did_action( 'llms_log_file_backup_created' ) );r
+		$this->assertEquals( $actions + 2, did_action( 'llms_log_file_backup_created' ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-logs.php
@@ -233,14 +233,25 @@ class LLMS_Test_Functions_Logs extends LLMS_UnitTestCase {
 
 		$actions = did_action( 'llms_log_file_backup_created' );
 
+		// Make sure the created files are the right ones.
+		$handler = function( $copy, $file, $handle ) {
+			$this->assertTrue( in_array( $handle, array( 'tobackup1', 'tobackup2', 'tobackup-withonehyphen', 'tobackup-with-mutli-hyphens' ), true ) );
+		};
+		add_action( 'llms_log_file_backup_created', $handler, 10, 3 );
+
 		llms_log( 'message', 'notbackedup1' );
 		llms_log( 'message', 'notbackedup2' );
+
 		$this->create_mock_log_file( 'tobackup1' );
 		$this->create_mock_log_file( 'tobackup2' );
+		$this->create_mock_log_file( 'tobackup-withonehyphen' );
+		$this->create_mock_log_file( 'tobackup-with-mutli-hyphens' );
 
 		llms_backup_logs();
 
-		$this->assertEquals( $actions + 2, did_action( 'llms_log_file_backup_created' ) );
+		$this->assertEquals( $actions + 4, did_action( 'llms_log_file_backup_created' ) );
+
+		remove_action( 'llms_log_file_backup_created', $handler, 10 );
 
 	}
 


### PR DESCRIPTION

## Description

This is an unfinished WIP

(Working towards) Fixes #1344 

The end goal will be to run the new function `llms_split_log()` on a cron (maybe?) to automatically split "large" log files.

## How has this been tested?

+ Added unit tests
+ Manually

## Screenshots <!-- if applicable -->

## Types of changes
+ Adds new log function to split logs when they are larger than a certain size

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

