### PR TITLE
Deprecate LLMS_Frontend_Password class

### DIFF
--- a/includes/forms/frontend/class.llms.frontend.password.php
+++ b/includes/forms/frontend/class.llms.frontend.password.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.35.0 Sanitize `$_POST` data.
- * @deprecated [version] LLMS_Frontend_Password is deprecated, functionality is available via LLMS_Controller_Account
+ * @deprecated [version] LLMS_Frontend_Password is deprecated, functionality is available via LLMS_Controller_Account.
  */
 class LLMS_Frontend_Password {
 

--- a/includes/forms/frontend/class.llms.frontend.password.php
+++ b/includes/forms/frontend/class.llms.frontend.password.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Forms/Frontend/Classes
  *
  * @since 1.0.0
- * @version 3.35.0
+ * @version [vesion]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.0.0
  * @since 3.35.0 Sanitize `$_POST` data.
+ * @deprecated [version] LLMS_Frontend_Password is deprecated, functionality is available via LLMS_Controller_Account
  */
 class LLMS_Frontend_Password {
 
@@ -25,10 +26,13 @@ class LLMS_Frontend_Password {
 	 *
 	 * @since 1.0.0
 	 * @since 3.35.0 Sanitize `$_POST` data.
+	 * @deprecated [version] `LLMS_Frontend_Password::retrieve_password()` is deprecated in favor of `LLMS_Controller_Account::lost_password()`.
 	 *
 	 * @return void
 	 */
 	public static function retrieve_password() {
+
+		llms_deprecated_function( 'LLMS_Frontend_Password::retrieve_password()', '[version]', 'LLMS_Controller_Account::lost_password()' );
 
 		global $wpdb;
 
@@ -116,49 +120,30 @@ class LLMS_Frontend_Password {
 	/**
 	 * Checks the password reset key
 	 *
+	 * @since 1.0.0
+	 * @deprecated [version] `LLMS_Frontend_Password::check_password_reset_key()` is deprecated in favor of `check_password_reset_key()`.
+	 *
 	 * @return string $user
 	 */
 	public static function check_password_reset_key( $key, $login ) {
-		global $wpdb;
 
-		$key = preg_replace( '/[^a-z0-9]/i', '', $key );
+		llms_deprecated_function( 'LLMS_Frontend_Password::check_password_reset_key()', '[version]', 'check_password_reset_key()' );
+		return check_password_reset_key( $key, $login );
 
-		if ( empty( $key ) || ! is_string( $key ) ) {
-
-			llms_add_notice( __( 'Invalid key', 'lifterlms' ), 'error' );
-			return false;
-
-		}
-
-		if ( empty( $login ) || ! is_string( $login ) ) {
-
-			llms_add_notice( __( 'Invalid key', 'lifterlms' ), 'error' );
-			return false;
-
-		}
-
-		$user = $wpdb->get_row( $wpdb->prepare( "SELECT * FROM $wpdb->users WHERE user_activation_key = %s AND user_login = %s", $key, $login ) );
-
-		if ( empty( $user ) ) {
-
-			llms_add_notice( __( 'Invalid key', 'lifterlms' ), 'error' );
-			return false;
-
-		}
-
-		return $user;
 	}
 
 	/**
 	 * Reset the users password
 	 *
+	 * @since 1.0.0
+	 * @deprecated [version] `LLMS_Frontend_Password::reset_password()` is deprecated in favor of `reset_password()`.
+	 *
 	 * @return void
 	 */
 	public static function reset_password( $user, $new_pass ) {
 
-		do_action( 'password_reset', $user, $new_pass );
-		wp_set_password( $new_pass, $user->ID );
-		wp_password_change_notification( $user );
+		llms_deprecated_function( 'LLMS_Frontend_Password::reset_password()', '[version]', 'reset_password()' );
+		reset_password( $user, $new_pass );
 
 	}
 


### PR DESCRIPTION
## Description

The `LLMS_Frontend_Password` class was replaced back around 3.8 and has not been properly deprecated.

All functionality is now available via either WP core functions that didn't exist back then or better LifterLMS core functions.

The class and class methods are updated and noted as deprecated and the class & class file will be removed in 5.0

Full deprecation list:

+ `LLMS_Frontend_Password` is deprecated, functionality is available via `LLMS_Controller_Account`
+ `LLMS_Frontend_Password::retrieve_password()` is deprecated in favor of `LLMS_Controller_Account::lost_password()`.
+ `LLMS_Frontend_Password::check_password_reset_key()` is deprecated in favor of `check_password_reset_key()`.
+ `LLMS_Frontend_Password::reset_password()` is deprecated in favor of `reset_password()`.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

