### PR TITLE
Lesson nav refactor

### DIFF
--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -796,7 +796,7 @@ implements LLMS_Interface_Post_Audio, LLMS_Interface_Post_Video {
 		$curr_position = $this->get_order();
 
 		// First cannot have a previous.
-		if ( 0 === $curr_position && 'prev' === $direction ) {
+		if ( 1 === $curr_position && 'prev' === $direction ) {
 			return false;
 		}
 
@@ -872,6 +872,11 @@ implements LLMS_Interface_Post_Audio, LLMS_Interface_Post_Video {
 
 			$curr_position = $curr_section->get_order();
 
+			// First cannot have a previous.
+			if ( 1 === $curr_position && 'prev' === $direction ) {
+				return false;
+			}
+
 			if ( 'next' === $direction ) {
 				$sibling_position = $curr_position + 1;
 				$order            = 'ASC';
@@ -917,8 +922,8 @@ implements LLMS_Interface_Post_Audio, LLMS_Interface_Post_Video {
 
 			if ( ! empty( $sections ) ) {
 				$sibling_section = llms_get_post( $sections[0]->ID );
-				$lessons         = $sibling_section ? $sibling_section->get_lessons( 'posts' ) : false;
-				$sibling_lesson  = 'next' === $direction ? array_shift( $lessons ) : array_pop( $lessons );
+				$lessons         = $sibling_section ? $sibling_section->get_lessons( 'posts' ) : array( false );
+				$sibling_lesson  = 'next' === $direction ? $lessons[0] : end( $lessons );
 			}
 		}
 


### PR DESCRIPTION
## Description
Updates `LLMS_Lesson::get_next_lesson()` and `LLMS_Lesson::get_previous_lesson()` to use shared helper methods to locate sibling lessons.

The code for these two methods is nearly identical except for the sorting directions and comparators. There's a few logical differences between them but, overall, there's a of redundancy.

This is a rebased version of #1318, with minor improvements according to that PR's review.

## How has this been tested?

- Existing unit tests
- Manual

## Screenshots <!-- if applicable -->

## Types of changes
Code improvement


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

