### PR TITLE
Improve some events query performances

### DIFF
--- a/includes/admin/reporting/tables/llms.table.students.php
+++ b/includes/admin/reporting/tables/llms.table.students.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
  * @since 3.2.0
- * @version 3.37.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,16 +25,17 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	/**
 	 * Unique ID for the Table
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $id = 'students';
 
 	/**
 	 * Value of the field being filtered by
-	 * Only applicable if $filterby is set
+	 *
+	 * Only applicable if $filterby is set.
 	 *
 	 * @since 3.31.0
-	 * @var  string
+	 * @var string
 	 */
 	protected $filter = '';
 
@@ -42,14 +43,14 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * Field results are filtered by
 	 *
 	 * @since 3.31.0
-	 * @var  string
+	 * @var string
 	 */
 	protected $filterby = 'course_membership';
 
 	/**
 	 * Is the Table Exportable?
 	 *
-	 * @var  boolean
+	 * @var boolean
 	 */
 	protected $is_exportable = true;
 
@@ -57,37 +58,38 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * Determine if the table is filterable
 	 *
 	 * @since 3.31.0
-	 * @var  boolean
+	 * @var boolean
 	 */
 	protected $is_filterable = true;
 
 	/**
 	 * If true, tfoot will add ajax pagination links
 	 *
-	 * @var  boolean
+	 * @var boolean
 	 */
 	protected $is_paginated = true;
 
 	/**
 	 * Determine of the table is searchable
 	 *
-	 * @var  boolean
+	 * @var boolean
 	 */
 	protected $is_searchable = true;
 
 	/**
 	 * Results sort order
-	 * 'ASC' or 'DESC'
-	 * Only applicable of $orderby is not set
 	 *
-	 * @var  string
+	 * 'ASC' or 'DESC'
+	 * Only applicable of $orderby is not set.
+	 *
+	 * @var string
 	 */
 	protected $order = 'ASC';
 
 	/**
 	 * Field results are sorted by
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $orderby = 'name';
 
@@ -105,10 +107,11 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * @since 3.15.0 Unknown.
 	 * @since 3.36.0 Added "Last Seen" column.
 	 * @since 3.36.1 Fixed "Last Seen" column displaying wrong date when the student last login date was saved as timestamp.
+	 * @since [version] Speed up the query used to retrieve the last seen column by avoiding the found rows calculation.
 	 *
-	 * @param    string $key        the column id / key
-	 * @param    obj    $student    Instance of the LLMS_Student
-	 * @return   mixed
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student Instance of the LLMS_Student.
+	 * @return mixed
 	 */
 	public function get_data( $key, $student ) {
 
@@ -166,11 +169,12 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 			case 'last_seen':
 				$query = new LLMS_Events_Query(
 					array(
-						'actor'    => $student->get_id(),
-						'per_page' => 1,
-						'sort'     => array(
+						'actor'         => $student->get_id(),
+						'per_page'      => 1,
+						'sort'          => array(
 							'date' => 'DESC',
 						),
+						'no_found_rows' => true,
 					)
 				);
 
@@ -233,7 +237,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 			default:
 				$value = $key;
 
-		}// End switch().
+		}
 
 		return $this->filter_get_data( $value, $key, $student );
 
@@ -241,13 +245,15 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 
 	/**
 	 * Retrieve data for a cell in an export file
-	 * Should be overridden in extending classes
 	 *
-	 * @param    string $key        the column id / key
-	 * @param    obj    $student    Instance of the LLMS_Student
-	 * @return   mixed
-	 * @since    3.15.0
-	 * @version  3.26.1
+	 * Should be overridden in extending classes.
+	 *
+	 * @since 3.15.0
+	 * @since 3.26.1 Unknown.
+	 *
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student Instance of the LLMS_Student.
+	 * @return mixed
 	 */
 	public function get_export_data( $key, $student ) {
 
@@ -329,7 +335,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 			default:
 				$value = $this->get_data( $key, $student );
 
-		}// End switch().
+		}
 
 		return $this->filter_get_data( $value, $key, $student, 'export' );
 
