### PR TITLE
Added public getter to retrieve llms form fields from a list of wp blocks

### DIFF
--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -364,19 +364,13 @@ class LLMS_Forms {
 			return false;
 		}
 
-		$fields = array();
-		foreach ( $this->get_field_blocks( $blocks ) as $block ) {
-			$settings = $this->block_to_field_settings( $block );
-			if ( $settings ) {
-				$field    = new LLMS_Form_Field( $settings );
-				$fields[] = $field->get_settings();
-			}
-		}
-
-		$fields = array_merge( $fields, $this->get_additional_fields( $location, $args ) );
+		$fields = array_merge(
+			$this->get_fields_settings_from_blocks( $blocks ),
+			$this->get_additional_fields( $location, $args )
+		);
 
 		/**
-		 * Modify the parsed array of LifterLMS Form Fields.
+		 * Modify the parsed array of LifterLMS Form Fields
 		 *
 		 * @since [version]
 		 *
@@ -386,6 +380,29 @@ class LLMS_Forms {
 		 */
 		return apply_filters( 'llms_get_form_fields', $fields, $location, $args );
 
+	}
+
+	/**
+	 * Retrieve an array of LLMS_Form_Fields settings arrays from an array of blocks
+	 *
+	 * @since [version]
+	 *
+	 * @param  array $blocks Array of WP Block arrays from `parse_blocks()`.
+	 * @return false|array
+	 */
+	public function get_fields_settings_from_blocks( $blocks ) {
+
+		$fields = array();
+
+		foreach ( $this->get_field_blocks( $blocks ) as $block ) {
+			$settings = $this->block_to_field_settings( $block );
+			if ( $settings ) {
+				$field    = new LLMS_Form_Field( $settings );
+				$fields[] = $field->get_settings();
+			}
+		}
+
+		return $fields;
 	}
 
 	/**


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Need this to retrieve the list of fields in a reusable block's content, so that when the reusable block is saved we can manipulate the fields (e.g. update the "tracked fields" option).

## How has this been tested?
manually, it just consists in moving part of the logic of an already existing method into a new public one.

## Screenshots <!-- if applicable -->

## Types of changes
n/a

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

