### PR TITLE
Add constants that can be used to identify when a library plugin is loaded as a library

### DIFF
--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 4.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -278,6 +278,7 @@ class LLMS_Loader {
 	 * Include libraries
 	 *
 	 * @since 4.0.0
+	 * @since [version] Adds constants which can be used to identify when included libraries have been loaded.
 	 *
 	 * @return void
 	 */
@@ -285,11 +286,13 @@ class LLMS_Loader {
 
 		// Block library.
 		if ( function_exists( 'has_blocks' ) && ! defined( 'LLMS_BLOCKS_VERSION' ) ) {
+			define( 'LLMS_BLOCKS_LIB', true );
 			require_once LLMS_PLUGIN_DIR . 'vendor/lifterlms/lifterlms-blocks/lifterlms-blocks.php';
 		}
 
 		// Rest API.
 		if ( ! class_exists( 'LifterLMS_REST_API' ) ) {
+			define( 'LLMS_REST_API_LIB', true );
 			require_once LLMS_PLUGIN_DIR . 'vendor/lifterlms/lifterlms-rest/lifterlms-rest.php';
 		}
 


### PR DESCRIPTION
## Description

Per #1141 & Related to https://github.com/gocodebox/lifterlms-rest/pull/204

The constants can be used by the library plugins to determine if they need to localize themselves or, when loaded as a library, if the LifterLMS core can take care of it.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

## Types of changes
Library localization improvements

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

