### PR TITLE
Add back partial reliance on `mb_convert_encoding()` but keep the previous implementation as a fall-back

### DIFF
--- a/includes/class-llms-dom-document.php
+++ b/includes/class-llms-dom-document.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * A convenient wrapper for the DOMDocument Class
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_DOM_Document Class
+ *
+ * @since [version]
+ */
+class LLMS_DOM_Document {
+
+	/**
+	 * Stores the load method name
+	 *
+	 * @var string
+	 */
+	private $load_method = 'load_with_mb_convert_encoding';
+
+	/**
+	 * Stores the HTML string to load
+	 *
+	 * @var string
+	 */
+	private $string;
+
+	/**
+	 * Stores the DOMDocument instance
+	 *
+	 * @var DOMDocument
+	 */
+	private $dom;
+
+	/**
+	 * Stores the libxml errors state
+	 *
+	 * @var boolean
+	 */
+	private $libxml_errors_state;
+
+	/**
+	 * This forces DOMDocument to convert non-utf8 characters into HTML entities and without relying on `mb_convert_encoding()`.
+	 *
+	 * @var string
+	 */
+	private $utf8_fixer = '<meta id="llms-get-dom-doc-utf-fixer" http-equiv="Content-Type" content="text/html; charset=utf-8">';
+
+	/**
+	 * Constructor
+	 *
+	 * @since [version]
+	 *
+	 * @param string $string An HTML string, either a full HTML document or a partial string.
+	 * @return void|WP_Error
+	 */
+	public function __construct( $string ) {
+
+		if ( ! class_exists( 'DOMDocument' ) ) {
+			return new WP_Error( 'llms-dom-document-missing', __( 'DOMDocument not available.', 'lifterlms' ) );
+		}
+
+		if ( ! apply_filters( 'llms_dom_document_use_mb_convert_encoding', true ) ) {
+			$this->$load_method = 'load_with_meta_utf_fixer';
+		}
+
+		$this->string = $string;
+		$this->dom    = new DOMDocument();
+	}
+
+	/**
+	 * Load the HTML string in the DOMDocument and returns it
+	 *
+	 * This function suppresses PHP warnings that would be thrown by DOMDocument when
+	 * loading a partial string or an HTML string with errors.
+	 *
+	 * @since [version]
+	 *
+	 * @return DOMDocument|WP_Error Returns an instance of DOMDocument with the html passed to the constructor loaded into it
+	 *                              or an error object when an error is encountered during loading.
+	 */
+	public function load() {
+
+		// Don't throw or log warnings.
+		$libxml_state = libxml_use_internal_errors( true );
+
+		$this->{$this->load_method}();
+
+		// Clear and restore errors.
+		libxml_clear_errors();
+		libxml_use_internal_errors( $libxml_state );
+
+		return $this->dom;
+
+	}
+
+	/**
+	 * Load the HTML string in the DOMDocument using mb_convert_econding
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function load_with_mb_convert_encoding() {
+		if ( ! $this->dom->loadHTML( mb_convert_encoding( $this->string, 'HTML-ENTITIES', 'UTF-8' ) ) ) {
+			$this->dom = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
+		}
+	}
+
+	/**
+	 * Load the HTML string in the DOMDocument using the meta ut8 fixer
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function load_with_meta_utf_fixer() {
+
+		if ( ! $this->dom->loadHTML( $this->utf8_fixer . $this->string ) ) {
+			$this->dom = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
+		}
+
+		if ( is_wp_error( $this->dom ) ) {
+			return;
+		}
+
+		// Remove the fixer meta element, if it's not removed it creates invalid HTML5 Markup.
+		$meta = $this->dom->getElementById( 'llms-get-dom-doc-utf-fixers' );
+		if ( $meta ) {
+			$meta->parentNode->removeChild( $meta ); // phpcs:ignore: WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		}
+
+	}
+
+}

--- a/includes/class-llms-dom-document.php
+++ b/includes/class-llms-dom-document.php
@@ -58,18 +58,19 @@ class LLMS_DOM_Document {
 	 * @since [version]
 	 *
 	 * @param string $source An HTML string, either a full HTML document or a partial string.
-	 * @return void|WP_Error
+	 * @return void
 	 */
 	public function __construct( $source ) {
 
 		if ( ! class_exists( 'DOMDocument' ) ) {
-			return new WP_Error( 'llms-dom-document-missing', __( 'DOMDocument not available.', 'lifterlms' ) );
+			$this->error = new WP_Error( 'llms-dom-document-missing', __( 'DOMDocument not available.', 'lifterlms' ) );
+			return;
 		}
 
 		/**
 		 * Filters the convert encoding method to be used when loading the source in the DOMDocument
 		 *
-		 * @param boolean $use_mb_convert_endoding Whether or not the convert encoding method should be used when loading the source in the DOMDocument.
+		 * @param boolean $use_mb_convert_encoding Whether or not the convert encoding method should be used when loading the source in the DOMDocument.
 		 *                                         Default is `true`. Requires `mbstring` PHP extension.
 		 */
 		$use_mb_convert_encoding = apply_filters( 'llms_dom_document_use_mb_convert_encoding', true );
@@ -89,10 +90,14 @@ class LLMS_DOM_Document {
 	 *
 	 * @since [version]
 	 *
-	 * @return boolean|WP_Error Returns true if the source is loaded fine.
-	 *                          Or an error object when an error is encountered during loading.
+	 * @return boolean|WP_Error Returns `true` if the source is loaded fine.
+	 *                          Or an error object when DOMDocument isn't available or an error is encountered during loading.
 	 */
 	public function load() {
+
+		if ( is_wp_error( $this->error ) && $this->error->has_errors() ) {
+			return $this->error;
+		}
 
 		// Don't throw or log warnings.
 		$libxml_state = libxml_use_internal_errors( true );
@@ -143,9 +148,6 @@ class LLMS_DOM_Document {
 	private function load_with_meta_utf_fixer() {
 		if ( ! $this->dom->loadHTML( $this->utf8_fixer . $this->source ) ) {
 			$this->error = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
-		}
-
-		if ( is_wp_error( $this->error ) ) {
 			return;
 		}
 

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 4.12.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -88,6 +88,7 @@ class LLMS_Loader {
 	 * @since 4.0.0
 	 * @since 4.4.0 Include `LLMS_Assets` class.
 	 * @since 4.12.0 Class `LLMS_Staging` always loaded instead of only loaded on admin panel.
+	 * @since [version] Include `LLMS_DOM_Document` class.
 	 *
 	 * @return void
 	 */

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -132,6 +132,7 @@ class LLMS_Loader {
 
 		// Classes.
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-assets.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-dom-document.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-events.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-events-core.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-events-query.php';

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -382,12 +382,7 @@ function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
 function llms_get_dom_document( $string ) {
 
 	$llms_dom = new LLMS_DOM_Document( $string );
-
-	if ( is_wp_error( $llms_dom ) ) {
-		return $llms_dom;
-	}
-
-	$load = $llms_dom->load();
+	$load     = $llms_dom->load();
 
 	return is_wp_error( $load ) ? $load : $llms_dom->dom();
 }

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -380,8 +380,16 @@ function llms_get_date_diff( $time1, $time2, $precision = 2 ) {
  *                              or an error object when DOMDocument isn't available or an error is encountered during loading.
  */
 function llms_get_dom_document( $string ) {
+
 	$llms_dom = new LLMS_DOM_Document( $string );
-	return is_wp_error( $llms_dom ) ? $llms_dom : $llms_dom->load();
+
+	if ( is_wp_error( $llms_dom ) ) {
+		return $llms_dom;
+	}
+
+	$load = $llms_dom->load();
+
+	return is_wp_error( $load ) ? $load : $llms_dom->dom();
 }
 
 /**

--- a/tests/phpunit/unit-tests/class-llms-test-llms-dom-document.php
+++ b/tests/phpunit/unit-tests/class-llms-test-llms-dom-document.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Test LLMS_DOM_Document
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group llms_dom_document
+ *
+ * @since [version]
+ */
+class LLMS_Test_LLMS_DOM_Document extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Test DOMDocument library missing
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_dom_document_missing_error() {
+		$llms_dom = new LLMS_DOM_Document( 'some string to load' );
+
+		// Simulate that the DOMDocument library is not available.
+		LLMS_Unit_Test_Util::set_private_property(
+			$llms_dom,
+			'error',
+			new WP_Error( 'llms-dom-document-missing', __( 'DOMDocument not available.', 'lifterlms' ) )
+		);
+		$load = $llms_dom->load();
+
+		$this->assertWPError( $load );
+		$this->assertWPErrorCodeEquals( 'llms-dom-document-missing', $load );
+	}
+
+	/**
+	 * Test loading string success
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_loading_success() {
+
+		$llms_dom = new LLMS_DOM_Document( 'some string to load' );
+		$this->assertTrue( $llms_dom->load() );
+	}
+
+	/**
+	 * Test loading method switch
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_loading_method_switch() {
+
+		// Check that by default the loading method is 'load_with_mb_convert_encoding'.
+		$llms_dom = new LLMS_DOM_Document( 'some string to load' );
+
+		$load_method = LLMS_Unit_Test_Util::get_private_property_value(
+			$llms_dom,
+			'load_method'
+		);
+
+		$this->assertEquals( 'load_with_mb_convert_encoding', $load_method );
+
+		// Force using utf fixer.
+		add_filter( 'llms_dom_document_use_mb_convert_encoding', '__return_false', 999 );
+
+		$llms_dom = new LLMS_DOM_Document( 'some other string to load' );
+
+		$load_method = LLMS_Unit_Test_Util::get_private_property_value(
+			$llms_dom,
+			'load_method'
+		);
+
+		remove_filter( 'llms_dom_document_use_mb_convert_encoding', '__return_false', 999 );
+
+		$this->assertEquals( 'load_with_meta_utf_fixer', $load_method );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -17,6 +17,7 @@
  * @since 4.4.1 Add tests for `llms_get_enrollable_post_types()` and `llms_get_enrollable_status_check_post_types()`.
  * @since 4.7.0 Add test for `llms_get_dom_document()`.
  * @since 4.10.1 Add test for possible 3rd party cpts conflicts using `llms_get_post()`.
+ * @since [version] Test `llms_get_dom_document()` relying on `mb_convert_encoding()` and not.
  */
 class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 
@@ -185,6 +186,8 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 	 *
 	 * @since 4.7.0
 	 * @since 4.8.0 Test against HTML strings, HTML documents, strings with character entities, and strings with non-utf8 characters.
+	 * @since [version] Test `llms_get_dom_document()` relying on `mb_convert_encoding()` and not.
+	 *               Also, use `$this->assertStringContainsString()` in place of `$this->assertStringContainsString()` to get a better erro message on failures.
 	 *
 	 * @return void
 	 */
@@ -220,14 +223,27 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			),
 		);
 
+		// Using `mb_convert_econding()`.
 		foreach ( $tests as $test ) {
 
 			$dom = llms_get_dom_document( $test[0] );
-			$this->assertTrue( $dom instanceof DOMDocument );
-			$this->assertStringContains( sprintf( '<body>%s</body></html>', $test[1] ), $dom->saveHTML() );
+			$this->assertTrue( $dom instanceof DOMDocument, $test[1] );
+			$this->assertStringContainsString( sprintf( '<body>%s</body></html>', $test[1] ), $dom->saveHTML() );
 
 		}
 
+		// Repeat the same test using "the meta fixer".
+		add_filter( 'llms_dom_document_use_mb_convert_encoding', '__return_false' );
+
+		foreach ( $tests as $test ) {
+
+			$dom = llms_get_dom_document( $test[0] );
+			$this->assertTrue( $dom instanceof DOMDocument, $test[1] );
+			$this->assertStringContainsString( sprintf( '<body>%s</body></html>', $test[1] ), $dom->saveHTML() );
+
+		}
+
+		remove_filter( 'llms_dom_document_use_mb_convert_encoding', '__return_false' );
 	}
 
 	/**


### PR DESCRIPTION
Also fix a potential fatal in the fall-back which tried to manipulate a non existent node.

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Fixes #1498 

## How has this been tested?
with existing unit tests and manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

