### PR TITLE
increase 3rd party support for wp core lostpassword_post hook (specifically WordFence)

### DIFF
--- a/includes/forms/controllers/class.llms.controller.account.php
+++ b/includes/forms/controllers/class.llms.controller.account.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Forms/Controllers/Classes
  *
  * @since 3.7.0
- * @version 4.21.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -136,6 +136,7 @@ class LLMS_Controller_Account {
 	 * @since 3.9.5 Unknown.
 	 * @since 3.35.0 Sanitize `$_POST` data.
 	 * @since 3.37.17 Refactored for readability and added new hooks.
+	 * @since [version] Increase 3rd party support for WP core hooks.
 	 *
 	 * @return null|WP_Error|true `null` when nonce cannot be verified.
 	 *                            `WP_Error` when an error is encountered.
@@ -173,6 +174,14 @@ class LLMS_Controller_Account {
 				$err->add( 'llms_pass_reset_invalid_login', __( 'Invalid username or e-mail address.', 'lifterlms' ) );
 			}
 		}
+
+		/**
+		 * Ensure 3rd parties that don't use the 2nd param of `lostpassword_post` still work with our reset functionality.
+		 *
+		 * This specifically adds support for WordFence's "max allowed password resets" under brute force protection, but
+		 * might be useful in other scenarios.
+		 */
+		$_POST['user_login'] = $login;
 
 		/**
 		 * Fires before errors are returned from a password reset request.


### PR DESCRIPTION
## Description

Copies `$_POST['llms_login']` data into `$_POST['user_login']`prior to calling the WP core `lostpassword_post` hook so that 3rd parties relying on the WP core's posted data can work as expeceted.

This specifically allows the WordFence Brute Force Password Reset blocking/rate limiting to work with our password reset the same as it does with the WP core's on `wp-login.php`

Closes https://github.com/gocodebox/private-issues/issues/26

Props: `[Hemant Patidar](https://www.linkedin.com/in/hemantsolo/)`

## How has this been tested?

+ Manually (for 3rd party compat with WordFence)
+ Existing unit tests

## Screenshots <!-- if applicable -->

## Types of changes
+ 3rd party compat

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

