### PR TITLE
Staging updates

### DIFF
--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 4.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -183,12 +183,15 @@ final class LifterLMS {
 	 * @since 1.0.0
 	 * @since 3.21.1 Unknown.
 	 * @since 4.0.0 Don't initialize removed `LLMS_Person()` class.
+	 * @since [version] Check site staging/duplicate status & trigger associated actions.
 	 *
 	 * @return void
 	 */
 	public function init() {
 
 		do_action( 'before_lifterlms_init' );
+
+		LLMS_Site::check_status();
 
 		$this->engagements();
 		$this->notifications();

--- a/includes/admin/class.llms.admin.notices.core.php
+++ b/includes/admin/class.llms.admin.notices.core.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.0.0
- * @version 4.5.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -14,7 +14,6 @@ defined( 'ABSPATH' ) || exit;
  * Manage core admin notices class
  *
  * @since 3.0.0
- * @since 3.32.0 Moved staging notice logic to `LLMS_Staging::handle_staging_notice_actions()`.
  */
 class LLMS_Admin_Notices_Core {
 
@@ -41,7 +40,9 @@ class LLMS_Admin_Notices_Core {
 	 *
 	 * Adds later for LLMS Settings screens to accommodate for settings that are updated later in the load cycle.
 	 *
-	 * @version 3.0.0
+	 * @since 3.0.0
+	 * @since [version] Remove hook for deprecated `check_staging()` notice.
+	 *
 	 * @return void
 	 */
 	public static function add_init_actions() {
@@ -57,7 +58,6 @@ class LLMS_Admin_Notices_Core {
 
 		add_action( $action, array( __CLASS__, 'sidebar_support' ), $priority );
 		add_action( $action, array( __CLASS__, 'gateways' ), $priority );
-		add_action( $action, array( __CLASS__, 'check_staging' ), $priority );
 
 	}
 
@@ -68,33 +68,15 @@ class LLMS_Admin_Notices_Core {
 	 * from the button on the general settings tab.
 	 *
 	 * @since 3.0.0
+	 * @since 3.7.4 Automatically disable recurring payments when a clone is detected.
 	 * @since 3.32.0 Moved logic for handling notice actions to LLMS_Staging::handle_staging_notice_actions().
+	 * @deprecated [version] `LLMS_Admin_Notices_Core::check_staging()` is deprecated in favor of `LLMS_Staging::notice()`.
 	 *
 	 * @return void
 	 */
 	public static function check_staging() {
-
-		$id = 'maybe-staging';
-
-		if ( ! LLMS_Site::is_clone_ignored() && ! LLMS_Admin_Notices::has_notice( $id ) && LLMS_Site::is_clone() ) {
-
-			do_action( 'llms_site_clone_detected' );
-
-			// Disable recurring payments immediately.
-			LLMS_Site::update_feature( 'recurring_payments', false );
-
-			LLMS_Admin_Notices::add_notice(
-				$id,
-				array(
-					'type'        => 'info',
-					'dismissible' => false,
-					'remindable'  => false,
-					'template'    => 'admin/notices/staging.php',
-				)
-			);
-
-		}
-
+		llms_deprecated_function( 'LLMS_Admin_Notices_Core::check_staging()', '[version]', 'LLMS_Staging::notice()' );
+		LLMS_Staging::notice();
 	}
 
 	/**

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 4.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -87,6 +87,7 @@ class LLMS_Loader {
 	 *
 	 * @since 4.0.0
 	 * @since 4.4.0 Include `LLMS_Assets` class.
+	 * @since [version] Class `LLMS_Staging` always loaded instead of only loaded on admin panel.
 	 *
 	 * @return void
 	 */
@@ -137,6 +138,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-grades.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-mime-type-extractor.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-sessions.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-staging.php';
 
 		// Classes (files to be renamed).
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.assets.php';
@@ -214,6 +216,7 @@ class LLMS_Loader {
 	 * @since 4.0.0
 	 * @since 4.7.0 Always load `LLMS_Admin_Reporting`.
 	 * @since 4.8.0 Add `LLMS_Export_API`.
+	 * @since [version] Class `LLMS_Staging` always loaded instead of only loaded on admin panel.
 	 *
 	 * @return void
 	 */
@@ -256,7 +259,6 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/post-types/tables/class.llms.table.student.management.php';
 
 		// Classes.
-		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-staging.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.dot.com.api.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.generator.php';
 

--- a/includes/class-llms-staging.php
+++ b/includes/class-llms-staging.php
@@ -126,7 +126,7 @@ class LLMS_Staging {
 	}
 
 	/**
-	 * Output a notice informing the use the site was put into staging mode.
+	 * Output a notice informing the user the site was put into staging mode.
 	 *
 	 * @since [version]
 	 *

--- a/includes/class-llms-staging.php
+++ b/includes/class-llms-staging.php
@@ -105,6 +105,7 @@ class LLMS_Staging {
 	 * Adds a "bubble" to the "Orders" menu item when recurring payments are disabled.
 	 *
 	 * @since 3.32.0
+	 * @since [version] Moved HTML for the warning bubble into it's own method.
 	 *
 	 * @return void
 	 */

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -137,7 +137,7 @@ class LLMS_Site {
 		if ( is_null( $status ) ) {
 
 			$features = self::get_features();
-			$status = isset( $features[ $feature ] ) ? $features[ $feature ] : false;
+			$status   = isset( $features[ $feature ] ) ? $features[ $feature ] : false;
 
 		}
 

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -10,7 +10,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.0.0
- * @version 3.7.4
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,7 +19,6 @@ defined( 'ABSPATH' ) || exit;
  * LLMS_Site class.
  *
  * @since 3.0.0
- * @since 3.7.4 Unknown.
  */
 class LLMS_Site {
 
@@ -42,6 +41,33 @@ class LLMS_Site {
 	}
 
 	/**
+	 * Check if the site is cloned and not ignored
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean Returns `true` when a clone is detected, otherwise `false`.
+	 */
+	public static function check_status() {
+
+		if ( ! self::is_clone_ignored() && self::is_clone() ) {
+
+			/**
+			 * Action triggered when the current website is determined to be a "cloned" site
+			 *
+			 * @since 3.7.4
+			 * @since [version] Moved from LLMS_Admin_Notices_Core::check_staging().
+			 */
+			do_action( 'llms_site_clone_detected' );
+
+			return true;
+
+		}
+
+		return false;
+
+	}
+
+	/**
 	 * Get the lock url for the current site
 	 * gets the WP site url and adds the lock string to it
 	 *
@@ -50,10 +76,8 @@ class LLMS_Site {
 	 * @return string
 	 */
 	public static function get_lock_url() {
-
 		$site_url = get_site_url();
 		return substr_replace( $site_url, self::$lock_string, strlen( $site_url ) / 2, 0 );
-
 	}
 
 	/**
@@ -64,9 +88,7 @@ class LLMS_Site {
 	 * @return void
 	 */
 	public static function set_lock_url() {
-
 		update_option( 'llms_site_url', self::get_lock_url() );
-
 	}
 
 	/**
@@ -85,6 +107,13 @@ class LLMS_Site {
 
 		$url = set_url_scheme( $url );
 
+		/**
+		 * Filters the stored LLMS_Site URL
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $url The cleaned LLMS_Site URL.
+		 */
 		return apply_filters( 'llms_site_get_url', $url );
 
 	}
@@ -92,29 +121,79 @@ class LLMS_Site {
 	/**
 	 * Get a single feature's status
 	 *
-	 * @since 3.0.0
-	 * @param string $feature Feature id/key.
+	 * Checks for a feature constant first and, if none is defined,
+	 * uses the stored site setting (with a fallback to the default value), and
+	 * a final fallback to `false` if the feature cannot be found.
 	 *
+	 * @since 3.0.0
+	 * @since [version] Allow feature configuration via constants.
+	 *
+	 * @param string $feature Feature id/key.
 	 * @return bool
 	 */
 	public static function get_feature( $feature ) {
-		$features = self::get_features();
-		if ( isset( $features[ $feature ] ) ) {
-			return $features[ $feature ];
+
+		$status = self::get_feature_constant( $feature );
+		if ( is_null( $status ) ) {
+
+			$features = self::get_features();
+			$status = isset( $features[ $feature ] ) ? $features[ $feature ] : false;
+
 		}
-		return false;
+
+		/**
+		 * Filters the status of a LLMS_Site feature.
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $status  Status of the feature.
+		 * @param string  $feature The feature ID/key.
+		 */
+		return apply_filters( 'llms_site_get_feature', $status, $feature );
+
 	}
 
 	/**
-	 * Get a list of automated features that it might be useful
-	 * to disable on testing or staging environments
+	 * Retrieve a constant value for a site feature
+	 *
+	 * This allows site features to be explicitly enabled or disabled
+	 * in a wp-config.php file.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $feature Feature id/key.
+	 * @return bool
+	 */
+	protected static function get_feature_constant( $feature ) {
+
+		$constant = sprintf( 'LLMS_SITE_FEATURE_%s', strtoupper( $feature ) );
+		if ( defined( $constant ) ) {
+			return constant( $constant );
+		}
+
+		return null;
+
+	}
+
+	/**
+	 * Get a list of automated features
+	 *
+	 * These features are features that should be disabled
+	 * in testing or staging environments.
 	 *
 	 * @since 3.0.0
 	 *
-	 * @return array
+	 * @return array An associative array of site features.
 	 */
 	public static function get_features() {
 
+		/**
+		 * Filters the default values for LLMS_Site features
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array $defaults An associative array of site features.
+		 */
 		$defaults = apply_filters(
 			'llms_site_default_features',
 			array(
@@ -132,7 +211,7 @@ class LLMS_Site {
 	 * @since 3.0.0
 	 *
 	 * @param string $feature Name / key of the feature.
-	 * @param bool   $val Status of the feature [true = enabled; false = disabled].
+	 * @param bool   $val     Status of the feature [true = enabled; false = disabled].
 	 * @return void
 	 */
 	public static function update_feature( $feature, $val ) {
@@ -145,32 +224,48 @@ class LLMS_Site {
 
 	/**
 	 * Determine if this is a cloned site
-	 * Compares the stored (and cleaned) llms_site_url against the WP site url
 	 *
-	 * @return   boolean        true if it's a cloned site (urls DO NOT match)
-	 *                          false if it's not (urls DO match)
-	 * @since    3.0.0
-	 * @version  3.0.0
+	 * Compares the stored (and cleaned) llms_site_url against the WP site url.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return boolean Returns `true` if it's a cloned site (urls do not match)
+	 *                 and `false` if it's not (urls DO match).
 	 */
 	public static function is_clone() {
 
+		/**
+		 * Filters whether or not the site is a "cloned" site
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param boolean $is_clone When `true` the site is considered a "clone", otherwise it is not.
+		 */
 		return apply_filters( 'llms_site_is_clone', ( get_site_url() !== self::get_url() ) );
 
 	}
 
 	/**
 	 * Determines whether or not the clone warning notice has been ignored
-	 * this prevents the warning from redisplaying when the site is a clone
-	 * and automatic payments remain disabled
+	 *
+	 * This prevents the warning from redisplaying when the site is a clone
+	 * and automatic payments remain disabled.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Use `llms_parse_bool()` to determine check the option value.
 	 *
 	 * @return boolean
 	 */
 	public static function is_clone_ignored() {
 
-		$ignore = apply_filters( 'llms_site_is_clone_ignored', get_option( 'llms_site_url_ignore', 'no' ) );
-		return ( 'yes' === $ignore );
+		/**
+		 * Filters whether or not the "clone" site has already been ignored.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param boolean $is_clone_ignored If `true`, the clone is ignored, otherwise it is not.
+		 */
+		return apply_filters( 'llms_site_is_clone_ignored', llms_parse_bool( get_option( 'llms_site_url_ignore', 'no' ) ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-site.php
+++ b/tests/phpunit/unit-tests/class-llms-test-site.php
@@ -1,16 +1,21 @@
 <?php
 /**
  * Tests for LLMS_Site
- * @since    3.7.4
- * @version  3.7.4
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group site
+ *
+ * @since 3.7.4
  */
 class LLMS_Test_Site extends LLMS_UnitTestCase {
 
 	/**
 	 * Test clear_lock_url() function
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return void
 	 */
 	public function test_clear_lock_url() {
 
@@ -21,16 +26,50 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test check_status() method
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_check_status() {
+
+		$actions  = did_action( 'llms_site_clone_detected' );
+		$original = get_site_url();
+
+		// Not a clone.
+		$this->assertFalse( LLMS_Site::check_status() );
+
+		// Simulate the site being cloned.
+		update_option( 'siteurl', 'http://fakeurl.tld' );
+
+		$this->assertTrue( LLMS_Site::check_status() );
+		$this->assertSame( ++$actions, did_action( 'llms_site_clone_detected' ) );
+
+		// Site has been ignored.
+		update_option( 'llms_site_url_ignore', 'yes' );
+		$this->assertFalse( LLMS_Site::check_status() );
+
+		// Restore URL.
+		update_option( 'siteurl', $original );
+
+	}
+
+	/**
 	 * Test lock url getter and setter functions
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Added urls with "www".
+	 *
+	 * @return void
 	 */
 	public function test_get_set_lock_url() {
 
 		$urls = array(
 			'https://whatever.com',
 			'http://whatever.com',
+			'https://www.whatever.com',
+			'http://www.whatever.com',
 			'https://w.com',
 			'https://whatever-with-a-dash.net',
 			'http://wh.at',
@@ -44,19 +83,19 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 
 			$site_url = get_site_url();
 
-			// this is what the lock url should be
+			// This is what the lock url should be.
 			$lock_url = substr_replace( $site_url, LLMS_Site::$lock_string, strlen( $site_url ) / 2, 0 );
 
-			// make sure they match
+			// Make sure they match.
 			$this->assertEquals( $lock_url, LLMS_Site::get_lock_url() );
 
-			// save it
+			// Save it.
 			LLMS_Site::set_lock_url();
 
-			// make sure it saves the right option
+			// Make sure it saves the right option.
 			$this->assertEquals( $lock_url, get_option( 'llms_site_url' ) );
 
-			// this should match the original URL
+			// This should match the original URL.
 			$this->assertEquals( $site_url, LLMS_Site::get_url() );
 
 		}
@@ -65,54 +104,65 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 
 	/**
 	 * Test feature getter and setter functions
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 * @since [version] Test against feature constants.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
 	 */
 	public function test_get_set_features() {
 
-		// should return an array of defaults even when option doesnt exist
+		// Should return an array of defaults even when option doesnt exist.
 		delete_option( 'llms_site_get_features' );
 		$this->assertTrue( is_array( LLMS_Site::get_features() ) );
 
-		// fake feature always returns false
+		// Fake feature always returns false.
 		$this->assertFalse( LLMS_Site::get_feature( 'mock_feature' ) );
 
-		foreach ( array( 'recurring_payments' ) as $feature ) {
+		// Test getters/setters with a real feature.
+		LLMS_Site::update_feature( 'recurring_payments', true );
+		$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
 
-			// test getters/setters
-			LLMS_Site::update_feature( $feature, true );
-			$this->assertTrue( LLMS_Site::get_feature( $feature ) );
+		LLMS_Site::update_feature( 'recurring_payments', false );
+		$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
 
-			LLMS_Site::update_feature( $feature, false );
-			$this->assertFalse( LLMS_Site::get_feature( $feature ) );
+		// Constant not set.
+		$this->assertNull( LLMS_Unit_Test_Util::call_method( 'LLMS_Site', 'get_feature_constant', array( 'recurring_payments' ) ) );
+		$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
 
-		}
+		// Constant is set.
+		llms_maybe_define_constant( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', true );
+		$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
 
 	}
 
+
 	/**
 	 * Test is_clone() function
-	 * @return   void
-	 * @since    3.7.4
-	 * @version  3.7.4
+	 *
+	 * @since 3.7.4
+	 *
+	 * @return void
 	 */
 	public function test_is_clone() {
 
 		$original = get_site_url();
 
-		// not a clone because the url is the lock url
+		// Not a clone because the url is the lock url.
 		$this->assertFalse( LLMS_Site::is_clone() );
 
-		// the url has changed
+		// The url has changed.
 		update_option( 'siteurl', 'http://fakeurl.tld' );
 		$this->assertTrue( LLMS_Site::is_clone() );
 
-		// change it back to the original
+		// Change it back to the original.
 		update_option( 'siteurl', $original );
 		$this->assertFalse( LLMS_Site::is_clone() );
 
-		// change the schema (should not be identified as a clone)
+		// Change the schema (should not be identified as a clone).
 		update_option( 'siteurl', set_url_scheme( $original, 'https' ) );
 		$this->assertFalse( LLMS_Site::is_clone() );
 
@@ -120,9 +170,10 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 
 	/**
 	 * Test is_clone_ignored() function
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return void
 	 */
 	public function test_is_clone_ignored() {
 

--- a/tests/phpunit/unit-tests/class-llms-test-staging.php
+++ b/tests/phpunit/unit-tests/class-llms-test-staging.php
@@ -1,0 +1,242 @@
+<?php
+/**
+ * Test LLMS_Staging class
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group staging
+ *
+ * @since [version]
+ */
+class LLMS_Test_Staging extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Setup before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setupBeforeClass() {
+
+		parent::setupBeforeClass();
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.notices.php';
+
+	}
+
+	/**
+	 * Test clone_detected()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_clone_detected() {
+
+		LLMS_Site::update_feature( 'recurring_payments', true );
+
+		LLMS_Staging::clone_detected();
+		$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
+
+	}
+
+	/**
+	 * Test handle_staging_notice_actions() when the method isn't called
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_staging_notice_actions_not_called() {
+
+		$this->assertNull( LLMS_Staging::handle_staging_notice_actions() );
+
+	}
+
+	/**
+	 * Test handle_staging_notice_actions() with an invalid nonce.
+	 *
+	 * @since [version]
+	 *
+	 * @expectedException WPDieException
+	 *
+	 * @return void
+	 */
+	public function test_handle_staging_notice_actions_invalid_nonce() {
+
+		$this->mockGetRequest( array(
+			'llms-staging-status' => 'enable',
+			'_llms_staging_nonce' => 'fake',
+		) );
+
+		LLMS_Staging::handle_staging_notice_actions();
+
+	}
+
+	/**
+	 * Test handle_staging_notice_actions() with an invalid user.
+	 *
+	 * @since [version]
+	 *
+	 * @expectedException WPDieException
+	 *
+	 * @return void
+	 */
+	public function test_handle_staging_notice_actions_invalid_user() {
+
+		$this->mockGetRequest( array(
+			'llms-staging-status' => 'enable',
+			'_llms_staging_nonce' => wp_create_nonce( 'llms_staging_status' ),
+		) );
+
+		LLMS_Staging::handle_staging_notice_actions();
+
+	}
+
+	/**
+	 * Test handle_staging_notice_actions() when enabling recurring payments
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_staging_notice_actions_enable() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$_SERVER['HTTP_REFERER'] = 'http://example.tld/wp-admin/?page=whatever';
+		$original = get_site_url();
+		update_option( 'siteurl', 'http://fakeurl.tld' );
+		LLMS_Site::update_feature( 'recurring_payments', false );
+
+		$this->mockGetRequest( array(
+			'llms-staging-status' => 'enable',
+			'_llms_staging_nonce' => wp_create_nonce( 'llms_staging_status' ),
+		) );
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( $_SERVER['HTTP_REFERER'] . ' [302] YES' );
+
+		try {
+
+			LLMS_Staging::handle_staging_notice_actions();
+
+		} catch( LLMS_Unit_Test_Exception_Redirect $exception ) {
+
+			$this->assertEquals( get_option( 'llms_site_url' ), LLMS_Site::get_lock_url() );
+			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
+			$this->assertFalse( LLMS_Admin_Notices::has_notice( 'maybe-staging' ) );
+
+			update_option( 'siteurl', $original );
+			unset( $_SERVER['HTTP_REFERER'] );
+
+			throw $exception;
+		}
+
+	}
+
+	/**
+	 * Test handle_staging_notice_actions() when enabling recurring payments
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_staging_notice_actions_disable() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$_SERVER['HTTP_REFERER'] = 'http://example.tld/wp-admin/?page=whatever';
+		$original = get_site_url();
+		update_option( 'siteurl', 'http://fakeurl.tld' );
+		LLMS_Site::update_feature( 'recurring_payments', true );
+
+		$this->mockGetRequest( array(
+			'llms-staging-status' => 'disable',
+			'_llms_staging_nonce' => wp_create_nonce( 'llms_staging_status' ),
+		) );
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( $_SERVER['HTTP_REFERER'] . ' [302] YES' );
+
+		try {
+
+			LLMS_Staging::handle_staging_notice_actions();
+
+		} catch( LLMS_Unit_Test_Exception_Redirect $exception ) {
+
+			$this->assertEquals( '', get_option( 'llms_site_url' ) );
+			$this->assertTrue( LLMS_Site::is_clone_ignored() );
+			$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
+			$this->assertFalse( LLMS_Admin_Notices::has_notice( 'maybe-staging' ) );
+
+			update_option( 'siteurl', $original );
+			unset( $_SERVER['HTTP_REFERER'] );
+
+			throw $exception;
+		}
+
+	}
+
+	/**
+	 * Test the menu_warning() method
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_menu_warning() {
+
+		$mock_menu = array(
+			array(
+				'Dashboard',
+				'read',
+				'index.php',
+				'',
+				'menu-top menu-top-first menu-icon-dashboard',
+				'menu-dashboard',
+				'dashicons-dashboard',
+			),
+			array(
+				'Orders',
+				'edit_posts',
+				'edit.php?post_type=llms_order',
+				'',
+				'menu-top menu-icon-llms_order',
+				'menu-posts-llms_order',
+				'dashicons-cart',
+			),
+		);
+
+		global $menu;
+		$menu = $mock_menu;
+
+		LLMS_Site::update_feature( 'recurring_payments', true );
+		LLMS_Staging::menu_warning();
+		$this->assertSame( $mock_menu, $menu );
+
+
+		LLMS_Site::update_feature( 'recurring_payments', false );
+		LLMS_Staging::menu_warning();
+		$this->assertSame( $mock_menu[0], $menu[0] );
+
+		$mock_menu[1][0] .= LLMS_Unit_Test_Util::call_method( 'LLMS_Staging', 'get_menu_warning_bubble' );
+		$this->assertSame( $mock_menu[1], $menu[1] );
+
+	}
+
+	/**
+	 * Test notice() method
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_notice() {
+
+		LLMS_Admin_Notices::delete_notice( 'maybe-staging' );
+		LLMS_Staging::notice();
+		$this->assertTrue( LLMS_Admin_Notices::has_notice( 'maybe-staging' ) );
+		LLMS_Admin_Notices::delete_notice( 'maybe-staging' );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -481,6 +481,32 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test a recurring payment processed in the same page load as a site "clone" is identified
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_recurring_charge_staging_clone_detected() {
+
+		do_action( 'llms_site_clone_detected' );
+
+		$plan = $this->get_mock_plan( '200.00', 1 );
+		$order = $this->get_mock_order( $plan );
+
+		// starting action numbers.
+		$skip_actions = did_action( 'llms_order_recurring_charge_skipped' );
+		$note_actions = did_action( 'llms_new_order_note_added' );
+
+		// Trigger recurring payment.
+		do_action( 'llms_charge_recurring_payment', $order->get( 'id' ) );
+
+		$this->assertSame( $note_actions + 1, did_action( 'llms_new_order_note_added' ) );
+		$this->assertSame( $skip_actions + 1, did_action( 'llms_order_recurring_charge_skipped' ) );
+
+	}
+
+	/**
 	 * Test gateway-related errors encountered during a recurring_charge attempt.
 	 *
 	 * @since 3.32.0


### PR DESCRIPTION
## Description

Updates staging and site feature code

The main goal is to ensure that visiting the admin panel (and logging in as an admin) is not required to automatically disable site features (like recurring payments) when a cloned site is detected.

There's two changes of note:

1) The method that is used to check if the site has been cloned runs on `init` in favor of `admin_init`

This change makes it so that after migrating a site it is *not necessary* to login to the site as an admin as a trigger for recurring payments to be disabled.

The current system assumes that no one would ever clone a site and then not immediately login to it.

2) I added the ability to define site features via constants. The reasoning for this would be to allow developers to define things that are always true in a particular environment.

For example, `define( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS`, false );` could be added to a staging/test site's wp-config.php file and that would not require *any login at all* to ensure that recurring payments are disabled.



## How has this been tested?

+ Manually
+ New & existing unit tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Improvements, bug fixes


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

