### PR TITLE
(Small) Refactor of dashboard voucher redemption functionality

### DIFF
--- a/includes/forms/controllers/class.llms.controller.account.php
+++ b/includes/forms/controllers/class.llms.controller.account.php
@@ -33,6 +33,7 @@ class LLMS_Controller_Account {
 		add_action( 'init', array( $this, 'lost_password' ) );
 		add_action( 'init', array( $this, 'reset_password' ) );
 		add_action( 'init', array( $this, 'cancel_subscription' ) );
+		add_action( 'init', array( $this, 'redeem_voucher' ) );
 
 	}
 
@@ -224,6 +225,33 @@ class LLMS_Controller_Account {
 
 		// Success.
 		llms_add_notice( __( 'Check your e-mail for the confirmation link.', 'lifterlms' ) );
+		return true;
+
+	}
+
+	/**
+	 * Redeem a voucher from the "Redeem Voucher" endpoint of the student dashboard
+	 *
+	 * @since [version]
+	 *
+	 * @return null|true|WP_Error Returns `null` when the form hasn't been submitted, there's a nonce error, or there's no logged in user.
+	 *                            Returns `true` on success and an error object when an error is encountered redeeming the voucher.
+	 */
+	public function redeem_voucher() {
+
+		if ( ! llms_verify_nonce( 'lifterlms_voucher_nonce', 'lifterlms_voucher_check' ) || ! get_current_user_id() ) {
+			return null;
+		}
+
+		$voucher  = new LLMS_Voucher();
+		$redeemed = $voucher->use_voucher( llms_filter_input( INPUT_POST, 'llms_voucher_code', FILTER_SANITIZE_STRING ), get_current_user_id() );
+
+		if ( is_wp_error( $redeemed ) ) {
+			llms_add_notice( $redeemed->get_error_message(), 'error' );
+			return $redeemed;
+		}
+
+		llms_add_notice( __( 'Voucher redeemed successfully!', 'lifterlms' ), 'success' );
 		return true;
 
 	}

--- a/includes/forms/frontend/class.llms.frontend.forms.php
+++ b/includes/forms/frontend/class.llms.frontend.forms.php
@@ -16,32 +16,22 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.30.3 Fixed spelling errors.
  * @since 3.35.0 Sanitize `$_POST` data.
