### PR TITLE
Add an option to dismiss admin notifications forever

### DIFF
--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -73,6 +73,7 @@ class LLMS_Admin_Notices {
 	 * @return   void
 	 * @since    3.0.0
 	 * @version  3.3.0 - added "flash" option
+	 * @version  [version] - added "dismiss_forever" option
 	 */
 	public static function add_notice( $notice_id, $html_or_options = '', $options = array() ) {
 
@@ -95,6 +96,7 @@ class LLMS_Admin_Notices {
 			array(
 				'dismissible'      => true,
 				'dismiss_for_days' => 7,
+				'dismiss_forever'  => false, // If true, will delete the notice after hide it.
 				'flash'            => false, // If true, will delete the notice after displaying it.
 				'html'             => '',
 				'remind_in_days'   => 7,
@@ -126,7 +128,7 @@ class LLMS_Admin_Notices {
 		if ( $notice ) {
 			if ( 'remind' === $trigger && $notice['remindable'] ) {
 				$delay = isset( $notice['remind_in_days'] ) ? $notice['remind_in_days'] : 0;
-			} elseif ( 'hide' === $trigger && $notice['dismissible'] ) {
+			} elseif ( 'hide' === $trigger && $notice['dismissible'] && ! $notice['dismiss_forever'] ) {
 				$delay = isset( $notice['dismiss_for_days'] ) ? $notice['dismiss_for_days'] : 7;
 			} else {
 				$delay = 0;


### PR DESCRIPTION
## Description
added dismiss_forever option for notice to dismiss and remove

Fixes #1360 

## How has this been tested?
set a notice which will dismiss forever, once hide the notice, check the option has never added back to the option table.

## Types of changes
 New feature (non-breaking change which adds functionality)
## Checklist:
- [X ] My code has been tested.
- [ X] My code passes all existing automated tests
- [X ] My code follows the LifterLMS Coding & Documentation Standards. 
