### PR TITLE
(5.0.*) When populating field data from the INPUT_POST make sure checkboxes are treated as array

### DIFF
--- a/includes/class-llms-form-field.php
+++ b/includes/class-llms-form-field.php
@@ -822,7 +822,7 @@ class LLMS_Form_Field {
 		if ( 'POST' === strtoupper( getenv( 'REQUEST_METHOD' ) ) ) {
 			$posted = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is verified prior to reaching this method.
 			if ( isset( $posted[ $this->settings['name'] ] ) ) {
-				$filter_options = 'checkbox' === $this->settings['type'] ? FILTER_REQUIRE_ARRAY : array();
+				$filter_options = is_array( $posted[ $this->settings['name'] ] ) ? FILTER_REQUIRE_ARRAY : array();
 				$user_val       = llms_filter_input( INPUT_POST, $this->settings['name'], FILTER_SANITIZE_STRING, $filter_options );
 			}
 		}

--- a/includes/class-llms-form-field.php
+++ b/includes/class-llms-form-field.php
@@ -822,7 +822,8 @@ class LLMS_Form_Field {
 		if ( 'POST' === strtoupper( getenv( 'REQUEST_METHOD' ) ) ) {
 			$posted = wp_unslash( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is verified prior to reaching this method.
 			if ( isset( $posted[ $this->settings['name'] ] ) ) {
-				$user_val = llms_filter_input( INPUT_POST, $this->settings['name'], FILTER_SANITIZE_STRING );
+				$filter_options = 'checkbox' === $this->settings['type'] ? FILTER_REQUIRE_ARRAY : array();
+				$user_val       = llms_filter_input( INPUT_POST, $this->settings['name'], FILTER_SANITIZE_STRING, $filter_options );
 			}
 		}
 

--- a/tests/phpunit/unit-tests/class-llms-test-form-field.php
+++ b/tests/phpunit/unit-tests/class-llms-test-form-field.php
@@ -822,4 +822,70 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Test field html generated on submision when value is an array
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_field_array_value_only_post_request() {
+
+		$checkbox_options = array(
+			'yes_key' => 'Yes',
+			'no_key'  => 'No',
+		);
+
+		$form_field_conf = array(
+			'name'    => 'array_type',
+			'type'    => 'checkbox',
+			'options' => $checkbox_options,
+		);
+
+		// Simulate a field submission where both the checkboxes are checked.
+		$this->mockPostRequest(
+			array(
+				'array_type' => array_keys( $checkbox_options ),
+			)
+		);
+
+		// Create a form field.
+		$form_field = llms_form_field(
+			$form_field_conf,
+			false
+		);
+
+		// Expect the html has 2 "checked" checkboxes.
+		$this->assertEquals(
+			2,
+			substr_count(
+				$form_field,
+				'"checked"'
+			)
+		);
+
+		// Simulate a field submission where only one checkbox is checked.
+		$this->mockPostRequest(
+			array(
+				'array_type' => array_keys( $checkbox_options )[1],
+			)
+		);
+
+		// Create a form field.
+		$form_field = llms_form_field(
+			$form_field_conf,
+			false
+		);
+
+		// Expect the html has 1 "checked" checkbox.
+		$this->assertEquals(
+			1,
+			substr_count(
+				$form_field,
+				'"checked"'
+			)
+		);
+
+	}
+
 }


### PR DESCRIPTION

## Description
Fixes an issue I haven't opened. Basically if a form gets a validation error server side, the checkbox values in the form are not correctly set, as they're not treated as arrays.
(A way to reproduce the validation error would be to submit a password change on the account edit form, using a wrong current password.)

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

