### PR TITLE
Allow submitting numeric fields with no max/min attribute set

### DIFF
--- a/includes/class-llms-form-validator.php
+++ b/includes/class-llms-form-validator.php
@@ -189,10 +189,10 @@ class LLMS_Form_Validator {
 			// Translators: %1$s field label or name; %2$s = user submitted value.
 			return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" is not valid number.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value ) );
 		} elseif ( isset( $field['attributes'] ) ) {
-			if ( ! empty( $field['attributes']['min'] ) || ( isset( $field['attributes']['min'] ) && '0' === $field['attributes']['min'] ) && $temp_value < $field['attributes']['min'] ) {
+			if ( ( ! empty( $field['attributes']['min'] ) || ( isset( $field['attributes']['min'] ) && '0' === $field['attributes']['min'] ) ) && $temp_value < $field['attributes']['min'] ) {
 				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = minimum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be greater than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['min'] ) );
-			} elseif ( ! empty( $field['attributes']['max'] ) || ( isset( $field['attributes']['max'] ) && '0' === $field['attributes']['max'] ) && $temp_value > $field['attributes']['max'] ) {
+			} elseif ( ( ! empty( $field['attributes']['max'] ) || ( isset( $field['attributes']['max'] ) && '0' === $field['attributes']['max'] ) ) && $temp_value > $field['attributes']['max'] ) {
 				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = maximum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be less than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['max'] ) );
 			}

--- a/includes/class-llms-form-validator.php
+++ b/includes/class-llms-form-validator.php
@@ -189,10 +189,10 @@ class LLMS_Form_Validator {
 			// Translators: %1$s field label or name; %2$s = user submitted value.
 			return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" is not valid number.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value ) );
 		} elseif ( isset( $field['attributes'] ) ) {
-			if ( isset( $field['attributes']['min'] ) && $temp_value < $field['attributes']['min'] ) {
+			if ( ! empty( $field['attributes']['min'] ) || ( isset( $field['attributes']['min'] ) && '0' === $field['attributes']['min'] ) && $temp_value < $field['attributes']['min'] ) {
 				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = minimum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be greater than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['min'] ) );
-			} elseif ( isset( $field['attributes']['max'] ) && $temp_value > $field['attributes']['max'] ) {
+			} elseif ( ! empty( $field['attributes']['max'] ) || ( isset( $field['attributes']['max'] ) && '0' === $field['attributes']['max'] ) && $temp_value > $field['attributes']['max'] ) {
 				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = maximum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be less than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['max'] ) );
 			}

--- a/tests/phpunit/unit-tests/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/class-llms-test-form-validator.php
@@ -582,6 +582,43 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test number field validation with empty limits
+	 *
+	 * When min|max attributes are set but empty (like empty string): default.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_validate_field_for_number_with_empty_limits() {
+
+		$field = $this->get_field_arr( 'number', array( 'name' => 'number_field' ) );
+
+		$field['attributes']['min'] = '';
+		$field['attributes']['max'] = '';
+
+		$this->assertTrue( $this->main->validate_field( '1', $field ) );
+		$this->assertIsWPError( $this->main->validate_field( ' fake 2 mock', $field ) );
+
+		$field['attributes']['min'] = '0';
+		$field['attributes']['max'] = '';
+
+		$this->assertTrue( $this->main->validate_field( '1', $field ) );
+		$this->assertIsWPError( $this->main->validate_field( ' fake 2 mock', $field ) );
+		$this->assertIsWPError( $this->main->validate_field( '-1', $field ) );
+		$this->assertStringContains( 'greater', $this->main->validate_field( '-1', $field )->get_error_message() );
+
+		$field['attributes']['min'] = '';
+		$field['attributes']['max'] = '5';
+
+		$this->assertTrue( $this->main->validate_field( '1', $field ) );
+		$this->assertIsWPError( $this->main->validate_field( ' fake 2 mock', $field ) );
+		$this->assertIsWPError( $this->main->validate_field( '6', $field ) );
+		$this->assertStringContains( 'less', $this->main->validate_field( '6', $field )->get_error_message() );
+
+	}
+
+	/**
 	 * Test special voucher field validation.
 	 *
 	 * @since [version]


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Fixes #1577|4

> a numeric field with no limits set doesn’t validate for positive numbers in front after submission, I got an error saying that the value should be less than 0 (sorry I think that was the error I haven’t copied :()

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

