### PR TITLE
Deprecate unused methods

### DIFF
--- a/includes/controllers/class.llms.controller.quizzes.php
+++ b/includes/controllers/class.llms.controller.quizzes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.9.0
- * @version 3.37.8
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -23,12 +23,12 @@ class LLMS_Controller_Quizzes {
 	 *
 	 * @since 3.9.0
 	 * @since 3.37.8 Add reporting actions handler action.
+	 * @since [version] Remove `add_action()` for deprecated `take_quiz()` method.
 	 *
 	 * @return void
 	 */
 	public function __construct() {
 
-		add_action( 'init', array( $this, 'take_quiz' ) );
 		add_action( 'admin_init', array( $this, 'maybe_handle_reporting_actions' ) );
 
 	}
@@ -67,10 +67,13 @@ class LLMS_Controller_Quizzes {
 	 *
 	 * @since 1.0.0
 	 * @since 3.9.0 Unknown.
+	 * @deprecated [version] `LLMS_Controller_Quizzes::take_quiz()` is deprecated in favor of `LLMS_AJAX_Handler::quiz_start()`.
 	 *
 	 * @return void
 	 */
 	public function take_quiz() {
+
+		_deprecated_function( 'LLMS_Controller_Quizzes::take_quiz()', '[version]', 'LLMS_AJAX_Handler::quiz_start()' );
 
 		// Invalid nonce or the form wasn't submitted.
 		if ( ! llms_verify_nonce( '_llms_take_quiz_nonce', 'take_quiz', 'POST' ) ) {

--- a/includes/models/model.llms.quiz.php
+++ b/includes/models/model.llms.quiz.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.3.0
- * @version 4.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -259,43 +259,6 @@ class LLMS_Quiz extends LLMS_Post_Model {
 	}
 
 	/**
-	 * Retrieve lessons this quiz is assigned to.
-	 *
-	 * @since Unknown.
-	 *
-	 * @param string $return Optional. Format of the return [ids|lessons]. Default `'ids'`.
-	 * @return array Array of WP_Post IDs (lesson post types).
-	 */
-	public function get_lessons( $return = 'ids' ) {
-
-		global $wpdb;
-		$query = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT post_id
-			 FROM {$wpdb->postmeta}
-			 WHERE meta_key = '_llms_assigned_quiz'
-			   AND meta_value = %d;",
-				$this->get( 'id' )
-			)
-		);
-
-		// return just the ids.
-		if ( 'ids' === $return ) {
-			return $query;
-		}
-
-		// setup lesson objects.
-		$ret = array();
-		foreach ( $query as $id ) {
-			$ret[] = llms_get_post( $id );
-		}
-
-		return $ret;
-
-	}
-
-
-	/**
 	 * Get the (points) value of a question.
 	 *
 	 * @since 3.3.0
@@ -327,6 +290,45 @@ class LLMS_Quiz extends LLMS_Post_Model {
 
 		$q = get_post_meta( $this->get( 'id' ), $this->meta_prefix . 'questions', true );
 		return $q ? $q : array();
+
+	}
+
+	/**
+	 * Retrieve lessons this quiz is assigned to.
+	 *
+	 * @since Unknown
+	 * @deprecated [version] Method `LLMS_Quiz::get_lessons()` is deprecated with no replacement.
+	 *
+	 * @param string $return Optional. Format of the return [ids|lessons]. Default `'ids'`.
+	 * @return array Array of WP_Post IDs (lesson post types).
+	 */
+	public function get_lessons( $return = 'ids' ) {
+
+		_deprecated_function( 'LLMS_Quiz::get_lessons()', '[version]' );
+
+		global $wpdb;
+		$query = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT post_id
+			 FROM {$wpdb->postmeta}
+			 WHERE meta_key = '_llms_assigned_quiz'
+			   AND meta_value = %d;",
+				$this->get( 'id' )
+			)
+		);
+
+		// return just the ids.
+		if ( 'ids' === $return ) {
+			return $query;
+		}
+
+		// setup lesson objects.
+		$ret = array();
+		foreach ( $query as $id ) {
+			$ret[] = llms_get_post( $id );
+		}
+
+		return $ret;
 
 	}
 


### PR DESCRIPTION
## Description

Adds deprecation notices to two unused class methods (these will be removed in 5.0)

+ Fixes #1238 
+ Fixes #1470

## How has this been tested?

+ Manually tested to ensure the site doesn't crash
+ These are unused methods so they don't actually get used anywhere that I can find.

## Screenshots <!-- if applicable -->

## Types of changes

+ Deprecation

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

