### PR TITLE
Force usage of integers for background process scheduling

### DIFF
--- a/includes/processors/class.llms.processor.course.data.php
+++ b/includes/processors/class.llms.processor.course.data.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Processors/Classes
  *
  * @since 3.15.0
- * @version 4.16.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -349,12 +349,15 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 * This will schedule an event that will setup the queue of items for the background process.
 	 *
 	 * @since 3.15.0
+	 * @since [version] Force `$course_id` to an absolute integer to avoid duplicate scheduling resulting from loose variable typing.
 	 *
 	 * @param int $course_id WP Post ID of the course.
 	 * @param int $time      Optionally pass a timestamp for when the event should be run.
 	 * @return void
 	 */
 	public function schedule_calculation( $course_id, $time = null ) {
+
+		$course_id = absint( $course_id );
 
 		$this->log( sprintf( 'Course data calculation triggered for course %d.', $course_id ) );
 


### PR DESCRIPTION

## Description
Fixes #1600 

## How has this been tested?

+ New and existing phpunit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

