### PR TITLE
Ensure aggregate course data is cleared when there are no students in a course

### DIFF
--- a/includes/processors/class.llms.processor.course.data.php
+++ b/includes/processors/class.llms.processor.course.data.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Processors/Classes
  *
  * @since 3.15.0
- * @version 4.16.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -75,9 +75,11 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 * @since 3.15.0
 	 * @since 4.12.0 Add throttling by course in progress and adjust last_run calculation to be specific to the course.
 	 *               Improve performance of the student query by removing unneeded sort columns.
+	 * @since [version] When there's no students found in the course, run the `task_complete()` method to ensure data
+	 *                  from a previous calculation is cleared.
 	 *
 	 * @param int $course_id WP Post ID of the course.
-	 * @return void
+	 * @return void|null
 	 */
 	public function dispatch_calc( $course_id ) {
 
@@ -94,9 +96,10 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 		// Get total number of pages.
 		$query = new LLMS_Student_Query( $args );
 
-		// Nothing to do.
+		// No students in the course, run task completion.
 		if ( ! $query->found_results ) {
-			return;
+			$course = llms_get_post( $course_id );
+			return $course instanceof LLMS_Course ? $this->task_complete( $course, $this->get_task_data(), true ) : null;
 		}
 
 		// Throttle processing.
@@ -177,6 +180,29 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 */
 	protected function get_last_run( $course_id ) {
 		return absint( get_post_meta( $course_id, '_llms_last_data_calc_run', true ) );
+	}
+
+	/**
+	 * Retrieve structured task data array.
+	 *
+	 * Ensures the expected required array keys are found on the task array
+	 * and optionally merges in an existing array of day with the (empty) defaults.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $data Existing array of day (from a previous task).
+	 * @return array
+	 */
+	protected function get_task_data( $data = array() ) {
+		return wp_parse_args(
+			$data,
+			array(
+				'students' => 0,
+				'progress' => 0,
+				'quizzes'  => 0,
+				'grade'    => 0,
+			)
+		);
 	}
 
 	/**
@@ -380,6 +406,7 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 * @since 3.15.0
 	 * @since 4.12.0 Moved task completion logic to `task_complete()`.
 	 * @since 4.16.0 Fix log string to properly record the post_id.
+	 * @since [version] Use `get_task_data()` to merge/retrieve aggregate task data.
 	 *
 	 * @param array $args Query arguments passed to LLMS_Student_Query.
 	 * @return boolean Always returns `false` to remove the item from the queue when processing is complete.
@@ -397,16 +424,9 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 		$data = ( 1 !== $args['page'] ) ? $course->get( 'temp_calc_data' ) : array();
 
 		// Merge with the defaults.
-		$data = wp_parse_args(
-			$data,
-			array(
-				'students' => 0,
-				'progress' => 0,
-				'quizzes'  => 0,
-				'grade'    => 0,
-			)
-		);
+		$data = $this->get_task_data( $data );
 
+		// Perform the query.
 		$query = new LLMS_Student_Query( $args );
 
 		foreach ( $query->get_students() as $student ) {

--- a/tests/phpunit/unit-tests/processors/class-llms-test-processor-course-data.php
+++ b/tests/phpunit/unit-tests/processors/class-llms-test-processor-course-data.php
@@ -129,7 +129,41 @@ class LLMS_Test_Processor_Course_Data extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test dispatch_calc()w
+	 * Test dispatch_calc() when there's no students in the course
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms/issues/1596#issuecomment-821585937
+	 *
+	 * @return void
+	 */
+	public function test_dispatch_calc_no_students() {
+
+		$course_id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$course    = llms_get_post( $course_id );
+
+		// Mock meta data that may exist on the course (from a previous run, for example).
+		$metas = array(
+			'average_grade' => array( 95, 0 ),
+			'average_progress' => array( 22, 0 ),
+			'enrolled_students' => array( 204, 0 ),
+			'last_data_calc_run' => array( time() - HOUR_IN_SECONDS, time() ),
+			'temp_calc_data' => array( array( 123 ), array() ),
+		);
+		foreach ( $metas as $key => $vals ) {
+			$course->set( $key, $vals[0] );
+		}
+
+		$this->main->dispatch_calc( $course_id );
+
+		foreach ( $metas as $key => $vals ) {
+			$this->assertEquals( $vals[1], $course->get( $key ), $key );
+		}
+
+	}
+
+	/**
+	 * Test dispatch_calc()
 	 *
 	 * @since 4.12.0
 	 *
@@ -184,6 +218,44 @@ class LLMS_Test_Processor_Course_Data extends LLMS_UnitTestCase {
 		$now = time();
 		update_post_meta( $course_id, '_llms_last_data_calc_run', $now );
 		$this->assertEquals( $now, LLMS_Unit_Test_Util::call_method( $this->main, 'get_last_run', array( $course_id ) ) );
+
+	}
+
+	/**
+	 * Test get_task_data()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_task_data() {
+
+		$data = array();
+
+		// Default data only.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_task_data' );
+		$this->assertEquals( array(
+			'students' => 0,
+			'progress' => 0,
+			'quizzes'  => 0,
+			'grade'    => 0,
+		), $res );
+
+
+		// Merge in some data
+		$merge = array(
+			'progress' => 25,
+			'students' => 203,
+			'custom' => 'abc',
+		);
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_task_data', array( $merge ) );
+		$this->assertEquals( array(
+			'students' => 203,
+			'progress' => 25,
+			'quizzes'  => 0,
+			'grade'    => 0,
+			'custom'   => 'abc',
+		), $res );
 
 	}
 


### PR DESCRIPTION
## Description

Addresses issues identified in #1596, though it does not fully resolve the issue

Namely addresses https://github.com/gocodebox/lifterlms/issues/1596#issuecomment-820659392


## How has this been tested?

+ New & existing phpunit tests


## Screenshots <!-- if applicable -->

## Types of changes
+Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

