### PR TITLE
Remove declared support for PHP 7.2

### DIFF
--- a/.config/travis/main.yml
+++ b/.config/travis/main.yml
@@ -28,7 +28,6 @@ php:
   - "8.0"
   - "7.4"
   - "7.3"
-  - "7.2"
 
 jobs:
   fast_finish: true

--- a/.llmsdevrc
+++ b/.llmsdevrc
@@ -6,7 +6,7 @@
 			"Tags": "learning management system, LMS, membership, elearning, online courses, quizzes, sell courses, badges, gamification, learning, Lifter, LifterLMS",
 			"Requires at least": "5.2",
 			"Tested up to": "5.7",
-			"Requires PHP": "7.2"
+			"Requires PHP": "7.3"
 		},
 		"changelog": {
 			"link": "https://make.lifterlms.com/tag/lifterlms/"

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -19,7 +19,7 @@
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Requires at least: 5.2
  * Tested up to: 5.7
- * Requires PHP: 7.2
+ * Requires PHP: 7.3
  *
  * * * * * * * * * * * * * * * * * * * * * *
  *                                         *


### PR DESCRIPTION
## Description

Closes #1415 

## How has this been tested?

It hasn't (and doesn't need to be)

## Screenshots <!-- if applicable -->

## Types of changes

Drop support for unsupported PHP 7.2


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

