### PR TITLE
Allow for improved user login validation with new filter

### DIFF
--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -676,6 +676,7 @@ class LLMS_Person_Handler {
 		// Validate the fields & allow custom validation to occur.
 		$valid = self::validate_fields( apply_filters( 'lifterlms_user_login_data', $data ), 'login' );
 
+		$valid = apply_filters( 'lifterlms_pre_user_login_errors', $valid, $data, false );
 		// If errors found, return them.
 		if ( is_wp_error( $valid ) ) {
 			return apply_filters( 'lifterlms_user_login_errors', $valid, $data, false );

--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -676,8 +676,15 @@ class LLMS_Person_Handler {
 		// Validate the fields & allow custom validation to occur.
 		$valid = self::validate_fields( apply_filters( 'lifterlms_user_login_data', $data ), 'login' );
 
-		// Allow for custom validation of user login data (previous filter doesn't fully allow for this)
-		$valid = apply_filters( 'llms_after_user_login_data_validation', $valid, $data, 'login' );
+		/**
+		 * Filters the validation result of user-submitted login data
+		 * 
+		 * @since [version]
+		 *
+		 * @param WP_Error|boolean $valid An error object containing validation errors or `true` if no validation errors found.
+		 * @param array            $data  User submitted login data.
+		 */
+		$valid = apply_filters( 'llms_after_user_login_data_validation', $valid, $data );
 
 		// If errors found, return them.
 		if ( is_wp_error( $valid ) ) {

--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -676,7 +676,9 @@ class LLMS_Person_Handler {
 		// Validate the fields & allow custom validation to occur.
 		$valid = self::validate_fields( apply_filters( 'lifterlms_user_login_data', $data ), 'login' );
 
-		$valid = apply_filters( 'lifterlms_pre_user_login_errors', $valid, $data, false );
+		// Allow for custom validation of user login data (previous filter doesn't fully allow for this)
+		$valid = apply_filters( 'llms_after_user_login_data_validation', $valid, $data, 'login' );
+
 		// If errors found, return them.
 		if ( is_wp_error( $valid ) ) {
 			return apply_filters( 'lifterlms_user_login_errors', $valid, $data, false );


### PR DESCRIPTION
Current login form validation involves modifying the actual form submission data before sending it to be validated.  There is no filter applied to the result of the validation.

Instead of modifying existing filters which is likely to break other integrations, I opted to create a new filter

 Re-using either of the filter before/after this new filter could cause unexpected behaviour with other integrations if they're relying on the data to be in a certain format.

In this new way we can now integrate with the login flow more thoroughly by supplying a `WP_Error` during the login process and triggering an exit of the login quite early, if necessary.

## Description

Neither of the 2 pre-existing filters allows for full login integration.

The filter immediately preceeding the new filter is applied to the data being validated, not the result of the validation. This is probably a bug and (I think) should probably behave more like the filter `lifterlms_user_registration_data` used in user registration.

The filter immediately following our new filter is only called when there is *already* a validation error, preventing the creation of a new error.

## How has this been tested?
This is simply a brand new filter that doesn't affect any existing flows or modifies any data. Tested on test LifterLMS installation.

## Types of changes

New Feature / Non-Breaking Change
A new filter to allow improved 3rd party integration with user login to (in)validate login as required. The existing code structure doesn't fully allow for integration (this is probably a bug)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