+ * @deprecated [version] LLMS_Frontend_Forms is deprecated, functionality is available via LLMS_Controller_Account.
  */
 class LLMS_Frontend_Forms {
-
-	/**
-	 * Constructor
-	 *
-	 * @since  1.0.0
-	 * @return void
-	 */
-	public function __construct() {
-
-		add_action( 'init', array( $this, 'voucher_check' ) );
-
-	}
 
 	/**
 	 * Reset password form
 	 *
 	 * @since Unknown
 	 * @since 3.35.0 Sanitize `$_POST` data.
-	 *
-	 * @todo It appears this function is not called from anywhere and can be deprecated.
+	 * @deprecated [version] LLMS_Frontend_Forms::reset_password() is deprecated in favor of LLMS_Controller_Account::reset_password().
 	 *
 	 * @return void
 	 */
 	public function reset_password() {
+
+		llms_deprecated_function( 'LLMS_Frontend_Forms::reset_password()', '[version]', 'LLMS_Controller_Account::reset_password()' );
 
 		if ( ! isset( $_POST['llms_reset_password'] ) ) {
 			return;
@@ -128,30 +118,17 @@ class LLMS_Frontend_Forms {
 	 * @since Unknown
 	 * @since 3.30.3 Fixed spelling errors.
 	 * @since 3.35.0 Sanitize `$_POST` data.
+	 * @deprecated [version] LLMS_Frontend_Forms::voucher_check() is deprecated in favor of LLMS_Controller_Account::redeem_voucher()
 	 *
 	 * @return bool
 	 */
 	public function voucher_check() {
 
-		if ( ! llms_verify_nonce( 'lifterlms_voucher_nonce', 'lifterlms_voucher_check' ) ) {
-			return false;
-		}
+		llms_deprecated_function( 'LLMS_Frontend_Forms::voucher_check()', '[version]', 'LLMS_Controller_Account::redeem_voucher()' );
 
-		if ( isset( $_POST['llms_voucher_code'] ) && ! empty( $_POST['llms_voucher_code'] ) ) {
+		$accounts = new LLMS_Controller_Account();
+		return $accounts->redeem_voucher();
 
-			$voucher  = new LLMS_Voucher();
-			$redeemed = $voucher->use_voucher( llms_filter_input( INPUT_POST, 'llms_voucher_code', FILTER_SANITIZE_STRING ), get_current_user_id() );
-
-			if ( is_wp_error( $redeemed ) ) {
-
-				llms_add_notice( $redeemed->get_error_message(), 'error' );
-
-			} else {
-
-				llms_add_notice( __( 'Voucher redeemed successfully!', 'lifterlms' ), 'success' );
-
-			}
-		}
 	}
 
 }

--- a/packages/llms-e2e-test-utils/src/create-user.js
+++ b/packages/llms-e2e-test-utils/src/create-user.js
@@ -9,10 +9,10 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
 /**
  * Asynchronously loop through an Object
  *
- * @since  3.37.8
+ * @since 1.0.0
  *
- * @param  {Object}    obj      Object to loop through.
- * @param  {Function}  callback Callback function, will be passed to params `key` and `val`.
+ * @param {Object}   obj      Object to loop through.
+ * @param {Function} callback Callback function, will be passed to params `key` and `val`.
  * @return {Void}
  */
 const forEach = async ( obj, callback ) => {
@@ -27,13 +27,14 @@ const forEach = async ( obj, callback ) => {
 /**
  * Create a new user.
  *
- * @since 3.37.8
+ * @since 1.0.0
  * @since 2.2.0 Returns the WP_User ID in the return object.
+ * @since [version] Options object is now optional.
  *
- * @param  {Object} opts Hash of user information used to create the new user.
+ * @param {Object} opts Hash of user information used to create the new user.
  * @return {Object}
  */
-export async function createUser( opts ) {
+export async function createUser( opts = {} ) {
 
 	await visitAdminPage( 'user-new.php' );
 

--- a/packages/llms-e2e-test-utils/src/create-voucher.js
+++ b/packages/llms-e2e-test-utils/src/create-voucher.js
@@ -1,0 +1,50 @@
+import { click } from './click';
+import { clickAndWait } from './click-and-wait';
+import { fillField } from './fill-field';
+import { select2Select } from './select2-select';
+
+import {
+	visitAdminPage,
+} from '@wordpress/e2e-test-utils';
+
+/**
+ * Create and publish a new course
+ *
+ * @since [version]
+ *
+ * @param {Object} args {
+ *     Creation arguments.
+ *
+ *     @type {String}  name       Voucher (post) title.
+ *     @type {String}  course     Name of a course to add to the voucher.
+ *     @type {String}  membership Name of a membership to add to the voucher.
+ *     @type {Integer} codes      Number of codes to generate.
+ *     @type {Integer} uses       Number of uses per code.
+ * }
+ * @return {String[]} Array of the generated voucher codes.
+ */
+export async function createVoucher( { name = 'A Voucher', course = 'LifterLMS Quickstart Course', membership = '', codes = 5, uses = 5 } = {} ) {
+
+	await visitAdminPage( 'post-new.php', `post_type=llms_voucher&post_title=${ name }` );
+
+	if ( course ) {
+		await select2Select( '#_llms_voucher_courses', course );
+	}
+
+	if ( membership ) {
+		await select2Select( '#_llms_voucher_memberships', membership );
+	}
+
+	await fillField( '#llms_voucher_add_quantity', codes );
+	await fillField( '#llms_voucher_add_uses', uses );
+
+	await click( '#llms_voucher_add_codes' );
+
+	await page.waitForSelector( '#llms_voucher_tbody tr' );
+
+	await clickAndWait( '#publish' );
+	await page.waitFor( 1000 ); // Non-interactive tests aren't publishing without a delay, not sure why.
+
+	return await page.$$eval( '#llms_voucher_tbody input[name="llms_voucher_code[]"', inputs => inputs.map( input => input.value ) );
+
+}

--- a/packages/llms-e2e-test-utils/src/index.js
+++ b/packages/llms-e2e-test-utils/src/index.js
@@ -2,7 +2,7 @@
  * Export all modules.
  *
  * @since 1.0.0
- * @version 2.2.0
+ * @version [version]
  */
 
 export { click } from './click';
@@ -17,6 +17,7 @@ export { createEngagement } from './create-engagement';
 export { createMembership } from './create-membership';
 export { createPost } from './create-post';
 export { createUser } from './create-user';
+export { createVoucher } from './create-voucher';
 
 export { dismissEditorWelcomeGuide } from './dismiss-editor-welcome-guide';
 
@@ -34,6 +35,7 @@ export { logoutUser } from './logout-user';
 export { registerStudent } from './register-student';
 export { runSetupWizard } from './run-setup-wizard';
 
+export { select2Select } from './select2-select';
 export { setSelect2Option } from './set-select2-option';
 
 export { toggleOpenRegistration } from './toggle-open-registration';

--- a/packages/llms-e2e-test-utils/src/register-student.js
+++ b/packages/llms-e2e-test-utils/src/register-student.js
@@ -1,3 +1,4 @@
+import { click }        from './click';
 import { clickAndWait } from './click-and-wait';
 import { fillField }    from './fill-field';
 import { logoutUser }   from './logout-user';
@@ -7,11 +8,13 @@ import { visitPage }    from './visit-page';
  * Register a new student via the LifterLMS Open Registration Page
  *
  * @since 2.1.2
+ * @since [version] Add `args.voucher` to enable voucher usage during registration.
  *
- * @param {String} args.email Optional. Email address. If not supplied one will be created from the first name and last name.
- * @param {String} args.pass  Optional. User password. If not supplied one will be automatically generated.
- * @param {String} args.first Optional. User's first name.
- * @param {String} args.last  Optional. User's last name.
+ * @param {String} args.email   Optional. Email address. If not supplied one will be created from the first name and last name.
+ * @param {String} args.pass    Optional. User password. If not supplied one will be automatically generated.
+ * @param {String} args.first   Optional. User's first name.
+ * @param {String} args.last    Optional. User's last name.
+ * @param {String} args.voucher Optional. Voucher code to use during registration.
  * @return {Object} {
  *     Object containing information about the newly created user.
  *
@@ -19,7 +22,7 @@ import { visitPage }    from './visit-page';
  *     @type {String} pass  User's password.
  * }
  */
-export async function registerStudent( { email = null, pass = null, first = 'Jamie', last = 'Doe' } = {} ) {
+export async function registerStudent( { email = null, pass = null, first = 'Jamie', last = 'Doe', voucher = '' } = {} ) {
 
 	const the_int = Math.floor( Math.random() * ( 99990 - 10000 + 1 ) ) + 10000;
 
@@ -34,6 +37,12 @@ export async function registerStudent( { email = null, pass = null, first = 'Jam
 	await fillField( '#password_confirm', pass );
 	await fillField( '#first_name', first );
 	await fillField( '#last_name', last );
+
+	if ( voucher ) {
+		await click( '#llms-voucher-toggle' );
+		await page.waitForSelector( '#llms_voucher' );
+		await fillField( '#llms_voucher', voucher );
+	}
 
 	await clickAndWait( '#llms_register_person' );
 

--- a/packages/llms-e2e-test-utils/src/select2-select.js
+++ b/packages/llms-e2e-test-utils/src/select2-select.js
@@ -1,0 +1,22 @@
+/**
+ * Select a value from a select2 dropdown field
+ *
+ * @since [version]
+ *
+ * @param {String} selector Query selector for the select element.
+ * @param {String} value    Option value to select.
+ * @return {Void}
+ */
+export async function select2Select( selector, value ) {
+
+	await page.$eval( selector, ( el ) => {
+		jQuery( el ).select2( 'open' );
+	} );
+
+	await page.waitFor( 1000 );
+	await page.keyboard.type( value );
+	await page.waitFor( 1000 );
+
+	await page.keyboard.press( 'Enter' );
+
+};

--- a/templates/myaccount/form-redeem-voucher.php
+++ b/templates/myaccount/form-redeem-voucher.php
@@ -4,7 +4,9 @@
  *
  * @package LifterLMS/Templates
  *
- * @since  2.0.0
+ * @since 2.0.0
+ * @since [version] Updated the label `for` attribute and added an `id` to the input element.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,14 +18,14 @@ defined( 'ABSPATH' ) || exit;
 
 <?php do_action( 'lifterlms_before_redeem_voucher' ); ?>
 
-<form method="POST">
+<form action="" method="POST">
 
 	<p class="form-row form-row-first">
-		<label for="account_first_name"><?php _e( 'Voucher Code', 'lifterlms' ); ?></label>
-		<input type="text" placeholder="<?php _e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" required="required">
+		<label for="llms-voucher-code"><?php _e( 'Voucher Code', 'lifterlms' ); ?></label>
+		<input id="llms-voucher-code" type="text" placeholder="<?php _e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" required="required">
 	</p>
 
-	<button type="submit"><?php _ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
+	<button id="llms-redeem-voucher-submit" type="submit"><?php _ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
 
 	<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
 

--- a/tests/e2e/tests/student/__snapshots__/open-registration.test.js.snap
+++ b/tests/e2e/tests/student/__snapshots__/open-registration.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OpenRegistration should register a new user with a voucher. 1`] = `" <h4 class=\\"llms-notification-title\\">Course enrollment success!</h4> <div class=\\"llms-notification-body\\"><p>Congratulations! You enrolled in LifterLMS Quickstart Course</p> </div> "`;

--- a/tests/e2e/tests/student/__snapshots__/voucher.test.js.snap
+++ b/tests/e2e/tests/student/__snapshots__/voucher.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StudentDashboard/RedeemVoucher Should display an error for an invalid voucher 1`] = `
+"
+			Voucher code \\"fakecode\\" could not be found.
+	"
+`;
+
+exports[`StudentDashboard/RedeemVoucher Should redeem a valid voucher 1`] = `"Voucher redeemed successfully!"`;
+
+exports[`StudentDashboard/RedeemVoucher Should redeem a valid voucher 2`] = `" <h4 class=\\"llms-notification-title\\">Course enrollment success!</h4> <div class=\\"llms-notification-body\\"><p>Congratulations! You enrolled in LifterLMS Quickstart Course</p> </div> "`;

--- a/tests/e2e/tests/student/open-registration.test.js
+++ b/tests/e2e/tests/student/open-registration.test.js
@@ -4,10 +4,12 @@
  * @since 3.37.8
  * @since 3.37.14 Fix package references.
  * @since 4.5.0 Use package functions.
+ * @since [version] Added registration test with a voucher.
  */
 
 import {
 	clickAndWait,
+	createVoucher,
 	fillField,
 	logoutUser,
 	registerStudent,
@@ -65,6 +67,19 @@ describe( 'OpenRegistration', () => {
 		await toggleOpenReg( true );
 		await registerStudent();
 		expect( await page.$eval( 'h2.llms-sd-title', el => el.textContent ) ).toBe( 'Dashboard' );
+
+	} );
+
+	it ( 'should register a new user with a voucher.', async() => {
+
+		await toggleOpenReg( true );
+		const codes = await createVoucher( { codes: 1, uses: 1 } );
+		await registerStudent( { voucher: codes[0] } );
+
+		expect( await page.$eval( 'h2.llms-sd-title', el => el.textContent ) ).toBe( 'Dashboard' );
+
+		await page.waitForSelector( '.llms-notification .llms-notification-main' );
+		expect( await page.$eval( '.llms-notification .llms-notification-main', el => el.innerHTML ) ).toMatchSnapshot();
 
 	} );
 

--- a/tests/e2e/tests/student/voucher.test.js
+++ b/tests/e2e/tests/student/voucher.test.js
@@ -1,0 +1,61 @@
+/**
+ * Test voucher redemption on the student dashboard
+ *
+ * @since [version]
+ */
+
+import {
+	clickAndWait,
+	createUser,
+	createVoucher,
+	fillField,
+	loginStudent,
+	logoutUser,
+	visitPage,
+} from '@lifterlms/llms-e2e-test-utils';
+
+describe( 'StudentDashboard/RedeemVoucher', () => {
+
+	afterEach( async () => {
+		await logoutUser();
+	} );
+
+	it ( 'Should redeem a valid voucher', async () => {
+
+		// Setup.
+		const
+			codes   = await createVoucher( { codes: 1, uses: 1 } ),
+			student = await createUser();
+
+		await logoutUser();
+
+		// Use the voucher.
+		await loginStudent( student.email, student.password );
+		await visitPage( 'dashboard/redeem-voucher' );
+		await fillField( '#llms-voucher-code', codes[0] );
+		await clickAndWait( '#llms-redeem-voucher-submit' );
+
+		// Success.
+		expect( await page.$eval( '.llms-notice.llms-success', el => el.textContent ) ).toMatchSnapshot();
+
+		await page.waitForSelector( '.llms-notification .llms-notification-main' );
+		expect( await page.$eval( '.llms-notification .llms-notification-main', el => el.innerHTML ) ).toMatchSnapshot();
+
+	} );
+
+	it ( 'Should display an error for an invalid voucher', async() => {
+
+		const student = await createUser();
+		await logoutUser();
+
+		await loginStudent( student.email, student.password );
+		await visitPage( 'dashboard/redeem-voucher' );
+		await fillField( '#llms-voucher-code', 'fakecode' );
+		await clickAndWait( '#llms-redeem-voucher-submit' );
+
+		// Error message.
+		expect( await page.$eval( '.llms-notice.llms-error', el => el.textContent ) ).toMatchSnapshot();
+
+	} );
+
+} );


### PR DESCRIPTION
## Description

Deprecates the class `LLMS_Frontend_Forms`

There's two methods in this class, the `reset_password()` method appears to have been replaced a while ago in the `LLMS_Controller_Account` class.

The `check_voucher()` method has been moved to this class as well.

This class can now be deprecated.

## How has this been tested?

+ Manually
+ New unit tests
+ New e2e tests

## Types of changes

+ Deprecate already unused method
+ Move a method to a new class and deprecate

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

