### PR TITLE
Improvements to rescheduler admin tool

### DIFF
--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Tools/Classes
  *
  * @since 4.6.0
- * @version 4.6.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,20 +30,22 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	 * This is displayed on the right side of the tool's list before the button.
 	 *
 	 * @since 4.6.0
+	 * @since [version] Modified language and use count from `FOUND_ROWS()`.
 	 *
 	 * @return string
 	 */
 	protected function get_description() {
 
-		$count = count( $this->get_orders() );
+		$orders = $this->get_orders();
+		$count  = wp_cache_get( sprintf( '%s-total-results', $this->id ), 'llms_tool_data' );
 
-		$desc  = __( 'Schedule recurring payment actions for orders which have not had a recurring payment action scheduled.', 'lifterlms' );
+		$desc  = __( 'Check active recurring orders to ensure their recurring payment action is properly scheduled for the next payment. If a recurring payment is due and not scheduled it will be rescheduled.', 'lifterlms' );
 		$desc .= ' ';
 		// Translators: %d = the number of pending batches.
 		$desc .= sprintf(
 			_n(
-				'There is currently %d order that will have a payment rescheduled.',
-				'There are currently %d orders that will have their payments rescheduled.',
+				'There is %d order that will checked.',
+				'There are %d orders that will be checked in batches of 50.',
 				$count,
 				'lifterlms'
 			),
@@ -104,6 +106,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	 * and expiration action based on its existing calculated order data.
 	 *
 	 * @since 4.6.0
+	 * @since [version] Set `plan_ended` metadata for orders with an ended plan and don't attempt to process them.
 	 *
 	 * @return int[] Returns an array of WP_Post IDs for orders successfully rescheduled by the method.
 	 */
@@ -113,6 +116,11 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		foreach ( $this->get_orders() as $id ) {
 			$order = llms_get_post( $id );
+			$next  = $order->get_next_payment_due_date();
+			if ( is_wp_error( $next ) && 'plan-ended' === $next->get_error_code() ) {
+				$order->set( 'plan_ended', 'yes' );
+				continue;
+			}
 			$order->maybe_schedule_payment( false );
 			$order->maybe_schedule_expiration();
 			if ( $order->get_next_scheduled_action_time( 'llms_charge_recurring_payment' ) ) {
@@ -121,6 +129,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		}
 
 		wp_cache_delete( $this->id, 'llms_tool_data' );
+		wp_cache_delete( sprintf( '%s-total-results', $this->id ), 'llms_tool_data' );
 
 		return $orders;
 
@@ -130,6 +139,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	 * Perform a DB query for orders to be handled by the tool
 	 *
 	 * @since 4.6.0
+	 * @since [version] Added `SQL_CALC_FOUND_ROWS` and improved query to exclude results with a completed payment plan.
 	 *
 	 * @return object[]
 	 */
@@ -137,10 +147,13 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		global $wpdb;
 
-		return $wpdb->get_results(
-			"SELECT p.ID
+		$orders = $wpdb->get_results(
+		"SELECT SQL_CALC_FOUND_ROWS p.ID
 			   FROM {$wpdb->posts} AS p
-	      LEFT JOIN {$wpdb->prefix}actionscheduler_actions AS a
+		  LEFT JOIN {$wpdb->postmeta} AS m
+			     ON p.ID = m.post_ID
+			    AND m.meta_key = '_llms_plan_ended'
+		  LEFT JOIN {$wpdb->prefix}actionscheduler_actions AS a
 			     ON a.args   = CONCAT( '{\"order_id\":', p.ID, '}' )
 			    AND a.hook   = 'llms_charge_recurring_payment'
 			    AND a.status = 'pending'
@@ -148,9 +161,15 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 			    AND p.post_type   = 'llms_order'
 			    AND p.post_status = 'llms-active'
 			    AND a.action_id IS NULL
-			  LIMIT 100
+			    AND m.meta_value IS NULL
+		   ORDER BY p.ID ASC
+			  LIMIT 50
 			;"
 		); // no-cache ok -- Caching implemented in `get_orders()`.
+
+		wp_cache_set( sprintf( '%s-total-results', $this->id ), $wpdb->get_var( 'SELECT FOUND_ROWS()' ), 'llms_tool_data' );
+
+		return $orders;
 
 	}
 

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -44,7 +44,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		// Translators: %d = the number of pending batches.
 		$desc .= sprintf(
 			_n(
-				'There is %d order that will checked.',
+				'There is %d order that will be checked.',
 				'There are %d orders that will be checked in batches of 50.',
 				$count,
 				'lifterlms'

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.0.0
- * @version 4.6.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -58,6 +58,7 @@ defined( 'ABSPATH' ) || exit;
  * @property   $plan_id  (int)  WP Post ID of the purchased access plan
  * @property   $plan_sku   (string)  SKU of the purchased access plan
  * @property   $plan_title  (string)  Title / Name of the purchased access plan
+ * @property   $plan_ended  (string)  Whether or not the payment plan has ended [yes|no]. Only applicable when the plan is not "unlimited".
  * @property   $product_id  (int)  WP Post ID of the purchased product
  * @property   $product_sku   (string)  SKU of the purchased product
  * @property   $product_title  (string)  Title / Name of the purchased product
@@ -78,12 +79,29 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.0.0
  * @since 3.32.0 Update to use latest action-scheduler functions.
  * @since 3.35.0 Prepare transaction revenue SQL query properly; Sanitize $_SERVER data.
+ * @since [version] Added `plan_ended` meta property.
  */
 class LLMS_Order extends LLMS_Post_Model {
 
-	protected $db_post_type    = 'llms_order';
+	/**
+	 * Datbase post type.
+	 *
+	 * @var string
+	 */
+	protected $db_post_type = 'llms_order';
+
+	/**
+	 * Model post type.
+	 *
+	 * @var string
+	 */
 	protected $model_post_type = 'order';
 
+	/**
+	 * Meta properties.
+	 *
+	 * @var array
+	 */
 	protected $properties = array(
 
 		'anonymized'           => 'yesno',
@@ -128,6 +146,7 @@ class LLMS_Order extends LLMS_Post_Model {
 		'order_key'            => 'text',
 		'order_type'           => 'text',
 		'payment_gateway'      => 'text',
+		'plan_ended'           => 'yesno',
 		'plan_sku'             => 'text',
 		'plan_title'           => 'text',
 		'product_sku'          => 'text',
@@ -1396,6 +1415,7 @@ class LLMS_Order extends LLMS_Post_Model {
 	 *
 	 * @since 3.0.0
 	 * @since 3.32.0 Update to use latest action-scheduler functions.
+	 * @since [version] Add `plan_ended` metadata when a plan ends.
 	 *
 	 * @return void
 	 */
@@ -1438,6 +1458,7 @@ class LLMS_Order extends LLMS_Post_Model {
 
 				// Add a note that the plan has completed.
 				$this->add_note( __( 'Order payment plan completed.', 'lifterlms' ) );
+				$this->set( 'plan_ended', 'yes' );
 
 			}
 		}

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -84,7 +84,7 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Order extends LLMS_Post_Model {
 
 	/**
-	 * Datbase post type.
+	 * Database post type.
 	 *
 	 * @var string
 	 */

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
@@ -87,6 +87,7 @@ class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCa
 	 */
 	private function clear_cache() {
 		wp_cache_delete( 'recurring-payment-rescheduler', 'llms_tool_data' );
+		wp_cache_delete( 'recurring-payment-rescheduler-total-results', 'llms_tool_data' );
 	}
 
 	/**
@@ -210,9 +211,36 @@ class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCa
 	}
 
 	/**
+	 * Test handle() properly handles "legacy" orders that don't have `plan_ended()` meta data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_orders_with_no_meta() {
+
+		// Force a WP_Error to be returned by LLMS_Order::get_next_payment_due_date().
+		add_filter( 'llms_order_calculate_next_payment_date', '__return_empty_string' );
+
+		$orders = $this->create_orders_to_handle( 1 );
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+
+		// No orders handled.
+		$this->assertEquals( array(), $res );
+
+		// The missing metadata has been added by the tool.
+		$this->assertEquals( 'yes', llms_get_post( $orders[0] )->get( 'plan_ended' ) );
+
+		remove_filter( 'llms_order_calculate_next_payment_date', '__return_empty_string' );
+
+	}
+
+	/**
 	 * Test query_orders()
 	 *
 	 * @since 4.6.0
+	 * @since [version] Add an order with `plan_ended` meta that should be ignored and add tests for `FOUND_ROWS()` cached data.
 	 *
 	 * @return void
 	 */
@@ -227,9 +255,16 @@ class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCa
 		// This order should not be in the returned array.
 		$to_ignore = $this->create_orders_to_handle( 1, false );
 
+		// Ignored because of `plan_ended` meta data.
+		$to_ignore_2 = $this->create_orders_to_handle( 1 );
+		llms_get_post( $to_ignore_2[0] )->set( 'plan_ended', 'yes' );
+
 		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'query_orders' );
 
 		$this->assertEqualSets( $to_handle, wp_list_pluck( $res, 'ID' ) );
+
+		// Test FOUND_ROWS() cache data.
+		$this->assertEquals( 3, wp_cache_get( sprintf( 'recurring-payment-rescheduler-total-results', $this->id ), 'llms_tool_data' ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
@@ -15,6 +15,7 @@
  *               Added default test override for test_edit_date() test to prevent output
  *               of skipped test that doesn't apply to the order model.
  * @since 4.6.0 Add coverage for `get_next_scheduled_action_time()`, `unschedule_expiration()`, and `unschedule_recurring_payment()`.
+ * @since [version] Update tests to handle new meta property `plan_ended`.
  */
 class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 
@@ -698,7 +699,10 @@ class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 				// plan ends so func should return a WP_Error
 				$order->set( 'date_billing_end', date( 'Y-m-d H:i:s', $future_expect - DAY_IN_SECONDS ) );
 				$order->maybe_schedule_payment( true );
-				$this->assertTrue( is_a( $order->get_next_payment_due_date(), 'WP_Error' ) );
+				$date = $order->get_next_payment_due_date();
+				$this->assertIsWPError( $date );
+				$this->assertWPErrorCodeEquals( 'plan-ended', $date );
+				$this->assertEquals( 'yes', $order->get( 'plan_ended' ) );
 				$order->set( 'date_billing_end', 0 );
 
 				$i++;
@@ -957,15 +961,13 @@ class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test recurring payment scheduling
+	 * Test recurring payment scheduling for a one-time order
 	 *
-	 * @since 3.19.0
-	 * @since 3.32.0 Update to use latest action-scheduler functions.
-	 * @since 4.6.0 Add coverage for `get_next_scheduled_action_time()`.
+	 * @since [version] Split from test_maybe_schedule_payment_recurring()
 	 *
 	 * @return void
 	 */
-	public function test_maybe_schedule_payment() {
+	public function test_maybe_schedule_payment_one_time() {
 
 		// Does nothing for a one-time order.
 		$plan = $this->get_mock_plan( '25.99', 0 );
@@ -973,7 +975,20 @@ class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 		$order->maybe_schedule_payment();
 		$this->assertEmpty( $order->get( 'date_next_payment' ) );
 
-		// Schedules for recurring.
+	}
+
+	/**
+	 * Test recurring payment scheduling for a recurring order
+	 *
+	 * @since 3.19.0
+	 * @since 3.32.0 Update to use latest action-scheduler functions.
+	 * @since 4.6.0 Add coverage for `get_next_scheduled_action_time()`.
+	 * @since [version] Split into it's own method to prevent variable clashes.
+	 *
+	 * @return void
+	 */
+	public function test_maybe_schedule_payment_recurring() {
+
 		$order = $this->get_mock_order();
 
 		$this->assertFalse( as_next_scheduled_action( 'llms_charge_recurring_payment', array(


### PR DESCRIPTION
## Description

Add new metadata `plan_ended` to the `LLMS_Order` model. This is applied when an order's plan ends and can be used to identify an ended order via metadata queries. Currently the calculation is handled by PHP which means you cannot easlily query for orders in this state via DB only. Unless you join the comments table, which we won't think about.

Improves the rescheduler tool:
+ Exclude orders with `plan_ended` meta data
+ Update language on the tool's ui
+ Report the total number of possible orders that can be handled by the tool 
+ Limit bathces to 50 to help with potential timeout issues

## How has this been tested?
+ new tests 
+ manual tests
+ existing tests

## Types of changes
Improvements and bug fixes

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

