### PR TITLE
Show sales reporting chart axis in the correct currency symbol

### DIFF
--- a/assets/js/llms-analytics.js
+++ b/assets/js/llms-analytics.js
@@ -6,6 +6,7 @@
  * @since 3.33.1 Fix issue that produced series options not aligned with the chart data.
  * @since 3.36.3 Added the `allow_clear` paramater when initializiing the `llmsStudentSelect2`.
  * @since 4.3.3 Legends will automatically display on top of the chart.
+ * @since [version] Show sales reporting currency symbol based on LifterLMS site options.
  *
  */( function( $, undefined ) {
 
@@ -14,15 +15,20 @@
 	/**
 	 * LifterLMS Admin Analytics
 	 *
-	 * @since    3.0.0
-	 * @version  3.5.0
+	 * @since 3.0.0
+	 * @since 3.5.0 Unknown
+	 * @since [version] Added `opts` parameter.
+	 *
+	 * @param {Object} options Options object.
+	 * @return {Object} Class instance.
 	 */
-	var Analytics = function() {
+	var Analytics = function( opts ) {
 
 		this.charts_loaded = false;
 		this.data          = {};
 		this.query         = $.parseJSON( $( '#llms-analytics-json' ).text() );
 		this.timeout       = 8000;
+		this.options       = opts;
 
 		this.$widgets = $( '.llms-widget[data-method]' );
 
@@ -108,8 +114,9 @@
 		 * @since 3.0.0
 		 * @since 3.17.6 Unknown
 		 * @since 4.3.3 Force the legend to appear on top of the chart.
+		 * @since [version] Display sales numbers according to the site's currency settings instead of the browser's locale.
 		 *
-		 * @return   void
+		 * @return {void}
 		 */
 		this.draw_chart = function() {
 
@@ -139,7 +146,7 @@
 					series: self.get_chart_series_options(),
 					vAxes: {
 						0: {
-							format: 'currency',
+							format: this.options.currency_format || 'currency',
 						},
 						1: {
 							format: '',
@@ -561,6 +568,6 @@
 
 	};
 
-	window.llms.analytics = new Analytics();
+	window.llms.analytics = new Analytics( window.llms.analytics || {} );
 
 } )( jQuery );

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 4.3.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -258,6 +258,7 @@ class LLMS_Admin_Assets {
 	 * @since 1.0.0
 	 * @since 3.7.5 Unknown.
 	 * @since 4.4.0 Add `ajax_nonce`.
+	 * @since [version] Add an analytics localization object.
 	 *
 	 * @return void
 	 */
@@ -283,11 +284,42 @@ class LLMS_Admin_Assets {
 				window.llms.ajax_nonce = "' . wp_create_nonce( LLMS_AJAX::NONCE ) . '";
 				window.llms.admin_url = "' . admin_url() . '";
 				window.llms.post = ' . json_encode( $postdata ) . ';
+				window.llms.analytics = ' . json_encode( $this->get_analytics_options() ) . ';
 			</script>
 		';
 
 		echo '<script type="text/javascript">window.LLMS = window.LLMS || {};</script>';
 		echo '<script type="text/javascript">window.LLMS.l10n = window.LLMS.l10n || {}; window.LLMS.l10n.strings = ' . LLMS_L10n::get_js_strings( true ) . ';</script>';
+
+	}
+
+	/**
+	 * Retrieve an array of options used to localize the `llms.analytics` JS instance.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function get_analytics_options() {
+
+		/**
+		 * Create a number format string readable by google charts
+		 *
+		 * Replacing `9.9` with `9,9` and `0,0` with `0.0` to prevent loading errors encountered
+		 * as a result of the chart pattern not allowing usage of a comma for the decimal separator.
+		 *
+		 * @see https://stackoverflow.com/a/18204679/400568
+		 */
+		$currency_format = str_replace( array( '9.9', '0,0', '9' ), array( '9,9', '0.0', '#' ), llms_price_raw( 9990.00 ) );
+
+		/**
+		 * Customize Javascript localization options passed to the `llms.analytics` JS instance.
+		 *
+		 * @since [version]
+		 *
+		 * @param array $opts Associative array of option data.
+		 */
+		return apply_filters( 'llms_get_analytics_js_options', compact( 'currency_format' ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
@@ -52,6 +52,37 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test get_analytics_options()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_analytics_options() {
+
+		$this->assertEquals( array( 'currency_format' => '$#,##0.00' ), LLMS_Unit_Test_Util::call_method( $this->main, 'get_analytics_options' ) );
+
+		// Simulate comma decimal separator that's forced back to decimals.
+		add_filter( 'lifterlms_thousand_separator', function( $sep ) { return '.'; } );
+		add_filter( 'lifterlms_decimal_separator', function( $sep ) { return ','; } );
+
+		$this->assertEquals( array( 'currency_format' => '$#,##0.00' ), LLMS_Unit_Test_Util::call_method( $this->main, 'get_analytics_options' ) );
+
+		remove_all_filters( 'lifterlms_thousand_separator' );
+		remove_all_filters( 'lifterlms_decimal_separator' );
+
+		// Simulate non US symbol on the right with a space.
+		add_filter( 'lifterlms_currency_symbol', function( $sym ) { return 'A'; } );
+		add_filter( 'lifterlms_price_format', function( $format ) { return '%2$s %1$s'; } );
+
+		$this->assertEquals( array( 'currency_format' => '#,##0.00 A' ), LLMS_Unit_Test_Util::call_method( $this->main, 'get_analytics_options' ) );
+
+		remove_all_filters( 'lifterlms_currency_symbol' );
+		remove_all_filters( 'lifterlms_price_format' );
+
+	}
+
+	/**
 	 * Test maybe_enqueue_reporting() on a screen where it shouldn't be registered.
 	 *
 	 * @since 4.3.3


### PR DESCRIPTION
## Description

Fixes #1096 

## How has this been tested?

+ Manually
+ New unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug Fix

## Additional Information

The google charts library will not support a currency format pattern for currencies with a `.` (period) as the thousand's separator and a `,` (comma) as the decimal separator. This PR forces it into the "accepted" format (the reverse) to allow the chart to load as expected. The result is that the correct currency symbol will displayed for these currencies but the "incorrect" characters will be displayed.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

