### PR TITLE
Staging Feature "Reversion" (kind of)

### DIFF
--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 4.12.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -84,6 +84,7 @@ final class LifterLMS {
 	 * @since 3.21.1 Unknown
 	 * @since 4.0.0 Load `$this->session` at `plugins_loaded` in favor of during class construction.
 	 *               Remove deprecated `__autoload()` & initialize new file loader class.
+	 * @since [version] Check site duplicate status on `admin_init`.
 	 *
 	 * @return void
 	 */
@@ -117,6 +118,8 @@ final class LifterLMS {
 		add_action( 'init', array( $this, 'init_session' ), 6 ); // After table installation which happens at init 5.
 		add_action( 'init', array( $this, 'include_template_functions' ) );
 		add_action( 'init', array( 'LLMS_Shortcodes', 'init' ) );
+
+		add_action( 'admin_init', array( 'LLMS_Site', 'check_status' ) );
 
 		// Tracking.
 		if ( defined( 'DOING_CRON' ) && DOING_CRON && 'yes' === get_option( 'llms_allow_tracking', 'no' ) ) {
@@ -184,14 +187,13 @@ final class LifterLMS {
 	 * @since 3.21.1 Unknown.
 	 * @since 4.0.0 Don't initialize removed `LLMS_Person()` class.
 	 * @since 4.12.0 Check site staging/duplicate status & trigger associated actions.
+	 * @since [version] Remove site staging/duplicate check and run only on `admin_init`.
 	 *
 	 * @return void
 	 */
 	public function init() {
 
 		do_action( 'before_lifterlms_init' );
-
-		LLMS_Site::check_status();
 
 		$this->engagements();
 		$this->notifications();

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.11.2
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -33,27 +33,30 @@ class LLMS_Admin_Page_Status {
 	 */
 	public static function add_core_tools( $tools ) {
 
-		return array_merge( $tools, array(
+		return array_merge(
+			$tools,
+			array(
 
-			'reset-tracking'     => array(
-				'description' => __( 'If you opted into LifterLMS Tracking and no longer wish to participate, you may opt out here.', 'lifterlms' ),
-				'label'       => __( 'Reset Tracking Settings', 'lifterlms' ),
-				'text'        => __( 'Reset Tracking Settings', 'lifterlms' ),
-			),
+				'reset-tracking' => array(
+					'description' => __( 'If you opted into LifterLMS Tracking and no longer wish to participate, you may opt out here.', 'lifterlms' ),
+					'label'       => __( 'Reset Tracking Settings', 'lifterlms' ),
+					'text'        => __( 'Reset Tracking Settings', 'lifterlms' ),
+				),
 
-			'clear-cache'        => array(
-				'description' => __( 'Clears the cached data displayed on various reporting screens. This does not affect actual student progress, it only clears cached progress data. This data will be regenerated the next time it is accessed.', 'lifterlms' ),
-				'label'       => __( 'Student Progress Cache', 'lifterlms' ),
-				'text'        => __( 'Clear cache', 'lifterlms' ),
-			),
+				'clear-cache'    => array(
+					'description' => __( 'Clears the cached data displayed on various reporting screens. This does not affect actual student progress, it only clears cached progress data. This data will be regenerated the next time it is accessed.', 'lifterlms' ),
+					'label'       => __( 'Student Progress Cache', 'lifterlms' ),
+					'text'        => __( 'Clear cache', 'lifterlms' ),
+				),
 
-			'setup-wizard'       => array(
-				'description' => __( 'If you want to run the LifterLMS Setup Wizard again or skipped it and want to return now, click below.', 'lifterlms' ),
-				'label'       => __( 'Setup Wizard', 'lifterlms' ),
-				'text'        => __( 'Return to Setup Wizard', 'lifterlms' ),
-			),
+				'setup-wizard'   => array(
+					'description' => __( 'If you want to run the LifterLMS Setup Wizard again or skipped it and want to return now, click below.', 'lifterlms' ),
+					'label'       => __( 'Setup Wizard', 'lifterlms' ),
+					'text'        => __( 'Return to Setup Wizard', 'lifterlms' ),
+				),
 
-		) );
+			)
+		);
 
 	}
 

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -24,6 +24,40 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Page_Status {
 
 	/**
+	 * Register "unclassed" core tools
+	 *
+	 * @since [version]
+	 *
+	 * @param array[] $tools List of tool definitions.
+	 * @return array[]
+	 */
+	public static function add_core_tools( $tools ) {
+
+		return array_merge( $tools, array(
+
+			'reset-tracking'     => array(
+				'description' => __( 'If you opted into LifterLMS Tracking and no longer wish to participate, you may opt out here.', 'lifterlms' ),
+				'label'       => __( 'Reset Tracking Settings', 'lifterlms' ),
+				'text'        => __( 'Reset Tracking Settings', 'lifterlms' ),
+			),
+
+			'clear-cache'        => array(
+				'description' => __( 'Clears the cached data displayed on various reporting screens. This does not affect actual student progress, it only clears cached progress data. This data will be regenerated the next time it is accessed.', 'lifterlms' ),
+				'label'       => __( 'Student Progress Cache', 'lifterlms' ),
+				'text'        => __( 'Clear cache', 'lifterlms' ),
+			),
+
+			'setup-wizard'       => array(
+				'description' => __( 'If you want to run the LifterLMS Setup Wizard again or skipped it and want to return now, click below.', 'lifterlms' ),
+				'label'       => __( 'Setup Wizard', 'lifterlms' ),
+				'text'        => __( 'Return to Setup Wizard', 'lifterlms' ),
+			),
+
+		) );
+
+	}
+
+	/**
 	 * Handle tools actions
 	 *
 	 * @since 3.11.2
@@ -31,6 +65,7 @@ class LLMS_Admin_Page_Status {
 	 * @since 3.37.14 Verify user capabilities when doing a tool action.
 	 *                Use `llms_redirect_and_exit()` in favor of `wp_safe_redirect()`.
 	 * @since 4.0.0 The `clear-sessions` tool has been moved to `LLMS_Admin_Tool_Clear_Sessions`.
+	 * @since [version] The `automatic-payments` tool has been moved to `LLMS_Admin_Tool_Reset_Automatic_Payments`.
 	 *
 	 * @return void
 	 */
@@ -47,16 +82,13 @@ class LLMS_Admin_Page_Status {
 		 *
 		 * @since Unknown
 		 *
+		 * @see llms_status_tools For the filter used to register tools.
+		 *
 		 * @param string $tool Tool name or ID.
 		 */
 		do_action( 'llms_status_tool', $tool );
 
 		switch ( $tool ) {
-
-			case 'automatic-payments':
-				LLMS_Site::clear_lock_url();
-				update_option( 'llms_site_url_ignore', 'no' );
-				break;
 
 			case 'clear-cache':
 				global $wpdb;
@@ -71,7 +103,7 @@ class LLMS_Admin_Page_Status {
 				break;
 
 			case 'setup-wizard':
-				llms_redirect_and_exit( esc_url_raw( admin_url( '?page=llms-setup' ) ) );
+				llms_redirect_and_exit( esc_url_raw( admin_url( 'admin.php?page=llms-setup' ) ) );
 				break;
 
 		}
@@ -298,41 +330,37 @@ class LLMS_Admin_Page_Status {
 	 *
 	 * @since 3.11.2
 	 * @since 4.0.0 The `clear-sessions` tool has been moved to `LLMS_Admin_Tool_Clear_Sessions`.
+	 * @since [version] Move "unclassed" core actions to be added to the `llms_status_tools` filter at priority 5 via `LLMS_Admin_Page_Status::add_core_tools()`.
 	 *
 	 * @return void
 	 */
 	private static function output_tools_content() {
 
-		$tools = apply_filters(
-			'llms_status_tools',
-			array(
+		// Load unclassed core tools at priority 5 to "preserve" their original order before we started classing tools.
+		add_filter( 'llms_status_tools', array( __CLASS__, 'add_core_tools' ), 5 );
 
-				'automatic-payments' => array(
-					'description' => __( 'Allows you to choose to enable or disable automatic recurring payments which may be disabled on a staging site.', 'lifterlms' ),
-					'label'       => __( 'Automatic Payments', 'lifterlms' ),
-					'text'        => __( 'Reset Automatic Payments', 'lifterlms' ),
-				),
-
-				'reset-tracking'     => array(
-					'description' => __( 'If you opted into LifterLMS Tracking and no longer wish to participate, you may opt out here.', 'lifterlms' ),
-					'label'       => __( 'Reset Tracking Settings', 'lifterlms' ),
-					'text'        => __( 'Reset Tracking Settings', 'lifterlms' ),
-				),
-
-				'clear-cache'        => array(
-					'description' => __( 'Clears the cached data displayed on various reporting screens. This does not affect actual student progress, it only clears cached progress data. This data will be regenerated the next time it is accessed.', 'lifterlms' ),
-					'label'       => __( 'Student Progress Cache', 'lifterlms' ),
-					'text'        => __( 'Clear cache', 'lifterlms' ),
-				),
-
-				'setup-wizard'       => array(
-					'description' => __( 'If you want to run the LifterLMS Setup Wizard again or skipped it and want to return now, click below.', 'lifterlms' ),
-					'label'       => __( 'Setup Wizard', 'lifterlms' ),
-					'text'        => __( 'Return to Setup Wizard', 'lifterlms' ),
-				),
-
-			)
-		);
+		/**
+		 * Register tools with the LifterLMS core
+		 *
+		 * When registering a custom tool you should additionally have an action triggered for the tool using the action
+		 * `llms_status_tool` which will be called to process or handle the action.
+		 *
+		 * @since Unknown
+		 *
+		 * @see llms_status_tool For the action called to handle a tool.
+		 *
+		 * @param array[] $tools {
+		 *     Associative array of status tool definitions.
+		 *
+		 *     The array key is a unique "id" for the tool and the array value should be an associative array
+		 *     as described below:
+		 *
+		 *     @type string $description Description of what the tool does.
+		 *     @type string $label       The title of the tool.
+		 *     @type string $text        The text displayed on the tool's button.
+		 * }
+		 */
+		$tools = apply_filters( 'llms_status_tools', array() );
 
 		?>
 		<form action="<?php echo esc_url( self::get_url( 'tools' ) ); ?>" method="POST">
@@ -352,5 +380,4 @@ class LLMS_Admin_Page_Status {
 		<?php
 
 	}
-
 }

--- a/includes/admin/tools/class-llms-admin-tool-reset-automatic-payments.php
+++ b/includes/admin/tools/class-llms-admin-tool-reset-automatic-payments.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Admin tool to reset the status of the recurring payments site feature
+ *
+ * @package LifterLMS/Admin/Tools/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Admin_Tool_Reset_Automatic_Payments
+ *
+ * @since [version]
+ */
+class LLMS_Admin_Tool_Reset_Automatic_Payments extends LLMS_Abstract_Admin_Tool {
+
+	/**
+	 * Tool ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'automatic-payments';
+
+	/**
+	 * Tool Load Priority
+	 *
+	 * To preserve the "original" tool order, load this before unclassed core tools.
+	 *
+	 * @var integer
+	 */
+	protected $priority = 4;
+
+	/**
+	 * Retrieve a description of the tool
+	 *
+	 * This is displayed on the right side of the tool's list before the button.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+		return __( 'Allows you to choose to enable or disable automatic recurring payments which may be disabled on a staging site.', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve the tool's label
+	 *
+	 * The label is the tool's title. It's displayed in the left column on the tool's list.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_label() {
+		return __( 'Reset Automatic Payments Status', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve the tool's button text
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_text() {
+		return __( 'Reset Automatic Payments Status', 'lifterlms' );
+	}
+
+	/**
+	 * Process the tool.
+	 *
+	 * This method should do whatever the tool actually does.
+	 *
+	 * By the time this tool is called a nonce and the user's capabilities have already been checked.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function handle() {
+
+		LLMS_Site::clear_lock_url();
+		update_option( 'llms_site_url_ignore', 'no' );
+		LLMS_Site::check_status();
+		llms_redirect_and_exit( esc_url_raw( admin_url( 'admin.php?page=llms-status&tab=tools' ) ) );
+
+	}
+
+	/**
+	 * Conditionally load the tool
+	 *
+	 * This tool should only load if the recurring payments site feature constant is NOT defined.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean Return `true` to load the tool and `false` to not load it.
+	 */
+	protected function should_load() {
+
+		return ! defined( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS' );
+
+	}
+
+}
+
+return new LLMS_Admin_Tool_Reset_Automatic_Payments();

--- a/includes/class-llms-staging.php
+++ b/includes/class-llms-staging.php
@@ -29,14 +29,14 @@ class LLMS_Staging {
 	 */
 	public static function init() {
 
+		if ( defined( 'LLMS_SITE_IS_CLONE' ) && LLMS_SITE_IS_CLONE ) {
+			llms_maybe_define_constant( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', false );
+		}
+
 		if ( ! defined( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS' ) ) {
 			add_action( 'llms_site_clone_detected', array( __CLASS__, 'clone_detected' ) );
 			add_action( 'admin_menu', array( __CLASS__, 'menu_warning' ) );
 			add_action( 'admin_init', array( __CLASS__, 'handle_staging_notice_actions' ) );
-		}
-
-		if ( defined( 'LLMS_SITE_IS_CLONE' ) && LLMS_SITE_IS_CLONE ) {
-			llms_maybe_define_constant( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', false );
 		}
 
 	}

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -10,7 +10,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.0.0
- * @version 4.12.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,12 +44,14 @@ class LLMS_Site {
 	 * Check if the site is cloned and not ignored
 	 *
 	 * @since 4.12.0
+	 * @since [version] Reverse the order of checks in the `if` statements for a minor performance improvement
+	 *               when the `LLMS_SITE_IS_CLONE` constant is being used.
 	 *
 	 * @return boolean Returns `true` when a clone is detected, otherwise `false`.
 	 */
 	public static function check_status() {
 
-		if ( ! self::is_clone_ignored() && self::is_clone() ) {
+		if ( self::is_clone() && ! self::is_clone_ignored() ) {
 
 			/**
 			 * Action triggered when the current website is determined to be a "cloned" site
@@ -228,11 +230,14 @@ class LLMS_Site {
 	 * Compares the stored (and cleaned) llms_site_url against the WP site url.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Add `LLMS_SITE_IS_CLONE` constant check.
 	 *
 	 * @return boolean Returns `true` if it's a cloned site (urls do not match)
 	 *                 and `false` if it's not (urls DO match).
 	 */
 	public static function is_clone() {
+
+		$is_clone = defined( 'LLMS_SITE_IS_CLONE' ) ? LLMS_SITE_IS_CLONE : ( get_site_url() !== self::get_url() );
 
 		/**
 		 * Filters whether or not the site is a "cloned" site
@@ -241,7 +246,7 @@ class LLMS_Site {
 		 *
 		 * @param boolean $is_clone When `true` the site is considered a "clone", otherwise it is not.
 		 */
-		return apply_filters( 'llms_site_is_clone', ( get_site_url() !== self::get_url() ) );
+		return apply_filters( 'llms_site_is_clone', $is_clone );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-page-status.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-page-status.php
@@ -108,36 +108,6 @@ class LLMS_Test_Admin_Page_Status extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the automatic payments reset tool.
-	 *
-	 * @since 3.37.14
-	 *
-	 * @return void
-	 */
-	public function test_do_tool_reset_auto_payments() {
-
-		// Get the original values of options to be cleared.
-		$orig_url    = get_option( 'llms_site_url' );
-		$orig_ignore = get_option( 'llms_site_url_ignore' );
-
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-
-		$this->mockPostRequest( array(
-			'_wpnonce'  => wp_create_nonce( 'llms_tool' ),
-			'llms_tool' => 'automatic-payments',
-		) );
-		LLMS_Unit_Test_Util::call_method( $this->main, 'do_tool' );
-
-		$this->assertEquals( '', get_option( 'llms_site_url' ) );
-		$this->assertEquals( 'no', get_option( 'llms_site_url_ignore' ) );
-
-		// Reset to the orig values.
-		update_option( 'llms_site_url', $orig_url );
-		update_option( 'llms_site_url_ignore', $orig_ignore );
-
-	}
-
-	/**
 	 * Test the overall progress cache clear tool.
 	 *
 	 * @since 3.37.14
@@ -194,13 +164,14 @@ class LLMS_Test_Admin_Page_Status extends LLMS_Unit_Test_Case {
 	 * Test the setup wizard redirect tool.
 	 *
 	 * @since 3.37.14
+	 * @since [version] Fix expected redirect URL.
 	 *
 	 * @return void
 	 */
 	public function test_do_tool_setup_wizard() {
 
 		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
-		$this->expectExceptionMessage( sprintf( '%s?page=llms-setup [302] YES', admin_url() ) );
+		$this->expectExceptionMessage( sprintf( '%s [302] YES', admin_url( 'admin.php?page=llms-setup') ) );
 
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
@@ -106,15 +106,21 @@ class LLMS_Test_Admin_Tool_Reset_Automatic_Payments extends LLMS_UnitTestCase {
 		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
 		$this->expectExceptionMessage( sprintf( '%s [302] YES', admin_url( 'admin.php?page=llms-status&tab=tools') ) );
 
-		LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+		try {
+			LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+		} catch( LLMS_Unit_Test_Exception_Redirect $exception ) {
 
-		$this->assertEquals( '', get_option( 'llms_site_url' ) );
-		$this->assertEquals( 'no', get_option( 'llms_site_url_ignore' ) );
-		$this->assertEquals( ++$actions, did_action( 'llms_site_clone_detected' ) );
+			$this->assertEquals( '', get_option( 'llms_site_url' ) );
+			$this->assertEquals( 'no', get_option( 'llms_site_url_ignore' ) );
+			$this->assertEquals( ++$actions, did_action( 'llms_site_clone_detected' ) );
 
-		// Reset to the orig values.
-		update_option( 'llms_site_url', $orig_url );
-		update_option( 'llms_site_url_ignore', $orig_ignore );
+			// Reset to the orig values.
+			update_option( 'llms_site_url', $orig_url );
+			update_option( 'llms_site_url_ignore', $orig_ignore );
+
+			throw $exception;
+
+		}
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Tests for the LLMS_Admin_Tool_Clear_Sessions class
+ *
+ * @package LifterLMS/Tests/Admins/Tools
+ *
+ * @group admin
+ * @group admin_tools
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Tool_Reset_Automatic_Payments extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup before class
+	 *
+	 * Include abstract class.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-reset-automatic-payments.php';
+
+	}
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = new LLMS_Admin_Tool_Reset_Automatic_Payments();
+
+	}
+
+	/**
+	 * Test get_description()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_description() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_label()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_text()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_text() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test handle()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle() {
+
+		$actions = did_action( 'llms_site_clone_detected' );
+
+		// Get the original values of options to be cleared.
+		$orig_url    = get_option( 'llms_site_url' );
+		$orig_ignore = get_option( 'llms_site_url_ignore' );
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( sprintf( '%s [302] YES', admin_url( 'admin.php?page=llms-status&tab=tools') ) );
+
+		LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+
+		$this->assertEquals( '', get_option( 'llms_site_url' ) );
+		$this->assertEquals( 'no', get_option( 'llms_site_url_ignore' ) );
+		$this->assertEquals( ++$actions, did_action( 'llms_site_clone_detected' ) );
+
+		// Reset to the orig values.
+		update_option( 'llms_site_url', $orig_url );
+		update_option( 'llms_site_url_ignore', $orig_ignore );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/class-llms-test-site.php
+++ b/tests/phpunit/unit-tests/class-llms-test-site.php
@@ -169,6 +169,51 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test is_clone() when using a constant set to `true`.
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_is_clone_constant_true() {
+
+		// Not a clone.
+		$this->assertFalse( LLMS_Site::is_clone() );
+
+		define( 'LLMS_SITE_IS_CLONE', true );
+		$this->assertTrue( LLMS_Site::is_clone() );
+
+	}
+
+	/**
+	 * Test is_clone() when using a constant set to `false`.
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_is_clone_constant_false() {
+
+		$original = get_site_url();
+
+		// Is a clone.
+		update_option( 'siteurl', 'http://fakeurl.tld' );
+		$this->assertTrue( LLMS_Site::is_clone() );
+
+		define( 'LLMS_SITE_IS_CLONE', false );
+		$this->assertFalse( LLMS_Site::is_clone() );
+
+		update_option( 'siteurl', $original );
+
+	}
+
+	/**
 	 * Test is_clone_ignored() function
 	 *
 	 * @since 3.8.0

--- a/tests/phpunit/unit-tests/class-llms-test-staging.php
+++ b/tests/phpunit/unit-tests/class-llms-test-staging.php
@@ -25,6 +25,82 @@ class LLMS_Test_Staging extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Removes actions added by the `init()` method (so that we can test the `init()` method)
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function remove_init_actions() {
+		remove_action( 'llms_site_clone_detected', array( 'LLMS_Staging', 'clone_detected' ), 10 );
+		remove_action( 'admin_menu', array( 'LLMS_Staging', 'menu_warning' ), 10 );
+		remove_action( 'admin_init', array( 'LLMS_Staging', 'handle_staging_notice_actions' ), 10 );
+	}
+
+	/**
+	 * Test init() actions when no recurring feature constant is set
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init() {
+
+		$this->remove_init_actions();
+
+		LLMS_Staging::init();
+
+		$this->assertEquals( 10, has_action( 'llms_site_clone_detected', array( 'LLMS_Staging', 'clone_detected' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_menu', array( 'LLMS_Staging', 'menu_warning' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_init', array( 'LLMS_Staging', 'handle_staging_notice_actions' ) ) );
+
+	}
+
+	/**
+	 * Test init() actions when a recurring feature constant is set
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_init_with_constant() {
+
+		$this->remove_init_actions();
+
+		define( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', true );
+
+		LLMS_Staging::init();
+
+		$this->assertFalse( has_action( 'llms_site_clone_detected', array( 'LLMS_Staging', 'clone_detected' ) ) );
+		$this->assertFalse( has_action( 'admin_menu', array( 'LLMS_Staging', 'menu_warning' ) ) );
+		$this->assertFalse( has_action( 'admin_init', array( 'LLMS_Staging', 'handle_staging_notice_actions' ) ) );
+
+	}
+
+	/**
+	 * Test init() actions when a recurring feature constant is set
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_init_clone_site_feature_cascade() {
+
+		define( 'LLMS_SITE_IS_CLONE', true );
+
+		LLMS_Staging::init();
+
+		$this->assertFalse( LLMS_SITE_FEATURE_RECURRING_PAYMENTS );
+
+	}
+
+	/**
 	 * Test clone_detected()
 	 *
 	 * @since 4.12.0

--- a/tests/phpunit/unit-tests/class-llms-test-staging.php
+++ b/tests/phpunit/unit-tests/class-llms-test-staging.php
@@ -137,6 +137,9 @@ class LLMS_Test_Staging extends LLMS_Unit_Test_Case {
 		$this->assertTrue( LLMS_Admin_Notices::has_notice( 'maybe-staging' ) );
 		LLMS_Admin_Notices::delete_notice( 'maybe-staging' );
 
+		// Return to front.
+		set_current_screen( 'front' );
+
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -481,32 +481,6 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test a recurring payment processed in the same page load as a site "clone" is identified
-	 *
-	 * @since 4.12.0
-	 *
-	 * @return void
-	 */
-	public function test_recurring_charge_staging_clone_detected() {
-
-		do_action( 'llms_site_clone_detected' );
-
-		$plan = $this->get_mock_plan( '200.00', 1 );
-		$order = $this->get_mock_order( $plan );
-
-		// starting action numbers.
-		$skip_actions = did_action( 'llms_order_recurring_charge_skipped' );
-		$note_actions = did_action( 'llms_new_order_note_added' );
-
-		// Trigger recurring payment.
-		do_action( 'llms_charge_recurring_payment', $order->get( 'id' ) );
-
-		$this->assertSame( $note_actions + 1, did_action( 'llms_new_order_note_added' ) );
-		$this->assertSame( $skip_actions + 1, did_action( 'llms_order_recurring_charge_skipped' ) );
-
-	}
-
-	/**
 	 * Test gateway-related errors encountered during a recurring_charge attempt.
 	 *
 	 * @since 3.32.0


### PR DESCRIPTION
## Description

Reverts (one) change made in #1492 resorting previous functionality that runs site duplication checks only on the admin panel for logged in users.

One user (so far) reported a false-positive in production as a result of these changes. We haven't been able to identify the source but after internal discussion we've determined it is best to rollback this change.

Additionally adds another constant `LLMS_SITE_IS_CLONE` which can be used to force a site as a clone (or not a clone)

Fixes an issue @eri-trabiccolo identified (but we never reported) when using the "Reset Automatic Payment Status" tool on the admin panel. When clicking the tool the page reloads but the notice wouldn't display until another subsequent page load (on the admin panel). This forces the check and then redirects to prevent that issue.

## How has this been tested?

+ Manually
+ New Tests
+ Existing Tests

## Screenshots <!-- if applicable -->

## Types of changes

+ Revert 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

