### PR TITLE
Automatically load LLMS_Admin_Reporting on the admin panel

### DIFF
--- a/includes/admin/class-llms-admin-users-table.php
+++ b/includes/admin/class-llms-admin-users-table.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.34.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -34,12 +34,11 @@ class LLMS_Admin_Users_Table {
 	 *
 	 * @since 3.34.0
 	 * @since 4.0.0 Add custom user table columns and action links.
+	 * @since [version] Remove `load_dependencies()` method hook.
 	 *
 	 * @return void
 	 */
 	public function __construct() {
-
-		add_action( 'current_screen', array( $this, 'load_dependencies' ) );
 
 		add_filter( 'manage_users_columns', array( $this, 'add_cols' ) );
 		add_filter( 'manage_users_custom_column', array( $this, 'output_col' ), 10, 3 );
@@ -140,23 +139,6 @@ class LLMS_Admin_Users_Table {
 	}
 
 	/**
-	 * Load dependencies used by the class.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
-	 */
-	public function load_dependencies() {
-
-		$screen = get_current_screen();
-
-		if ( $screen && 'users' === $screen->id ) {
-			require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
-		}
-
-	}
-
-	/**
 	 * Modify the query arguments of the users table query.
 	 *
 	 * If the current user is an instructor and no `role` argument is provided will limit the query to users
@@ -249,6 +231,26 @@ class LLMS_Admin_Users_Table {
 		}
 
 		return $output;
+
+	}
+
+	/**
+	 * Load dependencies used by the class.
+	 *
+	 * @since 4.0.0
+	 * @deprecated [version] `LLMS_Admin_Users_Table::load_dependencies()` is deprecated with no replacement. The included
+	 *                   class, `LLMS_Admin_Reporting` is now always loaded.
+	 *
+	 * @return void
+	 */
+	public function load_dependencies() {
+
+		llms_deprecated_function( 'LLMS_Admin_Users_Table::load_dependencies()', '[version]' );
+
+		$screen = get_current_screen();
+		if ( $screen && 'users' === $screen->id ) {
+			require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
+		}
 
 	}
 

--- a/includes/admin/class.llms.admin.menus.php
+++ b/includes/admin/class.llms.admin.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 3.37.19
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -281,6 +281,7 @@ class LLMS_Admin_Menus {
 	 * @since 3.2.0
 	 * @since 3.13.0 Unknown.
 	 * @since 3.35.0 Sanitize input data.
+	 * @since [version] Removed inclusion of `LLMS_Admin_Reporting` which is now loaded automatically.
 	 *
 	 * @return void
 	 */
@@ -290,9 +291,8 @@ class LLMS_Admin_Menus {
 			wp_die( __( 'You do not have permission to access this content.', 'lifterlms' ) );
 		}
 
-		require_once 'reporting/class.llms.admin.reporting.php';
-		$gb = new LLMS_Admin_Reporting();
-		$gb->output();
+		$reporting = new LLMS_Admin_Reporting();
+		$reporting->output();
 
 	}
 

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 4.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -211,6 +211,7 @@ class LLMS_Loader {
 	 * Includes that are required only on the admin panel
 	 *
 	 * @since 4.0.0
+	 * @since [version] Always load `LLMS_Admin_Reporting`.
 	 *
 	 * @return void
 	 */
@@ -260,6 +261,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/controllers/class.llms.controller.admin.quiz.attempts.php';
 
 		// Reporting.
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php';
 
 		// Load setup wizard conditionally.

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 3.39.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -112,13 +112,13 @@ class LLMS_AJAX_Handler {
 	 * Retrieve a new instance of admin table class from a handler string.
 	 *
 	 * @since 3.37.15
+	 * @since [version] Don't require `LLMS_Admin_Reporting`, it's loaded automatically.
 	 *
 	 * @param string $handler Unprefixed handler class string. For example "Students" or "Course_Students".
 	 * @return object|false Instance of the admin table class or false if the class can't be found.
 	 */
 	protected static function get_admin_table_instance( $handler ) {
 
-		require_once 'admin/reporting/class.llms.admin.reporting.php';
 		LLMS_Admin_Reporting::includes();
 
 		$handler = 'LLMS_Table_' . $handler;

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Test Admin Menus Class
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group admin_menus
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Menus extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setupBeforeClass() {
+		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.menus.php';
+	}
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = new LLMS_Admin_Menus();
+
+	}
+
+	/**
+	 * Test reporting_page_init() when there's permission issues.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_reporting_page_init_permissions_error() {
+
+		$this->mockGetRequest( array( 'student_id' => $this->factory->student->create() ) );
+
+		$this->setExpectedException( 'WPDieException', 'You do not have permission to access this content.' );
+
+		$this->main->reporting_page_init();
+
+	}
+
+	/**
+	 * Test reporting_page_init() when there's no permission issues
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_reporting_page_init_permission_success() {
+
+		set_current_screen( 'admin' );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->mockGetRequest( array( 'student_id' => $this->factory->student->create() ) );
+
+		$this->assertOutputContains( '<div class="wrap lifterlms llms-reporting tab--students">', array( $this->main, 'reporting_page_init' ) );
+
+		set_current_screen( 'front' );
+	}
+
+	/**
+	 * Test reporting_page_init() when there's no permission issues
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_reporting_page_init_no_permissions() {
+
+		set_current_screen( 'admin' );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertOutputContains( '<div class="wrap lifterlms llms-reporting tab--students">', array( $this->main, 'reporting_page_init' ) );
+
+		set_current_screen( 'front' );
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-users-table.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-users-table.php
@@ -15,11 +15,13 @@ class LLMS_Test_Admin_Users_table extends LLMS_Unit_Test_Case {
 	 * Setup before class
 	 *
 	 * @since 4.0.0
+	 * @since [version] Add `LLMS_Admin_Reporting` class.
 	 *
 	 * @return void
 	 */
 	public static function setupBeforeClass() {
 		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-users-table.php';
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-ajax-handler.php
+++ b/tests/phpunit/unit-tests/class-llms-test-ajax-handler.php
@@ -13,6 +13,18 @@
  */
 class LLMS_Test_AJAX_Handler extends LLMS_UnitTestCase {
 
+	/**
+	 * Setup before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setupBeforeClass() {
+		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/reporting/class.llms.admin.reporting.php';
+	}
+
 	public function setUp() {
 		parent::setUp();
 		add_filter( 'wp_die_handler', array( $this, '_wp_die_handler' ), 1 );


### PR DESCRIPTION
## Description

Always loads the class on the admin panel
Removes various places where the class is manually required since they're no longer needed.

Fixes #1297 

## How has this been tested?


## Screenshots <!-- if applicable -->

## Types of changes
+ Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

