### PR TITLE
Builder autosave option

### DIFF
--- a/assets/js/builder/Controllers/Sync.js
+++ b/assets/js/builder/Controllers/Sync.js
@@ -1,8 +1,8 @@
 /**
  * Sync builder data to the server
  *
- * @since    3.16.0
- * @version  3.19.4
+ * @since 3.16.0
+ * @version [version]
  */
 define( [], function() {
 
@@ -11,7 +11,7 @@ define( [], function() {
 		this.saving = false;
 
 		var self              = this,
-			autosave          = true,
+			autosave          = ( 'yes' === window.llms_builder.autosave ),
 			check_interval    = null,
 			check_interval_ms = settings.check_interval_ms || 10000,
 			detached          = new Backbone.Collection(),
@@ -20,9 +20,9 @@ define( [], function() {
 		/**
 		 * init
 		 *
-		 * @return   void
-		 * @since    3.16.7
-		 * @version  3.16.7
+		 * @since 3.16.7
+		 *
+		 * @return void
 		 */
 		function init() {
 
@@ -658,13 +658,20 @@ define( [], function() {
 			|__/  |__/ \_______/ \_______/|__/         \___/  |_______/  \_______/ \_______/   \___/
 		*/
 
+
 		/**
 		 * Add data to the WP heartbeat to persist new models, changes, and deletions to the DB
 		 *
-		 * @since    3.16.0
-		 * @version  3.16.7
+		 * @since 3.16.0
+		 * @since 3.16.7 Unknown
+		 * @since [version] Return early when autosaving is disabled.
 		 */
 		$( document ).on( 'heartbeat-send', function( event, data ) {
+
+			// Autosaving is disabled.
+			if ( ! autosave ) {
+				return;
+			}
 
 			// prevent simultaneous saves
 			if ( self.saving ) {
@@ -691,10 +698,15 @@ define( [], function() {
 		/**
 		 * Confirm detachments & deletions and replace temp IDs with new persisted IDs
 		 *
-		 * @since    3.16.0
-		 * @version  3.16.0
+		 * @since 3.16.0
+		 * @since [version] Return early when autosaving is disabled.
 		 */
 		$( document ).on( 'heartbeat-tick', function( event, data ) {
+
+			// Autosaving is disabled.
+			if ( ! autosave ) {
+				return;
+			}
 
 			if ( ! data.llms_builder ) {
 				return;
@@ -714,10 +726,15 @@ define( [], function() {
 		/**
 		 * On heartbeat errors publish an error to the main builder application
 		 *
-		 * @since    3.16.0
-		 * @version  3.16.0
+		 * @since 3.16.0
+		 * @since [version] Return early when autosaving is disabled.
 		 */
 		$( document ).on( 'heartbeat-error', function( event, data ) {
+
+			// Autosaving is disabled.
+			if ( ! autosave ) {
+				return;
+			}
 
 			window.llms_builder.debug.log( '==== start heartbeat-error ====', data, '==== finish heartbeat-error ====' );
 

--- a/assets/js/builder/Controllers/Sync.js
+++ b/assets/js/builder/Controllers/Sync.js
@@ -22,7 +22,7 @@ define( [], function() {
 		 *
 		 * @since 3.16.7
 		 *
-		 * @return void
+		 * @return {Void}
 		 */
 		function init() {
 

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.13.0
- * @version 3.38.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -65,6 +65,33 @@ class LLMS_Admin_Builder {
 			wp_admin_bar_appearance_menu( $wp_admin_bar );
 
 		}
+
+	}
+
+	/**
+	 * Retrieve the current user's builder autosave preferences
+	 *
+	 * Defaults to enabled for users who have never configured a setting value.
+	 *
+	 * @since [version]
+	 *
+	 * @return string Either "yes" or "no".
+	 */
+	protected static function get_autosave_status() {
+
+		$autosave = get_user_option( 'llms_builder_autosave' );
+		$autosave = empty( $autosave ) ? 'yes' : $autosave;
+
+		/**
+		 * Gets the status of autosave for the builder
+		 *
+		 * This can be configured on a per-user basis in the user's profile screen on the WP Admin Panel.
+		 *
+		 * @since [version]
+		 *
+		 * @param string $autosave Status of autosave for the current user. Either "yes" or "no".
+		 */
+		return apply_filters( 'llms_builder_autosave_enabled', $autosave );
 
 	}
 
@@ -503,9 +530,11 @@ class LLMS_Admin_Builder {
 	/**
 	 * Output the page content
 	 *
-	 * @return   void
-	 * @since    3.13.0
-	 * @version  3.19.2
+	 * @since 3.13.0
+	 * @since 3.19.2 Unknown.
+	 * @since [version] Added builder autosave preference defaults.
+	 *
+	 * @return void
 	 */
 	public static function output() {
 
@@ -574,6 +603,7 @@ class LLMS_Admin_Builder {
 			<?php
 			echo json_encode(
 				array(
+					'autosave'  => self::get_autosave_status(),
 					'admin_url' => admin_url(),
 					'course'    => $course->toArray(),
 					'debug'     => array(

--- a/includes/admin/class.llms.admin.user.custom.fields.php
+++ b/includes/admin/class.llms.admin.user.custom.fields.php
@@ -403,14 +403,9 @@ class LLMS_Admin_User_Custom_Fields {
 		}
 
 		// Save personal options.
-		if ( user_can( $user, 'edit_courses' ) ) {
-			if ( 'create' === $action ) {
-				$autosave = 'yes';
-			} else {
-				$autosave = empty( $_POST['llms_builder_autosave'] ) ? 'no' : 'yes';
-			}
+		if ( user_can( $user, 'edit_courses' ) && 'create' !== $action ) {
+			$autosave = empty( $_POST['llms_builder_autosave'] ) ? 'no' : 'yes';
 			update_user_meta( $user->ID, 'llms_builder_autosave', $autosave );
-
 		}
 
 	}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -19,9 +19,34 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	 * @return void
 	 */
 	public function setUp() {
-
 		parent::setUp();
 		$this->main = 'LLMS_Admin_Builder';
+	}
+
+	/**
+	 * Test get_autosave_states()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_autosave_status() {
+
+		// Defaults to yes.
+		$this->assertEquals( 'yes', LLMS_Unit_Test_Util::call_method( $this->main, 'get_autosave_status' ) );
+
+		// User has no value set.
+		$user = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user );
+		$this->assertEquals( 'yes', LLMS_Unit_Test_Util::call_method( $this->main, 'get_autosave_status' ) );
+
+		// Explicit yes.
+		update_user_meta( $user, 'llms_builder_autosave','yes' );
+		$this->assertEquals( 'yes', LLMS_Unit_Test_Util::call_method( $this->main, 'get_autosave_status' ) );
+
+		// Explicit no.
+		update_user_meta( $user, 'llms_builder_autosave','no' );
+		$this->assertEquals( 'no', LLMS_Unit_Test_Util::call_method( $this->main, 'get_autosave_status' ) );
 
 	}
 


### PR DESCRIPTION
## Description

+ Adds a user-specific option allowing course creators to determine whether or not the course builder will automatically save work

## How has this been tested?

+ Manually
+ new tests (not fully covered, I know)

## Screenshots <!-- if applicable -->

## Types of changes
+ Update, new feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

