### PR TITLE
Add an admin tool to handle rescheduling recurring payments

### DIFF
--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -113,7 +113,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		foreach ( $this->get_orders() as $id ) {
 			$order = llms_get_post( $id );
- 			$order->maybe_schedule_payment( false );
+			$order->maybe_schedule_payment( false );
 			$order->maybe_schedule_expiration();
 			if ( $order->get_next_scheduled_action_time( 'llms_charge_recurring_payment' ) ) {
 				$orders[] = $id;
@@ -137,7 +137,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		global $wpdb;
 
-		return $wpdb->get_results(
+		return $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching -- Caching implemented in `get_orders()`.
 			"SELECT p.ID
 			   FROM {$wpdb->posts} AS p
 	      LEFT JOIN {$wpdb->prefix}actionscheduler_actions AS a

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Admin tool used to autmoatically reschedule recurring orders missing a pending scheduled payment action
+ *
+ * @package LifterLMS/Admin/Tools/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Admin_Tool_Batch_Eraser
+ *
+ * @since [version]
+ */
+class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_Tool {
+
+	/**
+	 * Tool ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'recurring-payment-rescheduler';
+
+	/**
+	 * Retrieve a description of the tool
+	 *
+	 * This is displayed on the right side of the tool's list before the button.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+
+		$count = count( $this->get_orders() );
+
+		$desc  = __( 'Schedule recurring payment actions for orders which have not had a recurring payment action scheduled.', 'lifterlms' );
+		$desc .= ' ';
+		// Translators: %d = the number of pending batches.
+		$desc .= sprintf(
+			_n(
+				'There is currently %d order that will have a payment rescheduled.',
+				'There are currently %d orders that will have their payments rescheduled.',
+				$count,
+				'lifterlms'
+			),
+			$count
+		);
+
+		return $desc;
+
+	}
+
+	/**
+	 * Retrieve the tool's label
+	 *
+	 * The label is the tool's title. It's displayed in the left column on the tool's list.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_label() {
+		return __( 'Reschedule Recurring Payments', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve the tool's button text
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_text() {
+		return __( 'Reschedule Payments', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve a list of orders
+	 *
+	 * @since [version]
+	 *
+	 * @return int[]
+	 */
+	protected function get_orders() {
+
+		$orders = wp_cache_get( $this->id, 'llms_tool_data' );
+		if ( ! $orders ) {
+			$orders = wp_list_pluck( $this->query_orders(), 'ID' );
+			wp_cache_set( $this->id, $orders, 'llms_tool_data' );
+		}
+
+		return $orders;
+
+	}
+
+	/**
+	 * Schedules payments and expiration for an order
+	 *
+	 * Retrieves orders from the `get_orders()` method and schedules a recurring payment
+	 * and expiration action based on it's existing calculated order data.
+	 *
+	 * @since [version]
+	 *
+	 * @return int[] Returns an array of WP_Post IDs for orders successfully rescheduled by the method.
+	 */
+	protected function handle() {
+
+		$orders = array();
+
+		foreach ( $this->get_orders() as $id ) {
+			$order = llms_get_post( $id );
+ 			$order->maybe_schedule_payment( false );
+			$order->maybe_schedule_expiration();
+			if ( $order->get_next_scheduled_action_time( 'llms_charge_recurring_payment' ) ) {
+				$orders[] = $id;
+			}
+		}
+
+		wp_cache_delete( $this->id, 'llms_tool_data' );
+
+		return $orders;
+
+	}
+
+	/**
+	 * Perform a DB query for orders to be handled by the tool
+	 *
+	 * @since [version]
+	 *
+	 * @return object[]
+	 */
+	protected function query_orders() {
+
+		global $wpdb;
+
+		return $wpdb->get_results(
+			"SELECT p.ID
+			   FROM {$wpdb->posts} AS p
+	      LEFT JOIN {$wpdb->prefix}actionscheduler_actions AS a
+			     ON a.args   = CONCAT( '{\"order_id\":', p.ID, '}' )
+			    AND a.hook   = 'llms_charge_recurring_payment'
+			    AND a.status = 'pending'
+			  WHERE 1
+			    AND p.post_type   = 'llms_order'
+			    AND p.post_status = 'llms-active'
+			    AND a.action_id IS NULL
+			  LIMIT 100
+			;"
+		);
+
+	}
+
+	/**
+	 * Conditionally load the tool
+	 *
+	 * This tool should only load if there are orders that can be handled by the tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean Return `true` to load the tool and `false` to not load it.
+	 */
+	protected function should_load() {
+		return count( $this->get_orders() ) > 0;
+	}
+
+}
+
+return new LLMS_Admin_Tool_Recurring_Payment_Rescheduler();

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Admin_Tool_Batch_Eraser
+ * LLMS_Admin_Tool_Recurring_Payment_Rescheduler class
  *
  * @since [version]
  */
@@ -101,7 +101,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	 * Schedules payments and expiration for an order
 	 *
 	 * Retrieves orders from the `get_orders()` method and schedules a recurring payment
-	 * and expiration action based on it's existing calculated order data.
+	 * and expiration action based on its existing calculated order data.
 	 *
 	 * @since [version]
 	 *
@@ -137,7 +137,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		global $wpdb;
 
-		return $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching -- Caching implemented in `get_orders()`.
+		return $wpdb->get_results(
 			"SELECT p.ID
 			   FROM {$wpdb->posts} AS p
 	      LEFT JOIN {$wpdb->prefix}actionscheduler_actions AS a
@@ -150,7 +150,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 			    AND a.action_id IS NULL
 			  LIMIT 100
 			;"
-		);
+		); // no-cache ok -- Caching implemented in `get_orders()`.
 
 	}
 

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.0.0
- * @version 3.37.6
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -804,6 +804,18 @@ class LLMS_Order extends LLMS_Post_Model {
 
 		return date_i18n( $format, $next_payment_time );
 
+	}
+
+	/**
+	 * Retrieve the timestamp of the next scheduled event for a given action
+	 *
+	 * @since [version]
+	 *
+	 * @param string $action Action hook ID. Core actions are "llms_charge_recurring_payment" and "llms_access_plan_expiration".
+	 * @return int|false Returns the timestamp of the next action as an integer or `false` when no action exist.
+	 */
+	public function get_next_scheduled_action_time( $action ) {
+		return as_next_scheduled_action( $action, $this->get_action_args() );
 	}
 
 	/**
@@ -1642,12 +1654,13 @@ class LLMS_Order extends LLMS_Post_Model {
 	 *
 	 * @since 3.19.0
 	 * @since 3.32.0 Update to use latest action-scheduler functions.
+	 * @since [version] Use `$this->get_next_scheduled_action_time()` to determine if the action is currently scheduled.
 	 *
 	 * @return void
 	 */
 	public function unschedule_expiration() {
 
-		if ( as_next_scheduled_action( 'llms_access_plan_expiration', $this->get_action_args() ) ) {
+		if ( $this->get_next_scheduled_action_time( 'llms_access_plan_expiration' ) ) {
 			as_unschedule_action( 'llms_access_plan_expiration', $this->get_action_args() );
 		}
 
@@ -1660,12 +1673,13 @@ class LLMS_Order extends LLMS_Post_Model {
 	 *
 	 * @since 3.0.0
 	 * @since 3.32.0 Update to use latest action-scheduler functions.
+	 * @since [version] Use `$this->get_next_scheduled_action_time()` to determine if the action is currently scheduled.
 	 *
 	 * @return void
 	 */
 	public function unschedule_recurring_payment() {
 
-		if ( as_next_scheduled_action( 'llms_charge_recurring_payment', $this->get_action_args() ) ) {
+		if ( $this->get_next_scheduled_action_time( 'llms_charge_recurring_payment' ) ) {
 			as_unschedule_action( 'llms_charge_recurring_payment', $this->get_action_args() );
 		}
 

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Tests for the LLMS_Admin_Tool_Recurring_Payment_Rescheduler class
+ *
+ * @package LifterLMS/Tests/Admins/Tools
+ *
+ * @group admin
+ * @group admin_tools
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup before class
+	 *
+	 * Include abstract class.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php';
+
+	}
+
+	/**
+	 * Teardown the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+		$this->clear_cache();
+
+	}
+
+	/**
+	 * Create N number of orders in the DB
+	 *
+	 * @since [version]
+	 *
+	 * @param integer $count         Number of orders to create.
+	 * @param boolean $remove_action Whether or not to remove a scheduled payment action.
+	 *                               If `true`, creates orders that would be handled by the tool, otherwise creates orders
+	 *                               that should be missed by the tool's queries.
+	 * @return int[] An array of WP_Post IDs for the created orders.
+	 */
+	private function create_orders_to_handle( $count = 3, $remove_action = true ) {
+
+		$orders = array();
+
+		$i = 1;
+		while ( $i <= $count ) {
+
+			$order = $this->get_mock_order();
+			$order->set_status( 'llms-active' );
+			$order->maybe_schedule_payment();
+
+			if ( $remove_action ) {
+				$order->unschedule_recurring_payment();
+			}
+
+			$orders[] = $order->get( 'id' );
+
+			++$i;
+		}
+
+		return $orders;
+
+	}
+
+	/**
+	 * Clear cached batch count data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function clear_cache() {
+		wp_cache_delete( 'recurring-payment-rescheduler', 'llms_tool_data' );
+	}
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->main = new LLMS_Admin_Tool_Recurring_Payment_Rescheduler();
+	}
+
+	/**
+	 * Test get_description()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_description() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_label()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_text()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_text() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_orders() during a cache hit
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_orders_cache_hit() {
+
+		wp_cache_set( 'recurring-payment-rescheduler', 'mock cache', 'llms_tool_data' );
+		$this->assertEquals( 'mock cache',  LLMS_Unit_Test_Util::call_method( $this->main, 'get_orders' ) );
+
+	}
+
+	/**
+	 * Test get_orders() during a cache miss
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_orders_cache_miss() {
+
+		$orders = $this->create_orders_to_handle();
+
+		// Order IDs returned.
+		$this->assertEqualSets( $orders, LLMS_Unit_Test_Util::call_method( $this->main, 'get_orders' ) );
+
+		// Cache is set.
+		$this->assertEqualSets( $orders, wp_cache_get( 'recurring-payment-rescheduler', 'llms_tool_data' ) );
+
+	}
+
+	/**
+	 * Test handle()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle() {
+
+		$orders = $this->create_orders_to_handle();
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+
+		// All expected orders were handled.
+		$this->assertEqualSets( $orders, $res );
+
+		// Cache erased.
+		$this->assertFalse( wp_cache_get( 'recurring-payment-rescheduler', 'llms_tool_data' ) );
+
+		foreach ( $res as $id ) {
+
+			$order = llms_get_post( $id );
+
+			// Action is rescheduled.
+			$this->assertEquals( $order->get_next_payment_due_date( 'U' ), $order->get_next_scheduled_action_time( 'llms_charge_recurring_payment' ) );
+
+		}
+
+	}
+
+	/**
+	 * Test query_orders()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_query_orders() {
+
+		// No orders.
+		$this->assertEquals( array(), LLMS_Unit_Test_Util::call_method( $this->main, 'query_orders' ) );
+
+		// Should be found.
+		$to_handle = $this->create_orders_to_handle();
+
+		// This order should not be in the returned array.
+		$to_ignore = $this->create_orders_to_handle( 1, false );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'query_orders' );
+
+		$this->assertEqualSets( $to_handle, wp_list_pluck( $res, 'ID' ) );
+
+	}
+
+	/**
+	 * Test should_load()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function test_should_load() {
+
+		// No orders to handle.
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' ) );
+
+		// Orders to handle.
+		$this->create_orders_to_handle( 1 );
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
@@ -240,7 +240,7 @@ class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCa
 	 *
 	 * @return void
 	 */
-	protected function test_should_load() {
+	public function test_should_load() {
 
 		// No orders to handle.
 		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' ) );


### PR DESCRIPTION
## Description
This PR adds an admin tool which will identify orders with an *active* status that do not have an action scheduler recurring payment action associated with it.

Orders which may have encountered errors during creation might end up in this state and while it is possible to manually fix these through the admin panel UI, it's hard to identify orders in this state.

This tool makes bulk updating affected orders trivial.

This tool displays conditionally. It will not show on the tools list if the query does not detect any affected orders.

## How has this been tested?

+ Manual (details below)
+ New unit tests
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

![Screenshot_2020-10-16_17-01-57](https://user-images.githubusercontent.com/1290739/96323304-66ab0e80-0fd1-11eb-8168-01760ee48820.png)

## Types of changes
+ New feature
+ Minor changes to the `LLMS_Order` class
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->


## Manual testing

To test this manually:
+ Create one or more orders with recurring payments
+ Navigate to Status -> Scheduled Actions
+ Cancel 1 or more recurring payment actions (observer their scheduled date)
+ Navigate to the Status -> Tools & Utilities
+ Click the new button
+ Check scheduled actions again, these orders should have their actions rescheduled



HS-138030