### PR TITLE
WP 5.8 compat fix

### DIFF
--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -285,7 +285,7 @@ class LLMS_Admin_Assets {
 			echo "<script>window.llms.formLocations = JSON.parse( '" . wp_json_encode( wp_slash( LLMS_Forms::instance()->get_locations() ) ) . "' );</script>";
 		}
 
-		if ( ! empty( $screen->is_block_editor ) || 'customizer' === $screen ) {
+		if ( ! empty( $screen->is_block_editor ) || 'customize' === $screen->base ) {
 			echo "<script>window.llms.userInfoFields = JSON.parse( '" . wp_json_encode( wp_slash( llms_get_user_information_fields_for_editor() ) ) . "' );</script>";
 		}
 

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -285,7 +285,7 @@ class LLMS_Admin_Assets {
 			echo "<script>window.llms.formLocations = JSON.parse( '" . wp_json_encode( wp_slash( LLMS_Forms::instance()->get_locations() ) ) . "' );</script>";
 		}
 
-		if ( ! empty( $screen->is_block_editor ) ) {
+		if ( ! empty( $screen->is_block_editor ) || 'customizer' === $screen ) {
 			echo "<script>window.llms.userInfoFields = JSON.parse( '" . wp_json_encode( wp_slash( llms_get_user_information_fields_for_editor() ) ) . "' );</script>";
 		}
 


### PR DESCRIPTION
## Description
This fixes js error in the customizer with WP 5.8: blocks are available there too in the Widgets section.

I didn't test 5.8 thoroughly just wanted to fix this.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

