### PR TITLE
Student count

### DIFF
--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -174,7 +174,7 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.7.3 Unknown.
 	 *
-	 * @param string $type Optional. Type of prereq to retrieve id for [course|track]. Default is `'course'`.
+	 * @param string $type Optional. Type of prereq to retrieve id for [course|track]. Default is 'course'.
 	 * @return int|false Post ID of a course, taxonomy ID of a track, or false if none found.
 .	 */
 	public function get_prerequisite_id( $type = 'course' ) {
@@ -236,7 +236,7 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @param string $field Optional. Which field to return from the available term fields.
 	 *                      Any public variables from a WP_Term object are acceptable: term_id, name, slug, and more.
-	 *                      Default is `'name'`.
+	 *                      Default is 'name'.
 	 * @return string
 	 */
 	public function get_difficulty( $field = 'name' ) {
@@ -292,7 +292,7 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.24.0 Unknown.
 	 *
-	 * @param string $return Optional. Type of return [ids|posts|lessons]. Default is `'lessons'`.
+	 * @param string $return Optional. Type of return [ids|posts|lessons]. Default is 'lessons'.
 	 * @return int[]|WP_Post[]|LLMS_Lesson[] The type depends on value of `$return`.
 	 */
 	public function get_lessons( $return = 'lessons' ) {
@@ -377,7 +377,7 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.24.0 Unknown.
 	 *
-	 * @param string $return Optional. Type of return [ids|posts|sections]. Default is `'sections'`.
+	 * @param string $return Optional. Type of return [ids|posts|sections]. Default is 'sections'.
 	 * @return int[]|WP_Post[]|LLMS_Section[] The type depends on value of `$return`.
 	 */
 	public function get_sections( $return = 'sections' ) {
@@ -475,7 +475,7 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string|string[] $statuses Optional. List of enrollment statuses to query by. Students matching at least one of the provided statuses will be returned. Default is `'enrolled'`.
+	 * @param string|string[] $statuses Optional. List of enrollment statuses to query by. Students matching at least one of the provided statuses will be returned. Default is 'enrolled'.
 	 * @param integer         $limit    Optional. Number of results. Default is `50`.
 	 * @param integer         $skip     Optional. Number of results to skip (for pagination). Default is `0`.
 	 * @return array

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -156,6 +156,17 @@ implements LLMS_Interface_Post_Audio
 		foreach ( $this->get_lessons() as $lesson ) {
 			$points += $lesson->get( 'points' );
 		}
+
+		/**
+		 * Filters the total available points for the course.
+		 *
+		 * Hook description.
+		 *
+		 * @since 3.24.0
+		 *
+		 * @param int         $points Number of available points.
+		 * @param LLMS_Course $course Course object.
+		 */
 		return apply_filters( 'llms_course_get_available_points', $points, $this );
 	}
 
@@ -258,6 +269,15 @@ implements LLMS_Interface_Post_Audio
 	 */
 	public function get_instructors( $exclude_hidden = false ) {
 
+		/**
+		 * Filters the course's instructors list
+		 *
+		 * @since 3.13.0
+		 *
+		 * @param array       $instructors    Instructor data array.
+		 * @param LLMS_Course $course         Course object.
+		 * @param boolearn    $exclude_hidden If true, excludes hidden instructors from the return array.
+		 */
 		return apply_filters(
 			'llms_course_get_instructors',
 			$this->instructors()->get_instructors( $exclude_hidden ),
@@ -340,6 +360,15 @@ implements LLMS_Interface_Post_Audio
 
 		}
 
+		/**
+		 * Filters the course's sales page URL
+		 *
+		 * @since Unknown
+		 *
+		 * @param string      $url    Sales page URL.
+		 * @param LLMS_Course $course The course object.
+		 * @param string      $type   The sales page content type.
+		 */
 		return apply_filters( 'llms_course_get_sales_page_url', $url, $this, $type );
 	}
 
@@ -627,12 +656,25 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 3.20.0
 	 * @since 3.23.0 Unknown.
+	 * @since [version] Use strict `in_array()` comparison.
 	 *
-	 * @return string
+	 * @return boolean
 	 */
 	public function has_sales_page_redirect() {
+
 		$type = $this->get( 'sales_page_content_type' );
-		return apply_filters( 'llms_course_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ) ), $this, $type );
+
+		/**
+		 * Filters whether or not the course has a sales page redirect.
+		 *
+		 * @since Unknown.
+		 *
+		 * @param boolean     $has_redirect Whether or not the course has a sales page redirect.
+		 * @param LLMS_Course $course       Course object.
+		 * @param string      $type         The course's sales page content type property value.
+		 */
+		return apply_filters( 'llms_course_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ), true ), $this, $type );
+
 	}
 
 	/**
@@ -648,15 +690,23 @@ implements LLMS_Interface_Post_Audio
 		// If no period is set, enrollment is automatically open.
 		if ( 'yes' !== $this->get( 'enrollment_period' ) ) {
 
-			$ret = true;
+			$is_open = true;
 
 		} else {
 
-			$ret = ( $this->has_date_passed( 'enrollment_start_date' ) && ! $this->has_date_passed( 'enrollment_end_date' ) );
+			$is_open = ( $this->has_date_passed( 'enrollment_start_date' ) && ! $this->has_date_passed( 'enrollment_end_date' ) );
 
 		}
 
-		return apply_filters( 'llms_is_course_enrollment_open', $ret, $this );
+		/**
+		 * Filters whether or not course enrollment is open.
+		 *
+		 * @since Unknown
+		 *
+		 * @param boolean     $is_open Whether or not enrollment is open.
+		 * @param LLMS_Course $course  Course object.
+		 */
+		return apply_filters( 'llms_is_course_enrollment_open', $is_open, $this );
 
 	}
 
@@ -676,15 +726,23 @@ implements LLMS_Interface_Post_Audio
 		// If a course time period is not enabled, just return true (content is accessible).
 		if ( 'yes' !== $this->get( 'time_period' ) ) {
 
-			$ret = true;
+			$is_open = true;
 
 		} else {
 
-			$ret = ( $this->has_date_passed( 'start_date' ) && ! $this->has_date_passed( 'end_date' ) );
+			$is_open = ( $this->has_date_passed( 'start_date' ) && ! $this->has_date_passed( 'end_date' ) );
 
 		}
 
-		return apply_filters( 'llms_is_course_open', $ret, $this );
+		/**
+		 * Filters whether or not the course is considered open based on the current date.
+		 *
+		 * @since Unknown
+		 *
+		 * @param boolean     $is_open Whether or not enrollment is open.
+		 * @param LLMS_Course $course  Course object.
+		 */
+		return apply_filters( 'llms_is_course_open', $is_open, $this );
 
 	}
 

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -118,23 +118,27 @@ implements LLMS_Interface_Post_Audio
 	protected $model_post_type = 'course';
 
 	/**
-	 * @var array
 	 * @since 1.0.0
+	 * @deprecated [version] Unused property `LLMS_Course::$sections` is replaced by `LLMS_Course::get_sections()`.
+	 *
+	 * @var array
 	 */
 	public $sections;
 
 	/**
-	 * @var string
 	 * @since 1.0.0
+	 * @deprecated [version] Unused property `LLMS_Course::$sku` is deprecated with no replacement.
+	 *
+	 * @var string
 	 */
 	public $sku;
 
 	/**
 	 * Retrieve an instance of the Post Instructors model
 	 *
-	 * @return   LLMS_Post_Instructors
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @return LLMS_Post_Instructors
 	 */
 	public function instructors() {
 		return new LLMS_Post_Instructors( $this );
@@ -143,9 +147,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve the total points available for the course
 	 *
-	 * @return   int
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 *
+	 * @return int
 	 */
 	public function get_available_points() {
 		$points = 0;
@@ -158,11 +162,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get course's prerequisite id based on the type of prerequisite
 	 *
-	 * @param    string $type  Type of prereq to retrieve id for [course|track]
-	 * @return   int|false         Post ID of a course, taxonomy ID of a track, or false if none found
-	 * @since    3.0.0
-	 * @version  3.7.3
-	 */
+	 * @since 3.0.0
+	 * @since 3.7.3 Unknown.
+	 *
+	 * @param string $type Type of prereq to retrieve id for [course|track].
+	 * @return int|false Post ID of a course, taxonomy ID of a track, or false if none found
+.	 */
 	public function get_prerequisite_id( $type = 'course' ) {
 
 		if ( $this->has_prerequisite( $type ) ) {
@@ -190,11 +195,13 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Attempt to get oEmbed for an audio provider
-	 * Falls back to the [audio] shortcode if the oEmbed fails
+	 *
+	 * Falls back to the [audio] shortcode if the oEmbed fails.
+	 *
+	 * @since 1.0.0
+	 * @since 3.17.0 Unknown
 	 *
 	 * @return string
-	 * @since   1.0.0
-	 * @version 3.17.0
 	 */
 	public function get_audio() {
 		return $this->get_embed( 'audio' );
@@ -203,10 +210,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course categories
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
-	 * @since    3.3.0
-	 * @version  3.3.0
+	 * @since 3.3.0
+	 *
+	 * @param array $args Array of args passed to wp_get_post_terms.
+	 * @return array
 	 */
 	public function get_categories( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_cat', $args );
@@ -215,12 +222,12 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get Difficulty
 	 *
-	 * @param    string $field  which field to return from the available term fields
-	 *                          any public variables from a WP_Term object are acceptable
-	 *                          term_id, name, slug, and more
-	 * @return   string
-	 * @since    1.0.0
-	 * @version  3.24.0
+	 * @since 1.0.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param string $field Which field to return from the available term fields.
+	 *                      Any public variables from a WP_Term object are acceptable: term_id, name, slug, and more.
+	 * @return string
 	 */
 	public function get_difficulty( $field = 'name' ) {
 
@@ -244,10 +251,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course instructor information
 	 *
-	 * @param    boolean $exclude_hidden  if true, excludes hidden instructors from the return array
-	 * @return   array
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param boolean $exclude_hidden If true, excludes hidden instructors from the return array.
+	 * @return array
 	 */
 	public function get_instructors( $exclude_hidden = false ) {
 
@@ -263,10 +270,11 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get course lessons
 	 *
-	 * @param    string $return  type of return [ids|posts|lessons]
-	 * @return   int[]|WP_Post[]|LLMS_Lesson[] type depends on value of $return
-	 * @since    3.0.0
-	 * @version  3.24.0
+	 * @since 3.0.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param string $return Type of return [ids|posts|lessons].
+	 * @return int[]|WP_Post[]|LLMS_Lesson[] type depends on value of $return
 	 */
 	public function get_lessons( $return = 'lessons' ) {
 
@@ -289,9 +297,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an array of quizzes within a course
 	 *
-	 * @return   array            array of WP_Post IDs of the quizzes
-	 * @since    3.12.0
-	 * @version  3.16.0
+	 * @since 3.12.0
+	 * @since 3.16.0 Unknown.
+	 *
+	 * @return int[] Array of WP_Post IDs of the quizzes.
 	 */
 	public function get_quizzes() {
 
@@ -308,9 +317,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get the URL to a WP Page or Custom URL when sales page redirection is enabled
 	 *
-	 * @return   string
-	 * @since    3.20.0
-	 * @version  3.23.0
+	 * @since 3.20.0
+	 * @since 3.23.0 Unknown.
+	 *
+	 * @return string
 	 */
 	public function get_sales_page_url() {
 
@@ -336,10 +346,11 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get course sections
 	 *
-	 * @param    string $return  type of return [ids|posts|sections]
-	 * @return   int[]|WP_Post[]|LLMS_Section[] type depends on value of $return
-	 * @since    3.0.0
-	 * @version  3.24.0
+	 * @since 3.0.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param string $return Type of return [ids|posts|sections].
+	 * @return int[]|WP_Post[]|LLMS_Section[] The type depends on value of $return.
 	 */
 	public function get_sections( $return = 'sections' ) {
 
@@ -382,7 +393,7 @@ implements LLMS_Interface_Post_Audio
 	 * If, for whatever reason, it's not found, it will be calculated on demand and saved for later use.
 	 *
 	 * @since 3.15.0
-	 * @since [version] Use cached value where possible.
+	 * @since version] Use cached value where possible.
 	 *
 	 * @param boolean $skip_cache Default: `false`. Whether or not to bypass the cache. If `true`, bypasses the cache.
 	 * @return int
@@ -422,7 +433,7 @@ implements LLMS_Interface_Post_Audio
 		 *
 		 * @since [version]
 		 *
-		 * @param int         $count  Number of students enrolled in the course.
+		 * @param int $count Number of students enrolled in the course.
 		 * @param LLMS_Course $course Instance of the course object.
 		 */
 		$count = apply_filters( 'llms_course_get_student_count', $count, $this );
@@ -434,27 +445,24 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Get an array of student IDs based on enrollment status in the course
 	 *
-	 * @param    string|array $statuses  list of enrollment statuses to query by
-	 *                                   status query is an OR relationship
-	 * @param    integer      $limit        number of results
-	 * @param    integer      $skip         number of results to skip (for pagination)
-	 * @return   array
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string|string[] $statuses List of enrollment statuses to query by. Students matching at least one of the provided statuses will be returned.
+	 * @param integer         $limit    Number of results.
+	 * @param integer         $skip     Number of results to skip (for pagination).
+	 * @return array
 	 */
 	public function get_students( $statuses = 'enrolled', $limit = 50, $skip = 0 ) {
-
 		return llms_get_enrolled_students( $this->get( 'id' ), $statuses, $limit, $skip );
-
 	}
 
 	/**
 	 * Retrieve course tags
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
-	 * @since    3.3.0
-	 * @version  3.3.0
+	 * @since 3.3.0
+	 *
+	 * @param array $args Array of args passed to wp_get_post_terms.
+	 * @return array
 	 */
 	public function get_tags( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_tag', $args );
@@ -463,10 +471,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve course tracks
 	 *
-	 * @param    array $args  array of args passed to wp_get_post_terms
-	 * @return   array
-	 * @since    3.3.0
-	 * @version  3.3.0
+	 * @since 3.3.0
+	 *
+	 * @param array $args Array of args passed to wp_get_post_terms.
+	 * @return array
 	 */
 	public function get_tracks( $args = array() ) {
 		return wp_get_post_terms( $this->get( 'id' ), 'course_track', $args );
@@ -475,24 +483,24 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an array of students currently enrolled in the course
 	 *
-	 * @param    integer $limit   number of results
-	 * @param    integer $skip    number of results to skip (for pagination)
-	 * @return   array
-	 * @since    1.0.0
-	 * @version  3.0.0 - updated the function to be less complicated
+	 * @since 1.0.0
+	 * @since 3.0.0 Use `LLMS_Course::get_students()`.
+	 *
+	 * @param integer $limit Number of results.
+	 * @param integer $skip Number of results to skip (for pagination).
+	 * @return array
 	 */
 	public function get_enrolled_students( $limit, $skip ) {
-
 		return $this->get_students( 'enrolled', $limit, $skip );
-
 	}
 
 	/**
 	 * Get a user's percentage completion through the course
 	 *
-	 * @return  float
-	 * @since   1.0.0
-	 * @version 3.17.2
+	 * @since 1.0.0
+	 * @since 3.17.2 Unknown.
+	 *
+	 * @return float
 	 */
 	public function get_percent_complete( $user_id = '' ) {
 
@@ -507,9 +515,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Retrieve an instance of the LLMS_Product for this course
 	 *
-	 * @return   LLMS_Product instance of an LLMS_Product
-	 * @since    3.3.0
-	 * @version  3.3.0
+	 * @since 3.3.0
+	 *
+	 * @return LLMS_Product
 	 */
 	public function get_product() {
 		return new LLMS_Product( $this->get( 'id' ) );
@@ -517,11 +525,13 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Attempt to get oEmbed for a video provider
-	 * Falls back to the [video] shortcode if the oEmbed fails
 	 *
-	 * @return   string
-	 * @since    1.0.0
-	 * @version  3.17.0
+	 * Falls back to the [video] shortcode if the oEmbed fails.
+	 *
+	 * @since 1.0.0
+	 * @since 3.17.0 Unknown.
+	 *
+	 * @return string
 	 */
 	public function get_video() {
 		return $this->get_embed( 'video' );
@@ -530,11 +540,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Compare a course meta info date to the current date and get a bool
 	 *
-	 * @param    string $date_key  property key, eg "start_date" or "enrollment_end_date"
-	 * @return   boolean               true when the date is in the past
-	 *                                 false when the date is in the future
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string $date_key Property key, eg "start_date" or "enrollment_end_date".
+	 * @return boolean Returns `true` when the date is in the past and `false` when the date is in the future.
 	 */
 	public function has_date_passed( $date_key ) {
 
@@ -549,20 +558,19 @@ implements LLMS_Interface_Post_Audio
 		if ( ! $date ) {
 			return false;
 
-		} else {
-
-			return $now > $date;
-
 		}
+
+		return $now > $date;
 
 	}
 
 	/**
 	 * Determine if the course is at capacity based on course capacity settings
 	 *
-	 * @return   boolean    true if not at capacity, false if at or over capacity
-	 * @since    3.0.0
-	 * @version  3.15.0
+	 * @since 3.0.0
+	 * @since 3.15.0 Unknown.
+	 *
+	 * @return boolean Returns `true` if not at capacity & `false` if at or over capacity.
 	 */
 	public function has_capacity() {
 
@@ -617,9 +625,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if sales page redirection is enabled
 	 *
-	 * @return   string
-	 * @since    3.20.0
-	 * @version  3.23.0
+	 * @since 3.20.0
+	 * @since 3.23.0 Unknown.
+	 *
+	 * @return string
 	 */
 	public function has_sales_page_redirect() {
 		$type = $this->get( 'sales_page_content_type' );
@@ -629,9 +638,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if students can access course content based on the current date
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.7.0
+	 * @since 3.0.0
+	 * @since 3.7.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function is_enrollment_open() {
 
@@ -654,11 +664,12 @@ implements LLMS_Interface_Post_Audio
 	 * Determine if students can access course content based on the current date
 	 *
 	 * Note that enrollment does not affect the outcome of this check as regardless
-	 * of enrollment, once a course closes content is locked
+	 * of enrollment, once a course closes content is locked.
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.7.0
+	 * @since 3.0.0
+	 * @since 3.7.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function is_open() {
 
@@ -680,10 +691,10 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Determine if a prerequisite is completed for a student
 	 *
-	 * @param    string $type  type of prereq [course|track]
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * @since 3.0.0
+	 *
+	 * @param string $type Type of prereq [course|track].
+	 * @return boolean
 	 */
 	public function is_prerequisite_complete( $type = 'course', $student_id = null ) {
 
@@ -713,9 +724,9 @@ implements LLMS_Interface_Post_Audio
 	/**
 	 * Save instructor information
 	 *
-	 * @param    array $instructors  array of course instructor information
-	 * @since    3.13.0
-	 * @version  3.13.0
+	 * @since 3.13.0
+	 *
+	 * @param array $instructors Array of course instructor information.
 	 */
 	public function set_instructors( $instructors = array() ) {
 
@@ -725,12 +736,14 @@ implements LLMS_Interface_Post_Audio
 
 	/**
 	 * Add data to the course model when converted to array
-	 * Called before data is sorted and returned by $this->jsonSerialize()
 	 *
-	 * @param    array $arr   data to be serialized
-	 * @return   array
-	 * @since    3.3.0
-	 * @version  3.8.0
+	 * Called before data is sorted and returned by $this->jsonSerialize().
+	 *
+	 * @since 3.3.0
+	 * @since 3.8.0 Unknown.
+	 *
+	 * @param array $arr Data to be serialized.
+	 * @return array
 	 */
 	public function toArrayAfter( $arr ) {
 

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -176,8 +176,8 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.7.3 Unknown.
 	 *
-	 * @param string $type Type of prereq to retrieve id for [course|track].
-	 * @return int|false Post ID of a course, taxonomy ID of a track, or false if none found
+	 * @param string $type Optional. Type of prereq to retrieve id for [course|track]. Default is `'course'`.
+	 * @return int|false Post ID of a course, taxonomy ID of a track, or false if none found.
 .	 */
 	public function get_prerequisite_id( $type = 'course' ) {
 
@@ -236,8 +236,9 @@ implements LLMS_Interface_Post_Audio
 	 * @since 1.0.0
 	 * @since 3.24.0 Unknown.
 	 *
-	 * @param string $field Which field to return from the available term fields.
+	 * @param string $field Optional. Which field to return from the available term fields.
 	 *                      Any public variables from a WP_Term object are acceptable: term_id, name, slug, and more.
+	 *                      Default is `'name'`.
 	 * @return string
 	 */
 	public function get_difficulty( $field = 'name' ) {
@@ -264,7 +265,7 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 3.13.0
 	 *
-	 * @param boolean $exclude_hidden If true, excludes hidden instructors from the return array.
+	 * @param boolean $exclude_hidden Optional. If true, excludes hidden instructors from the return array. Default is `false`.
 	 * @return array
 	 */
 	public function get_instructors( $exclude_hidden = false ) {
@@ -293,8 +294,8 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.24.0 Unknown.
 	 *
-	 * @param string $return Type of return [ids|posts|lessons].
-	 * @return int[]|WP_Post[]|LLMS_Lesson[] type depends on value of $return
+	 * @param string $return Optional. Type of return [ids|posts|lessons]. Default is `'lessons'`.
+	 * @return int[]|WP_Post[]|LLMS_Lesson[] The type depends on value of `$return`.
 	 */
 	public function get_lessons( $return = 'lessons' ) {
 
@@ -378,8 +379,8 @@ implements LLMS_Interface_Post_Audio
 	 * @since 3.0.0
 	 * @since 3.24.0 Unknown.
 	 *
-	 * @param string $return Type of return [ids|posts|sections].
-	 * @return int[]|WP_Post[]|LLMS_Section[] The type depends on value of $return.
+	 * @param string $return Optional. Type of return [ids|posts|sections]. Default is `'sections'`.
+	 * @return int[]|WP_Post[]|LLMS_Section[] The type depends on value of `$return`.
 	 */
 	public function get_sections( $return = 'sections' ) {
 
@@ -462,7 +463,7 @@ implements LLMS_Interface_Post_Audio
 		 *
 		 * @since [version]
 		 *
-		 * @param int $count Number of students enrolled in the course.
+		 * @param int         $count  Number of students enrolled in the course.
 		 * @param LLMS_Course $course Instance of the course object.
 		 */
 		$count = apply_filters( 'llms_course_get_student_count', $count, $this );
@@ -476,9 +477,9 @@ implements LLMS_Interface_Post_Audio
 	 *
 	 * @since 3.0.0
 	 *
-	 * @param string|string[] $statuses List of enrollment statuses to query by. Students matching at least one of the provided statuses will be returned.
-	 * @param integer         $limit    Number of results.
-	 * @param integer         $skip     Number of results to skip (for pagination).
+	 * @param string|string[] $statuses Optional. List of enrollment statuses to query by. Students matching at least one of the provided statuses will be returned. Default is `'enrolled'`.
+	 * @param integer         $limit    Optional. Number of results. Default is `50`.
+	 * @param integer         $skip     Optional. Number of results to skip (for pagination). Default is `0`.
 	 * @return array
 	 */
 	public function get_students( $statuses = 'enrolled', $limit = 50, $skip = 0 ) {

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -17,33 +17,33 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.30.3 Explicitly define class properties.
  * @since 4.0.0 Remove previously deprecated class methods.
  *
- * @property string $audio_embed                URL to an oEmbed enable audio URL
- * @property float  $average_grade              Calculated value of the overall average grade of all *enrolled* students in the course.
- * @property float  $average_progress           Calculated value of the overall average progress of all *enrolled* students in the course.
- * @property int    $capacity                   Number of students who can be enrolled in the course before enrollment closes
- * @property string $capacity_message           Message displayed when capacity has been reached
- * @property string $content_restricted_message Message displayed when non-enrolled visitors try to access lessons/quizzes directly
- * @property string $course_closed_message      Message displayed to visitors when the course is accessed after the Course End Date has passed. Only applicable when $time_period is 'yes'
- * @property string $course_opens_message       Message displayed to visitors when the course is accessed before the Course Start Date has passed. Only applicable when $time_period is 'yes'
- * @property string $enable_capacity            Whether capacity restrictions are enabled [yes|no]
- * @property string $enrollment_closed_message  Message displayed to non-enrolled visitors when the course is accessed after the Enrollment End Date has passed. Only applicable when $enrollment_period is 'yes'
- * @property string $enrollment_end_date        After this date, registration closes
- * @property string $enrollment_opens_message   Message displayed to non-enrolled visitors when the course is accessed before the Enrollment Start Date has passed. Only applicable when $enrollment_period is 'yes'
- * @property string $enrollment_period          Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
- * @property string $enrollment_start_date      Before this date, registration is closed
- * @property string $end_date                   Date when a course closes. Students may no longer view content or complete lessons / quizzes after this date.
- * @property string $has_prerequisite           Determine if prerequisites are enabled [yes|no]
- * @property array  $instructors                Course instructor user information
- * @property int    $prerequisite               WP Post ID of a the prerequisite course
- * @property int    $prerequisite_track         WP Tax ID of a the prerequisite track
- * @property int    $sales_page_content_page_id WP Post ID of the WP page to redirect to when $sales_page_content_type is 'page'
- * @property string $sales_page_content_type    Sales page behavior [none,content,page,url]
- * @property string $sales_page_content_url     Redirect URL for a sales page, when $sales_page_content_type is 'url'
- * @property string $start_date                 Date when a course is opens. Students may register before this date but can only view content and complete lessons or quizzes after this date.
- * @property string $length                     User defined course length
- * @property string $tile_featured_video        Displays the featured video instead of the featured image on course tiles [yes|no]
- * @property string $time_period                Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
- * @property string $video_embed                URL to an oEmbed enable video URL
+ * @property string $audio_embed                URL to an oEmbed enable audio URL.
+ * @property float  $average_grade              Calculated value of the overall average grade of all *enrolled* students in the course..
+ * @property float  $average_progress           Calculated value of the overall average progress of all *enrolled* students in the course..
+ * @property int    $capacity                   Number of students who can be enrolled in the course before enrollment closes.
+ * @property string $capacity_message           Message displayed when capacity has been reached.
+ * @property string $content_restricted_message Message displayed when non-enrolled visitors try to access lessons/quizzes directly.
+ * @property string $course_closed_message      Message displayed to visitors when the course is accessed after the Course End Date has passed. Only applicable when $time_period is 'yes'.
+ * @property string $course_opens_message       Message displayed to visitors when the course is accessed before the Course Start Date has passed. Only applicable when $time_period is 'yes'.
+ * @property string $enable_capacity            Whether capacity restrictions are enabled [yes|no].
+ * @property string $enrollment_closed_message  Message displayed to non-enrolled visitors when the course is accessed after the Enrollment End Date has passed. Only applicable when $enrollment_period is 'yes'.
+ * @property string $enrollment_end_date        After this date, registration closes.
+ * @property string $enrollment_opens_message   Message displayed to non-enrolled visitors when the course is accessed before the Enrollment Start Date has passed. Only applicable when $enrollment_period is 'yes'.
+ * @property string $enrollment_period          Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned).
+ * @property string $enrollment_start_date      Before this date, registration is closed.
+ * @property string $end_date                   Date when a course closes. Students may no longer view content or complete lessons / quizzes after this date..
+ * @property string $has_prerequisite           Determine if prerequisites are enabled [yes|no].
+ * @property array  $instructors                Course instructor user information.
+ * @property int    $prerequisite               WP Post ID of a the prerequisite course.
+ * @property int    $prerequisite_track         WP Tax ID of a the prerequisite track.
+ * @property int    $sales_page_content_page_id WP Post ID of the WP page to redirect to when $sales_page_content_type is 'page'.
+ * @property string $sales_page_content_type    Sales page behavior [none,content,page,url].
+ * @property string $sales_page_content_url     Redirect URL for a sales page, when $sales_page_content_type is 'url'.
+ * @property string $start_date                 Date when a course is opens. Students may register before this date but can only view content and complete lessons or quizzes after this date..
+ * @property string $length                     User defined course length.
+ * @property string $tile_featured_video        Displays the featured video instead of the featured image on course tiles [yes|no].
+ * @property string $time_period                Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned).
+ * @property string $video_embed                URL to an oEmbed enable video URL.
  */
 class LLMS_Course
 extends LLMS_Post_Model

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -160,8 +160,6 @@ implements LLMS_Interface_Post_Audio
 		/**
 		 * Filters the total available points for the course.
 		 *
-		 * Hook description.
-		 *
 		 * @since 3.24.0
 		 *
 		 * @param int         $points Number of available points.

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -17,33 +17,33 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.30.3 Explicitly define class properties.
  * @since 4.0.0 Remove previously deprecated class methods.
  *
- * @property $audio_embed  (string)  URL to an oEmbed enable audio URL
- * @property $average_grade  (float)  Calculated value of the overall average grade of all *enrolled* students in the course.
- * @property $average_progress  (float)  Calculated value of the overall average progress of all *enrolled* students in the course.
- * @property $capacity  (int)  Number of students who can be enrolled in the course before enrollment closes
- * @property $capacity_message  (string)  Message displayed when capacity has been reached
- * @property $content_restricted_message  (string)  Message displayed when non-enrolled visitors try to access lessons/quizzes directly
- * @property $course_closed_message  (string)  Message displayed to visitors when the course is accessed after the Course End Date has passed. Only applicable when $time_period is 'yes'
- * @property $course_opens_message  (string)  Message displayed to visitors when the course is accessed before the Course Start Date has passed. Only applicable when $time_period is 'yes'
- * @property $enable_capacity  (string)  Whether capacity restrictions are enabled [yes|no]
- * @property $enrollment_closed_message  (string)  Message displayed to non-enrolled visitors when the course is accessed after the Enrollment End Date has passed. Only applicable when $enrollment_period is 'yes'
- * @property $enrollment_end_date   (string)  After this date, registration closes
- * @property $enrollment_opens_message  (string)  Message displayed to non-enrolled visitors when the course is accessed before the Enrollment Start Date has passed. Only applicable when $enrollment_period is 'yes'
- * @property $enrollment_period  (string)  Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
- * @property $enrollment_start_date  (string)  Before this date, registration is closed
- * @property $end_date   (string)  Date when a course closes. Students may no longer view content or complete lessons / quizzes after this date.
- * @property $has_prerequisite   (string)  Determine if prerequisites are enabled [yes|no]
- * @property $instructors  (array)  Course instructor user information
- * @property $prerequisite   (int)  WP Post ID of a the prerequisite course
- * @property $prerequisite_track   (int)  WP Tax ID of a the prerequisite track
- * @property sales_page_content_page_id  (int)  WP Post ID of the WP page to redirect to when $sales_page_content_type is 'page'
- * @property sales_page_content_type  (string)  Sales page behavior [none,content,page,url]
- * @property sales_page_content_url  (string)  Redirect URL for a sales page, when $sales_page_content_type is 'url'
- * @property $start_date  (string)  Date when a course is opens. Students may register before this date but can only view content and complete lessons or quizzes after this date.
- * @property $length  (string)  User defined course length
- * @property $tile_featured_video (string)  Displays the featured video instead of the featured image on course tiles [yes|no]
- * @property $time_period  (string)  Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
- * @property $video_embed  (string)  URL to an oEmbed enable video URL
+ * @property string $audio_embed                URL to an oEmbed enable audio URL
+ * @property float  $average_grade              Calculated value of the overall average grade of all *enrolled* students in the course.
+ * @property float  $average_progress           Calculated value of the overall average progress of all *enrolled* students in the course.
+ * @property int    $capacity                   Number of students who can be enrolled in the course before enrollment closes
+ * @property string $capacity_message           Message displayed when capacity has been reached
+ * @property string $content_restricted_message Message displayed when non-enrolled visitors try to access lessons/quizzes directly
+ * @property string $course_closed_message      Message displayed to visitors when the course is accessed after the Course End Date has passed. Only applicable when $time_period is 'yes'
+ * @property string $course_opens_message       Message displayed to visitors when the course is accessed before the Course Start Date has passed. Only applicable when $time_period is 'yes'
+ * @property string $enable_capacity            Whether capacity restrictions are enabled [yes|no]
+ * @property string $enrollment_closed_message  Message displayed to non-enrolled visitors when the course is accessed after the Enrollment End Date has passed. Only applicable when $enrollment_period is 'yes'
+ * @property string $enrollment_end_date        After this date, registration closes
+ * @property string $enrollment_opens_message   Message displayed to non-enrolled visitors when the course is accessed before the Enrollment Start Date has passed. Only applicable when $enrollment_period is 'yes'
+ * @property string $enrollment_period          Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
+ * @property string $enrollment_start_date      Before this date, registration is closed
+ * @property string $end_date                   Date when a course closes. Students may no longer view content or complete lessons / quizzes after this date.
+ * @property string $has_prerequisite           Determine if prerequisites are enabled [yes|no]
+ * @property array  $instructors                Course instructor user information
+ * @property int    $prerequisite               WP Post ID of a the prerequisite course
+ * @property int    $prerequisite_track         WP Tax ID of a the prerequisite track
+ * @property int    $sales_page_content_page_id WP Post ID of the WP page to redirect to when $sales_page_content_type is 'page'
+ * @property string $sales_page_content_type    Sales page behavior [none,content,page,url]
+ * @property string $sales_page_content_url     Redirect URL for a sales page, when $sales_page_content_type is 'url'
+ * @property string $start_date                 Date when a course is opens. Students may register before this date but can only view content and complete lessons or quizzes after this date.
+ * @property string $length                     User defined course length
+ * @property string $tile_featured_video        Displays the featured video instead of the featured image on course tiles [yes|no]
+ * @property string $time_period                Whether or not a course time period restriction is enabled [yes|no] (all checks should check for 'yes' as an empty string might be returned)
+ * @property string $video_embed                URL to an oEmbed enable video URL
  */
 class LLMS_Course
 extends LLMS_Post_Model

--- a/tests/phpunit/unit-tests/class-llms-test-generator-courses.php
+++ b/tests/phpunit/unit-tests/class-llms-test-generator-courses.php
@@ -226,6 +226,7 @@ class LLMS_Test_Generator_Courses extends LLMS_UnitTestCase {
 	 * Test create_course()
 	 *
 	 * @since 4.7.0
+	 * @since [version] Only test properties that exist on the raw data arrays.
 	 *
 	 * @return void
 	 */
@@ -253,7 +254,9 @@ class LLMS_Test_Generator_Courses extends LLMS_UnitTestCase {
 
 		// Test meta props are set.
 		foreach ( array_keys( LLMS_Unit_Test_Util::get_private_property_value( $course, 'properties' ) ) as $prop ) {
-			$this->assertEquals( $raw[ $prop ], $course->get( $prop ) );
+			if ( isset( $raw[ $prop ] ) ) {
+				$this->assertEquals( $raw[ $prop ], $course->get( $prop ) );
+			}
 		}
 
 		// Test custom values.

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -53,7 +53,6 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 			'enrollment_period'          => 'yesno',
 			'enrollment_start_date'      => 'text',
 			'has_prerequisite'           => 'yesno',
-			'instructors'                => 'array',
 			'length'                     => 'text',
 			'prerequisite'               => 'absint',
 			'prerequisite_track'         => 'absint',
@@ -77,6 +76,8 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	protected function get_data() {
 		return array(
 			'audio_embed' => 'http://example.tld/audio_embed',
+			'average_grade' => 25.55,
+			'average_progress' => 99.32,
 			'capacity' => 25,
 			'capacity_message' => 'Capacity Reached',
 			'course_closed_message' => 'Course has closed',

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -26,36 +26,44 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	/**
 	 * Get properties, used by test_getters_setters
 	 * This should match, exactly, the object's $properties array
-	 * @return   array
-	 * @since    3.4.0
-	 * @version  3.20.0
+	 *
+	 * @since 3.4.0
+	 * @since 3.20.0 Unknown.
+	 * @since [version] Added missing values.
+	 *
+	 * @return array
 	 */
 	protected function get_properties() {
 		return array(
-			'audio_embed' => 'text',
-			'capacity' => 'absint',
-			'capacity_message' => 'text',
-			'course_closed_message' => 'text',
-			'course_opens_message' => 'text',
+			// Public.
+			'audio_embed'                => 'text',
+			'average_grade'              => 'float',
+			'average_progress'           => 'float',
+			'capacity'                   => 'absint',
+			'capacity_message'           => 'text',
+			'course_closed_message'      => 'text',
+			'course_opens_message'       => 'text',
 			'content_restricted_message' => 'text',
-			'enable_capacity' => 'yesno',
-			'end_date' => 'text',
-			'enrollment_closed_message' => 'text',
-			'enrollment_end_date' => 'text',
-			'enrollment_opens_message' => 'text',
-			'enrollment_period' => 'yesno',
-			'enrollment_start_date' => 'text',
-			'has_prerequisite' => 'yesno',
-			'length' => 'text',
-			'prerequisite' => 'absint',
-			'prerequisite_track' => 'absint',
+			'enable_capacity'            => 'yesno',
+			'end_date'                   => 'text',
+			'enrolled_students'          => 'absint',
+			'enrollment_closed_message'  => 'text',
+			'enrollment_end_date'        => 'text',
+			'enrollment_opens_message'   => 'text',
+			'enrollment_period'          => 'yesno',
+			'enrollment_start_date'      => 'text',
+			'has_prerequisite'           => 'yesno',
+			'instructors'                => 'array',
+			'length'                     => 'text',
+			'prerequisite'               => 'absint',
+			'prerequisite_track'         => 'absint',
 			'sales_page_content_page_id' => 'absint',
-			'sales_page_content_type' => 'string',
-			'sales_page_content_url' => 'string',
-			'tile_featured_video' => 'yesno',
-			'time_period' => 'yesno',
-			'start_date' => 'text',
-			'video_embed' => 'text',
+			'sales_page_content_type'    => 'string',
+			'sales_page_content_url'     => 'string',
+			'tile_featured_video'        => 'yesno',
+			'time_period'                => 'yesno',
+			'start_date'                 => 'text',
+			'video_embed'                => 'text',
 		);
 	}
 
@@ -76,6 +84,7 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 			'content_restricted_message' => 'You cannot access this content',
 			'enable_capacity' => 'yes',
 			'end_date' => '2017-05-05',
+			'enrolled_students' => 25,
 			'enrollment_closed_message' => 'Enrollment is closed',
 			'enrollment_end_date' => '2017-05-05',
 			'enrollment_opens_message' => 'Enrollment opens later',
@@ -362,6 +371,39 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		array_map( function( $section ) {
 			$this->assertTrue( is_a( $section, 'LLMS_Section' ) );
 		}, $sections );
+
+	}
+
+	/**
+	 * Test get_student_count()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_student_count() {
+
+		$course_id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$course    = llms_get_post( $course_id );
+
+		// No value, uses default from course default property value (instead of using an empty string).
+		$this->assertSame( 0, $course->get_student_count() );
+
+		// Cached 0.
+		$this->assertSame( 0, $course->get_student_count() );
+
+		// Fake cache hit.
+		$course->set( 'enrolled_students', 52 );
+		$this->assertSame( 52, $course->get_student_count() );
+
+		// Use real data.
+		$this->factory->student->create_and_enroll_many( 2, $course_id );
+
+		// Skip cache.
+		$this->assertSame( 2, $course->get_student_count( true ) );
+
+		// Cached.
+		$this->assertSame( 2, $course->get_student_count() );
 
 	}
 


### PR DESCRIPTION
## Description

While working on #1485 I decided to store the number of enrolled students found in a course at the conclusion of the data processing so that we could use that calculated number on reporting screens in favor of pulling it via an SQL query when needed.

This PR updates the `LLMS_Course::get_student_count()` method to implement a "caching" mechanism that pulls the count information from postmeta data, when available.

The result is that the data should be generally available via the cache through the (updated) background processor and if it does need to be queried via SQL it will be stored on postmeta for future use.

Additionally, I know of at least 1 3rd-party theme that would use this to display the number of enrolled students on the frontend of the website too.

I also updated the docs for the `LLMS_Course` class

## How has this been tested?

+ Manually
+ New unit tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Performance improvements

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

