### PR TITLE
WIP: Fix default options when empty string is passed

### DIFF
--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -168,24 +168,27 @@ g	 */
 	 */
 	protected function get_settings() {
 
-		$settings[] = array(
-			'type'  => 'sectionstart',
-			'id'    => 'llms_integration_' . $this->id . '_start',
-			'class' => 'top',
+		$settings = array(
+			array(
+				'type'  => 'sectionstart',
+				'id'    => 'llms_integration_' . $this->id . '_start',
+				'class' => 'top',
+			);
+			array(
+				'desc'  => $this->description,
+				'id'    => 'llms_integration_' . $this->id . '_title',
+				'title' => $this->title,
+				'type'  => 'title',
+			);
+			array(
+				'desc'    => __( 'Check to enable this integration.', 'lifterlms' ),
+				'default' => 'no',
+				'id'      => $this->get_option_name( 'enabled' ),
+				'type'    => 'checkbox',
+				'title'   => __( 'Enable / Disable', 'lifterlms' ),
+			),
 		);
-		$settings[] = array(
-			'desc'  => $this->description,
-			'id'    => 'llms_integration_' . $this->id . '_title',
-			'title' => $this->title,
-			'type'  => 'title',
-		);
-		$settings[] = array(
-			'desc'    => __( 'Check to enable this integration.', 'lifterlms' ),
-			'default' => 'no',
-			'id'      => $this->get_option_name( 'enabled' ),
-			'type'    => 'checkbox',
-			'title'   => __( 'Enable / Disable', 'lifterlms' ),
-		);
+
 		if ( ! $this->is_installed() && ! empty( $this->description_missing ) ) {
 			$settings[] = array(
 				'id'    => 'llms_integration_' . $this->id . '_missing_requirements_desc',

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -20,7 +20,7 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	/**
 	 * Integration ID
 	 *
-	 * Defined by extending class as a variable
+	 * Defined by extending class as a variable.
 	 *
 	 * @var string
 	 */
@@ -61,8 +61,8 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	 *
 	 * In the `configure()` method call `plugin_basename()` on the main plugin file.
 	 *
-	 * @var strin
-g	 */
+	 * @var string
+	 */
 	protected $plugin_basename = '';
 
 	/**

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -61,8 +61,8 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	 *
 	 * In the `configure()` method call `plugin_basename()` on the main plugin file.
 	 *
-	 * @var string
-	 */
+	 * @var strin
+g	 */
 	protected $plugin_basename = '';
 
 	/**
@@ -254,30 +254,26 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	 * Add plugin settings Action Links
 	 *
 	 * @since 3.37.9
+	 * @since [version] Don't check `$context`. If the plugin isn't active this won't run anyway so it's a useless check.
 	 *
-	 * @param string[] $links Existing action links.
-	 * @param string   $file Path to the plugin file, relative to the plugin directory.
-	 * @param array    $data Plugin data
-	 * @param string   $context Plugin's content (eg: active, invactive, etc...);
+	 * @param string[] $links   Existing action links.
+	 * @param string   $file    Path to the plugin file, relative to the plugin directory.
+	 * @param array    $data    Plugin data.
+	 * @param string   $context Plugin's content (eg: active, invactive, etc...).
 	 * @return string[]
 	 */
 	public function plugin_action_links( $links, $file, $data, $context ) {
 
-		// Only add links if the plugin is active.
-		if ( in_array( $context, array( 'all', 'active' ), true ) ) {
+		$url = add_query_arg(
+			array(
+				'page'    => 'llms-settings',
+				'tab'     => 'integrations',
+				'section' => $this->id,
+			),
+			admin_url( 'admin.php' )
+		);
 
-			$url = add_query_arg(
-				array(
-					'page'    => 'llms-settings',
-					'tab'     => 'integrations',
-					'section' => $this->id,
-				),
-				admin_url( 'admin.php' )
-			);
-
-			$links[] = '<a href="' . esc_url( $url ) . '">' . _x( 'Settings', 'Link text for integration plugin settings', 'lifterlms' ) . '</a>';
-
-		}
+		$links[] = '<a href="' . esc_url( $url ) . '">' . _x( 'Settings', 'Link text for integration plugin settings', 'lifterlms' ) . '</a>';
 
 		return $links;
 

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -14,50 +14,52 @@ defined( 'ABSPATH' ) || exit;
  * LifterLMS Integration abstract class
  *
  * @since 3.0.0
- * @since 3.21.1 Updated.
- * @since 3.33.1 Added `get_priority` method to allow reading of the protected priority property.
- * @since 3.37.9 Added automatically generated "Settings" link to plugins screen.
  */
 abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 
 	/**
 	 * Integration ID
+	 *
 	 * Defined by extending class as a variable
 	 *
-	 * @var  string
+	 * @var string
 	 */
 	public $id = '';
 
 	/**
 	 * Integration Title
-	 * Should be defined by extending class in configure() function (so it can be i18n)
 	 *
-	 * @var  string
+	 * Should be defined by extending class in configure() function (so it can be translated).
+	 *
+	 * @var string
 	 */
 	public $title = '';
 
 	/**
 	 * Integration Description
-	 * Should be defined by extending class in configure() function (so it can be i18n)
 	 *
-	 * @var  string
+	 * Should be defined by extending class in configure() function (so it can be translated).
+	 *
+	 * @var string
 	 */
 	public $description = '';
 
 	/**
 	 * Integration Missing Dependencies Description
-	 * Should be defined by extending class in configure() function (so it can be i18n)
-	 * Displays on the settings screen when $this->is_installed() is false
-	 * to help users identify what requirements are missing
 	 *
-	 * @var  string
+	 * Should be defined by extending class in configure() function (so it can be translated).
+	 *
+	 * Displays on the settings screen when `$this->is_installed()` is `false` to help users
+	 * identify what requirements are missing.
+	 *
+	 * @var string
 	 */
 	public $description_missing = '';
 
 	/**
 	 * Reference to the integration plugin's main plugin file basename
 	 *
-	 * In the configure() method call `plugin_basename()` on the main plugin file.
+	 * In the `configure()` method call `plugin_basename()` on the main plugin file.
 	 *
 	 * @var string
 	 */
@@ -65,11 +67,10 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 
 	/**
 	 * Integration Priority
-	 * Determines the order of the settings on the Integrations settings table
-	 * Don't be arrogant developers, your integration may not be the most important to the user
-	 * even if it is the most important to you
 	 *
-	 * Core integrations fire at 5
+	 * Determines the order of the settings on the Integrations settings table.
+	 *
+	 * Built-in core integrations fire at 5.
 	 *
 	 * @var integer
 	 */
@@ -78,15 +79,27 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	/**
 	 * Constructor
 	 *
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.18.2
+	 * @since 3.8.0
+	 * @since 3.18.2 Unknown.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
 		$this->configure();
+
 		add_filter( 'lifterlms_integrations_settings_' . $this->id, array( $this, 'add_settings' ), $this->priority, 1 );
-		do_action( 'llms_integration_' . $this->id . '_init', $this );
+
+		/**
+		 * Trigger an action when the integration is initialized.
+		 *
+		 * The dynamic portion of this hook, `{$this->id}`, refers to the integration's unique ID.
+		 *
+		 * @since [version]
+		 *
+		 * @param object $instance Class instance of the class extending the `LLMS_Abstract_Integration` abstract.
+		 */
+		do_action( "llms_integration_{$this->id}_init", $this );
 
 		if ( ! empty( $this->plugin_basename ) ) {
 			add_action( "plugin_action_links_{$this->plugin_basename}", array( $this, 'plugin_action_links' ), 100, 4 );
@@ -96,22 +109,24 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 
 	/**
 	 * Configure the integration
-	 * Do things like configure ID and title here
 	 *
-	 * @return   void
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * Set required class properties and so on.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return void
 	 */
 	abstract protected function configure();
 
 	/**
 	 * Merge the default abstract settings with the actual integration settings
-	 * Automatically called via filter upon construction
 	 *
-	 * @param    array $settings   existing settings from other integrations
-	 * @return   array
-	 * @since    3.17.8
-	 * @version  3.17.8
+	 * Automatically called via filter upon construction.
+	 *
+	 * @since 3.17.8
+	 *
+	 * @param array $settings Existing settings from other integrations.
+	 * @return array
 	 */
 	public function add_settings( $settings ) {
 		return array_merge( $settings, $this->get_settings() );
@@ -119,12 +134,13 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 
 	/**
 	 * Get additional settings specific to the integration
-	 * extending classes should override this with the settings
-	 * specific to the integration
 	 *
-	 * @return   array
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * Extending classes should override this with the settings
+	 * specific to the integration.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return array
 	 */
 	protected function get_integration_settings() {
 		return array();
@@ -144,9 +160,10 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	/**
 	 * Retrieve an array of integration related settings
 	 *
-	 * @return   array
-	 * @since    3.8.0
-	 * @version  3.21.1
+	 * @since 3.8.0
+	 * @since 3.21.1 Unknown.
+	 *
+	 * @return array
 	 */
 	protected function get_settings() {
 
@@ -184,9 +201,11 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	}
 
 	/**
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * Retrieve the option name prefix.
+	 *
+	 * @since 3.8.0
+	 *
+	 * @return string
 	 */
 	protected function get_option_prefix() {
 		return $this->option_prefix . 'integration_' . $this->id . '_';
@@ -196,9 +215,10 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	 * Determine if the integration is enabled via the checkbox on the admin panel
 	 * and the necessary plugin (if any) is installed and activated
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.17.8
+	 * @since 3.0.0
+	 * @since 3.17.8 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function is_available() {
 		return ( $this->is_installed() && $this->is_enabled() );
@@ -207,22 +227,24 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 	/**
 	 * Determine if the integration had been enabled via checkbox
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.8.0
+	 * @since 3.0.0
+	 * @since 3.8.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function is_enabled() {
 		return ( 'yes' === $this->get_option( 'enabled', 'no' ) );
 	}
 
 	/**
-	 * Determine if the related plugin, theme, 3rd party is
-	 * installed and activated
-	 * extending classes should override this to perform dependency checks
+	 * Determine if required dependencies are installed.
 	 *
-	 * @return   boolean
-	 * @since    3.0.0
-	 * @version  3.8.0
+	 * Extending classes should override this to perform dependency checks.
+	 *
+	 * @since 3.0.0
+	 * @since 3.8.0 Unknown.
+	 *
+	 * @return boolean
 	 */
 	public function is_installed() {
 		return true;
@@ -258,6 +280,7 @@ abstract class LLMS_Abstract_Integration extends LLMS_Abstract_Options_Data {
 		}
 
 		return $links;
+
 	}
 
 }

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -240,6 +240,11 @@ g	 */
 	 */
 	public function get_option_default_value( $default_value, $full_option_name, $passed_default_value ) {
 
+		// If a default value is explicitly passed, use it.
+		if ( $passed_default_value ) {
+			return $default_value;
+		}
+
 		foreach ( $this->get_settings() as $setting ) {
 
 			if ( ! empty( $setting['id'] ) && $full_option_name === $setting['id'] ) {

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts
  *
  * @since 3.0.0
- * @version 3.37.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -161,7 +161,8 @@ g	 */
 	 * Retrieve an array of integration related settings
 	 *
 	 * @since 3.8.0
-	 * @since 3.21.1 Unknown.
+	 * @since 3.21.1 Automatically output the `$description_missing` message when requirements are not met.
+	 * @since [version] Add an 'id' to the missing description HTML setting.
 	 *
 	 * @return array
 	 */
@@ -187,6 +188,7 @@ g	 */
 		);
 		if ( ! $this->is_installed() && ! empty( $this->description_missing ) ) {
 			$settings[] = array(
+				'id'    => 'llms_integration_' . $this->id . '_missing_requirements_desc',
 				'type'  => 'custom-html',
 				'value' => '<em>' . $this->description_missing . '</em>',
 			);
@@ -197,7 +199,17 @@ g	 */
 			'id'   => 'llms_integration_' . $this->id . '_end',
 		);
 
-		return apply_filters( 'llms_integration_' . $this->id . '_get_settings', $settings, $this );
+		/**
+		 * Filters the integration's settings
+		 *
+		 * The dynamic portion of this hook, `{$this->id}`, refers to the integration's ID.
+		 *
+		 * @since 3.8.0
+		 *
+		 * @param array[] $settings Array of settings arrays.
+		 * @param object  $instance Class instance of the class extending the `LLMS_Abstract_Integration` abstract.
+		 */
+		return apply_filters( "llms_integration_{$this->id}_get_settings", $settings, $this );
 	}
 
 	/**

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -250,8 +250,7 @@ g	 */
 			if ( ! empty( $setting['id'] ) && $full_option_name === $setting['id'] ) {
 				$default_value = isset( $setting['default'] ) ? $setting['default'] : $default_value;
 				break;
- 			}
-
+			}
 		}
 
 		return $default_value;

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -248,8 +248,7 @@ g	 */
 		foreach ( $this->get_settings() as $setting ) {
 
 			if ( ! empty( $setting['id'] ) && $full_option_name === $setting['id'] ) {
-				$default_value = isset( $setting['default'] ) ? $setting['default'] : $default_value;
-				break;
+				return isset( $setting['default'] ) ? $setting['default'] : $default_value;
 			}
 		}
 

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -168,25 +168,23 @@ g	 */
 	 */
 	protected function get_settings() {
 
-		$settings = array(
-			array(
-				'type'  => 'sectionstart',
-				'id'    => 'llms_integration_' . $this->id . '_start',
-				'class' => 'top',
-			);
-			array(
-				'desc'  => $this->description,
-				'id'    => 'llms_integration_' . $this->id . '_title',
-				'title' => $this->title,
-				'type'  => 'title',
-			);
-			array(
-				'desc'    => __( 'Check to enable this integration.', 'lifterlms' ),
-				'default' => 'no',
-				'id'      => $this->get_option_name( 'enabled' ),
-				'type'    => 'checkbox',
-				'title'   => __( 'Enable / Disable', 'lifterlms' ),
-			),
+		$settings   = array();
+		$settings[] = array(
+			'type' => 'sectionstart',
+			'id'   => 'llms_integration_' . $this->id . '_start',
+		);
+		$settings[] = array(
+			'desc'  => $this->description,
+			'id'    => 'llms_integration_' . $this->id . '_title',
+			'title' => $this->title,
+			'type'  => 'title',
+		);
+		$settings[] = array(
+			'desc'    => __( 'Check to enable this integration.', 'lifterlms' ),
+			'default' => 'no',
+			'id'      => $this->get_option_name( 'enabled' ),
+			'type'    => 'checkbox',
+			'title'   => __( 'Enable / Disable', 'lifterlms' ),
 		);
 
 		if ( ! $this->is_installed() && ! empty( $this->description_missing ) ) {
@@ -196,6 +194,7 @@ g	 */
 				'value' => '<em>' . $this->description_missing . '</em>',
 			);
 		}
+
 		$settings   = array_merge( $settings, $this->get_integration_settings() );
 		$settings[] = array(
 			'type' => 'sectionend',

--- a/includes/abstracts/llms.abstract.integration.php
+++ b/includes/abstracts/llms.abstract.integration.php
@@ -224,6 +224,36 @@ g	 */
 	}
 
 	/**
+	 * Autoload default option values from values defined in the integration settings array
+	 *
+	 * This will only run when extending integration classes define a version property greater than 1.
+	 *
+	 * This is a callback function for the WP core filter `default_option_{$option}`.
+	 *
+	 * @since [version]
+	 *
+	 * @param mixed  $default_value        The default value. If no value is passed to `get_option()`, this will be an empty string.
+	 *                                     Otherwise it will be the default value passed to the method.
+	 * @param string $full_option_name     The full (prefixed) option name.
+	 * @param bool   $passed_default_value Whether or not a default value was passed to `get_option()`.
+	 * @return mixed The default option value.
+	 */
+	public function get_option_default_value( $default_value, $full_option_name, $passed_default_value ) {
+
+		foreach ( $this->get_settings() as $setting ) {
+
+			if ( ! empty( $setting['id'] ) && $full_option_name === $setting['id'] ) {
+				$default_value = isset( $setting['default'] ) ? $setting['default'] : $default_value;
+				break;
+ 			}
+
+		}
+
+		return $default_value;
+
+	}
+
+	/**
 	 * Determine if the integration is enabled via the checkbox on the admin panel
 	 * and the necessary plugin (if any) is installed and activated
 	 *

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -25,7 +25,7 @@ abstract class LLMS_Abstract_Options_Data {
 	protected $option_prefix = 'llms_';
 
 	/**
-	 * Class version
+	 * Options data abstract version
 	 *
 	 * This is used to determine the behavior of the `get_option()` method.
 	 *
@@ -62,6 +62,7 @@ abstract class LLMS_Abstract_Options_Data {
 		// Call this way so that the `$passed_default_value` of the filter is accurate based on the number of arguments actually passed.
 		$args = func_num_args() > 1 ? array( $full_name, $default ) : array( $full_name );
 		$val  = get_option( ...$args );
+
 		remove_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
 
 		return $val;

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.8.0
- * @version 3.17.8
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -57,7 +57,6 @@ abstract class LLMS_Abstract_Options_Data {
 			$default = 1 === func_num_args() ? '' : $default;
 			return $this->get_option_deprecated( $full_name, $default );
 		}
-
 
 		add_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
 

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -49,14 +49,15 @@ abstract class LLMS_Abstract_Options_Data {
 	 */
 	public function get_option( $name, $default = false ) {
 
+		$full_name = $this->get_option_name( $name );
+
 		// If the class is version 1, use the old method.
 		if ( 1 === $this->version ) {
 			// If only one argument is passed switch the default to the old argument default (an empty string).
 			$default = 1 === func_num_args() ? '' : $default;
-			return $this->get_option_deprecated( $name, $default );
+			return $this->get_option_deprecated( $full_name, $default );
 		}
 
-		$full_name = $this->get_option_name( $name );
 
 		add_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
 
@@ -79,12 +80,12 @@ abstract class LLMS_Abstract_Options_Data {
 	 *
 	 * @since [version]
 	 *
-	 * @param [type] $name [description]
-	 * @param string $default [description]
-	 * @return [type] [description]
+	 * @param string $name     Full (prefixed) option name.
+	 * @param mixed  $default  Default value to use if no option is found.
+	 * @return mixed The option value.
 	 */
 	private function get_option_deprecated( $name, $default = '' ) {
-		$val = get_option( $this->get_option_name( $name ), '' );
+		$val = get_option( $name, '' );
 		if ( '' === $val ) {
 			return $default;
 		}

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -25,20 +25,88 @@ abstract class LLMS_Abstract_Options_Data {
 	protected $option_prefix = 'llms_';
 
 	/**
+	 * Class version
+	 *
+	 * This is used to determine the behavior of the `get_option()` method.
+	 *
+	 * Concrete classes should use version 2 in order to use the new (future default)
+	 * behavior of the method.
+	 *
+	 * @var int
+	 */
+	protected $version = 1;
+
+
+	/**
 	 * Retrieve the value of an option from the database
 	 *
 	 * @since 3.8.0
+	 * @since [version] Changed the behavior of the function when the concrete class defines `$this->version` greater than 1.
 	 *
-	 * @param string $name    Option name (unprefixed).
-	 * @param mixed  $default Default value to use if no option is found.
-	 * @return mixed
+	 * @param string $name     Option name (unprefixed).
+	 * @param mixed  $default  Default value to use if no option is found.
+	 * @return mixed The option value.
 	 */
-	public function get_option( $name, $default = '' ) {
+	public function get_option( $name, $default = false ) {
+
+		// If the class is version 1, use the old method.
+		if ( 1 === $this->version ) {
+			// If only one argument is passed switch the default to the old argument default (an empty string).
+			$default = 1 === func_num_args() ? '' : $default;
+			return $this->get_option_deprecated( $name, $default );
+		}
+
+		$full_name = $this->get_option_name( $name );
+
+		add_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
+
+		// Call this way so that the `$passed_default_value` of the filter is accurate based on the number of arguments actually passed.
+		$args = func_num_args() > 1 ? array( $full_name, $default ) : array( $full_name );
+		$val = call_user_func_array( 'get_option', $args );
+		remove_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
+
+		return $val;
+
+	}
+
+	/**
+	 * Retrieve the value of an option from the database
+	 *
+	 * This is the "old" (to be deprecated) version of the function.
+	 *
+	 * We will transition extending classes little by little to use the new behavior and deprecate this once
+	 * all classes are fully transitioned.
+	 *
+	 * @since [version]
+	 *
+	 * @param [type] $name [description]
+	 * @param string $default [description]
+	 * @return [type] [description]
+	 */
+	private function get_option_deprecated( $name, $default = '' ) {
 		$val = get_option( $this->get_option_name( $name ), '' );
 		if ( '' === $val ) {
 			return $default;
 		}
 		return $val;
+	}
+
+	/**
+	 * Option default value autoloader
+	 *
+	 * By default, this method does nothing but extending classes can implement an autoloader to pull
+	 * default values from other sources.
+	 *
+	 * @since [version]
+	 *
+	 * @param mixed  $default_value        The default value. If no value is passed to `get_option()`, this will be an empty string.
+	 *                                     Otherwise it will be the default value passed to the method.
+	 * @param string $full_option_name     The full (prefixed) option name.
+	 * @param bool   $passed_default_value Whether or not a default value was passed to `get_option()`.
+	 * @return mixed The default option value.
+	 */
+	public function get_option_default_value( $default_value, $full_option_name, $passed_default_value ) {
+		return $default_value;
 	}
 
 	/**

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -63,7 +63,7 @@ abstract class LLMS_Abstract_Options_Data {
 
 		// Call this way so that the `$passed_default_value` of the filter is accurate based on the number of arguments actually passed.
 		$args = func_num_args() > 1 ? array( $full_name, $default ) : array( $full_name );
-		$val  = call_user_func_array( 'get_option', $args );
+		$val  = get_option( ...$args );
 		remove_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
 
 		return $val;

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -36,7 +36,6 @@ abstract class LLMS_Abstract_Options_Data {
 	 */
 	protected $version = 1;
 
-
 	/**
 	 * Retrieve the value of an option from the database
 	 *
@@ -96,6 +95,8 @@ abstract class LLMS_Abstract_Options_Data {
 	 *
 	 * By default, this method does nothing but extending classes can implement an autoloader to pull
 	 * default values from other sources.
+	 *
+	 * This is a callback function for the WP core filter `default_option_{$option}`.
 	 *
 	 * @since [version]
 	 *

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -62,7 +62,7 @@ abstract class LLMS_Abstract_Options_Data {
 
 		// Call this way so that the `$passed_default_value` of the filter is accurate based on the number of arguments actually passed.
 		$args = func_num_args() > 1 ? array( $full_name, $default ) : array( $full_name );
-		$val = call_user_func_array( 'get_option', $args );
+		$val  = call_user_func_array( 'get_option', $args );
 		remove_filter( "default_option_{$full_name}", array( $this, 'get_option_default_value' ), 10, 3 );
 
 		return $val;

--- a/includes/abstracts/llms.abstract.options.data.php
+++ b/includes/abstracts/llms.abstract.options.data.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * LifterLMS Options Table Data Store Abstract
+ * LifterLMS Options Table Data Store abstract class
  *
  * @package LifterLMS/Abstracts/Classes
  *
@@ -11,23 +11,27 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS Options Table Data Store abstract class
+ * LifterLMS Options Table Data Store abstract
  *
  * @since 3.8.0
- * @since 3.17.8 Added `set_option()` method.
  */
 abstract class LLMS_Abstract_Options_Data {
 
+	/**
+	 * Option name prefix.
+	 *
+	 * @var string
+	 */
 	protected $option_prefix = 'llms_';
 
 	/**
 	 * Retrieve the value of an option from the database
 	 *
-	 * @param    string $name     option name (unprefixed)
-	 * @param    mixed  $default  default value to use if no option is found
-	 * @return   mixed
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $name    Option name (unprefixed).
+	 * @param mixed  $default Default value to use if no option is found.
+	 * @return mixed
 	 */
 	public function get_option( $name, $default = '' ) {
 		$val = get_option( $this->get_option_name( $name ), '' );
@@ -40,9 +44,9 @@ abstract class LLMS_Abstract_Options_Data {
 	/**
 	 * Retrieve a prefix for options
 	 *
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @return string
 	 */
 	protected function get_option_prefix() {
 		return $this->option_prefix;
@@ -53,10 +57,10 @@ abstract class LLMS_Abstract_Options_Data {
 	 * Prefix automatically adds a trigger and type to the option name
 	 * in addition to llms_notification
 	 *
-	 * @param    string $name  option name (unprefixed)
-	 * @return   string
-	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @since 3.8.0
+	 *
+	 * @param string $name Option name (unprefixed).
+	 * @return string
 	 */
 	public function get_option_name( $name ) {
 		return $this->get_option_prefix() . $name;
@@ -65,12 +69,11 @@ abstract class LLMS_Abstract_Options_Data {
 	/**
 	 * Set the value of an option
 	 *
-	 * @param    string $name   option name (unprefixed)
-	 * @param    mixed  $value  option value
-	 * @return   bool               true if option value has changed
-	 *                              false if no update or update failed
-	 * @since    3.17.8
-	 * @version  3.17.8
+	 * @since 3.17.8
+	 *
+	 * @param string $name  Option name (unprefixed).
+	 * @param mixed  $value Option value.
+	 * @return bool Returns `true` if option value has changed and `false` if no update or the update failed.
 	 */
 	public function set_option( $name, $value ) {
 		return update_option( $this->get_option_name( $name ), $value );

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
@@ -130,9 +130,11 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 		LLMS_Unit_Test_Util::set_private_property( $stub, 'version', 2 );
 
 		$this->assertEquals( 'no', $stub->get_option( 'enabled' ) );
-		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'yes' ) );
+
+		// Don't autoload the default value when a default value is passed.
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'yes' ) );
 		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'no' ) );
-		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'fake' ) );
+		$this->assertEquals( 'fake', $stub->get_option( 'enabled', 'fake' ) );
 
 		$stub->set_option( 'enabled', 'yes' );
 		$this->assertEquals( 'yes', $stub->get_option( 'enabled' ) );

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
@@ -158,6 +158,9 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 		$this->assertEquals( 'no', $stub->get_option_default_value( '', $stub->get_option_name( 'enabled' ), false ) );
 		$this->assertEquals( 'no', $stub->get_option_default_value( 'yes', $stub->get_option_name( 'enabled' ), false ) );
 
+		// Default value explicitly passed.
+		$this->assertEquals( 'yes', $stub->get_option_default_value( 'yes', $stub->get_option_name( 'enabled' ), true ) );
+
 	}
 
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
@@ -116,4 +116,21 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test plugin_action_links()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_plugin_action_links() {
+
+		$mock_links    = array( '<a href="#">FAKE</a>' );
+		$expected_link = array( '<a href="http://example.org/wp-admin/admin.php?page=llms-settings&#038;tab=integrations&#038;section=mocker">Settings</a>' );
+		$stub          = $this->get_stub();
+
+		$this->assertEquals( array_merge( $mock_links, $expected_link ), $stub->plugin_action_links( $mock_links, 'mock', array(), 'all' ) );
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
@@ -1,24 +1,28 @@
 <?php
 /**
  * Tests for the LLMS_Abstract_Integration class
- * @group    abstracts
- * @group    integrations
- * @since    3.19.0
- * @version  3.19.0
+ *
+ * @package LifterLMS/Tests/Abstracts
+ *
+ * @group abstracts
+ * @group integrations
+ *
+ * @since 3.19.0
  */
 class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 
 	/**
 	 * Retrieve the abstract class mock stub
-	 * @return   obj
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return LLMS_Abstract_Integration
 	 */
 	private function get_stub() {
 
 		$stub = $this->getMockForAbstractClass( 'LLMS_Abstract_Integration' );
 
-		// setup variables that would be configured by abstract configure method
+		// Setup variables that would be configured by abstract configure method.
 		$stub->title = 'Mock Integration';
 		$stub->id = 'mocker';
 		$stub->description = 'this is a mock description of the integration';
@@ -28,44 +32,46 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * test add_settings() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 * Test add_settings() method
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_add_settings() {
 
 		$stub = $this->get_stub();
 
-		// must be an array
+		// Must be an array.
 		$this->assertTrue( is_array( $stub->add_settings( array() ) ) );
 
-		// only the default integration settings
+		// Only the default integration settings.
 		$this->assertEquals( 4, count( $stub->add_settings( array() ) ) );
 
-		// mimic other settings from other integrations
+		// Mimic other settings from other integrations.
 		$this->assertEquals( 10, count( $stub->add_settings( array( 1, 2, 3, 4, 5, 6 ) ) ) );
 
 	}
 
 	/**
 	 * Test is_available() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_is_available() {
 
 		$stub = $this->get_stub();
 
-		// by default it is not available
+		// By default it is not available.
 		$this->assertFalse( $stub->is_available() );
 
-		// enable it
+		// Enable it.
 		$stub->set_option( 'enabled', 'yes' );
 		$this->assertTrue( $stub->is_available() );
 
-		// explicitly disable it
+		// Explicitly disable it.
 		$stub->set_option( 'enabled', 'no' );
 		$this->assertFalse( $stub->is_available() );
 
@@ -73,33 +79,36 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 
 	/**
 	 * Test is_enabled() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_is_enabled() {
 
 		$stub = $this->get_stub();
 
-		// disabled by default (no option found)
+		// Disabled by default (no option found).
 		$this->assertFalse( $stub->is_enabled() );
 
-		// enable it
+		// Enable it.
 		$stub->set_option( 'enabled', 'yes' );
 		$this->assertTrue( $stub->is_enabled() );
 
-		// explicitly disable it
+		// Explicitly disable it.
 		$stub->set_option( 'enabled', 'no' );
 		$this->assertFalse( $stub->is_enabled() );
 
 	}
 
 	/**
-	 * test is_installed() method
-	 * by default this just returns true, extending classes override it
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 * Test is_installed() method
+	 *
+	 * By default this just returns true, extending classes override it
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_is_installed() {
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-integration.php
@@ -95,6 +95,71 @@ class LLMS_Test_Abstract_Integration extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test the get_option() method v1 behavior
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_v1() {
+
+		$stub = $this->get_stub();
+		$this->assertEquals( '', $stub->get_option( 'enabled' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'yes' ) );
+		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'no' ) );
+		$this->assertEquals( 'fake', $stub->get_option( 'enabled', 'fake' ) );
+
+		$stub->set_option( 'enabled', 'yes' );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'yes' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'no' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'fake' ) );
+
+	}
+
+	/**
+	 * Test the get_option() method v2 behavior
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_v2() {
+
+		$stub = $this->get_stub();
+		LLMS_Unit_Test_Util::set_private_property( $stub, 'version', 2 );
+
+		$this->assertEquals( 'no', $stub->get_option( 'enabled' ) );
+		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'yes' ) );
+		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'no' ) );
+		$this->assertEquals( 'no', $stub->get_option( 'enabled', 'fake' ) );
+
+		$stub->set_option( 'enabled', 'yes' );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'yes' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'no' ) );
+		$this->assertEquals( 'yes', $stub->get_option( 'enabled', 'fake' ) );
+
+	}
+
+	/**
+	 * Directly test the get_option_default_value() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_default_value() {
+
+		$stub = $this->get_stub();
+
+		$this->assertEquals( 'no', $stub->get_option_default_value( '', $stub->get_option_name( 'enabled' ), false ) );
+		$this->assertEquals( 'no', $stub->get_option_default_value( 'yes', $stub->get_option_name( 'enabled' ), false ) );
+
+	}
+
+
+	/**
 	 * Test the get_priority() method
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
@@ -2,6 +2,8 @@
 /**
  * Tests for the LLMS_Abstract_Integration class
  *
+ * @package LifterLMS/Tests/Abstracts
+ *
  * @group abstracts
  * @group options
  * @group settings
@@ -34,9 +36,13 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 		$stub = $this->get_stub();
 
-		// default value
+		// Default value.
 		$this->assertEquals( '', $stub->get_option( 'mock_option' ) );
 		$this->assertEquals( 'mockvalue', $stub->get_option( 'mock_option', 'mockvalue' ) );
+
+		// This is a bug?
+		update_option( 'llms_mock_option', '' );
+		$this->assertEquals( '', $stub->get_option( 'mock_option', 'mockvalue' ) );
 
 		update_option( 'llms_mock_option', 'mockvalue' );
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
@@ -1,19 +1,21 @@
 <?php
 /**
  * Tests for the LLMS_Abstract_Integration class
- * @group    abstracts
- * @group    options
- * @group    settings
- * @since    3.19.0
- * @version  3.19.0
+ *
+ * @group abstracts
+ * @group options
+ * @group settings
+ *
+ * @since 3.19.0
  */
 class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 	/**
 	 * Retrieve the abstract class mock stub
-	 * @return   obj
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return obj
 	 */
 	private function get_stub() {
 
@@ -23,9 +25,10 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 	/**
 	 * test get_option() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_get_option() {
 
@@ -44,9 +47,10 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 	/**
 	 * test get_option_name() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_get_option_name() {
 
@@ -66,9 +70,10 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 	/**
 	 * test set_option() method
-	 * @return   void
-	 * @since    3.19.0
-	 * @version  3.19.0
+	 *
+	 * @since 3.19.0
+	 *
+	 * @return void
 	 */
 	public function test_set_option() {
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-options-data.php
@@ -9,24 +9,24 @@
  * @group settings
  *
  * @since 3.19.0
+ * @since [version] Replaced the `get_stub()` method with `$this->main`, initialized in `setUp()`.
  */
 class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 
 	/**
-	 * Retrieve the abstract class mock stub
+	 * Setup the test case.
 	 *
-	 * @since 3.19.0
+	 * @since [version]
 	 *
-	 * @return obj
+	 * @return void
 	 */
-	private function get_stub() {
-
-		return $this->getMockForAbstractClass( 'LLMS_Abstract_Options_Data' );
-
+	public function setUp() {
+		parent::setUp();
+		$this->main = $this->getMockForAbstractClass( 'LLMS_Abstract_Options_Data' );
 	}
 
 	/**
-	 * test get_option() method
+	 * Test get_option(): version 1 behavior.
 	 *
 	 * @since 3.19.0
 	 *
@@ -34,20 +34,86 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 	 */
 	public function test_get_option() {
 
-		$stub = $this->get_stub();
-
 		// Default value.
-		$this->assertEquals( '', $stub->get_option( 'mock_option' ) );
-		$this->assertEquals( 'mockvalue', $stub->get_option( 'mock_option', 'mockvalue' ) );
-
-		// This is a bug?
-		update_option( 'llms_mock_option', '' );
-		$this->assertEquals( '', $stub->get_option( 'mock_option', 'mockvalue' ) );
+		$this->assertEquals( '', $this->main->get_option( 'mock_option' ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'mockvalue' ) );
 
 		update_option( 'llms_mock_option', 'mockvalue' );
 
-		$this->assertEquals( 'mockvalue', $stub->get_option( 'mock_option' ) );
-		$this->assertEquals( 'mockvalue', $stub->get_option( 'mock_option', 'anothermockvalue' ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option' ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'anothermockvalue' ) );
+
+	}
+
+	/**
+	 * Test get_option() when there's an empty string value explicitly saved in the database
+	 *
+	 * This test illustrates what's actually a bug but exists as expected behavior. Fixing this bug
+	 * might result in unexpected consequences throughout add-ons utilizing the existing behavior as
+	 * if it were intended and not a bug.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_v1_expected_bug() {
+
+		// An empty string value is expected here but due to the bug the supplied default value is supplied instead.
+		update_option( 'llms_mock_option', '' );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'mockvalue' ) );
+
+		// Option Does not exist so we should get the default value either way.
+		delete_option( 'llms_mock_option' );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'mockvalue' ) );
+
+	}
+
+	/**
+	 * Test get_option(): v2 behavior
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_v2_behavior() {
+
+		LLMS_Unit_Test_Util::set_private_property( $this->main, 'version', 2 );
+
+		// No default passed.
+		$this->assertEquals( '', $this->main->get_option( 'mock_option' ) );
+
+		// Default value passed.
+		$this->assertEquals( '', $this->main->get_option( 'mock_option', '' ) );
+		$this->assertEquals( false, $this->main->get_option( 'mock_option', false ) );
+		$this->assertEquals( array(), $this->main->get_option( 'mock_option', array() ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'mockvalue' ) );
+
+		update_option( 'llms_mock_option', 'mockvalue' );
+
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option' ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', '' ) );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'anothermockvalue' ) );
+
+	}
+
+	/**
+	 * Run test_get_option_v1_expected_bug() on v2 to see the bug fixed.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_option_v2_expected_bug_fixed() {
+
+		LLMS_Unit_Test_Util::set_private_property( $this->main, 'version', 2 );
+
+		// This fails on v1, see `test_get_option_v1_expected_bug()`.
+		update_option( 'llms_mock_option', '' );
+		$this->assertEquals( '', $this->main->get_option( 'mock_option', 'mockvalue' ) );
+
+		// Option Does not exist so we should get the default value.
+		delete_option( 'llms_mock_option' );
+		$this->assertEquals( 'mockvalue', $this->main->get_option( 'mock_option', 'mockvalue' ) );
 
 	}
 
@@ -55,22 +121,18 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 	 * test get_option_name() method
 	 *
 	 * @since 3.19.0
+	 * @since [version] Use unit test utils to update private property value.
 	 *
 	 * @return void
 	 */
 	public function test_get_option_name() {
 
-		$stub = $this->get_stub();
+		$this->assertEquals( 'llms_mock_option', $this->main->get_option_name( 'mock_option' ) );
 
-		$this->assertEquals( 'llms_mock_option', $stub->get_option_name( 'mock_option' ) );
+		// Change the option prefix as an extending class might via overriding the `get_option_prefix()` method
+		LLMS_Unit_Test_Util::set_private_property( $this->main, 'option_prefix', 'llms_extended_' );
 
-		// change the option prefix as an extending class might via overriding the `get_option_prefix()` method
-		$reflection = new ReflectionClass( $this->get_stub() );
-		$prop = $reflection->getProperty( 'option_prefix' );
-		$prop->setAccessible( true );
-		$prop->setValue( $stub, 'llms_extended_' );
-
-		$this->assertEquals( 'llms_extended_mock_option', $stub->get_option_name( 'mock_option' ) );
+		$this->assertEquals( 'llms_extended_mock_option', $this->main->get_option_name( 'mock_option' ) );
 
 	}
 
@@ -84,7 +146,7 @@ class LLMS_Test_Abstract_Options_Data extends LLMS_UnitTestCase {
 	public function test_set_option() {
 
 		delete_option( 'llms_mock_option' );
-		$this->assertEquals( true, $this->get_stub()->set_option( 'mock_option', 'mockvalue' ) );
+		$this->assertEquals( true, $this->main->set_option( 'mock_option', 'mockvalue' ) );
 		$this->assertEquals( 'mockvalue', get_option( 'llms_mock_option', 'mockvalue' ) );
 
 	}


### PR DESCRIPTION
## Description

Fixes #1568

This adds an opt-in version of the abstract that concrete classes can implement in order to choose to use the new version of the `get_option()` method.

The new version will additionally automatically add a filter on `default_option_{$option}` (https://developer.wordpress.org/reference/hooks/default_option_option/) which will allow autoloading of options from integration settings (or other places), depending on the implementation provided by the extending class. 

## How has this been tested?

Unit tests only. I've written tests that expose the bug (and fix the bug) using stubs only.

This means that nothing will actually change until we start defining `$version=2` in some classes.

I've marked this as a WIP so we can discuss the problem better.

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix / forward compat

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

