### PR TITLE
Don't localize step attribute for order's txn price

### DIFF
--- a/templates/admin/post-types/order-transactions.php
+++ b/templates/admin/post-types/order-transactions.php
@@ -5,7 +5,9 @@
  * @package LifterLMS/Templates/Admin
  *
  * @since 3.5.0
- * @version 3.26.1
+ * @since 3.26.1 Unknown.
+ * @since [version] Don't localize the price "step" html attribute.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,7 +17,7 @@ if ( ! is_admin() ) {
 }
 
 // Create a "step" attribute for price fields according to LLMS settings.
-$price_step = number_format( 0.01, get_lifterlms_decimals(), get_lifterlms_decimal_separator(), get_lifterlms_thousand_separator() );
+$price_step = number_format( 0.01, get_lifterlms_decimals() );
 
 ?>
 <table class="llms-table">


### PR DESCRIPTION
## Description
Similar to https://github.com/gocodebox/lifterlms/pull/1062
related to https://github.com/gocodebox/lifterlms/issues/883 as reported in the comment https://github.com/gocodebox/lifterlms/issues/883#issuecomment-509386070

This is "quite important" for everyone using commas as decimal separator (e.g. europeans, excluding u.k.?).

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

