### PR TITLE
Handle fields that allow multiple values (e.g. checkboxes)

### DIFF
--- a/includes/class-llms-form-field.php
+++ b/includes/class-llms-form-field.php
@@ -78,7 +78,7 @@ class LLMS_Form_Field {
 	 *
 	 * @since [version]
 	 *
-	 * @param string[]|string $classes Classes
+	 * @param string[]|string $classes  Classes.
 	 * @param string[]        $defaults Default classes.
 	 * @return string[]
 	 */
@@ -184,9 +184,9 @@ class LLMS_Form_Field {
 		 *
 		 * @since [version]
 		 *
-		 * @param string $html Override html.
-		 * @param array $settings Array of field settings initially passed to the class constructor.
-		 * @param LLMS_Form_Field $field Form field object.
+		 * @param string          $html     Override html.
+		 * @param array           $settings Array of field settings initially passed to the class constructor.
+		 * @param LLMS_Form_Field $field    Form field object.
 		 */
 		$override = apply_filters( 'llms_form_field_get_' . $this->settings['type'] . '_html', '', $this->settings, $this );
 		if ( ! empty( $override ) ) {
@@ -225,13 +225,17 @@ class LLMS_Form_Field {
 				} else {
 
 					$classes[] = 'llms-input-group';
-					$value     = ! empty( $this->settings['value'] ) ? $this->settings['value'] : $this->settings['default'];
+					$value     = ! empty( $this->settings['value'] ) || is_array( $this->settings['value'] ) ? $this->settings['value'] : $this->settings['default'];
 
 					foreach ( $this->settings['options'] as $key => $val ) {
 
-						$name = $this->settings['name'];
+						$name    = $this->settings['name'];
+						$checked = $value === $key;
+
 						if ( 'checkbox' === $this->settings['type'] ) {
-							$name .= '[]';
+							$name   .= '[]';
+							$value   = is_array( $value ) ? $value : array( $value );
+							$checked = in_array( $key, $value, true );
 						}
 
 						$field       = new self(
@@ -241,7 +245,7 @@ class LLMS_Form_Field {
 								'name'       => $name,
 								'value'      => $key,
 								'label'      => $val,
-								'checked'    => ( $value === $key ),
+								'checked'    => $checked,
 								'type'       => $this->settings['type'],
 							)
 						);
@@ -357,8 +361,8 @@ class LLMS_Form_Field {
 		 *
 		 * @since [version]
 		 *
-		 * @param string $pre The pre-rendered HTML content. Default `null`.
-		 * @param array $settings The prepared field settings array.
+		 * @param string          $pre       The pre-rendered HTML content. Default `null`.
+		 * @param array           $settings  The prepared field settings array.
 		 * @param LLMS_Form_Field $field_obj Form field instance.
 		 */
 		$pre = apply_filters( 'llms_form_field_pre_render', null, $this->settings, $this );
@@ -419,7 +423,7 @@ class LLMS_Form_Field {
 			 * @since Unknown.
 			 *
 			 * @param string $character The character used to denote a required field. Defaults to "*" (an asterisk).
-			 * @param array $settings Associative array of field settings.
+			 * @param array  $settings  Associative array of field settings.
 			 */
 			$char     = apply_filters( 'lifterlms_form_field_required_character', '*', $this->settings );
 			$required = sprintf( '<span class="llms-required">%s</span>', $char );
@@ -621,7 +625,12 @@ class LLMS_Form_Field {
 					$prepared[ $item_key ] = $val['text'];
 
 					if ( isset( $val['default'] ) && llms_parse_bool( $val['default'] ) ) {
-						$this->settings['default'] = $item_key;
+						if ( 'checkbox' === $this->settings['type'] ) { // Account for multiple defaults.
+							$this->settings['default']   = is_array( $this->settings['default'] ) ? $this->settings['default'] : array();
+							$this->settings['default'][] = $item_key;
+						} else {
+							$this->settings['default'] = $item_key;
+						}
 					}
 				}
 
@@ -671,8 +680,8 @@ class LLMS_Form_Field {
 				 *
 				 * @since [version]
 				 *
-				 * @param array $options Array of options.
-				 * @param array $settings Prepared field settings.
+				 * @param array $options              Array of options.
+				 * @param array $settings             Prepared field settings.
 				 * @param LLMS_Form_Field $fomr_field Form field object instance.
 				 */
 				$options = apply_filters( "llms_form_field_options_preset_{$preset_id}", array(), $this->settings, $this );
@@ -838,7 +847,7 @@ class LLMS_Form_Field {
 		}
 
 		// Add default value if there's no explicit value and a default value is set.
-		if ( ! $this->settings['value'] && '' !== $this->settings['default'] ) {
+		if ( ! $this->settings['value'] && ! is_array( $this->settings['value'] ) && '' !== $this->settings['default'] ) {
 			$this->settings['value'] = $this->settings['default'];
 		}
 

--- a/includes/class-llms-form-handler.php
+++ b/includes/class-llms-form-handler.php
@@ -223,18 +223,22 @@ class LLMS_Form_Handler {
 
 		$prepared = array();
 
-		foreach ( $posted_data as $name => $value ) {
+		foreach ( $fields as $field ) {
 
-			$field = $forms->get_field_by( $fields, 'name', $name );
-			if ( ! $field || empty( $field['data_store_key'] ) ) {
+			if ( empty( $field['data_store_key'] ) ) {
 				continue;
 			}
 
-			if ( ! isset( $prepared[ $field['data_store'] ] ) ) {
-				$prepared[ $field['data_store'] ] = array();
-			}
-			$prepared[ $field['data_store'] ][ $field['data_store_key'] ] = $value;
+			// We need to account for fields that are part of the form but are not present in the `$posted_data`
+			// e.g. unchecked check boxes.
+			if ( isset( $posted_data[ $field['name'] ] ) || 'checkbox' === $field['type'] ) {
 
+				if ( ! isset( $prepared[ $field['data_store'] ] ) ) {
+					$prepared[ $field['data_store'] ] = array();
+				}
+
+				$prepared[ $field['data_store'] ][ $field['data_store_key'] ] = isset( $posted_data[ $field['name'] ] ) ? $posted_data[ $field['name'] ] : array();
+			}
 		}
 
 		if ( 'registration' === $action ) {

--- a/includes/class-llms-form-validator.php
+++ b/includes/class-llms-form-validator.php
@@ -37,7 +37,7 @@ class LLMS_Form_Validator {
 	}
 
 	/**
-	 * Sanitize a single field according to its type.
+	 * Sanitize a single field according to its type
 	 *
 	 * @since [version]
 	 *
@@ -57,7 +57,7 @@ class LLMS_Form_Validator {
 
 		$func = isset( $map[ $field['type'] ] ) ? $map[ $field['type'] ] : 'sanitize_text_field';
 
-		// Turn the submitted value into array, so to unify validation of scalar and array posted values.
+		// Turn the submitted value into array, so to unify sanitization of scalar and array posted values.
 		$to_sanitize = is_array( $posted_value ) ? $posted_value : array( $posted_value );
 		$sanitized   = array();
 
@@ -95,12 +95,12 @@ class LLMS_Form_Validator {
 	}
 
 	/**
-	 * Sanitize all user-submitted data according to field settings.
+	 * Sanitize all user-submitted data according to field settings
 	 *
 	 * @since [version]
 	 *
 	 * @param array   $posted_data User-submitted form data.
-	 * @param array[] $fields LifterLMS form fields settings.
+	 * @param array[] $fields      LifterLMS form fields settings.
 	 * @return array
 	 */
 	public function sanitize_fields( $posted_data, $fields ) {
@@ -120,7 +120,7 @@ class LLMS_Form_Validator {
 	}
 
 	/**
-	 * Validate a posted value.
+	 * Validate a posted value
 	 *
 	 * @since [version]
 	 *
@@ -203,10 +203,10 @@ class LLMS_Form_Validator {
 			return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" is not valid number.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value ) );
 		} elseif ( isset( $field['attributes'] ) ) {
 			if ( ( ! empty( $field['attributes']['min'] ) || ( isset( $field['attributes']['min'] ) && '0' === $field['attributes']['min'] ) ) && $temp_value < $field['attributes']['min'] ) {
-				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = minimum allowed number.
+				// Translators: %1$s = field label or name; %2$s = user submitted value; %3$d = minimum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be greater than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['min'] ) );
 			} elseif ( ( ! empty( $field['attributes']['max'] ) || ( isset( $field['attributes']['max'] ) && '0' === $field['attributes']['max'] ) ) && $temp_value > $field['attributes']['max'] ) {
-				// Translators: %1$s field label or name; %2$s = user submitted value; %3$d = maximum allowed number.
+				// Translators: %1$s = field label or name; %2$s = user submitted value; %3$d = maximum allowed number.
 				return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The %1$s "%2$s" must be less than or equal to %3$d.', 'lifterlms' ), isset( $field['label'] ) ? $field['label'] : $field['name'], $posted_value, $field['attributes']['max'] ) );
 			}
 		}
@@ -248,7 +248,7 @@ class LLMS_Form_Validator {
 	protected function validate_field_tel( $posted_value ) {
 
 		if ( 0 < strlen( trim( preg_replace( '/[\s\#0-9\-\+\(\)\.]/', '', $posted_value ) ) ) ) {
-			// Translators: %s user submitted value.
+			// Translators: %s = user submitted value.
 			return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The phone number "%s" is not valid.', 'lifterlms' ), $posted_value ) );
 		}
 
@@ -267,7 +267,7 @@ class LLMS_Form_Validator {
 	protected function validate_field_url( $posted_value ) {
 
 		if ( ! filter_var( $posted_value, FILTER_VALIDATE_URL ) ) {
-			// Translators: %s user submitted value.
+			// Translators: %s = user submitted value.
 			return new WP_Error( 'llms-form-field-invalid', sprintf( __( 'The URL "%s" is not valid.', 'lifterlms' ), $posted_value ) );
 		}
 
@@ -379,7 +379,7 @@ class LLMS_Form_Validator {
 	 * @since [version]
 	 *
 	 * @param array   $posted_data Array of posted data.
-	 * @param array[] $fields      Array of LifterLMS Form Fields.
+	 * @param array[] $fields      Array of LifterLMS form fields.
 	 * @return WP_Error|true
 	 */
 	public function validate_matching_fields( $posted_data, $fields ) {

--- a/tests/phpunit/unit-tests/class-llms-test-form-field.php
+++ b/tests/phpunit/unit-tests/class-llms-test-form-field.php
@@ -290,7 +290,7 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 		$this->assertStringContains( 'value="mock_val"', $html );
 		$this->assertStringNotContains( 'checked="checked"', $html );
 
-		// checked.
+		// Checked.
 		$opts['checked'] = true;
 		$html = llms_form_field( $opts, false );
 		$this->assertStringContains( 'checked="checked"', $html );
@@ -349,17 +349,35 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 		$this->assertStringContains( '<div class="llms-form-field type-checkbox llms-cols-12 llms-cols-last"><input class="llms-field-checkbox" id="checkbox-id--opt1" name="checkbox-id[]" type="checkbox" value="opt1" /><label for="checkbox-id--opt1">Option1</label></div>', $html );
 		$this->assertStringContains( '<div class="llms-form-field type-checkbox llms-cols-12 llms-cols-last"><input class="llms-field-checkbox" id="checkbox-id--opt2" name="checkbox-id[]" type="checkbox" value="opt2" /><label for="checkbox-id--opt2">Option2</label></div>', $html );
 
-		// default value.
+		// Default value.
 		$opts['default'] = 'opt1';
 		$html = llms_form_field( $opts, false );
-		$this->assertStringContains( '<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt1" name="checkbox-id[]" type="checkbox" value="opt1" /><label for="checkbox-id--opt1">Option1</label>', $html );
+		$this->assertStringContains(
+			'<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt1" name="checkbox-id[]" type="checkbox" value="opt1" /><label for="checkbox-id--opt1">Option1</label>',
+			$html
+		);
+		$this->assertStringNotContains(
+			'<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt2" name="checkbox-id[]" type="checkbox" value="opt2" /><label for="checkbox-id--opt2">Option2</label>',
+			$html
+		);
 
-		// user has saved data.
+		// Test multiple defaults.
+		$opts['default'] = array( 'opt1', 'opt2' );
+		$html = llms_form_field( $opts, false );
+		$this->assertStringContains(
+			'<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt1" name="checkbox-id[]" type="checkbox" value="opt1" /><label for="checkbox-id--opt1">Option1</label>',
+			$html
+		);
+		$this->assertStringContains(
+			'<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt2" name="checkbox-id[]" type="checkbox" value="opt2" /><label for="checkbox-id--opt2">Option2</label>',
+			$html
+		);
+
+		// User has saved data.
 		$this->get_user_with_meta( 'checkbox-id', 'opt2' );
 		$html = llms_form_field( $opts, false );
 		$this->assertStringContains( '<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt2" name="checkbox-id[]" type="checkbox" value="opt2" /><label for="checkbox-id--opt2">Option2</label>', $html );
 		$this->assertStringNotContains( '<input checked="checked" class="llms-field-checkbox" id="checkbox-id--opt1" name="checkbox-id[]" type="checkbox" value="opt1" /><label for="checkbox-id--opt1">Option1</label>', $html );
-
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/class-llms-test-form-validator.php
@@ -20,6 +20,8 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	 *
 	 * @link https://github.com/WordPress/wordpress-develop/blob/master/tests/phpunit/tests/formatting/SanitizeTextField.php Most data adapted from WP Core tests.
 	 *
+	 * @since [version]
+	 *
 	 * @return array
 	 */
 	protected function data_for_text_fields() {
@@ -51,7 +53,7 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			),
 			array(
 				array(),
-				'',
+				array(),
 			),
 			array(
 				llms(),

--- a/tests/phpunit/unit-tests/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/class-llms-test-form-validator.php
@@ -67,6 +67,18 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 				true,
 				'1',
 			),
+			array(
+				array(
+					'text 1',
+					'text 2',
+					false,
+				),
+				array(
+					'text 1',
+					'text 2',
+					'',
+				),
+			),
 		);
 
 	}
@@ -177,6 +189,19 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test sanitize_field() for fields whose values are arrays.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	/*public function test_sanitize_field_arra)y() {
+
+		$tests = $this->data_for_text_fields(;
+		$t
+	}*/
+
+	/**
 	 * Sanitize email fields.
 	 *
 	 * @since [version]
@@ -186,19 +211,24 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	public function test_sanitize_field_for_email() {
 
 		$emails = array(
-			"hello'hi@hello.com"           => "hello'hi@hello.com",
-			'hello@hello.com'              => 'hello@hello.com',
-			'admin@hello.net'              => '    admin@hello.net',
-			'admin+hi@hello.edu'           => 'admin+hi@hello.edu',
-			'hello@so.many.subdomains.org' => 'hello@so.many.subdomains.org',
-			'ip@204.32.111.32'             => 'ip@204.32.111.32',
-			'l@l.ms'                       => 'l@l.ms',
-			''                             => 'fake',
+			"hello'hi@hello.com"                 => "hello'hi@hello.com",
+			'hello@hello.com'                    => 'hello@hello.com',
+			'admin@hello.net'                    => '    admin@hello.net',
+			'admin+hi@hello.edu'                 => 'admin+hi@hello.edu',
+			'hello@so.many.subdomains.org'       => 'hello@so.many.subdomains.org',
+			'ip@204.32.111.32'                   => 'ip@204.32.111.32',
+			'l@l.ms'                             => 'l@l.ms',
+			''                                   => 'fake',
 		);
 
 		foreach ( $emails as $clean => $dirty ) {
 			$this->assertEquals( $clean, $this->main->sanitize_field( $dirty, $this->get_field_arr( 'email' ) ) );
 		}
+
+		$this->assertEquals(
+			array( 'hello@hello.com', 'l@l.ms', '' ),
+			$this->main->sanitize_field( array( 'hello@hello.com', 'l@l.ms', 'j' ), $this->get_field_arr( 'email' ) )
+		);
 
 	}
 
@@ -223,6 +253,8 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			array( false, 'f@k.e' ),
 			array( false, ' f' ),
 			array( false, 'fake.mock.com' ),
+			array( true, array( 'ip@204.32.111.32', 'hello@hello.com' ) ),
+			array( false, array( 'ip@204.32.111.32', 'hello@hello.com', ' f' ) ),
 		);
 
 		foreach ( $emails as $test ) {
@@ -346,6 +378,11 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			$this->assertEquals( $clean, $this->main->sanitize_field( $dirty, $this->get_field_arr( 'tel' ) ) );
 		}
 
+		$this->assertEquals(
+			array( '000 000 0000 #000', '+00' ),
+			$this->main->sanitize_field( array( '000 000 0000 #000', '+00 aaa bbb cccc' ), $this->get_field_arr( 'tel' ) )
+		);
+
 	}
 
 	/**
@@ -366,6 +403,8 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			array( true, '000 000 0000 #000' ),
 			array( false, '+00 aaa bbb cccc' ),
 			array( false, 'fake' ),
+			array( true, array( '000 000 0000 #000', '(000) 000 0000' ) ),
+			array( false, array( '000 000 0000 #000', '+00 aaa bbb cccc' ) ),
 		);
 
 		foreach ( $emails as $test ) {
@@ -406,6 +445,16 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 		$tests[] = array(
 			"internal  whitespace   okay",
 			"internal  whitespace   okay",
+		);
+		$tests[] = array(
+			array(
+				"internal  whitespace   okay",
+				"tabs \nokay too",
+			),
+			array(
+				"internal  whitespace   okay",
+				"tabs \nokay too",
+			),
 		);
 
 		foreach ( $tests as $data ) {
@@ -458,6 +507,16 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 				'https://example.tld/?qs=whatever+<script>alert(1)</script>',
 				'https://example.tld/?qs=whatever+scriptalert(1)/script',
 			),
+			array(
+				array(
+					'http://www.example.tld',
+					'https://example.tld/?qs=whatever+<script>alert(1)</script>',
+				),
+				array(
+					'http://www.example.tld',
+					'https://example.tld/?qs=whatever+scriptalert(1)/script',
+				),
+			),
 		);
 
 		foreach ( $tests as $data ) {
@@ -480,6 +539,9 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			array( false, 'test.php' ),
 			array( false, 'example.tld' ),
 			array( true, 'https://example.tld' ),
+			array( true, 'https://example.tld' ),
+			array( true, array( 'https://example.tld', 'https://another-example.ltd' ) ),
+			array( false, array( 'https://example.tld', 'another-example.ltd' ) ),
 		);
 
 		foreach ( $tests as $test ) {
@@ -521,6 +583,16 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			$this->assertEquals( $clean, $this->main->sanitize_field( $dirty, $this->get_field_arr( 'number' ) ) );
 		}
 
+		$this->assertEquals(
+			array( '1', '100' ),
+			$this->main->sanitize_field( array( '1', '100' ), $this->get_field_arr( 'number' ) )
+		);
+
+		$this->assertEquals(
+			array( '1', '100', '2' ),
+			$this->main->sanitize_field( array( '1', '100', ' fake 2 mock' ), $this->get_field_arr( 'number' ) )
+		);
+
 	}
 
 	/**
@@ -546,6 +618,8 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 			array( true, '1,000.00' ),
 			array( true, '1.000,00' ),
 			array( false, ' fake 2 mock' ),
+			array( true, array( '1.000,00', '1' ) ),
+			array( false, array( '1.000,00', '1', ' fake 2 mock' ) ),
 		);
 
 		foreach ( $tests as $test ) {


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
WIP, aims to fix https://github.com/gocodebox/lifterlms/issues/1577

> 6 - I’ve rapidly submitted a form with checkboxes checked, in the DB, though the checkbox value was empty.
> 9 - Multiple defaults for checkboxes (grouped) are not rendered, only the latest is

At the moment it already fixes 6)


## How has this been tested?
manually and existing (modified) unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

