### PR TITLE
Replace llms_log() with llms_deprecated_function()

### DIFF
--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -124,7 +124,7 @@ class LLMS_Notifications {
 	 */
 	public function dispatch_processors() {
 
-		llms_log( 'LLMS_Notifications::dispatch_processors() is deprecated. Use LLMS_Notifications::schedule_processors_dispatch() instead.' );
+		llms_deprecated_function( 'LLMS_Notifications::dispatch_processors()', '3.38.0', 'LLMS_Notifications::schedule_processors_dispatch()' );
 
 		foreach ( $this->processors_to_dispatch as $key => $name ) {
 			$processor = $this->get_processor( $name );


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

Fixes #1391

Use `llms_deprecated_function()` instead of llms_log() to mark a function as deprecated.
`llms_deprecated_function()` uses wp core's [_deprecated_function](https://developer.wordpress.org/reference/functions/_deprecated_function/) internally, which will trigger an error if WP_DEBUG is `true`.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

