### PR TITLE
Remove reliace on mb_string functions

### DIFF
--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 4.3.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -178,6 +178,7 @@ class LLMS_Certificates {
 	 * @since 3.24.3 Unknown.
 	 * @since 3.37.3 Refactored method into multiple functions.
 	 * @since 4.3.1 If `$this->scrape_certificate()` generates a `WP_Error` early return it.
+	 * @since [version] Remove redundant check for the presence of `DOMDocument`.
 	 *
 	 * @param int $certificate_id WP_Post ID of the earned certificate.
 	 * @return WP_Error|string HTML of the certificate on success, otherwise an error object.
@@ -186,15 +187,12 @@ class LLMS_Certificates {
 
 		// Retrieve the raw HTML of the page.
 		$html = $this->scrape_certificate( $certificate_id );
-
 		if ( is_wp_error( $html ) ) {
 			return $html;
 		}
 
-		// If DOMDocument exists, modify the DOM before exporting.
-		if ( class_exists( 'DOMDocument' ) ) {
-			$html = $this->modify_dom( $html );
-		}
+		// Modify the DOM.
+		$html = $this->modify_dom( $html );
 
 		/**
 		 * Modify the HTML of a certificate export.
@@ -222,21 +220,20 @@ class LLMS_Certificates {
 	 *
 	 * @since 3.37.3
 	 * @since 3.38.1 Use `LLMS_Mime_Type_Extractor::from_file_path()` in place of `mime_content_type()` to avoid issues with PHP installs that do not support it.
+	 * @since [version] Use `llms_get_dom_document()` in favor of loading `DOMDOcument` directly.
 	 *
 	 * @param string $html Certificate HTML.
 	 * @return string
 	 */
 	private function modify_dom( $html ) {
 
-		// Don't throw or log warnings.
-		$libxml_state = libxml_use_internal_errors( true );
-
-		$dom = new DOMDocument();
-
-		// Error loading the dom, return the original HTML.
-		if ( ! $dom->loadHTML( mb_convert_encoding( $html, 'HTML-ENTITIES', 'UTF-8' ) ) ) {
+		$dom = llms_get_dom_document( $html );
+		if ( is_wp_error( $dom ) ) {
 			return $html;
 		}
+
+		// Don't throw or log warnings.
+		$libxml_state = libxml_use_internal_errors( true );
 
 		// Remove all <scripts>.
 		$scripts = $dom->getElementsByTagName( 'script' );

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 4.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -344,6 +344,7 @@ function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
  * loading a partial string or an HTML string with errors.
  *
  * @since 4.7.0
+ * @since [version] Remove reliance on `mb_convert_encoding()`.
  *
  * @param string $string An HTML string, either a full HTML document or a partial string.
  * @return DOMDocument|WP_Error Returns an instance of DOMDocument with `$string` loaded into it
@@ -359,7 +360,7 @@ function llms_get_dom_document( $string ) {
 	$libxml_state = libxml_use_internal_errors( true );
 
 	$dom = new DOMDocument();
-	if ( ! $dom->loadHTML( mb_convert_encoding( $string, 'HTML-ENTITIES', 'UTF-8' ) ) ) {
+	if ( ! $dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $string ) ) {
 		$dom = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
 	}
 

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -370,7 +370,7 @@ function llms_get_dom_document( $string ) {
 	// Remove the fixer meta element, if it's not removed it creates invalid HTML5 Markup.
 	$meta = $dom->getElementById( 'llms-get-dom-doc-utf-fixer' );
 	if ( $dom ) {
-		$meta->parentNode->removeChild( $meta );
+		$meta->parentNode->removeChild( $meta ); // phpcs:ignore: WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 	}
 
 	// Clear and restore errors.

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -359,9 +359,18 @@ function llms_get_dom_document( $string ) {
 	// Don't throw or log warnings.
 	$libxml_state = libxml_use_internal_errors( true );
 
+	// This forces DOMDocument to convert non-utf8 characters into HTML entities and without relying on `mb_convert_encoding()`.
+	$utf8_fixer = '<meta id="llms-get-dom-doc-utf-fixer" http-equiv="Content-Type" content="text/html; charset=utf-8">';
+
 	$dom = new DOMDocument();
-	if ( ! $dom->loadHTML( '<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $string ) ) {
+	if ( ! $dom->loadHTML( $utf8_fixer . $string ) ) {
 		$dom = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
+	}
+
+	// Remove the fixer meta element, if it's not removed it creates invalid HTML5 Markup.
+	$meta = $dom->getElementById( 'llms-get-dom-doc-utf-fixer' );
+	if ( $dom ) {
+		$meta->parentNode->removeChild( $meta );
 	}
 
 	// Clear and restore errors.

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -207,15 +207,15 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			),
 			array(
 				'Ḷ𝝄𝔯𝚎ɱ ĭ𝓹ᵴǘɱ ժөḻ𝝈ɍ 𝘀𝗂ᴛ.',
-				'<p>Ḷ𝝄𝔯𝚎ɱ ĭ𝓹ᵴǘɱ ժөḻ𝝈ɍ 𝘀𝗂ᴛ.</p>',
+				'<p>&#7734;&#120644;&#120111;&#120462;&#625; &#301;&#120057;&#7540;&#472;&#625; &#1386;&#1257;&#7739;&#120648;&#589; &#120320;&#120258;&#7451;.</p>',
 			),
 			array(
-				'Contains &mdash; Char &ndash; Codes!',
-				'<p>Contains — Char – Codes!</p>',
+				'Contains &mdash; Char Codes and special – !',
+				'<p>Contains &mdash; Char Codes and special &ndash; !</p>',
 			),
 			array(
-				'<!DOCTYPE html><html lang="en-US"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width" /></head><body>Full HTML Doc.</body></html>',
-				'Full HTML Doc.',
+				'<!DOCTYPE html><html lang="en-US"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width" /></head><body>And &gt;>&gt; a <b>full</b> HTML docum𝞔nt!</body></html>',
+				'And &gt;&gt;&gt; a <b>full</b> HTML docum&#120724;nt!',
 			),
 		);
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -183,12 +183,49 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	 * Test llms_get_dom_document()
 	 *
 	 * @since 4.7.0
+	 * @since [version] Test against HTML strings, HTML documents, strings with character entities, and strings with non-utf8 characters.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_dom_document() {
 
-		$this->assertTrue( llms_get_dom_document( 'mock string' ) instanceof DOMDocument );
+		/**
+		 * Array of test strings
+		 *
+		 * First value is the input string & the second value is the expected output string.
+		 *
+		 * @var array[]
+		 */
+		$tests = array(
+			array(
+				'simple text string',
+				'<p>simple text string</p>',
+			),
+			array(
+				'<h1>html text string</h1><br><div class="test"><em>wow!</em></div>',
+				'<h1>html text string</h1><br><div class="test"><em>wow!</em></div>',
+			),
+			array(
+				'Ḷ𝝄𝔯𝚎ɱ ĭ𝓹ᵴǘɱ ժөḻ𝝈ɍ 𝘀𝗂ᴛ.',
+				'<p>Ḷ𝝄𝔯𝚎ɱ ĭ𝓹ᵴǘɱ ժөḻ𝝈ɍ 𝘀𝗂ᴛ.</p>',
+			),
+			array(
+				'Contains &mdash; Char &ndash; Codes!',
+				'<p>Contains — Char – Codes!</p>',
+			),
+			array(
+				'<!DOCTYPE html><html lang="en-US"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width" /></head><body>Full HTML Doc.</body></html>',
+				'Full HTML Doc.',
+			),
+		);
+
+		foreach ( $tests as $test ) {
+
+			$dom = llms_get_dom_document( $test[0] );
+			$this->assertTrue( $dom instanceof DOMDocument );
+			$this->assertStringContains( sprintf( '<body>%s</body></html>', $test[1] ), $dom->saveHTML() );
+
+		}
 
 	}
 


### PR DESCRIPTION
## Description

+ Fixes #1426
+ Fixes #1118 

## How has this been tested?

+ Manually
+ New tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Bug fix
+ Drops dependency on php `mb_string` module

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

