### PR TITLE
tie-breaker for multiple enrollment statuses with the same date & time

### DIFF
--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -598,6 +598,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	 * @since 3.17.0 Unknown.
 	 * @since 3.37.9 Added filter `llms_user_enrollment_status_allowed_post_types`.
 	 * @since 4.4.1 Moved filter `llms_user_enrollment_status_allowed_post_types` to function `llms_get_enrollable_status_check_post_types()`.
+	 * @since [version] Added a tie-breaker when there are multiple enrollment statuses with the same date & time.
 	 *
 	 * @param  int  $product_id  WP Post ID of a Course, Section, Lesson, or Membership
 	 * @param  bool $use_cache   If true, returns cached data if available, if false will run a db query
@@ -640,7 +641,9 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			// Get the most recent recorded status.
 			$status = $wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->prefix}lifterlms_user_postmeta WHERE meta_key = '_status' AND user_id = %d AND post_id = %d ORDER BY updated_date DESC LIMIT 1",
+					"SELECT meta_value FROM {$wpdb->prefix}lifterlms_user_postmeta " .
+					"WHERE meta_key = '_status' AND user_id = %d AND post_id = %d " .
+					"ORDER BY updated_date DESC, meta_id DESC LIMIT 1",
 					array( $this->get_id(), $product_id )
 				)
 			);

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -641,9 +641,9 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			// Get the most recent recorded status.
 			$status = $wpdb->get_var(
 				$wpdb->prepare(
-					"SELECT meta_value FROM {$wpdb->prefix}lifterlms_user_postmeta " .
-					"WHERE meta_key = '_status' AND user_id = %d AND post_id = %d " .
-					"ORDER BY updated_date DESC, meta_id DESC LIMIT 1",
+					"SELECT meta_value FROM {$wpdb->prefix}lifterlms_user_postmeta
+					 WHERE meta_key = '_status' AND user_id = %d AND post_id = %d
+					 ORDER BY updated_date DESC, meta_id DESC LIMIT 1;",
 					array( $this->get_id(), $product_id )
 				)
 			);

--- a/tests/phpunit/unit-tests/user/class-llms-test-student.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-student.php
@@ -316,6 +316,7 @@ class LLMS_Test_Student extends LLMS_UnitTestCase {
 	 * @since 3.17.0
 	 * @since 3.33.0 Add test after enrollment deletion.
 	 * @since 3.36.2 Added tests on membership enrollment with related courses enrollments deletion.
+	 * @since [version] Removed the sleep delay between status changes to test statuses with the same date & time.
 	 *
 	 * @return void
 	 */
@@ -336,14 +337,10 @@ class LLMS_Test_Student extends LLMS_UnitTestCase {
 		$this->assertEquals( 'enrolled', $student->get_enrollment_status( $course->get_lessons( 'ids' )[0] ) );
 		$this->assertEquals( 'enrolled', $student->get_enrollment_status( $course->get_lessons( 'ids' )[0] ), false );
 
-		sleep( 1 );
-
 		// expired
 		$student->unenroll( $course_id );
 		$this->assertEquals( 'expired', $student->get_enrollment_status( $course_id ) );
 		$this->assertEquals( 'expired', $student->get_enrollment_status( $course_id, false ) );
-
-		sleep( 1 );
 
 		// deleted
 		$student->delete_enrollment( $course_id );


### PR DESCRIPTION
## Description
Added a tie-breaker when there are multiple enrollment statuses with the same date & time.

## How has this been tested?
I enrolled a student and then immediately changed the enrollment status to 'expired'.
I ran the LifterLMS PHPUnit test suite.

## Types of changes
This is a bug fix that prevents `LLMS_Student->get_enrollment_status()` from returning the first status when it should return the last status.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

