### PR TITLE
content filtering conditions

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -318,6 +318,7 @@ class LLMS_Admin_Builder {
 	 * @since 3.19.2 Unknown.
 	 * @since 4.16.0 Remove all filters/actions applied to the title/content when handling the ajax_save by deafault.
 	 *               This is specially to prevent plugin conflicts, see https://github.com/gocodebox/lifterlms/issues/1530.
+	 * @since [version] Remove `remove_all_*` hooks added in version 4.16.0.
 	 *
 	 * @param array $request $_REQUEST
 	 * @return array
@@ -333,10 +334,6 @@ class LLMS_Admin_Builder {
 
 			case 'ajax_save':
 				if ( isset( $request['llms_builder'] ) ) {
-
-					// Remove filters/actions applied to the title and content.
-					remove_all_actions( 'the_title' );
-					remove_all_actions( 'the_content' );
 
 					$request['llms_builder'] = stripslashes( $request['llms_builder'] );
 					wp_send_json( self::heartbeat_received( array(), $request ) );

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.13.0
- * @version 4.16.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS\Classes
  *
  * @since 1.0.0
- * @version 4.5.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -344,6 +344,7 @@ class LLMS_Post_Types {
 	 * @since 3.33.0 `llms_question` post type is not publicly queryable anymore.
 	 * @since 3.37.12 Added 'revisions' support to course, lesson, and llms_mebership post types.
 	 * @since 4.5.1 Removed "excerpt" support for the course post type.
+	 * @since [version] Add "llms-sales-page" feature to course and membership post types.
 	 *
 	 * @return void
 	 */
@@ -385,7 +386,7 @@ class LLMS_Post_Types {
 					'feeds'      => true,
 				),
 				'query_var'           => true,
-				'supports'            => array( 'title', 'author', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-clone-post', 'llms-export-post' ),
+				'supports'            => array( 'title', 'author', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-clone-post', 'llms-export-post', 'llms-sales-page' ),
 				'has_archive'         => ( $catalog_id && get_page( $catalog_id ) ) ? get_page_uri( $catalog_id ) : _x( 'courses', 'course archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,
@@ -580,7 +581,7 @@ class LLMS_Post_Types {
 					'feeds'      => true,
 				),
 				'query_var'           => true,
-				'supports'            => array( 'title', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions' ),
+				'supports'            => array( 'title', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-sales-page' ),
 				'has_archive'         => ( $membership_page_id && get_page( $membership_page_id ) ) ? get_page_uri( $membership_page_id ) : _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,

--- a/includes/functions/llms-functions-content.php
+++ b/includes/functions/llms-functions-content.php
@@ -31,9 +31,10 @@ if ( ! function_exists( 'llms_get_post_content' ) ) {
 			return $content;
 		}
 
+		$restrictions = llms_page_restricted( $post->ID );
+
 		if ( in_array( $post->post_type, array( 'course', 'llms_membership', 'lesson', 'llms_quiz' ), true ) ) {
 
-			$restrictions    = llms_page_restricted( $post->ID );
 			$post_type       = str_replace( 'llms_', '', $post->post_type );
 			$template_before = 'single-' . $post_type . '-before';
 			$template_after  = 'single-' . $post_type . '-after';

--- a/includes/functions/llms-functions-content.php
+++ b/includes/functions/llms-functions-content.php
@@ -115,29 +115,31 @@ function llms_get_post_sales_page_content( $post, $default = '' ) {
  * other plugins that may desire running `apply_filters( 'the_content', $content )` to apply our
  * plugin's filters.
  *
- * Additionally, we don't want to return template information when processing REST requests.
- *
  * @since [version]
  *
+ * @param callable $callback Optional. Callback function to be added as a callback for the filter `the_content`. Default 'llms_get_post_content'.
+ * @param integer  $priority Optional. Priority used when adding the filter. Default: 10.
  * @return boolean Returns `true` if content filters are added and `false` if not.
  */
-function llms_post_content_init() {
+function llms_post_content_init( $callback = 'llms_get_post_content', $priority = 10 ) {
 
-	// Don't filter any requests on the admin panel or when processing REST requests.
-	$should_filter = ( ! is_admin() && ! llms_is_rest() );
+	// Don't filter post content on the admin panel.
+	$should_filter = ( false === is_admin() );
 
 	/**
 	 * Filters whether or not LifterLMS content filters should be applied.
 	 *
 	 * @since [version]
 	 *
-	 * @param boolean $should_filter Whether or not to filter the content.
+	 * @param boolean  $should_filter Whether or not to filter the content.
+	 * @param callable $callback      Callback function to be added as a callback for the filter `the_content`.
 	 */
-	if ( apply_filters( 'llms_should_filter_post_content', $should_filter ) ) {
-		return add_filter( 'the_content', 'llms_get_post_content' );
+	if ( apply_filters( 'llms_should_filter_post_content', $should_filter, $callback ) ) {
+		return add_filter( 'the_content', $callback, $priority );
 	}
 
 	return false;
 
 }
-add_action( 'init', 'llms_post_content_init' );
+
+llms_post_content_init();

--- a/includes/functions/llms-functions-content.php
+++ b/includes/functions/llms-functions-content.php
@@ -63,7 +63,6 @@ if ( ! function_exists( 'llms_get_post_content' ) ) {
 				$template_after  = llms_get_template_part_contents( 'content', 'single-lesson-after' );
 			}
 		} elseif ( 'llms_quiz' === $post->post_type ) {
-
 			$template_before = llms_get_template_part_contents( 'content', 'single-quiz-before' );
 			$template_after  = llms_get_template_part_contents( 'content', 'single-quiz-after' );
 
@@ -84,7 +83,7 @@ if ( ! function_exists( 'llms_get_post_content' ) ) {
 		/**
 		 * Filter the post_content of a LifterLMS post type.
 		 *
-		 * @since Unknown.
+		 * @since [version]
 		 *
 		 * @param string  $content         Post content.
 		 * @param WP_Post $post            Post object.
@@ -94,4 +93,40 @@ if ( ! function_exists( 'llms_get_post_content' ) ) {
 
 	}
 }
-add_filter( 'the_content', 'llms_get_post_content' );
+
+/**
+ * Initialize LifterLMS post type content filters
+ *
+ * This method is used to determine whether or `llms_get_post_content()` should automatically
+ * be added as a filter callback for the WP core `the_content` filter.
+ *
+ * When working with posts on the admin panel (during course building, importing) we don't want
+ * other plugins that may desire running `apply_filters( 'the_content', $content )` to apply our
+ * plugin's filters.
+ *
+ * Additionally, we don't want to return template information when processing REST requests.
+ *
+ * @since [version]
+ *
+ * @return boolean Returns `true` if content filters are added and `false` if not.
+ */
+function llms_post_content_init() {
+
+	// Don't filter any requests on the admin panel or when processing REST requests.
+	$should_filter = ( ! is_admin() && ! llms_is_rest() );
+
+	/**
+	 * Filters whether or not LifterLMS content filters should be applied.
+	 *
+	 * @since [version]
+	 *
+	 * @param boolean $should_filter Whether or not to filter the content.
+	 */
+	if ( apply_filters( 'llms_should_filter_post_content', $should_filter ) ) {
+		return add_filter( 'the_content', 'llms_get_post_content' );
+	}
+
+	return false;
+
+}
+add_action( 'init', 'llms_post_content_init' );

--- a/templates/content-no-access-after.php
+++ b/templates/content-no-access-after.php
@@ -1,16 +1,19 @@
 <?php
 /**
- * The Template for displaying all single courses.
+ * Template displayed after content on a restricted page
  *
- * @author      codeBOX
- * @package     lifterLMS/Templates
+ * @package LifterLMS/Templates
+ *
+ * @since 1.0.0
+ * @since [version] Removed redundant notice output call and replaced duplicated hook with a new hook.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
-global $post;
-llms_print_notices();
-
-?>
-<?php
-do_action( 'lifterlms_no_access_main_content' );
+/**
+ * Action triggered after the main content of a restricted page is rendered
+ *
+ * @since [version]
+ */
+do_action( 'lifterlms_no_access_after' );

--- a/templates/content-no-access-before.php
+++ b/templates/content-no-access-before.php
@@ -1,16 +1,21 @@
 <?php
 /**
- * The Template for displaying all single courses.
+ * Template displayed before the main content on a restricted page
  *
- * @author      codeBOX
- * @package     lifterLMS/Templates
+ * @package LifterLMS/Templates
+ *
+ * @since 1.0.0
+ * @since [version] Removed redundant notice output call and replaced duplicated hook with a new hook.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
-global $post;
 llms_print_notices();
 
-?>
-<?php
+/**
+ * Action triggered before the main content of a restricted page is rendered
+ *
+ * @since [version]
+ */
 do_action( 'lifterlms_no_access_main_content' );

--- a/templates/quiz/meta-information.php
+++ b/templates/quiz/meta-information.php
@@ -5,16 +5,25 @@
  * @package LifterLMS/Templates
  *
  * @since 3.9.0
- * @version 4.0.0-beta.2
+ * @since 4.0.0 Unknown.
+ * @since [version] Return early if accessed without a logged in user or the quiz can't be loaded from the `$post` global.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 global $post;
 
-$quiz            = llms_get_post( $post );
+$student = llms_get_student();
+if ( ! $student ) {
+	return;
+}
+
+$quiz = llms_get_post( $post );
+if ( ! $quiz ) {
+	return;
+}
 $passing_percent = $quiz->get( 'passing_percent' );
-$student         = llms_get_student();
 ?>
 
 <h2 class="llms-quiz-meta-title"><?php _e( 'Quiz Information', 'lifterlms' ); ?></h2>

--- a/templates/quiz/results.php
+++ b/templates/quiz/results.php
@@ -6,7 +6,8 @@
  *
  * @since 1.0.0
  * @since 3.35.0 Access `$_GET` data via `llms_filter_input()`.
- * @version 3.35.0
+ * @since [version] Return early if accessed without a logged in user.
+ * @version [version]
  *
  * @property LLMS_Quiz_Attempt $attempt Attempt object.
  */
@@ -19,7 +20,11 @@ if ( ! $quiz ) {
 	return;
 }
 
-$student  = llms_get_student();
+$student = llms_get_student();
+if ( ! $student ) {
+	return;
+}
+
 $attempts = $student->quizzes()->get_attempts_by_quiz(
 	$quiz->get( 'id' ),
 	array(

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-content.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-content.php
@@ -1,10 +1,13 @@
 <?php
 /**
  * Tests for LifterLMS User Postmeta functions
- * @group    functions
- * @group    content_functions
- * @since    3.25.1
- * @version  3.25.1
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group functions
+ * @group content_functions
+ *
+ * @since 3.25.1
  */
 class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 
@@ -13,6 +16,8 @@ class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 	}
 
 	public function test_llms_get_post_content() {
+
+		llms_post_content_init();
 
 		$content = '<p>Lorem ipsum dolor sit amet.</p>';
 		$post_types = array( 'llms_membership', 'course', 'lesson', 'post', 'page' );
@@ -31,6 +36,78 @@ class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 			}
 
 		}
+
+	}
+
+	/**
+	 * Test that llms_get_post_content() will return early if the `$post` global is not set.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_post_content_no_global() {
+
+		llms_post_content_init();
+
+		$input = 'whatever';
+		$this->assertEquals( $input, llms_get_post_content( $input ) );
+
+	}
+
+	/**
+	 * Test llms_post_content_init() when filters should be applied
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_post_content_init() {
+
+		remove_filter( 'the_content', 'llms_get_post_content' );
+
+		$this->assertTrue( llms_post_content_init() );
+		$this->assertEquals( 10, has_filter( 'the_content', 'llms_get_post_content' ) );
+
+	}
+
+	/**
+	 * Test llms_post_content_init() when on the admin panel
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_post_content_init_is_admin() {
+
+		remove_filter( 'the_content', 'llms_get_post_content' );
+
+		set_current_screen( 'admin.php' );
+
+		$this->assertFalse( llms_post_content_init() );
+		$this->assertFalse( has_filter( 'the_content', 'llms_get_post_content' ) );
+
+		set_current_screen( 'front' ); // Reset.
+
+	}
+
+	/**
+	 * Test llms_post_content_init() during REST requests
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_llms_post_content_init_is_rest() {
+
+		remove_filter( 'the_content', 'llms_get_post_content' );
+
+		define( 'REST_REQUEST', true );
+		$this->assertFalse( llms_post_content_init() );
+		$this->assertFalse( has_filter( 'the_content', 'llms_get_post_content' ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-content.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-content.php
@@ -369,10 +369,24 @@ class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test llms_get_post_sales_page_content() for an unsupported post type.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function test_llms_get_post_sales_page_content_unsupported() {
-		$this->assertEquals( 'default content', llms_get_post_sales_page_content( $this->factory->post->create_and_get(), 'default_content' ) );
+		$this->assertEquals( 'default content', llms_get_post_sales_page_content( $this->factory->post->create_and_get(), 'default content' ) );
 	}
 
+	/**
+	 * Test llms_get_post_sales_page_content() for supported post types.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function test_llms_get_post_sales_page_content_supported() {
 
 		$post_excerpt = 'excerpt content';
@@ -380,11 +394,12 @@ class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 		foreach ( array( 'course', 'llms_membership' ) as $post_type ) {
 
 			$post = $this->factory->post->create_and_get( compact( 'post_type', 'post_excerpt' ) );
-			$this->assertEquals( 'default content', llms_get_post_sales_page_content( $post, 'default_content' ) );
+			update_post_meta( $post->ID, '_llms_sales_page_content_type', 'redirect' );
+			$this->assertEquals( 'default content', llms_get_post_sales_page_content( $post, 'default content' ) );
 
 			update_post_meta( $post->ID, '_llms_sales_page_content_type', 'content' );
 
-			$this->assertEquals( $post_excerpt, llms_get_post_sales_page_content( $post, 'default_content' ) );
+			$this->assertEquals( "<p>excerpt content</p>\n", llms_get_post_sales_page_content( $post, 'default content' ) );
 		}
 
 	}
@@ -426,22 +441,18 @@ class LLMS_Test_Functions_Content extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test llms_post_content_init() during REST requests
+	 * Test llms_post_content_init() when filters should be applied
 	 *
 	 * @since [version]
 	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 *
 	 * @return void
 	 */
-	public function test_llms_post_content_init_is_rest() {
+	public function test_llms_post_content_custom() {
 
-		remove_filter( 'the_content', 'llms_get_post_content' );
+		$this->assertTrue( llms_post_content_init( 'a_fake_callback', 85 ) );
+		$this->assertEquals( 85, has_filter( 'the_content', 'a_fake_callback' ) );
 
-		define( 'REST_REQUEST', true );
-		$this->assertFalse( llms_post_content_init() );
-		$this->assertFalse( has_filter( 'the_content', 'llms_get_post_content' ) );
+		remove_filter( 'the_content', 'a_fake_callback' );
 
 	}
 


### PR DESCRIPTION
## Description

I think this is a descent approach to fixing the issue(s) we've been encountering as a result of recent changes introduced into Yoast 15.8.

The changes which have caused these errors to start appearing were introduced in 15.8, specifically https://github.com/Yoast/wordpress-seo/commit/9b4f7caa591ea570ccd7dcec56968b21954ecdd0 which loads the `$post` global.

Previously, since the global wasn't setup in the conditions where we're now encountering issues (the course builder and during cloning / importing on the admin panel) we didn't have any problems. But now that the `$post` global exists on sites running Yoast (it looks like this is loaded on the admin panel by Yoast intentionally but I can't tell exactly why, nor have I tried to figure it out).

This PR introduces conditional loading of our filters so that on the admin panel (generally, even though we care specifically about the course builder and course importer / cloninig function) and during REST requests the templates and restriction logic handled by `llms_get_post_content()` isn't executed.

This is a WIP. I haven't finished testing it and probably even writing it. I'm hoping to get this deployed this weekend because Yoast conflict bug reports are coming in regularly since 15.8 dropped and the severity is raising for us as a result.

Fixes #1536 
Fixes #1530 

This should also fix https://github.com/gocodebox/lifterlms-assignments/issues/55 (but I haven't run a test against this yet, just theoretically)

## How has this been tested?

+ Added new unit tests, needs more thorough testing to actually ensure the conflict with Yoast (and theoretical conflict with other plugins) doesn't happen anymore. I think this will all fix it based on @eri-trabiccolo recommendations across the various related issues and (failed) PRs to fix the issue.


## Screenshots <!-- if applicable -->

## Types of changes

+ bug fix


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