@@ -338,21 +344,22 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	/**
 	 * Get the Text to be used as the placeholder in a searchable tables search input
 	 *
-	 * @return   string
-	 * @since    3.2.0
-	 * @version  3.15.0
+	 * @since 3.2.0
+	 * @since 3.15.0 Unknown.
+	 *
+	 * @return string
 	 */
 	public function get_table_search_form_placeholder() {
 		return apply_filters( 'llms_table_get_' . $this->id . '_search_placeholder', __( 'Search students by name or email...', 'lifterlms' ) );
 	}
 
 	/**
-	 * Get HTML for the filters displayed in the head of the table.
+	 * Get HTML for the filters displayed in the head of the table
 	 *
 	 * This overrides the LLMS_Admin_Table method.
 	 *
 	 * @since 3.31.0
-	 * @since 3.37.2
+	 * @since 3.37.2 Unknown.
 	 *
 	 * @return string
 	 */
@@ -420,10 +427,11 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	/**
 	 * Execute a query to retrieve results from the table
 	 *
-	 * @param    array $args  array of query args
-	 * @return   void
-	 * @since    3.2.0
-	 * @version  3.28.0
+	 * @since 3.2.0
+	 * @since 3.28.0 Unknown.
+	 *
+	 * @param array $args Array of query args.
+	 * @return void
 	 */
 	public function get_results( $args = array() ) {
 
@@ -460,9 +468,9 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	/**
 	 * Setup the array of sort arguments to pass to the LLMS_Student_Query for the table
 	 *
-	 * @return  array
-	 * @since   3.28.0
-	 * @version 3.28.0
+	 * @since 3.28.0
+	 *
+	 * @return array
 	 */
 	private function get_sort() {
 
@@ -510,7 +518,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 				);
 				break;
 
-		}// End switch().
+		}
 
 		return $sort;
 
@@ -522,8 +530,8 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * @since 3.28.0
 	 * @since 3.31.0 Added logic to parse 'filterby' and 'filter' args when this table is filterable.
 	 *
-	 * @param   array $args array of arguments.
-	 * @return  void
+	 * @param array $args Array of arguments.
+	 * @return void
 	 */
 	protected function parse_args( $args = array() ) {
 
@@ -556,9 +564,10 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	/**
 	 * Define the structure of arguments used to pass to the get_results method
 	 *
-	 * @return   array
-	 * @since    2.3.0
-	 * @version  3.28.0
+	 * @since 2.3.0
+	 * @since 3.28.0 Unknown.
+	 *
+	 * @return array
 	 */
 	public function set_args() {
 		return array(
@@ -573,7 +582,7 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 	 * @since 3.15.0 Unknown.
 	 * @since 3.36.0 Add "Last Seen" column.
 	 *
-	 * @return   array
+	 * @return array
 	 */
 	public function set_columns() {
 		return array(

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.36.0
- * @version 3.36.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +20,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	/**
 	 * Identify the Query
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	protected $id = 'events';
 
@@ -28,6 +28,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * Retrieve default arguments for a query
 	 *
 	 * @since 3.36.0
+	 * @since [version] Drop usage of `this->get_filter( 'default_args' )` in favor of `'llms_events_query_default_args'`.
 	 *
 	 * @return array
 	 */
@@ -56,7 +57,15 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 			return $args;
 		}
 
-		return apply_filters( $this->get_filter( 'default_args' ), $args, $this );
+		/**
+		 * Filters the events query default args
+		 *
+		 * @since 3.36.0
+		 *
+		 * @param array             $args         Array of default arguments to set up the query with.
+		 * @param LLMS_Events_Query $events_query Instance of LLMS_Events_Query.
+		 */
+		return apply_filters( 'llms_events_query_default_args', $args, $this );
 
 	}
 
@@ -64,6 +73,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * Retrieve an array of LLMS_Event objects for the given result set returned by the query
 	 *
 	 * @since 3.36.0
+	 * @since [version] Drop usage of `$this->get_filter('get_events')` in favor of `'llms_events_query_get_events'`.
 	 *
 	 * @return array
 	 */
@@ -83,7 +93,15 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 			return $events;
 		}
 
-		return apply_filters( $this->get_filter( 'get_events' ), $events, $this );
+		/**
+		 * Filters the list of events
+		 *
+		 * @since 3.36.0
+		 *
+		 * @param LLMS_Event[]      $events       Array of LLMS_Event instances.
+		 * @param LLMS_Events_Query $events_query Instance of LLMS_Events_Query.
+		 */
+		return apply_filters( 'llms_events_query_get_events', $events, $this );
 
 	}
 
@@ -96,7 +114,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 */
 	protected function parse_args() {
 
-		// sanitize post & user ids.
+		// Sanitize post & user ids.
 		foreach ( array( 'actor', 'actor_not_in', 'object', 'object_not_in', 'include', 'exclude' ) as $key ) {
 			$this->arguments[ $key ] = $this->sanitize_id_array( $this->arguments[ $key ] );
 		}
@@ -117,6 +135,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 3.36.0
+	 * @since [version] Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 *
 	 * @return string
 	 */
@@ -124,7 +143,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
+		return "SELECT {$this->sql_select_columns( 'id' )}
 				FROM {$wpdb->prefix}lifterlms_events
 				{$this->sql_where()}
 				{$this->sql_orderby()}
@@ -136,6 +155,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * SQL "where" clause for the query
 	 *
 	 * @since 3.36.0
+	 * @since [version] Drop usage of `$this->get_filter('where')` in favor of `'llms_events_query_where'`.
 	 *
 	 * @return string
 	 */
@@ -173,7 +193,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 			}
 		}
 
