### PR TITLE
Filter shortcode post in

### DIFF
--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -86,15 +86,15 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 
 		}
 
-                /**
-                 * Filter the array of IDs returned for use in querying courses to display.
-                 *
-                 * @since 4.15.1
-                 *
-                 * @param array          $ids       The IDs of courses that will be displayed.
-                 * @param LLMS_Student   $student   The student object for the current user.
-                 * @param string         $mine      The "mine" attribute of the shortcode.
-                 */
+		/**
+		 * Filter the array of IDs returned for use in querying courses to display.
+		 *
+		 * @since 4.15.1
+		 *
+		 * @param array          $ids       The IDs of courses that will be displayed.
+		 * @param LLMS_Student   $student   The student object for the current user.
+		 * @param string         $mine      The "mine" attribute of the shortcode.
+		 */
 		return apply_filters( 'llms_courses_shortcode_get_post_in', $ids, $student, $mine );
 	}
 

--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -86,7 +86,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 
 		}
 
-		return $ids;
+		return apply_filters('courses_shortcode_get_post__in', $ids, $student, $mine);
 	}
 
 	/**

--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -89,13 +89,13 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 		/**
 		 * Filter the array of IDs returned for use in querying courses to display.
 		 *
-		 * @since 4.15.1
+		 * @since [version]
 		 *
-		 * @param array          $ids       The IDs of courses that will be displayed.
-		 * @param LLMS_Student   $student   The student object for the current user.
-		 * @param string         $mine      The "mine" attribute of the shortcode.
+		 * @param array        $ids     The IDs of courses that will be displayed.
+		 * @param LLMS_Student $student The student object for the current user.
+		 * @param string       $mine    The "mine" attribute of the shortcode.
 		 */
-		return apply_filters( 'llms_courses_shortcode_get_post_in', $ids, $student, $mine );
+		return apply_filters( 'llms_courses_shortcode_get_post__in', $ids, $student, $mine );
 	}
 
 	/**

--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -86,7 +86,16 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 
 		}
 
-		return apply_filters('courses_shortcode_get_post__in', $ids, $student, $mine);
+                /**
+                 * Filter the array of IDs returned for use in querying courses to display.
+                 *
+                 * @since 4.15.1
+                 *
+                 * @param array          $ids       The IDs of courses that will be displayed.
+                 * @param LLMS_Student   $student   The student object for the current user.
+                 * @param string         $mine      The "mine" attribute of the shortcode.
+                 */
+		return apply_filters( 'llms_courses_shortcode_get_post_in', $ids, $student, $mine );
 	}
 
 	/**


### PR DESCRIPTION
## Description
Add a filter `llms_courses_shortcode_get_post_in` which allows filtering of the course IDs that will be displayed by the courses shortcode.

Fixes #1516

## How has this been tested?
This has been tested and used in development and production for several weeks with the latest version of WordPress and the latest version of LifterLMS.  We have been using the filter to control what courses are displayed to users and it is working as expected.

## Screenshots
N/A

## Types of changes
The only thing changed was to add a filter on the return value of LLMS_Shortcode_Courses::get_post__in().  Only one line of code was changed, plus the addition of inline documentation.

## Checklist:
- [X] My code has been tested.
- [ ] My code passes all existing automated tests. (After a lot of work attempting to get LifterLMS Tests to work, I still was not able to get this test to run.  It appeared to have a dependency that I didn't have installed on my system.  Since the change only involve a single filter on one line of code, I gave up trying to make it work.)
- [X] My code follows the LifterLMS Coding & Documentation Standards.

