### PR TITLE
Add support for multiple roles in LLMS_User_Permissions::editable_roles()

### DIFF
--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -47,6 +47,7 @@ class LLMS_User_Permissions {
 	 * @since 3.13.0
 	 * @since 3.34.0 Moved the `llms_editable_roles` filter to the class method get_editable_roles().
 	 * @since 3.37.14 Use strict comparison.
+	 * @since [version] Better handling of users with multiple roles.
 	 *
 	 * @link https://codex.wordpress.org/Plugin_API/Filter_Reference/editable_roles
 	 *

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -60,17 +60,17 @@ class LLMS_User_Permissions {
 			return $all_roles;
 		}
 
-		$roles = array();
+		$user       = wp_get_current_user();
+		$user_roles = $user->roles;
 
-		$user = wp_get_current_user();
+		if ( in_array( 'administrator', $user_roles, true ) ) {
+			return $all_roles;
+		}
 
 		$editable_roles = self::get_editable_roles();
 
-		foreach ( $user->roles as $user_role ) {
-			if ( 'administrator' === $user_role ) {
-				return $all_roles;
-			}
-
+		$roles = array();
+		foreach ( $user_roles as $user_role ) {
 			if ( isset( $editable_roles[ $user_role ] ) ) {
 				$roles = array_merge( $roles, $editable_roles[ $user_role ] );
 			}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -69,6 +69,10 @@ class LLMS_User_Permissions {
 
 		$editable_roles = self::get_editable_roles();
 
+		if ( empty( array_intersect( $user_roles, array_keys( $editable_roles ) ) ) ) {
+			return $all_roles;
+		}
+
 		$roles = array();
 		foreach ( $user_roles as $user_role ) {
 			if ( isset( $editable_roles[ $user_role ] ) ) {

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -72,7 +72,7 @@ class LLMS_User_Permissions {
 
 		$roles = array_unique( $roles );
 
-		foreach ( $all_roles as $role ) {
+		foreach ( array_keys( $all_roles ) as $role ) {
 			if ( ! in_array( $role, $roles, true ) ) {
 				unset( $all_roles[ $role ] );
 			}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -72,7 +72,7 @@ class LLMS_User_Permissions {
 		$roles = array_unique( $roles );
 
 		foreach ( $all_roles as $role ) {
-			if ( ! in_array( $role, $roles ) ) {
+			if ( ! in_array( $role, $roles, true ) ) {
 				unset( $all_roles[ $role ] );
 			}
 		}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -55,6 +55,8 @@ class LLMS_User_Permissions {
 	 */
 	public function editable_roles( $all_roles ) {
 
+		$roles = array();
+
 		$user = wp_get_current_user();
 
 		$lms_roles = self::get_editable_roles();
@@ -63,11 +65,15 @@ class LLMS_User_Permissions {
 
 			if ( in_array( $role, $user->roles, true ) ) {
 
-				foreach ( $all_roles as $the_role => $caps ) {
-					if ( ! in_array( $the_role, $allowed_roles, true ) ) {
-						unset( $all_roles[ $the_role ] );
-					}
-				}
+				$roles = array_merge( $roles, $allowed_roles );
+			}
+		}
+
+		$roles = array_unique( $roles );
+
+		foreach ( $all_roles as $role ) {
+			if ( ! in_array( $role, $roles, true ) ) {
+				unset( $all_roles[ $role ] );
 			}
 		}
 

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -56,6 +56,10 @@ class LLMS_User_Permissions {
 	 */
 	public function editable_roles( $all_roles ) {
 
+		if ( is_multisite() && is_super_admin() ) {
+			return $all_roles;
+		}
+
 		$roles = array();
 
 		$user = wp_get_current_user();

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -62,10 +62,14 @@ class LLMS_User_Permissions {
 
 		$lms_roles = self::get_editable_roles();
 
-		foreach ( $lms_roles as $role => $allowed_roles ) {
+		foreach ( $user->roles as $user_role ) {
+			if ( 'administrator' === $user_role ) {
+				return array_keys( $all_roles );
+			}
 
-			if ( in_array( $role, $user->roles, true ) ) {
+			$allowed_roles = $lms_roles[ $user_role ];
 
+			if ( ! is_null( $allowed_roles ) ) {
 				$roles = array_merge( $roles, $allowed_roles );
 			}
 		}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -55,6 +55,8 @@ class LLMS_User_Permissions {
 	 */
 	public function editable_roles( $all_roles ) {
 
+		$roles = array();
+
 		$user = wp_get_current_user();
 
 		$lms_roles = self::get_editable_roles();
@@ -63,11 +65,15 @@ class LLMS_User_Permissions {
 
 			if ( in_array( $role, $user->roles, true ) ) {
 
-				foreach ( $all_roles as $the_role => $caps ) {
-					if ( ! in_array( $the_role, $allowed_roles, true ) ) {
-						unset( $all_roles[ $the_role ] );
-					}
-				}
+				$roles = array_merge( $roles, $allowed_roles );
+			}
+		}
+
+		$roles = array_unique( $roles );
+
+		foreach ( $all_roles as $role ) {
+			if ( ! in_array( $role, $roles ) ) {
+				unset( $all_roles[ $role ] );
 			}
 		}
 

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -64,7 +64,7 @@ class LLMS_User_Permissions {
 
 		foreach ( $user->roles as $user_role ) {
 			if ( 'administrator' === $user_role ) {
-				return array_keys( $all_roles );
+				return $all_roles;
 			}
 
 			if ( isset( $lms_roles[ $user_role ] ) ) {

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.13.0
- * @version 3.41.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -81,7 +81,7 @@ class LLMS_User_Permissions {
 		$llms_roles = array_keys( LLMS_Roles::get_roles() );
 
 		foreach ( array_keys( $all_roles ) as $role ) {
-			// only filter out LLMS roles.
+			// Only filter out LLMS roles.
 			if ( ! in_array( $role, $roles, true ) && in_array( $role, $llms_roles, true ) ) {
 				unset( $all_roles[ $role ] );
 			}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -82,11 +82,8 @@ class LLMS_User_Permissions {
 
 		$roles = array_unique( $roles );
 
-		$llms_roles = array_keys( LLMS_Roles::get_roles() );
-
 		foreach ( array_keys( $all_roles ) as $role ) {
-			// Only filter out LLMS roles.
-			if ( ! in_array( $role, $roles, true ) && in_array( $role, $llms_roles, true ) ) {
+			if ( ! in_array( $role, $roles, true ) ) {
 				unset( $all_roles[ $role ] );
 			}
 		}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -60,22 +60,25 @@ class LLMS_User_Permissions {
 
 		$user = wp_get_current_user();
 
-		$lms_roles = self::get_editable_roles();
+		$editable_roles = self::get_editable_roles();
 
 		foreach ( $user->roles as $user_role ) {
 			if ( 'administrator' === $user_role ) {
 				return $all_roles;
 			}
 
-			if ( isset( $lms_roles[ $user_role ] ) ) {
-				$roles = array_merge( $roles, $lms_roles[ $user_role ] );
+			if ( isset( $editable_roles[ $user_role ] ) ) {
+				$roles = array_merge( $roles, $editable_roles[ $user_role ] );
 			}
 		}
 
 		$roles = array_unique( $roles );
 
+		$llms_roles = array_keys( LLMS_Roles::get_roles() );
+
 		foreach ( array_keys( $all_roles ) as $role ) {
-			if ( ! in_array( $role, $roles, true ) ) {
+			// only filter out LLMS roles.
+			if ( ! in_array( $role, $roles, true ) && in_array( $role, $llms_roles, true ) ) {
 				unset( $all_roles[ $role ] );
 			}
 		}

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -67,10 +67,8 @@ class LLMS_User_Permissions {
 				return array_keys( $all_roles );
 			}
 
-			$allowed_roles = $lms_roles[ $user_role ];
-
-			if ( ! is_null( $allowed_roles ) ) {
-				$roles = array_merge( $roles, $allowed_roles );
+			if ( isset( $lms_roles[ $user_role ] ) ) {
+				$roles = array_merge( $roles, $lms_roles[ $user_role ] );
 			}
 		}
 

--- a/includes/class.llms.user.permissions.php
+++ b/includes/class.llms.user.permissions.php
@@ -55,8 +55,6 @@ class LLMS_User_Permissions {
 	 */
 	public function editable_roles( $all_roles ) {
 
-		$roles = array();
-
 		$user = wp_get_current_user();
 
 		$lms_roles = self::get_editable_roles();
@@ -65,15 +63,11 @@ class LLMS_User_Permissions {
 
 			if ( in_array( $role, $user->roles, true ) ) {
 
-				$roles = array_merge( $roles, $allowed_roles );
-			}
-		}
-
-		$roles = array_unique( $roles );
-
-		foreach ( $all_roles as $role ) {
-			if ( ! in_array( $role, $roles, true ) ) {
-				unset( $all_roles[ $role ] );
+				foreach ( $all_roles as $the_role => $caps ) {
+					if ( ! in_array( $the_role, $allowed_roles, true ) ) {
+						unset( $all_roles[ $the_role ] );
+					}
+				}
 			}
 		}
 

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -178,13 +178,13 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$all_roles = wp_roles()->roles;
 
 		wp_set_current_user( $users['assistant'] );
-		$assistant_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$assistant_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		// assert that assistants cannot edit any roles
 		$this->assertEmpty( $assistant_editable_roles );
 
 		wp_set_current_user( $users['admin'] );
-		$administrator_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$administrator_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		// assert that administrator can edit all roles
 		foreach ( array_keys( $all_roles ) as $role ) {
@@ -206,15 +206,15 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$all_roles = wp_roles()->roles;
 
 		wp_set_current_user( $users['lms_manager'] );
-		$lms_manager_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$lms_manager_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		wp_set_current_user( $users['instructor'] );
-		$instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		wp_set_current_user( $users['lms_manager'] );
 		$user = wp_get_current_user();
 		$user->add_role( 'instructor' );
-		$lms_manager_instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$lms_manager_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		// assert that lms_manager with instructor role has editable roles from both roles
 		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
@@ -227,7 +227,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['admin'] );
 		$user = wp_get_current_user();
 		$user->add_role( 'instructor' );
-		$administrator_instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$administrator_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
 		// assert that administrator with instructor role can edit all roles
 		foreach ( array_keys( $all_roles ) as $role ) {

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -175,7 +175,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 
 		$users = $this->create_mock_users();
 
-		$all_roles = LLMS_Roles::get_roles();
+		$all_roles = wp_roles()->roles;
 
 		wp_set_current_user( $users['lms_manager'] );
 		$lms_manager_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -177,11 +177,17 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 
 		$all_roles = wp_roles()->roles;
 
+		$llms_roles = LLMS_Roles::get_roles();
+
 		wp_set_current_user( $users['assistant'] );
 		$assistant_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// assert that assistants cannot edit any roles
-		$this->assertEmpty( $assistant_editable_roles );
+		// assert that assistants cannot edit any LLMS roles
+		foreach ( array_keys( $llms_roles ) as $llms_role ) {
+			$this->assertNotContains( $llms_role, $assistant_editable_roles );
+		}
+		// assert that assistants can edit external roles
+		$this->assertNotEmpty( $assistant_editable_roles );
 
 		wp_set_current_user( $users['admin'] );
 		$administrator_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -8,6 +8,7 @@
  *
  * @since 3.34.0
  * @since 3.41.0 Add new tests to better handle users with multiple roles.
+ * @since [version] Add new tests to test editable roles.
  */
 class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -186,16 +186,25 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['lms_manager'] );
 		$user = wp_get_current_user();
 		$user->add_role( 'instructor' );
-		$editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		$lms_manager_instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
 
 		// assert that lms_manager with instructor role has editable roles from both roles
 		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
-			$this->assertContains( $lms_manager_editable_role, $editable_roles );
+			$this->assertContains( $lms_manager_editable_role, $lms_manager_instructor_editable_roles );
 		}
 		foreach ( $instructor_editable_roles as $instructor_editable_role ) {
-			$this->assertContains( $instructor_editable_role, $editable_roles );
+			$this->assertContains( $instructor_editable_role, $lms_manager_instructor_editable_roles );
 		}
 
+		wp_set_current_user( $users['admin'] );
+		$user = wp_get_current_user();
+		$user->add_role( 'instructor' );
+		$administrator_instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		// assert that administrator with instructor role can edit all roles
+		foreach ( array_keys( $all_roles ) as $role ) {
+			$this->assertContains( $role, $administrator_instructor_editable_roles );
+		}
 	}
 
 	public function test_student_crud_caps() {

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -182,17 +182,17 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['assistant'] );
 		$assistant_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// assert that assistants cannot edit any LLMS roles
+		// Assert that assistants cannot edit any LLMS roles
 		foreach ( array_keys( $llms_roles ) as $llms_role ) {
 			$this->assertNotContains( $llms_role, $assistant_editable_roles );
 		}
-		// assert that assistants can edit external roles
+		// Assert that assistants can edit external roles
 		$this->assertNotEmpty( $assistant_editable_roles );
 
 		wp_set_current_user( $users['admin'] );
 		$administrator_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// assert that administrator can edit all roles
+		// Assert that administrator can edit all roles
 		foreach ( array_keys( $all_roles ) as $role ) {
 			$this->assertContains( $role, $administrator_editable_roles );
 		}
@@ -222,7 +222,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$user->add_role( 'instructor' );
 		$lms_manager_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// assert that lms_manager with instructor role has editable roles from both roles
+		// Assert that lms_manager with instructor role has editable roles from both roles
 		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
 			$this->assertContains( $lms_manager_editable_role, $lms_manager_instructor_editable_roles );
 		}
@@ -235,7 +235,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$user->add_role( 'instructor' );
 		$administrator_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// assert that administrator with instructor role can edit all roles
+		// Assert that administrator with instructor role can edit all roles
 		foreach ( array_keys( $all_roles ) as $role ) {
 			$this->assertContains( $role, $administrator_instructor_editable_roles );
 		}

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -164,6 +164,40 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test the editable_roles() filter for users with multiple roles.
+	 *
+	 * @return void
+	 */
+	public function test_editable_roles_multiple_roles() {
+
+		extract( $this->create_mock_users() );
+
+		$all_roles = LLMS_Roles::get_roles();
+
+		$lms_manager = new WP_User( $lms_manager );
+		wp_set_current_user( $lms_manager );
+		$lms_manager_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		$instructor = new WP_User( $instructor );
+		wp_set_current_user( $instructor );
+		$instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		$lms_manager_with_instructor_role = new WP_User( $lms_manager );
+		$lms_manager_with_instructor_role->add_role( 'instructor' );
+		wp_set_current_user( $lms_manager_with_instructor_role );
+		$lms_manager_with_instructor_role_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		// assert that lms_manager with instructor role has editable roles from both roles
+		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
+			$this->assertContains( $lms_manager_editable_role, $lms_manager_with_instructor_role_editable_roles );
+		}
+		foreach ( $instructor_editable_roles as $instructor_editable_role ) {
+			$this->assertContains( $instructor_editable_role, $lms_manager_with_instructor_role_editable_roles );
+		}
+
+	}
+
 	public function test_student_crud_caps() {
 
 		$users = $this->create_mock_users();

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -165,6 +165,34 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test the editable_roles() filter for users with single roles.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_editable_roles_single_role() {
+
+		$users = $this->create_mock_users();
+
+		$all_roles = wp_roles()->roles;
+
+		wp_set_current_user( $users['assistant'] );
+		$assistant_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		// assert that assistants cannot edit any roles
+		$this->assertEmpty( $assistant_editable_roles );
+
+		wp_set_current_user( $users['admin'] );
+		$administrator_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+
+		// assert that administrator can edit all roles
+		foreach ( array_keys( $all_roles ) as $role ) {
+			$this->assertContains( $role, $administrator_editable_roles );
+		}
+	}
+
+	/**
 	 * Test the editable_roles() filter for users with multiple roles.
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -177,17 +177,31 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 
 		$all_roles = wp_roles()->roles;
 
-		$llms_roles = LLMS_Roles::get_roles();
+		$editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'get_editable_roles');
+
+		wp_set_current_user( $users['lms_manager'] );
+		$lms_manager_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
+
+		// Assert that lms_managers can edit mapped roles
+		foreach ( $editable_roles['lms_manager'] as $editable_role ) {
+			$this->assertContains( $editable_role, $lms_manager_editable_roles );
+		}
+
+		wp_set_current_user( $users['instructor'] );
+		$instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
+
+		// Assert that instructor can edit mapped roles
+		foreach ( $editable_roles['instructor'] as $editable_role ) {
+			$this->assertContains( $editable_role, $instructor_editable_roles );
+		}
 
 		wp_set_current_user( $users['assistant'] );
 		$assistant_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that assistants cannot edit any LLMS roles
-		foreach ( array_keys( $llms_roles ) as $llms_role ) {
-			$this->assertNotContains( $llms_role, $assistant_editable_roles );
+		// Assert that assistants can edit all roles
+		foreach ( array_keys( $all_roles ) as $role ) {
+			$this->assertContains( $role, $assistant_editable_roles );
 		}
-		// Assert that assistants can edit external roles
-		$this->assertNotEmpty( $assistant_editable_roles );
 
 		wp_set_current_user( $users['admin'] );
 		$administrator_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -182,7 +182,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['lms_manager'] );
 		$lms_manager_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that lms_managers can edit mapped roles
+		// Assert that lms_managers can edit mapped roles.
 		foreach ( $editable_roles['lms_manager'] as $editable_role ) {
 			$this->assertContains( $editable_role, $lms_manager_editable_roles );
 		}
@@ -190,7 +190,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['instructor'] );
 		$instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that instructor can edit mapped roles
+		// Assert that instructor can edit mapped roles.
 		foreach ( $editable_roles['instructor'] as $editable_role ) {
 			$this->assertContains( $editable_role, $instructor_editable_roles );
 		}
@@ -198,7 +198,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['assistant'] );
 		$assistant_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that assistants can edit all roles
+		// Assert that assistants can edit all roles.
 		foreach ( array_keys( $all_roles ) as $role ) {
 			$this->assertContains( $role, $assistant_editable_roles );
 		}
@@ -206,7 +206,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		wp_set_current_user( $users['admin'] );
 		$administrator_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that administrator can edit all roles
+		// Assert that administrator can edit all roles.
 		foreach ( array_keys( $all_roles ) as $role ) {
 			$this->assertContains( $role, $administrator_editable_roles );
 		}
@@ -236,7 +236,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$user->add_role( 'instructor' );
 		$lms_manager_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that lms_manager with instructor role has editable roles from both roles
+		// Assert that lms_manager with instructor role has editable roles from both roles.
 		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
 			$this->assertContains( $lms_manager_editable_role, $lms_manager_instructor_editable_roles );
 		}
@@ -249,7 +249,7 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 		$user->add_role( 'instructor' );
 		$administrator_instructor_editable_roles = array_keys ( LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) ) );
 
-		// Assert that administrator with instructor role can edit all roles
+		// Assert that administrator with instructor role can edit all roles.
 		foreach ( array_keys( $all_roles ) as $role ) {
 			$this->assertContains( $role, $administrator_instructor_editable_roles );
 		}

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -171,29 +171,27 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 	 */
 	public function test_editable_roles_multiple_roles() {
 
-		extract( $this->create_mock_users() );
+		$users = $this->create_mock_users();
 
 		$all_roles = LLMS_Roles::get_roles();
 
-		$lms_manager = new WP_User( $lms_manager );
-		wp_set_current_user( $lms_manager );
+		wp_set_current_user( $users['lms_manager'] );
 		$lms_manager_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
 
-		$instructor = new WP_User( $instructor );
-		wp_set_current_user( $instructor );
+		wp_set_current_user( $users['instructor'] );
 		$instructor_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
 
-		$lms_manager_with_instructor_role = new WP_User( $lms_manager );
-		$lms_manager_with_instructor_role->add_role( 'instructor' );
-		wp_set_current_user( $lms_manager_with_instructor_role );
-		$lms_manager_with_instructor_role_editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
+		wp_set_current_user( $users['lms_manager'] );
+		$user = wp_get_current_user();
+		$user->add_role( 'instructor' );
+		$editable_roles = LLMS_Unit_Test_Util::call_method( $this->obj, 'editable_roles', array( $all_roles ) );
 
 		// assert that lms_manager with instructor role has editable roles from both roles
 		foreach ( $lms_manager_editable_roles as $lms_manager_editable_role ) {
-			$this->assertContains( $lms_manager_editable_role, $lms_manager_with_instructor_role_editable_roles );
+			$this->assertContains( $lms_manager_editable_role, $editable_roles );
 		}
 		foreach ( $instructor_editable_roles as $instructor_editable_role ) {
-			$this->assertContains( $instructor_editable_role, $lms_manager_with_instructor_role_editable_roles );
+			$this->assertContains( $instructor_editable_role, $editable_roles );
 		}
 
 	}

--- a/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-user-permissions.php
@@ -167,6 +167,8 @@ class LLMS_Test_User_Permissions extends LLMS_UnitTestCase {
 	/**
 	 * Test the editable_roles() filter for users with multiple roles.
 	 *
+	 * @since [version]
+	 *
 	 * @return void
 	 */
 	public function test_editable_roles_multiple_roles() {


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

Fixes #1356 

Whitelists editable roles using addition instead of subtraction.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

