### PR TITLE
Quiz start button template: early bail on orphan quiz

### DIFF
--- a/templates/quiz/start-button.php
+++ b/templates/quiz/start-button.php
@@ -2,8 +2,9 @@
 /**
  * Quiz Start & Next lesson buttons
  *
- * @since    1.0.0
- * @version  3.25.0
+ * @since 1.0.0
+ * @since 3.25.0 Unknown.
+ * @since [version] Early bail on orphan quiz.
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,11 +12,22 @@ defined( 'ABSPATH' ) || exit;
 global $post;
 $quiz   = llms_get_post( $post );
 $lesson = $quiz->get_lesson();
+
+if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
+	return;
+}
 ?>
 
 <div class="llms-quiz-buttons llms-button-wrapper" id="quiz-start-button">
 
-	<?php do_action( 'lifterlms_before_start_quiz' ); ?>
+	<?php
+		/**
+		 * Fired before the start quiz button
+		 *
+		 * @since Unknown
+		 */
+		do_action( 'lifterlms_before_start_quiz' );
+	?>
 
 	<?php if ( $quiz ) : ?>
 
@@ -31,7 +43,18 @@ $lesson = $quiz->get_lesson();
 				<?php wp_nonce_field( 'llms_start_quiz' ); ?>
 
 				<button class="llms-start-quiz-button llms-button-action button" id="llms_start_quiz" name="llms_start_quiz" type="submit">
-					<?php echo apply_filters( 'lifterlms_begin_quiz_button_text', __( 'Start Quiz', 'lifterlms' ), $quiz, $lesson ); ?>
+					<?php
+						/**
+						 * Filters the quiz button text
+						 *
+						 * @since Unknown
+						 *
+						 * @param string      $button_text The start quiz button text.
+						 * @param LLMS_Quiz   $quiz        The current quiz instance.
+						 * @param LLMS_Lesson $lesson      The parent lesson instance.
+						 */
+						echo apply_filters( 'lifterlms_begin_quiz_button_text', __( 'Start Quiz', 'lifterlms' ), $quiz, $lesson );
+					?>
 				</button>
 
 			<?php else : ?>
@@ -49,6 +72,13 @@ $lesson = $quiz->get_lesson();
 
 	<?php endif; ?>
 
-	<?php do_action( 'lifterlms_after_start_quiz' ); ?>
+	<?php
+		/**
+		 * Fired after the start quiz button
+		 *
+		 * @since Unknown
+		 */
+		do_action( 'lifterlms_after_start_quiz' );
+	?>
 
 </div>


### PR DESCRIPTION
## Description
Fixes #1536 

The reason why I'm pushing this though, is mostly because we will want to be able to retrieve the quiz content (rendered) of an orphan quiz via rest-api without generating errors.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

