### PR TITLE
Allow view manager to be used on the student dashboard

### DIFF
--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -115,7 +115,7 @@ class LLMS_View_Manager {
 
 			$wp_admin_bar->add_node(
 				array(
-					'href'   => $this->get_url( $slug ),
+					'href'   => LLMS_View_Manager::get_url( $slug ),
 					'id'     => 'llms-view-as--' . $slug,
 					'parent' => 'llms-view-as-menu',
 					'title'  => sprintf( __( 'View as %s', 'lifterlms' ), $title ),
@@ -123,25 +123,6 @@ class LLMS_View_Manager {
 			);
 
 		}
-
-	}
-
-	/**
-	 * Add view manager query args to a given url
-	 *
-	 * @since [version]
-	 *
-	 * @param string|false $href The URL or `false` to use the current `$_SERVER['REQUEST_URI']`.
-	 * @param string       $role The role to view the URL as. Accepts any role defined in the `get_views()` method.
-	 * @param array        $args Additional query arguments to add to the URL.
-	 *
-	 * @return string
-	 */
-	public static function create_url( $href, $role, $args = array() ) {
-
-		$args['llms-view-as'] = $role;
-		$href = add_query_arg( $args, $href );
-		return html_entity_decode( esc_url( wp_nonce_url( $href, 'llms-view-as', 'view_nonce' ) ) );
 
 	}
 
@@ -167,19 +148,24 @@ class LLMS_View_Manager {
 	 *
 	 * @since 3.7.0
 	 * @since 4.2.0 Take into account already present query args. e.g. ?plan=X.
-	 * @since [version] Use `LLMS_View_Manager::create_url()`.
+	 * @since [version] Changed method signature to add the `$href` parameter and changed access from private to public static.
 	 *
-	 * @param string $role View option [self|visitor|student].
-	 * @param array  $args Optional. Additional query args to add to the url. Default empty array.
+	 * @param string       $role Role to view the screen as. Accepts "self", "visitor", or "student".
+	 * @param string|false $href Optional. The URL to create a URL for. If `false`, uses `$_SERVER['REQUEST_URI']`.
+	 * @param array        $args Optional. Additional query args to add to the url. Default empty array.
 	 * @return string
 	 */
-	private function get_url( $role, $args = array() ) {
+	public static function get_url( $role, $href = false, $args = array() ) {
 
-		// Returns the current url without the `llms-view-as` and `view_nonce` query args.
+		// If we want to view as "self" we should remove the query vars (if they're set).
 		if ( 'self' === $role ) {
-			return remove_query_arg( array( 'llms-view-as', 'view_nonce' ) );
+			return remove_query_arg( array( 'llms-view-as', 'view_nonce' ), $href );
 		}
-		return LLMS_View_Manager::create_url( false, $role, $args );
+
+		// Create a new URL.
+		$args['llms-view-as'] = $role;
+		$href = add_query_arg( $args, $href );
+		return html_entity_decode( esc_url( wp_nonce_url( $href, 'llms-view-as', 'view_nonce' ) ) );
 
 	}
 

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -115,7 +115,7 @@ class LLMS_View_Manager {
 
 			$wp_admin_bar->add_node(
 				array(
-					'href'   => LLMS_View_Manager::get_url( $slug ),
+					'href'   => self::get_url( $slug ),
 					'id'     => 'llms-view-as--' . $slug,
 					'parent' => 'llms-view-as-menu',
 					'title'  => sprintf( __( 'View as %s', 'lifterlms' ), $title ),
@@ -164,7 +164,7 @@ class LLMS_View_Manager {
 
 		// Create a new URL.
 		$args['llms-view-as'] = $role;
-		$href = add_query_arg( $args, $href );
+		$href                 = add_query_arg( $args, $href );
 		return html_entity_decode( esc_url( wp_nonce_url( $href, 'llms-view-as', 'view_nonce' ) ) );
 
 	}

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -216,6 +216,17 @@ class LLMS_View_Manager {
 	}
 
 	/**
+	 * Test get_views() method
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_views() {
+		$this->assertEquals( array( 'self', 'visitor', 'student' ), array_keys( LLMS_Unit_Test_Util::call_method( $this->main, 'get_views' ) ) );
+	}
+
+	/**
 	 * Get a list of available views.
 	 *
 	 * @since 3.7.0

--- a/includes/class.llms.view.manager.php
+++ b/includes/class.llms.view.manager.php
@@ -279,7 +279,6 @@ class LLMS_View_Manager {
 
 		return $value;
 
-
 	}
 
 	/**

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard' ) ) {
 		do_action( 'lifterlms_before_student_dashboard' );
 
 		// If user is not logged in.
-		if ( ! is_user_logged_in() ) {
+		if ( ! apply_filters( 'llms_display_student_dashboard', is_user_logged_in() ) ) {
 
 			/**
 			 * Allow adding a notice message to be displayed in the student dashboard where `llms_print_notices()` will be invoked.

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -40,8 +40,24 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard' ) ) {
 		 */
 		do_action( 'lifterlms_before_student_dashboard' );
 
-		// If user is not logged in.
-		if ( ! apply_filters( 'llms_display_student_dashboard', is_user_logged_in() ) ) {
+		/**
+		 * Filters whether or not to display the student dashboard
+		 *
+		 * By default, this condition will show the dashboard to a logged in user
+		 * and the login/registration forms (as well as the password recovery flow)
+		 * to logged out users.
+		 *
+		 * The `LLMS_View_Manager` class uses this filter to modify the dashboard view
+		 * conditionally based on the requested view role.
+		 *
+		 * @since [version]
+		 *
+		 * @param type $arg Description.
+		 */
+		$display_dashboard = apply_filters( 'llms_display_student_dashboard', is_user_logged_in() );
+
+		// Not displaying the dashboard (the user is not logged in), we'll show login/registration forms.
+		if ( ! $display_dashboard ) {
 
 			/**
 			 * Allow adding a notice message to be displayed in the student dashboard where `llms_print_notices()` will be invoked.

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -1082,6 +1082,7 @@ if ( ! function_exists( 'llms_get_image_size' ) ) {
  */
 if ( ! function_exists( 'llms_get_login_form' ) ) {
 	function llms_get_login_form( $message = null, $redirect = null, $layout = null ) {
+
 		llms_get_template(
 			'global/form-login.php',
 			array(

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Templates
  *
  * @since 3.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,7 +18,17 @@ if ( ! isset( $layout ) ) {
 	$layout = apply_filters( 'llms_login_form_layout', 'columns' );
 }
 
-if ( is_user_logged_in() ) {
+/**
+ * Filters whether or not the login form should be displayed
+ *
+ * By default, the registration form is hidden from logged-in users and
+ * displayed to logged out users.
+ *
+ * @since [version]
+ *
+ * @param boolean $hide_form Whether or not to hide the form. If `true`, the form is hidden, otherwise it is displayed.
+ */
+if ( apply_filters( 'llms_hide_login_form', is_user_logged_in() ) ) {
 	return;
 }
 

--- a/templates/global/form-registration.php
+++ b/templates/global/form-registration.php
@@ -5,15 +5,24 @@
  * @package LifterLMS/Templates
  *
  * @since 3.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 $field_data = isset( $_POST ) ? $_POST : array(); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Data is sanitized in LLMS_Person_Handler::fill_fields().
 
-// don't allow logged in users to register.
-if ( get_current_user_id() ) {
+/**
+ * Filters whether or not the registration form should be displayed
+ *
+ * By default, the registration form is hidden from logged-in users and
+ * displayed to logged out users.
+ *
+ * @since [version]
+ *
+ * @param boolean $hide_form Whether or not to hide the form. If `true`, the form is hidden, otherwise it is displayed.
+ */
+if ( apply_filters( 'llms_hide_registration_form', is_user_logged_in() ) ) {
 	return;
 }
 ?>

--- a/tests/e2e/tests/page-restrictions/course.test.js
+++ b/tests/e2e/tests/page-restrictions/course.test.js
@@ -15,7 +15,6 @@ import {
 import {
 	createURL,
 	loginUser,
-	visitAdminPage
 } from '@wordpress/e2e-test-utils';
 
 describe( 'CourseRestrictions', () => {

--- a/tests/e2e/tests/view-manager/__snapshots__/view-manager.test.js.snap
+++ b/tests/e2e/tests/view-manager/__snapshots__/view-manager.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ViewManager Checkout should show an already enrolled notice when viewing as a student. 1`] = `"You already have access to this Course! Visit your dashboard <a href=\\"http://localhost:8080/dashboard/\\">here.</a>"`;

--- a/tests/e2e/tests/view-manager/view-manager.test.js
+++ b/tests/e2e/tests/view-manager/view-manager.test.js
@@ -1,0 +1,133 @@
+/**
+ * Test the LifterLMS View Manager
+ *
+ * @since [version]
+ */
+
+import {
+	clickAndWait,
+	createAccessPlan,
+	createCourse,
+	logoutUser,
+	toggleOpenRegistration,
+	visitPage,
+} from '@lifterlms/llms-e2e-test-utils';
+
+import {
+	visitAdminPage
+} from '@wordpress/e2e-test-utils';
+
+
+/**
+ * Select a view from the view manager menu in the WP Admin bar.
+ *
+ * @since [version]
+ *
+ * @param {String} view View name to select. Accepts "self", "visitor", or "student".
+ * @return {Void}
+ */
+async function selectView( view ) {
+
+	const
+		topLevelSelector = '#wp-admin-bar-llms-view-as-menu',
+		viewSelector     = `#wp-admin-bar-llms-view-as--${ view }`;
+
+	await page.waitForSelector( topLevelSelector );
+	await page.hover( topLevelSelector );
+
+	await page.waitForSelector( viewSelector );
+	await clickAndWait( `${ viewSelector } a.ab-item` );
+
+}
+
+describe( 'ViewManager', () => {
+
+	beforeAll( async () => {
+		// Ensure we're a logged in admin that can use the view manager.
+		await visitAdminPage( '/' );
+	} );
+
+	afterAll( async () => {
+		await logoutUser();
+	} );
+
+	describe( 'Dashboard', () => {
+
+		beforeAll( async () => {
+			await toggleOpenRegistration( true );
+		} );
+		afterAll( async () => {
+			await toggleOpenRegistration( false );
+		} );
+
+		beforeEach( async () => {
+			await visitPage( 'dashboard' );
+		} );
+
+		it ( 'should show forms when viewing as a visitor.', async () => {
+
+			await selectView( 'visitor' );
+
+			// Login and registration forms should exist.
+			await page.waitForSelector( '.llms-person-login-form-wrapper' );
+			await page.waitForSelector( '.llms-new-person-form-wrapper' );
+
+			// Dashboard header should not exist.
+			expect( await page.$( '.llms-sd-header' ) ).toBeNull();
+
+		} );
+
+		it ( 'should show the dashboard when viewing as a student.', async () => {
+
+			await selectView( 'student' );
+
+			// Login and registration forms should not exist.
+			expect( await page.$( '.llms-person-login-form-wrapper' ) ).toBeNull();
+			expect( await page.$( '.llms-new-person-form-wrapper' ) ).toBeNull();
+
+			// Dashboard header should exist.
+			await page.waitForSelector( '.llms-sd-header' );
+
+		} );
+
+	} );
+
+	describe( 'Checkout', () => {
+
+		beforeAll( async () => {
+
+			const
+				courseId = await createCourse( 'View Manager Test' ),
+				planUrl = await createAccessPlan( {
+					postId: courseId,
+					price: 5.00,
+				} );
+
+			await page.goto( planUrl );
+
+		} );
+
+		it ( 'should show the checkout form when viewing as a visitor.', async () => {
+
+			await selectView( 'visitor' );
+
+			// Should show the checkout form.
+			await page.waitForSelector( '#llms-product-purchase-form' );
+
+		} );
+
+		it ( 'should show an already enrolled notice when viewing as a student.', async () => {
+
+			await selectView( 'student' );
+
+			// Should show a notice.
+			expect( await page.$eval( '.llms-checkout-wrapper .llms-notice', el => el.innerHTML ) ).toMatchSnapshot();
+
+			// Should not show the checkout form.
+			expect( await page.$( '#llms-product-purchase-form' ) ).toBeNull();
+
+		} );
+
+	} );
+
+} );

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -24,6 +24,19 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 
 	}
 
+	private function get_admin_bar() {
+
+		add_filter( 'show_admin_bar', '__return_true' );
+		_wp_admin_bar_init();
+
+		global $wp_admin_bar;
+
+		remove_filter( 'show_admin_bar', '__return_true' );
+
+		return $wp_admin_bar;
+
+	}
+
 	/**
 	 * Mock `$_GET` data to control the return of `get_view()`.
 	 *
@@ -79,6 +92,44 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 		) );
 		$this->main = new LLMS_View_Manager();
 		$this->assertFalse( has_action( 'init', array( $this->main, 'add_actions' ) ) );
+	}
+
+	/**
+	 * Test add_menu_items() when the display manager shouldn't be displayed.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_menu_items_no_display() {
+
+		$bar = $this->get_admin_bar();
+
+		$this->main->add_menu_items( $bar );
+
+		$this->assertNull( $bar->get_nodes() );
+
+	}
+
+	/**
+	 * Test add_menu_items()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_menu_items() {
+
+		$bar = $this->get_admin_bar();
+
+		add_filter( 'llms_view_manager_should_display', '__return_true' );
+
+		$this->main->add_menu_items( $bar );
+
+		$this->assertEquals( array( 'llms-view-as-menu', 'llms-view-as--visitor', 'llms-view-as--student' ), array_keys( $bar->get_nodes() ) );
+
+		remove_filter( 'llms_view_manager_should_display', '__return_true' );
+
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -188,6 +188,59 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test get_view() when there's nonce errors.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_view_nonce_error() {
+
+		// Nothing set.
+		$this->assertEquals( 'self', LLMS_Unit_Test_Util::call_method( $this->main, 'get_view' ) );
+
+		// Invalid nonce.
+		$this->mockGetRequest( array(
+			'view_nonce'   => 'fake',
+			'llms-view-as' => 'student',
+		) );
+		$this->assertEquals( 'self', LLMS_Unit_Test_Util::call_method( $this->main, 'get_view' ) );
+
+	}
+
+	/**
+	 * Test get_view() with an invalid view.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_view_invalid_view() {
+
+		$this->mock_view_data( 'fake' );
+		$this->assertEquals( 'self', LLMS_Unit_Test_Util::call_method( $this->main, 'get_view' ) );
+
+	}
+
+	/**
+	 * Test get_view() with valid data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_view() {
+
+		foreach ( array_keys( LLMS_Unit_Test_Util::call_method( $this->main, 'get_views' ) ) as $view ) {
+
+			$this->mock_view_data( $view );
+			$this->assertEquals( $view, LLMS_Unit_Test_Util::call_method( $this->main, 'get_view' ) );
+
+		}
+
+	}
+
+	/**
 	 * Test modify_dashboard()
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -24,6 +24,13 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Initiate (and retrieve) an instance of WP_Admin_Bar
+	 *
+	 * @since [version]
+	 *
+	 * @return WP_Admin_Bar
+	 */
 	private function get_admin_bar() {
 
 		add_filter( 'show_admin_bar', '__return_true' );

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -25,6 +25,23 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Mock `$_GET` data to control the return of `get_view()`.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $role Requested view role.
+	 * @return void
+	 */
+	public function mock_view_data( $role ) {
+
+		$this->mockGetRequest( array(
+			'view_nonce'   => wp_create_nonce( 'llms-view-as' ),
+			'llms-view-as' => $role,
+		) );
+
+	}
+
+	/**
 	 * Test constructor
 	 *
 	 * @since 4.5.1
@@ -65,6 +82,28 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test modify_dashboard()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_modify_dashboard() {
+
+		// Unchanged when viewing as self.
+		$this->assertNull( $this->main->modify_dashboard( null ) );
+
+		// Visitors can't load the dashboard (they see forms).
+		$this->mock_view_data( 'visitor' );
+		$this->assertFalse( $this->main->modify_dashboard( null ) );
+
+		// Students see the dashboard.
+		$this->mock_view_data( 'student' );
+		$this->assertTrue( $this->main->modify_dashboard( null ) );
+
+	}
+
+	/**
 	 * Test should_display() when viewing valid post types with a valid user
 	 *
 	 * @since 4.5.1
@@ -96,6 +135,20 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
 
+	}
+
+	/**
+	 * Test should_display() when viewing the student dashboard with a valid user
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_display_on_dashboard() {
+		LLMS_Install::create_pages();
+		$this->go_to( llms_get_page_url( 'myaccount' ) );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_display' ) );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/class-llms-test-view-manager.php
+++ b/tests/phpunit/unit-tests/class-llms-test-view-manager.php
@@ -82,6 +82,61 @@ class LLMS_Test_View_Manager extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test get_url() with a supplied URL and additional QS args.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_url_with_url() {
+
+		$url = parse_url( LLMS_View_Manager::get_url(  'visitor', 'https://mock.tld/test?whatever=0', array( 'more' => 'yes' ) ) );
+
+		// Make sure URL is preserved properly.
+		$this->assertEquals( 'https', $url['scheme'] );
+		$this->assertEquals( 'mock.tld', $url['host'] );
+		$this->assertEquals( '/test', $url['path'] );
+
+		// Check query vars.
+		parse_str( $url['query'], $qs );
+		$this->assertEquals( '0', $qs['whatever'] );
+		$this->assertEquals( 'yes', $qs['more'] );
+		$this->assertEquals( 'visitor', $qs['llms-view-as'] );
+
+		// Ensure generated nonce is valid.
+		$this->assertEquals( 1, wp_verify_nonce( $qs['view_nonce'], 'llms-view-as' ) );
+
+	}
+
+	/**
+	 * Test get_url() with a supplied URL and additional QS args.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_url_without_url() {
+
+		$_SERVER['REQUEST_URI'] = 'https://fake.tld';
+
+		$url = parse_url( LLMS_View_Manager::get_url(  'student' ) );
+
+		// Make sure URL is preserved properly.
+		$this->assertEquals( 'https', $url['scheme'] );
+		$this->assertEquals( 'fake.tld', $url['host'] );
+
+		// Check query vars.
+		parse_str( $url['query'], $qs );
+		$this->assertEquals( 'student', $qs['llms-view-as'] );
+
+		// Ensure generated nonce is valid.
+		$this->assertEquals( 1, wp_verify_nonce( $qs['view_nonce'], 'llms-view-as' ) );
+
+		$_SERVER['REQUEST_URI'] = '';
+
+	}
+
+	/**
 	 * Test modify_dashboard()
 	 *
 	 * @since [version]


### PR DESCRIPTION
## Description

Adds the ability to use the "View Manager" functionality to flip the student dashboard.

This will make it easy for an admin to inspect their open registration / login form (without having to log out).

The most common use case here will be seeing how changes to the open registration form will look on the frontend.

## How has this been tested?

+ Unit tests
+ Manual tests
+ More testing to be written and done

## Screenshots <!-- if applicable -->

## Types of changes

New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

