### PR TITLE
Introduce an util to retrieve the ID of the first available user who can install llms stuff

### DIFF
--- a/includes/class-llms-forms.php
+++ b/includes/class-llms-forms.php
@@ -227,7 +227,7 @@ class LLMS_Forms {
 			'post_title'   => $data['title'],
 			'post_type'    => $this->get_post_type(),
 			'meta_input'   => $data['meta'],
-			'post_author'  => LLMS_Install::get_can_install_user_id(),
+			'post_author'  => $existing ? $existing->post_author : LLMS_Install::get_can_install_user_id(),
 		);
 
 		/**

--- a/includes/class-llms-forms.php
+++ b/includes/class-llms-forms.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * Register and manage LifterLMS user forms.
+ * Register and manage LifterLMS user forms
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since [version]
  * @version [version]
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Forms class..
+ * LLMS_Forms class
  *
  * @since [version]
  */
@@ -20,7 +20,7 @@ class LLMS_Forms {
 	/**
 	 * Singleton instance
 	 *
-	 * @var  null
+	 * @var null
 	 */
 	protected static $instance = null;
 
@@ -46,7 +46,7 @@ class LLMS_Forms {
 	}
 
 	/**
-	 * Private Constructor.
+	 * Private Constructor
 	 *
 	 * @since [version]
 	 *
@@ -74,9 +74,6 @@ class LLMS_Forms {
 	 * and explicitly enable or disable usernames.
 	 *
 	 * @since [version]
-	 *
-	 * @see {Reference}
-	 * @link {URL}
 	 *
 	 * @return bool
 	 */
@@ -200,7 +197,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location_id Location id.
-	 * @param bool   $update If `true` and the form already exists, will update the existing form.
+	 * @param bool   $update      If `true` and the form already exists, will update the existing form.
 	 * @return int|false Returns the created/update form post ID on success.
 	 *                   If the location doesn't exist, returns `false`.
 	 *                   If the form already exists and `$update` is `false` will return `false`.
@@ -230,6 +227,7 @@ class LLMS_Forms {
 			'post_title'   => $data['title'],
 			'post_type'    => $this->get_post_type(),
 			'meta_input'   => $data['meta'],
+			'post_author'  => LLMS_Install::get_can_install_user_id(),
 		);
 
 		/**
@@ -237,9 +235,9 @@ class LLMS_Forms {
 		 *
 		 * @since [version]
 		 *
-		 * @param array $args Array of arguments to be passed to wp_insert_post
-		 * @param $string $location_id Location ID/name.
-		 * @param array $data Array of location information from LLMS_Forms::get_locations().
+		 * @param array  $args        Array of arguments to be passed to wp_insert_post
+		 * @param string $location_id Location ID/name.
+		 * @param array  $data        Array of location information from LLMS_Forms::get_locations().
 		 */
 		$args = apply_filters( 'llms_forms_install_post_args', $args, $location_id, $data );
 
@@ -291,7 +289,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additional arguments passed to the short-circuit filter in `f()`.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter in `f()`.
 	 * @return array|false
 	 */
 	public function get_form_blocks( $location, $args = array() ) {
@@ -316,7 +314,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additioal arguments passed to the short-circuit filter in `get_form_post()`.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter in `get_form_post()`.
 	 * @return false|array
 	 */
 	public function get_form_fields( $location, $args = array() ) {
@@ -342,9 +340,9 @@ class LLMS_Forms {
 		 *
 		 * @since [version]
 		 *
-		 * @param array[] $fields Array of LifterLMS Form Field settings data.
-		 * @param string $location Form location, one of: "checkout", "registration", or "account".
-		 * @param array $args Additioal arguments passed to the short-circuit filter in `get_form_post()`.
+		 * @param array[] $fields   Array of LifterLMS Form Field settings data.
+		 * @param string  $location Form location, one of: "checkout", "registration", or "account".
+		 * @param array   $args     Additional arguments passed to the short-circuit filter in `get_form_post()`.
 		 */
 		return apply_filters( 'llms_get_form_fields', $fields, $location, $args );
 
@@ -356,8 +354,8 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param array[] $fields List of LifterLMS Form Fields.
-	 * @param string  $key Setting key to search for.
-	 * @param mixed   $val Setting valued to search for.
+	 * @param string  $key    Setting key to search for.
+	 * @param mixed   $val    Setting valued to search for.
 	 * @param string  $return Determine the return value. Use "field" to return the field settings
 	 *                        array. Use "index" to return the index of the field in the $fields array.
 	 * @return array|int|false `false` when the field isn't found in $fields, otherwise returns the field settings
@@ -381,7 +379,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additioal arguments passed to the short-circuit filter in `get_form_post()`.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter in `get_form_post()`.
 	 * @return string
 	 */
 	public function get_form_html( $location, $args = array() ) {
@@ -403,7 +401,7 @@ class LLMS_Forms {
 		 *
 		 * @param string $html     Form fields HTML.
 		 * @param string $location Form location, one of: "checkout", "registration", or "account".
-		 * @param array  $args     Additioal arguments passed to the short-circuit filter in `get_form_post()`.
+		 * @param array  $args     Additional arguments passed to the short-circuit filter in `get_form_post()`.
 		 */
 		return apply_filters( 'llms_get_form_html', $html, $location, $args );
 
@@ -415,7 +413,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additioal arguments passed to the short-circuit filter.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter.
 	 * @return WP_Post|false
 	 */
 	public function get_form_post( $location, $args = array() ) {
@@ -427,9 +425,9 @@ class LLMS_Forms {
 		 *
 		 * @since [version]
 		 *
-		 * @param null|WP_Post $post Return a WP_Post object to short-circuit default lookup query.
-		 * @param string $location Form location. Either "checkout", "registration", or "account".
-		 * @param array $args Additional custom arguments.
+		 * @param null|WP_Post $post     Return a WP_Post object to short-circuit default lookup query.
+		 * @param string       $location Form location. Either "checkout", "registration", or "account".
+		 * @param array        $args     Additional custom arguments.
 		 */
 		$post = apply_filters( 'llms_get_form_post_pre_query', null, $location, $args );
 		if ( is_a( $post, 'WP_Post' ) ) {
@@ -466,7 +464,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additioal arguments passed to the short-circuit filter.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter.
 	 * @return array[]
 	 */
 	private function get_additional_fields( $location, $args = array() ) {
@@ -477,9 +475,9 @@ class LLMS_Forms {
 		 * @since 3.0.0
 		 * @since [version] Moved from deprecated function `LLMS_Person_Handler::get_available_fields()`.
 		 *
-		 * @param array[] $fields Array of field array suitable to pass to `llms_form_field()`.
+		 * @param array[] $fields  Array of field array suitable to pass to `llms_form_field()`.
 		 * @param string $location Form location, one of: "checkout", "registration", or "account".
-		 * @param array $args Additioal arguments passed to the short-circuit filter.
+		 * @param array $args      Additional arguments passed to the short-circuit filter.
 		 */
 		return apply_filters( 'lifterlms_get_person_fields', array(), $location, $args );
 
@@ -493,7 +491,7 @@ class LLMS_Forms {
 	 * @since [version]
 	 *
 	 * @param string $location Form location, one of: "checkout", "registration", or "account".
-	 * @param array  $args Additioal arguments passed to the short-circuit filter.
+	 * @param array  $args     Additional arguments passed to the short-circuit filter.
 	 * @return string
 	 */
 	private function get_additional_fields_html( $location, $args = array() ) {
@@ -687,8 +685,8 @@ class LLMS_Forms {
 		 *
 		 * @since [version]
 		 *
-		 * @param bool $visible Whether or not the block is visible.
-		 * @param array $block Parsed block array.
+		 * @param bool  $visible Whether or not the block is visible.
+		 * @param array $block   Parsed block array.
 		 */
 		return apply_filters( 'llms_forms_is_block_visible', llms_parse_bool( $render ), $block );
 
@@ -779,7 +777,7 @@ class LLMS_Forms {
 	 *
 	 * @since [version]
 	 *
-	 * @param string $html Block HTML.
+	 * @param string $html  Block HTML.
 	 * @param array  $block Array of block information.
 	 * @return string
 	 */

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -870,6 +870,37 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_sessions` (
 
 	}
 
+	/**
+	 * Get the WP User ID of the first available user who can 'manage_options'
+	 *
+	 * @since [version]
+	 *
+	 * @return int Returns the ID of the current user if they can 'manage_options'.
+	 *             Otherwise returns the ID of the first Administrator if they can 'manage_options'.
+	 *             Returns 0 if the first Administrator cannot 'manage_options' or the current site has no Administrators.
+	 */
+	public static function get_can_install_user_id() {
+
+		$capability = 'manage_options';
+
+		if ( current_user_can( $capability ) ) {
+			return get_current_user_id();
+		}
+
+		// Get the first user with administrator role.
+		// Here, for simplicity, we're assuming the administrator's role capabilities are the original ones.
+		$first_admin_user = get_users(
+			array(
+				'role'    => 'Administrator',
+				'number'  => 1,
+				'orderby' => 'ID',
+			)
+		);
+
+		// Return 0 if the first Administrator cannot 'manage_options' or the current site has no Administrators.
+		return ! empty( $first_admin_user ) && $first_admin_user[0]->has_cap( $capability ) ? $first_admin_user[0]->ID : 0;
+
+	}
 }
 
 LLMS_Install::init();

--- a/tests/phpunit/unit-tests/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/class-llms-test-forms.php
@@ -385,6 +385,95 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test forms author on install
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_forms_author_on_install() {
+
+		// Clean user* tables.
+		global $wpdb;
+		$wpdb->query( "TRUNCATE TABLE $wpdb->users" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->usermeta" );
+
+		// Create a subscriber.
+		$subscriber = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+
+		$locs = $this->forms->get_locations();
+
+		// Install forms
+		$installed = $this->forms->install();
+
+		foreach ( $installed as $loc => $id ) {
+			// No admin users, expect 0.
+			$this->assertEquals( 0, get_post( $id )->post_author, $id );
+		}
+
+		// Delete forms.
+		$wpdb->delete( $wpdb->posts, array( 'post_type' => 'llms_form' ) );
+
+		// Create two admins.
+		$admins = $this->factory->user->create_many( 2, array( 'role' => 'administrator' ) );
+
+		// Install forms.
+		$installed = $this->forms->install();
+
+		foreach ( $installed as $loc => $id ) {
+			// Expect the first admin to be the forms author.
+			$this->assertEquals( $admins[0], get_post( $id )->post_author, $id );
+		}
+
+		// Delete forms.
+		$wpdb->delete( $wpdb->posts, array( 'post_type' => 'llms_form' ) );
+
+		// Log in as subscriber.
+		wp_set_current_user( $subscriber );
+
+		// Install forms.
+		$installed = $this->forms->install();
+
+		foreach ( $installed as $loc => $id ) {
+			// Expect the first admin to be the forms author.
+			$this->assertEquals( $admins[0], get_post( $id )->post_author, $id );
+		}
+
+		// Delete forms.
+		$wpdb->delete( $wpdb->posts, array( 'post_type' => 'llms_form' ) );
+
+		// Log in as first admin.
+		wp_set_current_user( $admins[0] );
+
+		// Install forms.
+		$installed = $this->forms->install();
+
+		foreach ( $installed as $loc => $id ) {
+			// Expect the first admin to be the forms author.
+			$this->assertEquals( $admins[0], get_post( $id )->post_author, $id );
+		}
+
+		// Delete forms.
+		$wpdb->delete( $wpdb->posts, array( 'post_type' => 'llms_form' ) );
+
+		// Log in as second admin.
+		wp_set_current_user( $admins[1] );
+
+		// Install forms.
+		$installed = $this->forms->install();
+
+		foreach ( $installed as $loc => $id ) {
+			// Expect the first admin to be the forms author.
+			$this->assertEquals( $admins[1], get_post( $id )->post_author, $id );
+		}
+
+		// Clean user* tables.
+		$wpdb->query( "TRUNCATE TABLE $wpdb->users" );
+		$wpdb->query( "TRUNCATE TABLE $wpdb->usermeta" );
+
+	}
+
+	/**
 	 * Test the get_capability() method
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/class-llms-test-forms.php
@@ -467,10 +467,6 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 			$this->assertEquals( $admins[1], get_post( $id )->post_author, $id );
 		}
 
-		// Clean user* tables.
-		$wpdb->query( "TRUNCATE TABLE $wpdb->users" );
-		$wpdb->query( "TRUNCATE TABLE $wpdb->usermeta" );
-
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/class-llms-test-install.php
+++ b/tests/phpunit/unit-tests/class-llms-test-install.php
@@ -374,10 +374,6 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 		// Expect the second admin to be returned.
 		$this->assertEquals( $admins[1], LLMS_Install::get_can_install_user_id() );
 
-		// Clean user* tables.
-		$wpdb->query( "TRUNCATE TABLE $wpdb->users" );
-		$wpdb->query( "TRUNCATE TABLE $wpdb->usermeta" );
-
 	}
 
 }

--- a/tests/phpunit/unit-tests/class-llms-test-install.php
+++ b/tests/phpunit/unit-tests/class-llms-test-install.php
@@ -7,7 +7,7 @@
  * @group install
  *
  * @since 3.3.1
- * @since 3.37.8 Fix directory path to uninstall.php
+ * @since 3.37.8 Fix directory path to uninstall.php.
  * @since 4.0.0 Test creation of all tables; fix caching issue when testing full install; add new cron test.
  * @since 4.5.0 Test log backup cron.
  */
@@ -15,19 +15,20 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Tests for check_version()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_check_version() {
 
-		// ensure the database update runs
+		// Ensure the database update runs.
 		update_option( 'lifterlms_current_version', (float) LLMS()->version - 1 );
 		update_option( 'lifterlms_db_version', LLMS()->version );
 		LLMS_Install::check_version();
 		$this->assertTrue( did_action( 'lifterlms_updated' ) === 1 );
 
-		// ensure that if both are equal the database doesn't run again
+		// Ensure that if both are equal the database doesn't run again.
 		update_option( 'lifterlms_current_version', LLMS()->version );
 		update_option( 'lifterlms_db_version', LLMS()->version );
 		LLMS_Install::check_version();
@@ -71,25 +72,26 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Tests for create_difficulties() & remove_difficulties()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_create_difficulties_crud() {
 
-		// terms may or may not exist and should exist after creation
+		// Terms may or may not exist and should exist after creation.
 		LLMS_Install::create_difficulties();
 		foreach( LLMS_Install::get_difficulties() as $name ) {
 			$this->assertInstanceOf( 'WP_Term', get_term_by( 'name', $name, 'course_difficulty' ) );
 		}
 
-		// terms should not exist after deleting terms
+		// Terms should not exist after deleting terms.
 		LLMS_Install::remove_difficulties();
 		foreach( LLMS_Install::get_difficulties() as $name ) {
 			$this->assertFalse( get_term_by( 'name', $name, 'course_difficulty' ) );
 		}
 
-		// terms should exist after creating difficulties
+		// Terms should exist after creating difficulties.
 		LLMS_Install::create_difficulties();
 		foreach( LLMS_Install::get_difficulties() as $name ) {
 			$this->assertInstanceOf( 'WP_Term', get_term_by( 'name', $name, 'course_difficulty' ) );
@@ -99,9 +101,10 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Test create_files()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_create_files() {
 
@@ -115,24 +118,26 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Tests for create_options()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.5.1
+	 *
+	 * @since 3.3.1
+	 * @since 3.5.1 Unknown.
+	 *
+	 * @return void
 	 */
 	public function test_create_options() {
 
-		// clear options
+		// Clear options.
 		global $wpdb;
 		$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name LIKE 'lifterlms\_%';" );
 
-		// install options
+		// Install options.
 		LLMS_Install::create_options();
 
-		// check they exist
+		// Check they exist.
 		$settings = LLMS_Admin_Settings::get_settings_tabs();
 
 		foreach ( $settings as $section ) {
-			// skip general settings since this screen doesn't actually have any settings on it
+			// Skip general settings since this screen doesn't actually have any settings on it.
 			if ( 'general' === $section->id ) {
 				continue;
 			}
@@ -147,13 +152,14 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Tests for create_pages()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_create_pages() {
 
-		// clear options
+		// Clear options.
 		delete_option( 'lifterlms_shop_page_id' );
 		delete_option( 'lifterlms_memberships_page_id' );
 		delete_option( 'lifterlms_checkout_page_id' );
@@ -166,13 +172,13 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 		$this->assertGreaterThan( 0, get_option( 'lifterlms_checkout_page_id' ) );
 		$this->assertGreaterThan( 0, get_option( 'lifterlms_myaccount_page_id' ) );
 
-		// Delete pages
+		// Delete pages.
 		wp_delete_post( get_option( 'lifterlms_shop_page_id' ), true );
 		wp_delete_post( get_option( 'lifterlms_memberships_page_id' ), true );
 		wp_delete_post( get_option( 'lifterlms_checkout_page_id' ), true );
 		wp_delete_post( get_option( 'lifterlms_myaccount_page_id' ), true );
 
-		// Clear options
+		// Clear options.
 		delete_option( 'lifterlms_shop_page_id' );
 		delete_option( 'lifterlms_memberships_page_id' );
 		delete_option( 'lifterlms_checkout_page_id' );
@@ -225,13 +231,14 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Test create_visibilities()
-	 * @return   void
-	 * @since    3.6.0
-	 * @version  3.6.0
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return void
 	 */
 	public function test_create_visibilities() {
 
-		// terms may or may not exist and should exist after creation
+		// Terms may or may not exist and should exist after creation.
 		LLMS_Install::create_visibilities();
 		foreach( array_keys( llms_get_product_visibility_options() ) as $name ) {
 			$this->assertInstanceOf( 'WP_Term', get_term_by( 'name', $name, 'llms_product_visibility' ) );
@@ -241,9 +248,10 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Test get_difficulties()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_get_difficulties() {
 
@@ -254,9 +262,10 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Test update_db_version()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_update_db_version() {
 
@@ -273,9 +282,10 @@ class LLMS_Test_Install extends LLMS_UnitTestCase {
 
 	/**
 	 * Test update_llms_version()
-	 * @return   void
-	 * @since    3.3.1
-	 * @version  3.3.1
+	 *
+	 * @since 3.3.1
+	 *
+	 * @return void
 	 */
 	public function test_update_llms_version() {
 


### PR DESCRIPTION
and use it as post_author for the default form

## Description

Fixes #1577|5
5) I’ve noticed in the DB that the post author is 0 for the default llms_form post types. I think it should be 1.
as we discussed in the comments there below

## How has this been tested?
only manually as of now

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->


@thomasplevy do you agree with this?

I mean, if you don't have an administrator user or your administrator doesn't have the manage_options cap, the forms author will be 0, we can't search forever for a valid user... right?