### PR TITLE
Remove declared support for WP 5.2

### DIFF
--- a/.config/travis/main.yml
+++ b/.config/travis/main.yml
@@ -22,7 +22,6 @@ env:
     - WP_VERSION="5.5"
     - WP_VERSION="5.4"
     - WP_VERSION="5.3"
-    - WP_VERSION="5.2"
 
 php:
   - "8.0"
@@ -39,9 +38,6 @@ jobs:
   - php: nightly
 
   exclude:
-  # These WP Versions don't work on PHP 7.4
-  - php: "7.4"
-    env: WP_VERSION="5.2"
   # These WP Versions don't work on PHP 8.0
   - php: "8.0"
     env: WP_VERSION="5.5"
@@ -49,8 +45,6 @@ jobs:
     env: WP_VERSION="5.4"
   - php: "8.0"
     env: WP_VERSION="5.3"
-  - php: "8.0"
-    env: WP_VERSION="5.2"
 
   include:
   - php: "8.0"

--- a/.llmsdevrc
+++ b/.llmsdevrc
@@ -4,7 +4,7 @@
 		"shortDescription": "LifterLMS is a powerful WordPress learning management system plugin that makes it easy to create, sell, and protect engaging online courses and training based membership websites.",
 		"meta": {
 			"Tags": "learning management system, LMS, membership, elearning, online courses, quizzes, sell courses, badges, gamification, learning, Lifter, LifterLMS",
-			"Requires at least": "5.2",
+			"Requires at least": "5.3",
 			"Tested up to": "5.7",
 			"Requires PHP": "7.2"
 		},

--- a/lifterlms.php
+++ b/lifterlms.php
@@ -17,7 +17,7 @@
  * Domain Path: /languages
  * License: GPLv3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
- * Requires at least: 5.2
+ * Requires at least: 5.3
  * Tested up to: 5.7
  * Requires PHP: 7.2
  *


### PR DESCRIPTION
## Description

Opening this preemptively, it can't be merged into dev (and released) until after WP 5.7 release on 3/9/21

Closes #1550 

## How has this been tested?

It hasn't (and doesn't need to be)

## Screenshots <!-- if applicable -->

## Types of changes

Raises minimum supported WP core version to 5.3

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

