### PR TITLE
Replace llms_log() + apply_filters() with apply_filters_deprecated()

### DIFF
--- a/includes/functions/llms.functions.quiz.php
+++ b/includes/functions/llms.functions.quiz.php
@@ -118,9 +118,6 @@ function llms_get_quiz_attempt_statuses() {
  */
 function llms_get_quiz_theme_setting( $setting = '', $default = '' ) {
 
-	// Deprecation notice for filter (and function).
-	llms_log( 'Filter `llms_get_quiz_theme_settings` deprecated since 3.17.6. For more information see new methods at https://lifterlms.com/docs/course-builder-custom-fields-for-developers/' );
-
 	/**
 	 * Deprecated.
 	 *
@@ -129,7 +126,7 @@ function llms_get_quiz_theme_setting( $setting = '', $default = '' ) {
 	 *
 	 * @param array[] $settings Array of quiz theme settings.
 	 */
-	$settings = apply_filters(
+	$settings = apply_filters_deprecated(
 		'llms_get_quiz_theme_settings',
 		array(
 			'layout' => array(
@@ -138,7 +135,8 @@ function llms_get_quiz_theme_setting( $setting = '', $default = '' ) {
 				'options' => array(),
 				'type'    => 'select', // Either: select or image_select.
 			),
-		)
+		),
+		'3.17.6'
 	);
 
 	if ( $setting ) {


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

Fixes #1302

Use [apply_filters_deprecated()](https://developer.wordpress.org/reference/functions/apply_filters_deprecated/) instead of `llms_log()` + `apply_filters()` to trigger deprecation notice.

I searched throughout the codebase and this was the only place I could find using `llms_log()` + `apply_filters()` to trigger a deprecation notice.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

