### PR TITLE
Undefined variable in LLMS_Abstract_Notification_View->get_html().

### DIFF
--- a/includes/abstracts/llms.abstract.notification.view.php
+++ b/includes/abstracts/llms.abstract.notification.view.php
@@ -452,7 +452,7 @@ abstract class LLMS_Abstract_Notification_View extends LLMS_Abstract_Options_Dat
 
 			// 3rd party/custom types.
 			default:
-				$html = apply_filters( $this->get_filter( 'get_' . $type . '_html' ), $html, $this );
+				$html = apply_filters( $this->get_filter( 'get_' . $type . '_html' ), null, $this );
 
 		}
 


### PR DESCRIPTION
## Description
Fixed issue in LLMS_Abstract_Notification_View->get_html() with using an undefined $html variable.

## How has this been tested?
phpunit

## Types of changes
Prevents undefined variable PHP warning messages in the logs.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

