### PR TITLE
Use an HR in favor of a hidden h1 on add-ons admin screen

### DIFF
--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -271,7 +271,7 @@ class LLMS_Admin_AddOns {
 	 * Output HTML for the current screen
 	 *
 	 * @since 3.5.0
-	 * @since 3.28.0 Unknown
+	 * @since 3.28.0 Unknown.
 	 * @since [version] Use `hr.wp-header-end` in favor of a second (hidden) <h1> to "catch" admin notices.
 	 *
 	 * @return void

--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.5.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -270,9 +270,11 @@ class LLMS_Admin_AddOns {
 	/**
 	 * Output HTML for the current screen
 	 *
-	 * @return   void
-	 * @since    3.5.0
-	 * @version  3.28.0
+	 * @since 3.5.0
+	 * @since 3.28.0 Unknown
+	 * @since [version] Use `hr.wp-header-end` in favor of a second (hidden) <h1> to "catch" admin notices.
+	 *
+	 * @return void
 	 */
 	public function output() {
 
@@ -285,7 +287,7 @@ class LLMS_Admin_AddOns {
 
 			<h1 class="wp-heading-inline"><?php _e( 'LifterLMS Add-Ons, Courses, and Resources', 'lifterlms' ); ?></h1>
 			<?php do_action( 'llms_addons_page_after_title' ); ?>
-			<h1 class="screen-reader-text"><?php _e( 'LifterLMS Add-Ons, Courses, and Resources', 'lifterlms' ); ?></h1>
+			<hr class="wp-header-end">
 
 			<?php $this->output_navigation(); ?>
 			<form action="" method="POST">


### PR DESCRIPTION
## Description

While testing the helper plugin on php8 I noticed that admin notices were getting "caught" between the inline title and the "My Keys" button.

This PR fixes this by using the `<hr>` element used by the WP core to signify the "end of the header" and it looks like this element "catches" admin notices in favor of putting them below the first `<h1>` tag.

Note that the issue is only apparent when the helper is activated and the change has no noticeable regressive impact when the helper is not installed.

## How has this been tested?

+ Manually


## Screenshots <!-- if applicable -->

Without fix:
![Screenshot_2020-12-02_14-34-35](https://user-images.githubusercontent.com/1290739/100934125-24fff580-34a3-11eb-8483-8690f6990d96.png)

With fix:
![Screenshot_2020-12-02_14-33-16](https://user-images.githubusercontent.com/1290739/100934056-0ac61780-34a3-11eb-9535-4b3d3156d639.png)

Without helper (and fix):
![Screenshot_2020-12-02_14-36-59](https://user-images.githubusercontent.com/1290739/100934394-86c05f80-34a3-11eb-8821-3d2ce352ec8e.png)



## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

