### PR TITLE
Fix PHP Notice when trying to retrieve next lesson from an empty sibling section

### DIFF
--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 4.10.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -858,6 +858,7 @@ implements LLMS_Interface_Post_Audio, LLMS_Interface_Post_Video {
 	 * lesson from the course's previous section.
 	 *
 	 * @since 4.10.2
+	 * @since [version] Fix PHP Notice when trying to retrieve next lesson from an empty section.
 	 *
 	 * @param string $direction Direction of navigation. Accepts either "prev" or "next".
 	 * @return false|int WP_Post ID of the sibling lesson or `false` if one doesn't exist.
@@ -923,11 +924,11 @@ implements LLMS_Interface_Post_Audio, LLMS_Interface_Post_Video {
 			if ( ! empty( $sections ) ) {
 				$sibling_section = llms_get_post( $sections[0]->ID );
 				$lessons         = $sibling_section ? $sibling_section->get_lessons( 'posts' ) : array( false );
-				$sibling_lesson  = 'next' === $direction ? $lessons[0] : end( $lessons );
+				$sibling_lesson  = 'next' === $direction ? reset( $lessons ) : end( $lessons );
 			}
 		}
 
-		return is_a( $sibling_lesson, 'WP_Post' ) ? $sibling_lesson->ID : $sibling_lesson;
+		return $sibling_lesson instanceof WP_Post ? $sibling_lesson->ID : $sibling_lesson;
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -11,7 +11,8 @@
  *               the course start date and empty course start date.
  *               Also added `$date_delta` property to be used to test dates against current time.
  * @since 4.4.0 Added tests on next/previous lessons retrieval.
- * @since 4.4.2 Add additional navigation testing scenarios.
+ * @since 4.4.2 Added additional navigation testing scenarios.
+ * @since [version] Addeed additional tests when retrieving next/prev lesson with empty sibling sections.
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
@@ -594,4 +595,38 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test next/prev lesson with empty sibling sections
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_navigation_empty_sibling_section() {
+
+		$course = $this->factory->course->create_and_get(
+			array(
+				'sections' => 2,
+				'lessons' => 1,
+				'quizzes' => 0
+			)
+		);
+
+		$lessons = $course->get_lessons();
+
+		// Detach the second lesson from the second section.
+		$second_section = $lessons[1]->get_parent_section();
+		$lessons[1]->set_parent_section('');
+		// Check the next lesson of the first one is false.
+		$this->assertEquals( false, $lessons[0]->get_next_lesson() );
+
+		// Re-attach the second lesson to the second section.
+		$lessons[1]->set_parent_section( $second_section );
+
+		// Detach the first lesson from the first section.
+		$lessons[0]->set_parent_section('');
+		// Check the previous lesson of the second one is false.
+		$this->assertEquals( false, $lessons[1]->get_previous_lesson() );
+
+	}
 }


### PR DESCRIPTION
## Description
Fixes #1479

## How has this been tested?
New and existing unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

