### PR TITLE
Admin notices CS & Test class

### DIFF
--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -149,7 +149,7 @@ class LLMS_Admin_Notices {
 			 *
 			 * @since [version]
 			 */
-			do_action( "lifterlms_{$trigger}_{$notice_id}_notice";
+			do_action( "lifterlms_{$trigger}_{$notice_id}_notice" );
 		}
 	}
 

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.0.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -212,12 +212,13 @@ class LLMS_Admin_Notices {
 	 * Determine if a notice is already set
 	 *
 	 * @since 3.0.0
+	 * @since [version] Use a strict comparison.
 	 *
 	 * @param string $notice_id  Id of the notice.
 	 * @return boolean
 	 */
 	public static function has_notice( $notice_id ) {
-		return in_array( $notice_id, self::get_notices() );
+		return in_array( $notice_id, self::get_notices(), true );
 	}
 
 	/**

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -71,9 +71,9 @@ class LLMS_Admin_Notices {
 	 * @param string $notice_id       Unique id of the notice.
 	 * @param string $html_or_options Html content of the notice for short notices that don't need a template
 	 *                                or an array of options, html of the notice will be in a template
-	 *                                passed as the "template" param of this array
+	 *                                passed as the "template" param of this array.
 	 * @param array  $options         Array of options, when passing html directly via $html_or_options.
-	 *                                Notice options should be passed in this array
+	 *                                Notice options should be passed in this array.
 	 * @return void
 	 */
 	public static function add_notice( $notice_id, $html_or_options = '', $options = array() ) {

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -63,6 +63,7 @@ class LLMS_Admin_Notices {
 
 	/**
 	 * Add a notice
+	 *
 	 * Saves options to the database to be output later
 	 *
 	 * @since 3.0.0

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -120,6 +120,7 @@ class LLMS_Admin_Notices {
 	 * @since 3.4.3 Unknown.
 	 *
 	 * @param string $notice_id Unique id of the notice.
+	 * @param string $trigger   Deletion action/trigger, accepts 'delete' (default), 'hide', or 'remind'.
 	 * @return void
 	 */
 	public static function delete_notice( $notice_id, $trigger = 'delete' ) {
@@ -137,7 +138,18 @@ class LLMS_Admin_Notices {
 			if ( $delay ) {
 				set_transient( 'llms_admin_notice_' . $notice_id . '_delay', 'yes', DAY_IN_SECONDS * $delay );
 			}
-			do_action( 'lifterlms_' . $trigger . '_' . $notice_id . '_notice' );
+
+			/**
+			 * Hook run when a notice is dismissed.
+			 *
+			 * The dynamic portion of this hook `{$trigger}` refers to the deletion trigger, either 'delete',
+			 * 'hide', or 'remind'.
+			 *
+			 * The dynamic portion of this hook, `{$notice_id}` refers to the ID of the notice being dismissed.
+			 *
+			 * @since [version]
+			 */
+			do_action( "lifterlms_{$trigger}_{$notice_id}_notice";
 		}
 	}
 

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -44,7 +44,7 @@ class LLMS_Admin_Notices {
 	/**
 	 * Add output notice actions depending on the current screen
 	 *
-	 * Adds later for LLMS Settings screens to accommodate for settings that are updated later in the load cycle
+	 * Adds later for LLMS Settings screens to accommodate for settings that are updated later in the load cycle.
 	 *
 	 * @since 3.0.0
 	 *
@@ -203,6 +203,7 @@ class LLMS_Admin_Notices {
 	 * Get notices
 	 *
 	 * @since 3.0.0
+	 *
 	 * @return array
 	 */
 	public static function get_notices() {
@@ -215,7 +216,7 @@ class LLMS_Admin_Notices {
 	 * @since 3.0.0
 	 * @since [version] Use a strict comparison.
 	 *
-	 * @param string $notice_id  Id of the notice.
+	 * @param string $notice_id Id of the notice.
 	 * @return boolean
 	 */
 	public static function has_notice( $notice_id ) {

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -28,9 +28,9 @@ class LLMS_Admin_Notices {
 	/**
 	 * Static constructor
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return void
 	 */
 	public static function init() {
 
@@ -44,10 +44,12 @@ class LLMS_Admin_Notices {
 
 	/**
 	 * Add output notice actions depending on the current screen
+	 *
 	 * Adds later for LLMS Settings screens to accommodate for settings that are updated later in the load cycle
 	 *
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return void
 	 */
 	public static function add_output_actions() {
 
@@ -64,15 +66,16 @@ class LLMS_Admin_Notices {
 	 * Add a notice
 	 * Saves options to the database to be output later
 	 *
-	 * @param    string $notice_id        unique id of the notice
-	 * @param    string $html_or_options  html content of the notice for short notices that don't need a template
-	 *                                      or array of options, html of the notice will be in a template
-	 *                                      passed as the "template" param of this array
-	 * @param    array  $options          array of options, when passing html directly via $html_or_options
-	 *                                      notice options should be passed in this array
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.3.0 - added "flash" option
+	 * @since 3.0.0
+	 * @since 3.3.0 Added "flash" option.
+	 *
+	 * @param string $notice_id       Unique id of the notice.
+	 * @param string $html_or_options Html content of the notice for short notices that don't need a template
+	 *                                or an array of options, html of the notice will be in a template
+	 *                                passed as the "template" param of this array
+	 * @param array  $options         Array of options, when passing html directly via $html_or_options.
+	 *                                Notice options should be passed in this array
+	 * @return void
 	 */
 	public static function add_notice( $notice_id, $html_or_options = '', $options = array() ) {
 
@@ -114,10 +117,11 @@ class LLMS_Admin_Notices {
 	/**
 	 * Delete a notice by id
 	 *
-	 * @param    string $notice_id  unique id of the notice
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.4.3
+	 * @since 3.0.0
+	 * @since 3.4.3 Unknown.
+	 *
+	 * @param string $notice_id Unique id of the notice.
+	 * @return void
 	 */
 	public static function delete_notice( $notice_id, $trigger = 'delete' ) {
 		self::$notices = array_diff( self::get_notices(), array( $notice_id ) );
@@ -141,11 +145,11 @@ class LLMS_Admin_Notices {
 	/**
 	 * Flash a notice on screen, isn't saved and is automatically deleted after being displayed
 	 *
-	 * @param    string $message  Message text / html to display onscreen
-	 * @param    string $type     notice type [info|warning|success|error]
-	 * @return   void
-	 * @since    3.3.0
-	 * @version  3.3.0
+	 * @since 3.3.0
+	 *
+	 * @param string $message Message text / html to display onscreen.
+	 * @param string $type    Notice type [info|warning|success|error].
+	 * @return void
 	 */
 	public static function flash_notice( $message, $type = 'info' ) {
 
@@ -174,10 +178,10 @@ class LLMS_Admin_Notices {
 	/**
 	 * Get notice details array from the DB
 	 *
-	 * @param    string $notice_id  notice id
-	 * @return   array
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string $notice_id Notice id.
+	 * @return array
 	 */
 	public static function get_notice( $notice_id ) {
 		return get_option( 'llms_admin_notice_' . $notice_id, '' );
@@ -186,9 +190,8 @@ class LLMS_Admin_Notices {
 	/**
 	 * Get notices
 	 *
+	 * @since 3.0.0
 	 * @return array
-	 * @since    3.0.0
-	 * @version  3.0.0
 	 */
 	public static function get_notices() {
 		return self::$notices;
@@ -197,10 +200,10 @@ class LLMS_Admin_Notices {
 	/**
 	 * Determine if a notice is already set
 	 *
-	 * @param    string $notice_id   id of the notice
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string $notice_id  Id of the notice.
+	 * @return boolean
 	 */
 	public static function has_notice( $notice_id ) {
 		return in_array( $notice_id, self::get_notices() );
@@ -208,7 +211,8 @@ class LLMS_Admin_Notices {
 
 	/**
 	 * Called when "Dismiss X" or "Remind Me" is clicked on a notice
-	 * Validates request and deletes the notice
+	 *
+	 * Validates request and deletes the notice.
 	 *
 	 * @since 3.0.0
 	 * @since 3.35.0 Unslash input data.
@@ -237,10 +241,11 @@ class LLMS_Admin_Notices {
 	/**
 	 * Output a single notice by ID
 	 *
-	 * @param    string $notice_id  notice id
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.7.4
+	 * @since 3.0.0
+	 * @since 3.7.4 Unknown.
+	 *
+	 * @param string $notice_id Notice id.
+	 * @return void
 	 */
 	public static function output_notice( $notice_id ) {
 
@@ -284,16 +289,16 @@ class LLMS_Admin_Notices {
 			if ( isset( $notice['flash'] ) && $notice['flash'] ) {
 				self::delete_notice( $notice_id, 'delete' );
 			}
-		}// End if().
+		}
 
 	}
 
 	/**
 	 * Output all saved notices
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return void
 	 */
 	public static function output_notices() {
 		foreach ( self::get_notices() as $notice_id ) {
@@ -304,9 +309,9 @@ class LLMS_Admin_Notices {
 	/**
 	 * Save notices in the database
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @return void
 	 */
 	public static function save_notices() {
 		update_option( 'llms_admin_notices', self::get_notices() );

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Admin_Notices class
  *
  * @since 3.0.0
- * @since 3.35.0 Unslash input data.
  */
 class LLMS_Admin_Notices {
 
@@ -318,4 +317,5 @@ class LLMS_Admin_Notices {
 	}
 
 }
+
 LLMS_Admin_Notices::init();

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -14,7 +14,7 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 	/**
 	 * Setup before class
 	 *
-	 * @since 4.7.0
+	 * @since [version]
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Test Admin Notices Class
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group admin_notices
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup before class
+	 *
+	 * @since 4.7.0
+	 *
+	 * @return void
+	 */
+	public static function setupBeforeClass() {
+		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.notices.php';
+	}
+
+	/**
+	 * Test init() properly initializes the `$notices` class variable
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_notices_var() {
+
+		$expect = array( 'fake' );
+		update_option( 'llms_admin_notices', $expect );
+
+		LLMS_Admin_Notices::init();
+
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::get_private_property_value( 'LLMS_Admin_Notices', 'notices' ) );
+
+	}
+
+	/**
+	 * Test init() properly adds action hooks
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_add_actions() {
+
+		remove_action( 'wp_loaded', array( 'LLMS_Admin_Notices', 'hide_notices' ) );
+		remove_action( 'current_screen', array( 'LLMS_Admin_Notices', 'add_output_actions' ) );
+		remove_action( 'shutdown', array( 'LLMS_Admin_Notices', 'save_notices' ) );
+
+		LLMS_Admin_Notices::init();
+
+		$this->assertEquals( 10, has_action( 'wp_loaded', array( 'LLMS_Admin_Notices', 'hide_notices' ) ) );
+		$this->assertEquals( 10, has_action( 'current_screen', array( 'LLMS_Admin_Notices', 'add_output_actions' ) ) );
+		$this->assertEquals( 10, has_action( 'shutdown', array( 'LLMS_Admin_Notices', 'save_notices' ) ) );
+
+	}
+
+}


### PR DESCRIPTION
## Description

While starting to look into #1443 I fixed some CS issues in the `LLMS_Admin_Notices` class and added a test class so we can add test coverage for the (mostly) uncovered file.

## How has this been tested?

+ Manually


## Screenshots <!-- if applicable -->

## Types of changes

+ CS, mostly
+ the only change that affects code execution is adding a strict comparator to `in_array()` which causes no issues because the notice ids are always strings anyway.


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