-		// matching fields.
+		// Matching fields.
 		$matching = array( 'object_type', 'event_type', 'event_action' );
 		foreach ( $matching as $key ) {
 			$val = $this->get( $key );
@@ -182,7 +202,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 			}
 		}
 
-		// date fields.
+		// Date fields.
 		$before = $this->get( 'date_before' );
 		if ( $before ) {
 			$sql .= $wpdb->prepare( ' AND date < %s', $before );
@@ -197,7 +217,15 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 			return $sql;
 		}
 
-		return apply_filters( $this->get_filter( 'where' ), $sql, $this );
+		/**
+		 * Filters the query WHERE clause
+		 *
+		 * @since 3.36.0
+		 *
+		 * @param string            $sql          The WHERE clause of the query.
+		 * @param LLMS_Events_Query $events_query Instance of LLMS_Events_Query.
+		 */
+		return apply_filters( 'llms_events_query_where', $sql, $this );
 
 	}
 

--- a/includes/class-llms-sessions.php
+++ b/includes/class-llms-sessions.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.36.0
- * @version 4.5.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -205,6 +205,8 @@ class LLMS_Sessions {
 	 * in the last 30 minutes.
 	 *
 	 * @since 3.36.0
+	 * @since [version] When retrieving the last event, instantiate the events query passing `no_found_rows` arg as `true`,
+	 *              to improve performance.
 	 *
 	 * @param LLMS_Event $start Event record for the start of the session.
 	 * @return bool
@@ -233,10 +235,11 @@ class LLMS_Sessions {
 		$events = $this->get_session_events(
 			$start,
 			array(
-				'per_page' => 1,
-				'sort'     => array(
+				'per_page'      => 1,
+				'sort'          => array(
 					'date' => 'DESC',
 				),
+				'no_found_rows' => true,
 			)
 		);
 

--- a/tests/phpunit/unit-tests/class-llms-test-events-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-events-query.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Test events query
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group events
+ * @group query
+ * @group dbquery
+ *
+ * @since [version]
+ */
+class LLMS_Test_Events_Query extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since 3.36.0
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * Teardown the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		global $wpdb;
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}lifterlms_events" );
+	}
+
+
+	/**
+	 * Test that the events query, using default args, calculates found rows
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_query_with_default_args_calculates_found_rows() {
+		$query = new LLMS_Events_Query();
+		$sql = LLMS_Unit_Test_Util::call_method( $query, 'preprare_query' );
+		$this->assertSame( 0, strpos( $sql, 'SELECT SQL_CALC_FOUND_ROWS' ) );
+	}
+
+	/**
+	 * Test that the events query, passing no_found_rows as true doesn't calculate found rows
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_query_correctly_doesnt_calculate_found_rows() {
+		$query = new LLMS_Events_Query(
+			array(
+				'no_found_rows' => true,
+			)
+		);
+		$sql = LLMS_Unit_Test_Util::call_method( $query, 'preprare_query' );
+		$this->assertSame( false, strpos( $sql, 'SQL_CALC_FOUND_ROWS' ) );
+	}
+
+}


### PR DESCRIPTION
## Description
per #933

Also get rid of `get_filter()` in the LLMS_Events_Query class.

## How has this been tested?
manually, existing and new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Performance improvement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

