### PR TITLE
Add a hook for 3rd party tools

### DIFF
--- a/includes/admin/class.llms.admin.menus.php
+++ b/includes/admin/class.llms.admin.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 4.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -300,6 +300,7 @@ class LLMS_Admin_Menus {
 	 * Include files used on the Status page.
 	 *
 	 * @since 3.37.19
+	 * @since [version] Added `llms_load_admin_tools` action.
 	 *
 	 * @return void
 	 */
@@ -313,6 +314,13 @@ class LLMS_Admin_Menus {
 		foreach ( glob( LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-*.php' ) as $tool_path ) {
 			require_once $tool_path;
 		}
+
+		/**
+		 * Action which can be used by 3rd parties to load custom admin page tools.
+		 *
+		 * @since [version]
+		 */
+		do_action( 'llms_load_admin_tools' );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
@@ -90,4 +90,40 @@ class LLMS_Test_Admin_Menus extends LLMS_Unit_Test_Case {
 		set_current_screen( 'front' );
 	}
 
+	/**
+	 * Test status_page_includes()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_status_page_includes() {
+
+		$classes = array(
+			'LLMS_Admin_Page_Status',
+
+			'LLMS_Admin_Tool_Batch_Eraser',
+			'LLMS_Admin_Tool_Clear_Sessions',
+			'LLMS_Admin_Tool_Recurring_Payment_Rescheduler',
+		);
+
+		$actions = did_action( 'llms_load_admin_tools' );
+
+		foreach ( $classes as $class ) {
+			$this->assertFalse( class_exists( $class ) );
+		}
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'status_page_includes' );
+
+		// Classes included.
+		foreach ( $classes as $class ) {
+			$this->assertTrue( class_exists( $class ) );
+		}
+
+		// Action ran.
+		$this->assertSame( ++$actions, did_action( 'llms_load_admin_tools' ) );
+
+
+	}
+
 }


### PR DESCRIPTION
## Description

While working on https://github.com/gocodebox/lifterlms-gateway-authorize-net/issues/10 I noticed that it's quite difficult to load a custom admin tool from outside the core plugin and ensure it also triggers properly

This is due to the loading order and triggered actions.

I was able to get a tool display by loading the tool class at `admin_init` with priority 10 or later but was unable to get the `handle()` method of the tool class to run.

This adds an action which can be used to load the tool immediately after core tools and, as such, it will both display and be handled as expected.

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes

+ 3rd party compat enchancement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

