### PR TITLE
Fix log sprintf argument numbers.

### DIFF
--- a/includes/processors/class.llms.processor.course.data.php
+++ b/includes/processors/class.llms.processor.course.data.php
@@ -385,7 +385,7 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 */
 	public function task( $args ) {
 
-		$this->log( sprintf( 'Course data calculation task called for course %2$d with args: %2$s', $args['post_id'], wp_json_encode( $args ) ) );
+		$this->log( sprintf( 'Course data calculation task called for course %1$d with args: %2$s', $args['post_id'], wp_json_encode( $args ) ) );
 
 		$course = llms_get_post( $args['post_id'] );
 
@@ -447,7 +447,7 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 */
 	protected function task_complete( $course, $data, $last_page ) {
 
-		$this->log( sprintf( 'Course data calculation task completed for course %2$d with data: %2$s', $course->get( 'id' ), wp_json_encode( $data ) ) );
+		$this->log( sprintf( 'Course data calculation task completed for course %1$d with data: %2$s', $course->get( 'id' ), wp_json_encode( $data ) ) );
 
 		// Save our work on the last run.
 		if ( $last_page ) {


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
When logging, the course id was not used in the sprintf arguments.

## How has this been tested?
I examined the llms-logs/processor file.

## Types of changes
Fixes logging output.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

