### PR TITLE
Improve the Importer success message

### DIFF
--- a/includes/admin/class.llms.admin.import.php
+++ b/includes/admin/class.llms.admin.import.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.3.0
- * @version 3.37.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -36,55 +36,60 @@ class LLMS_Admin_Import {
 	}
 
 	/**
-	 * Localize statistic information for display on success.
+	 * Convert an array of generated content IDs to a list of anchor tags to edit the generated content
 	 *
-	 * @since 3.35.0
+	 * @since [version]
 	 *
-	 * @param string $stat Statistic key name.
+	 * @param int[]  $ids  Array of object IDs. Either WP_Post IDs or WP_User IDs.
+	 * @param string $type Object types. Either "post" or "user".
+	 * @return string A comma-separated list of HTML anchor tags.
+	 */
+	protected function get_generated_content_list( $ids, $type ) {
+
+		$list = array();
+		foreach ( $ids as $id ) {
+
+			if ( 'post' === $type ) {
+				$link = get_edit_post_link( $id );
+				$text = get_the_title( $id );
+			} elseif ( 'user' === $type ) {
+				$link = get_edit_user_link( $id );
+				$text = get_user_by( 'ID', $id )->display_name;
+			}
+
+			$list[] = sprintf( '<a href="%1$s">%2$s</a>', esc_url( $link ), $text );
+
+		}
+
+		return implode( ', ', $list );
+
+	}
+
+	/**
+	 * Retrieves a "Success" message providing information about the imported content.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Generator $generator Generator instance.
 	 * @return string
 	 */
