### PR TITLE
Generator clone post status & title

### DIFF
--- a/includes/class-llms-generator-courses.php
+++ b/includes/class-llms-generator-courses.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.7.0
- * @version 4.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -81,19 +81,29 @@ class LLMS_Generator_Courses extends LLMS_Abstract_Generator_Posts {
 	}
 
 	/**
+	 * Generator called when cloning a course
+	 *
+	 * @since [version]
+	 *
+	 * @param array $raw Raw course data array
+	 * @return int|null WP_Post ID of the generated course or `null` on failure.
+	 */
+	public function clone_course( $raw ) {
+		return $this->generate_course( $this->setup_raw_for_clone( $raw ) );
+	}
+
+	/**
 	 * Generator called when cloning a lesson
 	 *
 	 * @since 3.14.8
-	 * @since 4.7.0 Moved from `LLMS_Generator` and made `protected` instead of `private`.
+	 * @since 4.7.0 Moved from `LLMS_Generator` and made `public` instead of `private`.
+	 * @since [version] Use `setup_raw_for_clone()` to normalize the
 	 *
 	 * @param array $raw Raw data array.
 	 * @return int|WP_Error WP_Post ID of the created lesson on success and an error object on failure.
 	 */
 	public function clone_lesson( $raw ) {
-
-		$raw['title'] .= sprintf( ' (%s)', __( 'Clone', 'lifterlms' ) );
-		return $this->create_lesson( $raw, 0, '', '' );
-
+		return $this->create_lesson( $this->setup_raw_for_clone( $raw ), 0, '', '' );
 	}
 
 	/**
@@ -638,6 +648,46 @@ class LLMS_Generator_Courses extends LLMS_Abstract_Generator_Posts {
 		$choice['choice']['src'] = wp_get_attachment_url( $id );
 
 		return $choice;
+
+	}
+
+
+	/**
+	 * Modifies incoming raw data when creating a clone of a course or lesson
+	 *
+	 * When a clone is created, it will automatically have "(Clone)" appended to the existing title
+	 * and will be created with the "Draft" status.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $raw Raw data array for the course or lesson.
+	 * @return array
+	 */
+	protected function setup_raw_for_clone( $raw ) {
+
+		/**
+		 * Filters the suffix appended to the WP_Post title of a duplicated post when cloning a course or lesson
+		 *
+		 * @since [version]
+		 *
+		 * @param string         $status    The WP_Post status to use for the duplicate of the post. Default: "draft".
+		 * @param array          $raw       Raw data array passed into the generator.
+		 * @param LLMS_Generator $generator Generator instance.
+		 */
+		$raw['title'] .= apply_filters( 'llms_generator_cloned_post_title_suffix', sprintf( ' (%s)', __( 'Clone', 'lifterlms' ) ), $raw, $this );
+
+		/**
+		 * Filters the WP_Post status used for the duplicated post when cloning a course or lesson
+		 *
+		 * @since [version]
+		 *
+		 * @param string         $status    The WP_Post status to use for the duplicate of the post. Default: "draft".
+		 * @param array          $raw       Raw data array passed into the generator.
+		 * @param LLMS_Generator $generator Generator instance.
+		 */
+		$raw['status'] = apply_filters( 'llms_generator_cloned_post_status', 'draft', $raw, $this );
+
+		return $raw;
 
 	}
 

--- a/includes/class-llms-generator-courses.php
+++ b/includes/class-llms-generator-courses.php
@@ -85,7 +85,7 @@ class LLMS_Generator_Courses extends LLMS_Abstract_Generator_Posts {
 	 *
 	 * @since [version]
 	 *
-	 * @param array $raw Raw course data array
+	 * @param array $raw Raw course data array.
 	 * @return int|null WP_Post ID of the generated course or `null` on failure.
 	 */
 	public function clone_course( $raw ) {

--- a/includes/class.llms.generator.php
+++ b/includes/class.llms.generator.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.3.0
- * @version 4.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -220,6 +220,7 @@ class LLMS_Generator {
 	 * @since 3.3.0
 	 * @since 3.14.8 Unknown.
 	 * @since 4.7.0 Load generators from `LLMS_Generator_Courses()`.
+	 * @since [version] Use `clone_course()` method for cloning courses in favor of `genrate_course()`.
 	 *
 	 * @return array
 	 */
@@ -237,7 +238,7 @@ class LLMS_Generator {
 			array(
 				'LifterLMS/BulkCourseExporter'    => array( $this->courses_generator, 'generate_courses' ),
 				'LifterLMS/BulkCourseGenerator'   => array( $this->courses_generator, 'generate_courses' ),
-				'LifterLMS/SingleCourseCloner'    => array( $this->courses_generator, 'generate_course' ),
+				'LifterLMS/SingleCourseCloner'    => array( $this->courses_generator, 'clone_course' ),
 				'LifterLMS/SingleCourseExporter'  => array( $this->courses_generator, 'generate_course' ),
 				'LifterLMS/SingleCourseGenerator' => array( $this->courses_generator, 'generate_course' ),
 				'LifterLMS/SingleLessonCloner'    => array( $this->courses_generator, 'clone_lesson' ),

--- a/tests/phpunit/unit-tests/class-llms-test-generator-courses.php
+++ b/tests/phpunit/unit-tests/class-llms-test-generator-courses.php
@@ -87,9 +87,34 @@ class LLMS_Test_Generator_Courses extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test clone_course()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_clone_course() {
+
+		$raw = array(
+			'title'   => 'Sample Course',
+			'content' => 'Content',
+		);
+
+		$id = $this->main->clone_course( $raw );
+		$this->assertTrue( is_numeric( $id ) );
+		$post = get_post( $id );
+		$this->assertEquals( 'course', $post->post_type );
+		$this->assertEquals( 'Sample Course (Clone)', $post->post_title );
+		$this->assertEquals( 'Content', $post->post_content );
+		$this->assertEquals( 'draft', $post->post_status );
+
+	}
+
+	/**
 	 * Test clone_lesson()
 	 *
 	 * @since 4.7.0
+	 * @since [version] Add check against post status.
 	 *
 	 * @return void
 	 */
@@ -106,6 +131,7 @@ class LLMS_Test_Generator_Courses extends LLMS_UnitTestCase {
 		$this->assertEquals( 'lesson', $post->post_type );
 		$this->assertEquals( 'Sample Lesson (Clone)', $post->post_title );
 		$this->assertEquals( 'Content', $post->post_content );
+		$this->assertEquals( 'draft', $post->post_status );
 
 	}
 


### PR DESCRIPTION
## Description

Closes #1433 

This PR implements the changes discussed in the above issue and adds an additional change to the the generator's clone functionality:

+ Cloned courses are marked as drafts (previously would have the same status as the cloned course)
+ Cloned courses have the suffix "(Clone)" Appended to the existing title (previously would have the same title)
+ Clone lessons are marked as drafts (previously they'd be the same status as the cloned lesson).
+ Cloned lessons will have the suffix "(Clone)" appended to the existing title (no change in behavior)

This unifies the "clone" experience between both post types instead of having different experiences for each one.

The change to lesson status I don't think will be an unwelcome change. When cloning, the cloned lesson will now always be listed as the first item on the post table list as a result of being unpublished and being the most recently modified post in the list. This seems desirable (and expected)

## How has this been tested?

+ Manually
+ New (and modified) unit tests
+ Existing tests 

## Types of changes

Updates


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

