### PR TITLE
Prevent view manager from displaying for users without "bypass restrictions" permissions

### DIFF
--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.7.0
- * @version 4.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -34,11 +34,9 @@ class LLMS_View_Manager {
 	public function __construct() {
 
 		// Do nothing if we're creating a pending order.
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
-		if ( ! empty( $_POST['action'] ) && 'create_pending_order' === $_POST['action'] ) {
+		if ( ! empty( $_POST['action'] ) && 'create_pending_order' === $_POST['action'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			return;
 		}
-		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		add_action( 'init', array( $this, 'add_actions' ) );
 
@@ -63,7 +61,7 @@ class LLMS_View_Manager {
 		add_filter( 'llms_is_course_enrollment_open', array( $this, 'modify_course_open' ), 10, 1 );
 
 		// Filters we'll only run when view as links are called.
-		if ( isset( $_GET['llms-view-as'] ) ) {
+		if ( isset( $_GET['llms-view-as'] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Recommended
 
 			add_filter( 'llms_is_course_complete', array( $this, 'modify_completion' ), 10, 1 );
 			add_filter( 'llms_is_lesson_complete', array( $this, 'modify_completion' ), 10, 1 );
@@ -85,33 +83,20 @@ class LLMS_View_Manager {
 	 * @since 3.7.0
 	 * @since 3.16.0 Unknown.
 	 * @since 4.2.0 Updated icon.
+	 * @since [version] Use `should_display()` method to determine if the view manager should be added to the admin bar.
 	 *
 	 * @return void
 	 */
 	public function add_menu_items() {
 
-		// Don't display on admin panel.
-		if ( is_admin() ) {
-			return;
-		}
-
-		// Check this to prevent leaked globals creating a false positive below.
-		if ( is_post_type_archive() ) {
-			return;
-		}
-
-		// Don't need to do anything for most post types.
-		global $post;
-		if ( ! $post || ( ! is_llms_checkout() && ! in_array( $post->post_type, array( 'course', 'lesson', 'llms_membership', 'llms_quiz' ), true ) ) ) {
+		if ( ! $this->should_display() ) {
 			return;
 		}
 
 		global $wp_admin_bar;
 
-		$view = $this->get_view();
-
+		$view  = $this->get_view();
 		$views = $this->get_views();
-
 		$title = sprintf( __( 'Viewing as %s', 'lifterlms' ), $views[ $view ] );
 
 		$wp_admin_bar->add_node(
@@ -124,6 +109,7 @@ class LLMS_View_Manager {
 
 		foreach ( $views as $slug => $title ) {
 
+			// Exclude the current view.
 			if ( $slug === $view ) {
 				continue;
 			}
@@ -359,6 +345,39 @@ class LLMS_View_Manager {
 		wp_add_inline_script( 'llms-view-manager', $this->get_inline_script(), 'after' );
 
 	}
+
+
+	/**
+	 * Determine whether or not the view manager should be added to the WP Admin Bar
+	 *
+	 * The view manager is only displayed when the following criteria is met:
+	 * + The current user must have a role that is allowed to bypass LifterLMS restrictions
+	 * + Must be viewing a single course, lesson, membership, or quiz or the LifterLMS checkout page.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	protected function should_display() {
+
+		$display = false;
+
+		if ( llms_can_user_bypass_restrictions( get_current_user_id() ) ) {
+			global $post;
+			$display = is_admin() || is_post_type_archive() || ! $post || ( ! is_llms_checkout() && ! in_array( $post->post_type, array( 'course', 'lesson', 'llms_membership', 'llms_quiz' ), true ) ) ? false : true;
+		}
+
+		/**
+		 * Filters whether or not the "View As..." menu item should be displayed in the WP Admin Bar
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $display Whether or not the menu item should be displayed.
+		 */
+		return apply_filters( 'llms_view_manager_should_display', $display );
+
+	}
+
 
 }
 

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Test view manager
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group view_manager
+ *
+ * @since [version]
+ */
+class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = new LLMS_View_Manager();
+
+	}
+
+	/**
+	 * Test constructor
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test__construct() {
+
+		// Remove existing action.
+		remove_action( 'init', array( $this->main, 'add_actions' ) );
+		$this->assertFalse( has_action( 'init', array( $this->main, 'add_actions' ) ) );
+
+		// Reinit.
+		$this->main = new LLMS_View_Manager();
+		$this->assertEquals( 10, has_action( 'init', array( $this->main, 'add_actions' ) ) );
+
+	}
+
+	/**
+	 * Test constructor when a pending order is being created.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test__construct_pending_order() {
+
+		// Remove existing action.
+		remove_action( 'init', array( $this->main, 'add_actions' ) );
+		$this->assertFalse( has_action( 'init', array( $this->main, 'add_actions' ) ) );
+
+		// Reinit.
+		$this->mockPostRequest( array(
+			'action' => 'create_pending_order',
+		) );
+		$this->main = new LLMS_View_Manager();
+		$this->assertFalse( has_action( 'init', array( $this->main, 'add_actions' ) ) );
+	}
+
+	/**
+	 * Test should_display() when viewing valid post types with a valid user
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_on_valid_post_types() {
+
+		global $post;
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		foreach ( array( 'course', 'lesson', 'llms_membership', 'llms_quiz' ) as $post_type ) {
+			$post = $this->factory->post->create_and_get( compact( 'post_type' ) );
+			$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+		}
+
+	}
+
+	/**
+	 * Test should_display() when viewing checkout valid with a valid user
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_on_checkout() {
+		LLMS_Install::create_pages();
+		$this->go_to( llms_get_page_url( 'checkout' ) );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+
+	}
+
+	/**
+	 * Test should_display() when no user is present
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_no_user() {
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+	}
+
+	/**
+	 * Test should_display() when an invalid user is logged in
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_invalid_user() {
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'student' ) ) );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+	}
+
+	/**
+	 * Test should_display() on the admin panel
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_in_admin() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		set_current_screen( 'users.php' );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+
+	}
+
+	/**
+	 * Test should_display() on a post type archive
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_post_type_archive() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->go_to( get_post_type_archive_link( 'course' ) );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+
+	}
+
+	/**
+	 * Test should_display() when a valid using is viewing an invalid post type
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_on_invalid_post_types() {
+
+		global $post;
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			$post = $this->factory->post->create_and_get( compact( 'post_type' ) );
+			$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+		}
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -133,6 +133,7 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 		set_current_screen( 'users.php' );
 		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
+		set_current_screen( 'front' ); // Reset for later tests.
 
 	}
 


### PR DESCRIPTION
## Description

+ Small refactor to `LLMS_View_Manager` to move display logic into it's own (filterable) method
+ Add logic to ensure that only users who can bypass restrictions will be shown the view manager options

Fixes #1368 

## How has this been tested?

+ Manual
+ New unit tests
+ Adding the `add_filter( 'show_admin_bar', '__return_true', 9999999 );` to an mu plugin and logging in as a student user allows easy testing of the issue in #1368. Without this PR you'll see the view manager, with this PR you will not.


## Screenshots <!-- if applicable -->

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

