### PR TITLE
Stop scrubbing the post name because it may has url encoded characters

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -446,7 +446,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 		// if we found a valid, apply default llms get get filter and return the value.
 		if ( isset( $val ) ) {
 
-			if ( ! $raw && 'content' !== $key ) {
+			if ( ! $raw && 'content' !== $key && 'name' !== $key ) {
 				$val = $this->scrub( $key, $val );
 			}
 

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -446,7 +446,19 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 		// if we found a valid, apply default llms get get filter and return the value.
 		if ( isset( $val ) ) {
 
-			if ( ! $raw && 'content' !== $key && 'name' !== $key ) {
+			/**
+			 * Filters the list of properties which should be excluded from scrubbing during a property read.
+			 *
+			 * The dynamic portion of this hook, `{$this->model_post_type}`, refers to the post's model type,
+			 * for example "course" for an `LLMS_Course`, "membership" for an `LLMS_Membership`, etc...
+			 *
+			 * @since [version]
+			 *
+			 * @param string[]        $props An array of property keys to be excluded from scrubbing.
+			 * @param LLMS_Post_Model $this  Instance of the post object.
+			 */
+			$exclude = apply_filters( "llms_get_{$this->model_post_type}_no_scrub_props", array( 'content', 'name' ), $this );
+			if ( ! $raw && ! in_array( $key, $exclude, true ) ) {
 				$val = $this->scrub( $key, $val );
 			}
 


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->
This PR, fix a bug in using the post name when it has a url encoded characters for example when it has an arabic characters
And the current scrub uses the "sanitize_text_field" function which is remove the url encoded characters, in this block:
```
#/wp-includes/formatting.php 5401

while ( preg_match( '/%[a-f0-9]{2}/i', $filtered, $match ) ) {
	$filtered = str_replace( $match[0], '', $filtered );
	$found    = true;
}
```

Fixes #<!-- insert the related issue number here -->

## Steps to reproduce

- Create a course with an arabic characters in it's slug
- Enroll in it
- Open the "My Grades" page
- Click on the link of the course

You will see a blank page because the url is wrong

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

- Manually

## Screenshots <!-- if applicable -->
![Screenshot from 2020-10-29 19-32-54](https://user-images.githubusercontent.com/2883734/97603608-a89a7280-1a1d-11eb-88e1-70861aa9d2d3.png)
![Screenshot from 2020-10-29 19-30-39](https://user-images.githubusercontent.com/2883734/97603706-c1a32380-1a1d-11eb-8553-c04faff87923.png)

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

- Bug fix

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

