### PR TITLE
Fix post update message for post types that aren't publicly queryable

### DIFF
--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -91,7 +91,7 @@ class LLMS_Admin_Post_Types {
 
 			$link_format = ' <a href="%1$s">%2$s</a>.';
 
-			$permalink_html    = sprintf( $link_format, $permalink, sprintf( __( 'View %s', 'lifterlms' ), $name ) );
+			$permalink_html    = $obj->publicly_queryable ? sprintf( $link_format, $permalink, sprintf( __( 'View %s', 'lifterlms' ), $name ) ) : '';
 			$preview_link_html = sprintf( $link_format, $permalink, sprintf( __( 'Preview %s', 'lifterlms' ), $name ) );
 
 			$messages[ $type ] = array(

--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -86,13 +86,19 @@ class LLMS_Admin_Post_Types {
 			$obj  = get_post_type_object( $type );
 			$name = $obj->labels->singular_name;
 
-			$permalink    = get_permalink( $post->ID );
-			$preview_link = add_query_arg( 'preview', 'true', $permalink );
+			$permalink_html    = '';
+			$preview_link_html = '';
 
-			$link_format = ' <a href="%1$s">%2$s</a>.';
+			if ( $obj->publicly_queryable ) {
 
-			$permalink_html    = $obj->publicly_queryable ? sprintf( $link_format, $permalink, sprintf( __( 'View %s', 'lifterlms' ), $name ) ) : '';
-			$preview_link_html = sprintf( $link_format, $permalink, sprintf( __( 'Preview %s', 'lifterlms' ), $name ) );
+				$permalink    = get_permalink( $post->ID );
+				$preview_link = add_query_arg( 'preview', 'true', $permalink );
+
+				$link_format = ' <a href="%1$s">%2$s</a>.';
+
+				$permalink_html    = sprintf( $link_format, $permalink, sprintf( __( 'View %s', 'lifterlms' ), $name ) );
+				$preview_link_html = sprintf( $link_format, $permalink, sprintf( __( 'Preview %s', 'lifterlms' ), $name ) );
+			}
 
 			$messages[ $type ] = array(
 				0  => '',

--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since Unknown
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -59,6 +59,7 @@ class LLMS_Admin_Post_Types {
 	 *
 	 * @since Unknown.
 	 * @version 3.35.0 Fix l10n calls.
+	 * @since [version] added publicly_queryable check for permalink and perview.
 	 *
 	 * @return array $messages
 	 */

--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -59,7 +59,7 @@ class LLMS_Admin_Post_Types {
 	 *
 	 * @since Unknown.
 	 * @version 3.35.0 Fix l10n calls.
-	 * @since [version] added publicly_queryable check for permalink and perview.
+	 * @since [version] Added `publicly_queryable` check for permalink and preview.
 	 *
 	 * @return array $messages
 	 */


### PR DESCRIPTION
## Description
add publicly_queryable checking on object to make sure it can be query from the front end.

Fixes #1250 

## How has this been tested?
login as admin, update email, message "Email updated" appear, without the view email with an invalid link

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ x] My code has been tested.
- [X ] My code passes all existing automated tests.
- [X ] My code follows the LifterLMS Coding & Documentation Standards.

