### PR TITLE
Fix pagination breaks for [lifterlms_courses] and [lifterlms_memberships] on static front page

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Shortcodes/Classes
  *
  * @since 3.14.0
- * @version 3.31.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,7 +25,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	/**
 	 * Shortcode tag
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	public $tag = 'lifterlms_courses';
 
@@ -33,11 +33,11 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 * Get shortcode attributes
 	 *
 	 * Retrieves an array of default attributes which are automatically merged
-	 * with the user submitted attributes and passed to $this->get_output()
+	 * with the user submitted attributes and passed to $this->get_output().
 	 *
-	 * @return   array
-	 * @since    3.14.0
-	 * @version  3.14.0
+	 * @since 3.14.0
+	 *
+	 * @return array
 	 */
 	protected function get_default_attributes() {
 		return array(
@@ -147,13 +147,14 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 *
 	 * @since 3.14.0
 	 * @since 3.31.0 Changed access from private to protected.
+	 * @since [version] Handle pagination when the shortcode is used on the static front page.
 	 *
 	 * @return WP_Query
 	 */
 	protected function get_wp_query() {
 
 		$args = array(
-			'paged'          => get_query_var( 'paged' ),
+			'paged'          => is_front_page() ? get_query_var( 'page' ) : get_query_var( 'paged' ),
 			'post__in'       => $this->get_post__in(),
 			'post_type'      => 'course',
 			'post_status'    => $this->get_attribute( 'post_status' ),
@@ -171,7 +172,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	 * Retrieve the actual content of the shortcode
 	 *
 	 * $atts & $content are both filtered before being passed to get_output()
-	 * output is filtered so the return of get_output() doesn't need its own filter
+	 * output is filtered so the return of get_output() doesn't need its own filter.
 	 *
 	 * @since 3.14.0
 	 * @since 3.30.2 Output a message instead of the entire course catalog when "mine" is used and and current student is not enrolled in any courses.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes/Shortcodes
  *
  * @since 1.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -293,6 +293,7 @@ class LLMS_Shortcodes {
 	 *
 	 * @since 1.4.4
 	 * @since 3.0.2
+	 * @since [version] Handle pagination when the shortcode is used on the static front page.
 	 *
 	 * @param array $atts Associative array of shortcode attributes.
 	 * @return string
@@ -313,7 +314,7 @@ class LLMS_Shortcodes {
 		}
 
 		$args = array(
-			'paged'          => get_query_var( 'paged' ),
+			'paged'          => is_front_page() ? get_query_var( 'page' ) : get_query_var( 'paged' ),
 			'post_type'      => 'llms_membership',
 			'post_status'    => 'publish',
 			'posts_per_page' => isset( $atts['posts_per_page'] ) ? $atts['posts_per_page'] : -1,
@@ -361,7 +362,7 @@ class LLMS_Shortcodes {
 					'base'      => str_replace( 999999, '%#%', esc_url( get_pagenum_link( 999999 ) ) ),
 					'format'    => '?page=%#%',
 					'total'     => $query->max_num_pages,
-					'current'   => max( 1, get_query_var( 'paged' ) ),
+					'current'   => max( 1, $args['paged'] ),
 					'prev_next' => true,
 					'prev_text' => '«' . __( 'Previous', 'lifterlms' ),
 					'next_text' => __( 'Next', 'lifterlms' ) . '»',


### PR DESCRIPTION
## Description
Fixes #1258 

## How has this been tested?
manually adding alternatively the courses and the memberships shortcodes on a static page. I tested that the pagination worked fine there.
Then I set it as static front page, and tested again the pagination worked with both the shortcodes.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

