### PR TITLE
Clear (saved) bg processor data after a dispatch

### DIFF
--- a/includes/abstracts/llms.abstract.processor.php
+++ b/includes/abstracts/llms.abstract.processor.php
@@ -35,7 +35,7 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	 * Initializer
 	 *
 	 * Acts as a constructor that extending processors should implement
-	 * at the very least should populate the $this->actions array
+	 * at the very least should populate the $this->actions array.
 	 *
 	 * @since 3.15.0
 	 *
@@ -196,9 +196,10 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Log data to the processors log when processors debugging is enabled
 	 *
-	 * @param mixed $data  Data to log.
-	 * @return void
 	 * @since 3.15.0
+	 *
+	 * @param mixed $data Data to log.
+	 * @return void
 	 */
 	protected function log( $data ) {
 

--- a/includes/abstracts/llms.abstract.processor.php
+++ b/includes/abstracts/llms.abstract.processor.php
@@ -33,28 +33,15 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 
 	/**
 	 * Initializer
+	 *
 	 * Acts as a constructor that extending processors should implement
 	 * at the very least should populate the $this->actions array
 	 *
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return void
 	 */
 	abstract protected function init();
-
-	/**
-	 * Inherited from WP_Background Process
-	 * Extending classes should implement
-	 * this is called for each item pushed into the queue
-	 *
-	 * @param    array    $item  item in the queue
-	 * @return   boolean         true to keep the item in the queue and process again
-	 *                           false to remove the item from the queue
-	 * @since    3.15.0
-	 * @version  3.15.0
-	 */
-	// phpcs:ignore -- commented out code
-	// abstract protected function task( $item );
 
 	/**
 	 * Array of actions that should be watched to trigger
@@ -66,10 +53,10 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 
 	/**
 	 * Constructor
-	 * Initializes and adds actions
 	 *
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -88,9 +75,9 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Add actions defined in $this->actions
 	 *
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return void
 	 */
 	public function add_actions() {
 
@@ -112,12 +99,13 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 
 	/**
 	 * Disable a processor
-	 * Useful when bulk enrolling into a membership (for example)
-	 * so we don't trigger course data calculations a few hundred times
 	 *
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * Useful when bulk enrolling into a membership (for example)
+	 * so we don't trigger course data calculations a few hundred times.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @return void
 	 */
 	public function disable() {
 
@@ -144,6 +132,8 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	 * Overrides the parent method to reset the (saved) `$data` property and
 	 * prevent duplicate data being pushed into future batches.
 	 *
+	 * @since [version]
+	 *
 	 * @return array|WP_Error Result of wp_remote_post()
 	 */
 	public function dispatch() {
@@ -165,9 +155,9 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Retrieve a filtered array of actions to be added by $this->add_actions
 	 *
-	 * @return   array
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @return array
 	 */
 	private function get_actions() {
 
@@ -179,11 +169,11 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	 * Retrieve data for the current processor that can be used
 	 * in future processes
 	 *
-	 * @param    string $key      if set, return a specific piece of data rather than the whole array
-	 * @param    string $default  when returning a specific piece of data, allows a default value to be passed
-	 * @return   array|mixed
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @param string $key     If set, return a specific piece of data rather than the whole array.
+	 * @param string $default When returning a specific piece of data, allows a default value to be passed.
+	 * @return array|mixed
 	 */
 	public function get_data( $key = null, $default = '' ) {
 
@@ -206,10 +196,9 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Log data to the processors log when processors debugging is enabled
 	 *
-	 * @param    mixed $data  data to log
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @param mixed $data  Data to log.
+	 * @return void
+	 * @since 3.15.0
 	 */
 	protected function log( $data ) {
 
@@ -222,10 +211,10 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Persist data to the database related to the processor
 	 *
-	 * @param    array $data   data to save
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @param array $data Data to save.
+	 * @return void
 	 */
 	private function save_data( $data ) {
 
@@ -245,11 +234,11 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Update data to the database related to the processor
 	 *
-	 * @param    string $key   key name
-	 * @param    mixed  $value  value
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 *
+	 * @param string $key   Key name.
+	 * @param mixed  $value Value.
+	 * @return void
 	 */
 	public function set_data( $key, $value ) {
 
@@ -264,10 +253,10 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	/**
 	 * Delete a piece of data from the database by key
 	 *
-	 * @since    3.15.0
+	 * @since 3.15.0
 	 *
-	 * @param    string $key  key name to remove
-	 * @return   void
+	 * @param string $key Key name to remove.
+	 * @return void
 	 */
 	public function unset_data( $key ) {
 

--- a/includes/abstracts/llms.abstract.processor.php
+++ b/includes/abstracts/llms.abstract.processor.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.15.0
- * @version 3.15.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -55,7 +55,6 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 	 */
 	// phpcs:ignore -- commented out code
 	// abstract protected function task( $item );
-
 
 	/**
 	 * Array of actions that should be watched to trigger
@@ -136,6 +135,30 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 			remove_action( $action, array( $this, $data['callback'] ), $data['priority'], $data['arguments'] );
 
 		}
+
+	}
+
+	/**
+	 * Dispatch
+	 *
+	 * Overrides the parent method to reset the (saved) `$data` property and
+	 * prevent duplicate data being pushed into future batches.
+	 *
+	 * @return array|WP_Error Result of wp_remote_post()
+	 */
+	public function dispatch() {
+
+		// Perform the parent method.
+		$ret = parent::dispatch();
+
+		/**
+		 * Empty the (saved) data to prevent duplicate data in future batches.
+		 *
+		 * @link https://github.com/gocodebox/lifterlms/issues/1602
+		 */
+		$this->data = array();
+
+		return $ret;
 
 	}
 
@@ -256,5 +279,6 @@ abstract class LLMS_Abstract_Processor extends WP_Background_Process {
 		$this->save_data( $data );
 
 	}
+
 
 }


### PR DESCRIPTION
## Description

Fixes #1602

## How has this been tested?

+ New & existing phpunit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