-	protected function localize_stat( $stat ) {
+	protected function get_success_message( $generator ) {
 
-		switch ( $stat ) {
+		$msg  = '<strong>' . __( 'Import Successful!', 'lifterlms' ) . '</strong><br>';
+		$msg .= '<ul>';
 
-			case 'authors':
-				$name = __( 'Authors', 'lifterlms' );
-				break;
+		$generated = $generator->get_generated_content();
 
-			case 'courses':
-				$name = __( 'Courses', 'lifterlms' );
-				break;
+		if ( ! empty( $generated['course'] ) ) {
+			$msg .= '<li>'. sprintf( __( 'Imported courses: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['course'], 'post' ) ) . '</li>';
+		}
+		if ( ! empty( $generated['user'] ) ) {
+			$msg .= '<li>'. sprintf( __( 'Imported users: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['user'], 'user' ) ) . '</li>';
+		}
 
-			case 'sections':
-				$name = __( 'Sections', 'lifterlms' );
-				break;
+		$msg .= '</ul>';
 
-			case 'lessons':
-				$name = __( 'Lessons', 'lifterlms' );
-				break;
-
-			case 'plans':
-				$name = __( 'Plans', 'lifterlms' );
-				break;
-
-			case 'quizzes':
-				$name = __( 'Quizzes', 'lifterlms' );
-				break;
-
-			case 'questions':
-				$name = __( 'Questions', 'lifterlms' );
-				break;
-
-			case 'terms':
-				$name = __( 'Terms', 'lifterlms' );
-				break;
-
-			default:
-				$name = $stat;
-
-		}// End switch().
-
-		return $name;
+		return $msg;
 
 	}
 
@@ -93,6 +98,7 @@ class LLMS_Admin_Import {
 	 *
 	 * @since 3.3.0
 	 * @since 3.35.0 Import template from the admin views directory instead of the frontend templates directory.
+	 * @since [version] Moved logic for generating success message into its own method.
 	 *
 	 * @return void
 	 */
@@ -115,11 +121,7 @@ class LLMS_Admin_Import {
 	 */
 	public function upload_import() {
 
-		if ( ! llms_verify_nonce( 'llms_importer_nonce', 'llms-importer' ) || empty( $_FILES['llms_import'] ) ) {
-			return false;
-		}
-
-		if ( ! current_user_can( 'manage_lifterlms' ) ) {
+		if ( ! llms_verify_nonce( 'llms_importer_nonce', 'llms-importer' ) || ! current_user_can( 'manage_lifterlms' ) || empty( $_FILES['llms_import'] ) ) {
 			return false;
 		}
 
@@ -152,14 +154,7 @@ class LLMS_Admin_Import {
 			return $generator->error;
 		}
 
-		$msg  = '<strong>' . __( 'Import Successful', 'lifterlms' ) . '</strong><br>';
-		$msg .= '<ul>';
-		foreach ( $generator->get_results() as $stat => $count ) {
-			$msg .= '<li>' . sprintf( '%s: %d', $this->localize_stat( $stat ), $count ) . '</li>';
-		}
-		$msg .= '</ul>';
-
-		LLMS_Admin_Notices::flash_notice( $msg, 'success' );
+		LLMS_Admin_Notices::flash_notice( $this->get_success_message( $generator ), 'success' );
 		return true;
 
 	}
@@ -220,13 +215,69 @@ class LLMS_Admin_Import {
 			if ( 'json' !== strtolower( $info['extension'] ) ) {
 				$msg = __( 'Only valid JSON files can be imported.', 'lifterlms' );
 			}
-		}// End if().
+		}
 
 		if ( ! empty( $msg ) ) {
 			return new WP_Error( 'llms_import_file_error', $msg );
 		}
 
 		return true;
+
+	}
+
+	/**
+	 * Localize statistic information for display on success.
+	 *
+	 * @since 3.35.0
+	 * @deprecated [version] `LLMS_Admin_Import::localize_stat()` is deprecated with no replacement.
+	 *
+	 * @param string $stat Statistic key name.
+	 * @return string
+	 */
+	protected function localize_stat( $stat ) {
+
+		llms_deprecated_function( 'LLMS_Admin_Import::localize_stat()', '[version]' );
+
+		switch ( $stat ) {
+
+			case 'authors':
+				$name = __( 'Authors', 'lifterlms' );
+				break;
+
+			case 'courses':
+				$name = __( 'Courses', 'lifterlms' );
+				break;
+
+			case 'sections':
+				$name = __( 'Sections', 'lifterlms' );
+				break;
+
+			case 'lessons':
+				$name = __( 'Lessons', 'lifterlms' );
+				break;
+
+			case 'plans':
+				$name = __( 'Plans', 'lifterlms' );
+				break;
+
+			case 'quizzes':
+				$name = __( 'Quizzes', 'lifterlms' );
+				break;
+
+			case 'questions':
+				$name = __( 'Questions', 'lifterlms' );
+				break;
+
+			case 'terms':
+				$name = __( 'Terms', 'lifterlms' );
+				break;
+
+			default:
+				$name = $stat;
+
+		}
+
+		return $name;
 
 	}
 

--- a/includes/admin/class.llms.admin.import.php
+++ b/includes/admin/class.llms.admin.import.php
@@ -81,10 +81,10 @@ class LLMS_Admin_Import {
 		$generated = $generator->get_generated_content();
 
 		if ( ! empty( $generated['course'] ) ) {
-			$msg .= '<li>'. sprintf( __( 'Imported courses: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['course'], 'post' ) ) . '</li>';
+			$msg .= '<li>' . sprintf( __( 'Imported courses: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['course'], 'post' ) ) . '</li>';
 		}
 		if ( ! empty( $generated['user'] ) ) {
-			$msg .= '<li>'. sprintf( __( 'Imported users: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['user'], 'user' ) ) . '</li>';
+			$msg .= '<li>' . sprintf( __( 'Imported users: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['user'], 'user' ) ) . '</li>';
 		}
 
 		$msg .= '</ul>';

--- a/includes/admin/class.llms.admin.import.php
+++ b/includes/admin/class.llms.admin.import.php
@@ -41,7 +41,7 @@ class LLMS_Admin_Import {
 	 * @since [version]
 	 *
 	 * @param int[]  $ids  Array of object IDs. Either WP_Post IDs or WP_User IDs.
-	 * @param string $type Object types. Either "post" or "user".
+	 * @param string $type Object's type. Either "post" or "user".
 	 * @return string A comma-separated list of HTML anchor tags.
 	 */
 	protected function get_generated_content_list( $ids, $type ) {
@@ -81,9 +81,11 @@ class LLMS_Admin_Import {
 		$generated = $generator->get_generated_content();
 
 		if ( ! empty( $generated['course'] ) ) {
+			// Translators: %s = comma-separated list of anchors to the imported courses.
 			$msg .= '<li>' . sprintf( __( 'Imported courses: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['course'], 'post' ) ) . '</li>';
 		}
 		if ( ! empty( $generated['user'] ) ) {
+			// Translators: %s = comma-separated list of anchors to the imported users.
 			$msg .= '<li>' . sprintf( __( 'Imported users: %s', 'lifterlms' ), $this->get_generated_content_list( $generated['user'], 'user' ) ) . '</li>';
 		}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
@@ -9,7 +9,7 @@
  *
  * @since 3.35.0
  * @since 3.37.8 Update path to assets directory.
- * @since [version] Test success message genration.
+ * @since [version] Test success message generation.
  */
 class LLMS_Test_Admin_Import extends LLMS_UnitTestCase {
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
@@ -9,6 +9,7 @@
  *
  * @since 3.35.0
  * @since 3.37.8 Update path to assets directory.
+ * @since [version] Test success message genration.
  */
 class LLMS_Test_Admin_Import extends LLMS_UnitTestCase {
 
@@ -64,6 +65,37 @@ class LLMS_Test_Admin_Import extends LLMS_UnitTestCase {
 			'error' => $err,
 			'size' => filesize( $file ),
 		);
+
+	}
+
+	/**
+	 * Test get_success_message()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_success_message() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$generator = new LLMS_Generator( array() );
+		$course = $this->factory->post->create_many( 2, array( 'post_type' => 'course' ) );
+		$user = $this->factory->user->create_many( 1 );
+		LLMS_Unit_Test_Util::set_private_property( $generator, 'generated', compact( 'course', 'user' ) );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->import, 'get_success_message', array( $generator ) );
+
+		$this->assertStringContains( 'Import Successful!', $res );
+
+		foreach( $course as $id ) {
+			$this->assertStringContains( esc_url( get_edit_post_link( $id ) ), $res );
+			$this->assertStringContains( get_the_title( $id ), $res );
+		}
+
+		$user = new WP_User( $user[0] );
+		$this->assertStringContains( esc_url( get_edit_user_link( $user->ID ) ), $res );
+		$this->assertStringContains( $user->display_name, $res );
 
 	}
 
@@ -238,6 +270,19 @@ class LLMS_Test_Admin_Import extends LLMS_UnitTestCase {
 		$this->mock_file_upload();
 
 		$this->assertTrue( $this->import->upload_import() );
+
+	}
+
+	/**
+	 * Test output() method
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output() {
+
+		$this->assertOutputContains( '<div class="wrap lifterlms llms-import-export">', array( $this->import, 'output' ) );
 
 	}
 


### PR DESCRIPTION
## Description

When doing final testing on generator improvements merged in from #1386 I noticed that as a result of adding new keys to the `LLMS_Generator` generated content property we now have a success message with duplicates since it lists the counts for *all* stats in the return.

I've made some changes and now, instead of listing our all of the generated content with numbers, the success message only contains two items:

1. Courses imported
2. Users imported

And instead of listing just a count of how many of each item were imported it creates a comma-separated list of anchors to the edit post/user admin page with the text of the anchor being the course title or user's display name.

This makes the success message, I hope, generally more usable instead of just relaying information.

I've never received any feedback about this but I would imagine that the first step after importing something is to have a look at it. This reduces the number of steps needed to perform that action.

We *lose* the counts but I don't think this really matters.

## How has this been tested?

+ Added New tests
+ Existing tests pass
+ Manually

## Screenshots <!-- if applicable -->

![Screenshot_2020-10-21_16-03-28](https://user-images.githubusercontent.com/1290739/96800059-4c9a7300-13b9-11eb-8886-f9249c337bd7.png)

New message ^

## Types of changes

+ Updates

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

