### PR TITLE
Unsupported versions

### DIFF
--- a/includes/admin/settings/class.llms.settings.accounts.php
+++ b/includes/admin/settings/class.llms.settings.accounts.php
@@ -208,10 +208,22 @@ class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 					'type' => 'sectionstart',
 				),
 				array(
-					'title' => __( 'User Privacy Options', 'lifterlms' ),
+					'title' => __( 'User Information & Privacy Options', 'lifterlms' ),
 					'type'  => 'title',
 					'id'    => 'user_info_field_options_title',
 				),
+
+				array(
+					'title' => __( 'User Information Field Settings', 'lifterlms' ),
+					'type'  => 'subtitle',
+					'desc'  => __( 'Since version 5.0, all user information fields are customized using the form editor.', 'lifterlms' ),
+				),
+				array(
+					'type' => 'custom-html',
+					'value' => '<p><a class="button-primary" href="' . admin_url( 'edit.php?post_type=llms_form' ) . '">' . __( 'Edit Forms', 'lifterlms' ) . '</a></p>',
+				),
+
+
 				array(
 					'title' => __( 'Terms and Conditions', 'lifterlms' ),
 					'type'  => 'subtitle',

--- a/includes/admin/settings/class.llms.settings.accounts.php
+++ b/includes/admin/settings/class.llms.settings.accounts.php
@@ -219,10 +219,9 @@ class LLMS_Settings_Accounts extends LLMS_Settings_Page {
 					'desc'  => __( 'Since version 5.0, all user information fields are customized using the form editor.', 'lifterlms' ),
 				),
 				array(
-					'type' => 'custom-html',
+					'type'  => 'custom-html',
 					'value' => '<p><a class="button-primary" href="' . admin_url( 'edit.php?post_type=llms_form' ) . '">' . __( 'Edit Forms', 'lifterlms' ) . '</a></p>',
 				),
-
 
 				array(
 					'title' => __( 'Terms and Conditions', 'lifterlms' ),

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -232,6 +232,7 @@ class LLMS_Loader {
 	 * @since 4.7.0 Always load `LLMS_Admin_Reporting`.
 	 * @since 4.8.0 Add `LLMS_Export_API`.
 	 * @since 4.12.0 Class `LLMS_Staging` always loaded instead of only loaded on admin panel.
+	 * @since [version] Include `LLMS_Forms_Unsupported_Versions` class.
 	 *
 	 * @return void
 	 */
@@ -258,6 +259,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-export-api.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-mailhawk.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-sendwp.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/forms/class-llms-forms-unsupported-versions.php';
 
 		// Admin classes (files to be renamed).
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class.llms.admin.import.php';

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -329,7 +329,6 @@ class LLMS_Loader {
 				define( $lib['const'], true );
 				require_once $lib['file'];
 			}
-
 		}
 
 		// Action Scheduler.

--- a/includes/forms/class-llms-forms-unsupported-versions.php
+++ b/includes/forms/class-llms-forms-unsupported-versions.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * LLMS_Forms_Unsupported_Versions file
+ *
+ * @package LifterLMS/Classes/Forms
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles admin interface changes when forms cannot be managed with the block editor
+ *
+ * The file, class, and all class methods will be removed without warning when the overall supported
+ * WordPress version is 5.7. Class methods are public in order to function within the WordPress API
+ * but should be considered private for this reason.
+ *
+ * @since [version]
+ *
+ * @access private
+ */
+class LLMS_Forms_Unsupported_Versions {
+
+	/**
+	 * Constructor
+	 *
+	 * @since [version]
+	 *
+	 * @access private
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+
+		if ( LLMS_Forms::instance()->are_requirements_met() ) {
+			return;
+		}
+
+		add_action( 'current_screen', array( $this, 'init' ) );
+
+	}
+
+	/**
+	 * Add actions depending on the current screen
+	 *
+	 * @since [version]
+	 *
+	 * @access private
+	 *
+	 * @return void
+	 */
+	public function init() {
+
+		$screen = get_current_screen();
+
+		if ( 'edit-llms_form' === $screen->id ) {
+
+			add_action( 'admin_print_styles', array( $this, 'print_styles' ) );
+			add_action( 'admin_notices', array( $this, 'output_notice' ) );
+
+		} elseif ( 'llms_form' === $screen->id ) {
+
+			llms_redirect_and_exit( admin_url( 'edit.php?post_type=llms_form' ) );
+
+		}
+
+	}
+
+	/**
+	 * Output an admin error notice alerting users when requirements are not met.
+	 *
+	 * @since [version]
+	 *
+	 * @access private
+	 *
+	 * @return void
+	 */
+	public function output_notice() {
+		?>
+		<div class="notice notice-error">
+			<p><b><?php _e( 'Minimum Version Requirements Error', 'lifterlms' ); ?></b></p>
+			<p><?php printf( __( 'In order to manage LifterLMS Forms you must upgrade to at least WordPress version %s or later or install the latest version of the Gutenberg plugin.', 'lifterlms' ), LLMS_Forms::instance()::MIN_WP_VERSION ); ?></p>
+			<p><?php _e( 'If you do not upgrade, your forms will display properly on the frontend and users will be able to create accounts, enroll, and checkout but you will be unable to customize them.', 'lifterlms' ); ?></p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Output dirty inline CSS to prevent interaction with the posts table list
+	 *
+	 * @since [version]
+	 *
+	 * @access private
+	 *
+	 * @return void
+	 */
+	public function print_styles() {
+		echo '<style type="text/css" id="llms-forms-unsupported-styles">#the-list { pointer-events: none; filter: blur( 1px ); }</style>';
+	}
+
+}
+
+return new LLMS_Forms_Unsupported_Versions();

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -78,7 +78,7 @@ class LLMS_Forms {
 	 */
 	public function are_requirements_met() {
 		global $wp_version;
-		return version_compare( $wp_version, self::MIN_WP_VERSION, '>=' );
+		return version_compare( $wp_version, self::MIN_WP_VERSION, '>=' ) || is_plugin_active( 'gutenberg/gutenberg.php' );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-unsupported-versions.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-unsupported-versions.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Test LLMS_Forms_Unsupported_Versions
+ *
+ * @package LifterLMS/Tests/Forms
+ *
+ * @group forms
+ * @group forms_unsupported_versions
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Forms_Unsupported_Versions extends LLMS_UnitTestCase {
+
+	/**
+	 * Set up before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+		require_once LLMS_PLUGIN_DIR . 'includes/forms/class-llms-forms-unsupported-versions.php';
+	}
+
+	public function setUp() {
+
+		parent::setUp();
+		$this->init_main();
+
+	}
+
+	/**
+	 * Construct a new main class for testing.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function init_main() {
+		$this->main = new LLMS_Forms_Unsupported_Versions();
+	}
+
+	/**
+	 * Test constructor
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_constructor() {
+
+		$this->assertFalse( has_action( 'current_screen', array( $this->main, 'init' ) ) );
+
+		global $wp_version;
+		$temp = $wp_version;
+		$wp_version = '5.6.2';
+
+		$this->init_main();
+		$this->assertEquals( 10, has_action( 'current_screen', array( $this->main, 'init' ) ) );
+
+		$wp_version = $temp;
+
+	}
+
+	/**
+	 * Test init() when nothing should happen
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_for_other() {
+
+		set_current_screen( 'admin.php' );
+
+		$this->main->init();
+
+		$this->assertFalse( has_action( 'admin_print_styles', array( $this->main, 'print_styles' ) ) );
+		$this->assertFalse( has_action( 'admin_notices', array( $this->main, 'output_notice' ) ) );
+
+		set_current_screen( 'front' );
+
+	}
+
+	/**
+	 * Test init() for the forms post table list
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_for_post_table() {
+
+		set_current_screen( 'edit-llms_form' );
+
+		$this->main->init();
+
+		$this->assertEquals( 10, has_action( 'admin_print_styles', array( $this->main, 'print_styles' ) ) );
+		$this->assertEquals( 10, has_action( 'admin_notices', array( $this->main, 'output_notice' ) ) );
+
+		set_current_screen( 'front' );
+
+	}
+
+	/**
+	 * Test init() when accessing a form block editor directly
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_for_form_post() {
+
+		set_current_screen( 'llms_form' );
+
+		$this->expectException( LLMS_Unit_Test_Exception_Redirect::class );
+		$this->expectExceptionMessage( 'http://example.org/wp-admin/edit.php?post_type=llms_form [302] YES' );
+
+		try {
+
+			$this->main->init();
+
+		} catch ( LLMS_Unit_Test_Exception_Redirect $exception ) {
+
+			set_current_screen( 'front' );
+			throw $exception;
+
+		}
+
+	}
+}


### PR DESCRIPTION
## Description

Add UI & handling for the forms editor and forms post table list for WP core versions < 5.7

## How has this been tested?

+ Manually
+ New tests

## Screenshots <!-- if applicable -->

## Types of changes

Updates

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

