### PR TITLE
Add a new admin tool to wip legacy user information fields options

### DIFF
--- a/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
+++ b/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * LLMS_Admin_Tool_Wipe_Legacy_Account_Options
+ *
+ * @package LifterLMS/Admin/Tools/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin tool to wipe legacy account options
+ *
+ * @since [version]
+ */
+class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_Tool {
+
+	/**
+	 * Tool ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'wipe-legacy-account-options';
+
+	/**
+	 * Retrieve a description of the tool
+	 *
+	 * This is displayed on the right side of the tool's list before the button.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+		return __( 'Remove legacy pre LifterLMS 5.0 user information fields options.', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve the tool's label
+	 *
+	 * The label is the tool's title. It's displayed in the left column on the tool's list.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_label() {
+		return __( 'Wipe Legacy User Information options', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve the tool's button text
+	 *
+	 * @since 5.0.0
+	 *
+	 * @return string
+	 */
+	protected function get_text() {
+		return __( 'Wipe Legacy Options', 'lifterlms' );
+	}
+
+	/**
+	 * Process the tool.
+	 *
+	 * Deletes all core reusable blocks and then recreates the core forms,
+	 * which additionally recreates the core reusable blocks.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	protected function handle() {
+
+		$options_to_wipe = array(
+			'lifterlms_registration_generate_username',
+			'lifterlms_registration_password_strength',
+			'lifterlms_registration_password_min_strength',
+			'lifterlms_user_info_field_names_checkout_visibility',
+			'lifterlms_user_info_field_address_checkout_visibility',
+			'lifterlms_user_info_field_phone_checkout_visibility',
+			'lifterlms_user_info_field_email_confirmation_checkout_visibility',
+			'lifterlms_user_info_field_names_registration_visibility',
+			'lifterlms_user_info_field_address_registration_visibility',
+			'lifterlms_user_info_field_phone_registration_visibility',
+			'lifterlms_user_info_field_email_confirmation_registration_visibility',
+			'lifterlms_voucher_field_registration_visibility',
+			'lifterlms_user_info_field_names_account_visibility',
+			'lifterlms_user_info_field_address_account_visibility',
+			'lifterlms_user_info_field_phone_account_visibility',
+			'lifterlms_user_info_field_email_confirmation_account_visibility',
+		);
+
+		global $wpdb;
+
+		$sql = "
+		DELETE FROM {$wpdb->options}
+		WHERE option_name IN (" . implode( ', ', array_fill( 0, count( $options_to_wipe ), '%s' ) ) . ')';
+
+		$wpdb->query(
+			$wpdb->prepare(
+				$sql,
+				$options_to_wipe
+			)
+		); // db call ok; no-cache ok.
+
+		return true;
+
+	}
+
+	/**
+	 * Conditionally load the tool
+	 *
+	 * This tool should only load if there are legacy options (we only check 'lifterlms_registration_generate_username').
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean Return `true` to load the tool and `false` to not load it.
+	 */
+	protected function should_load() {
+		return ( 'not-set' !== get_option( 'lifterlms_registration_generate_username', 'not-set' ) );
+
+	}
+}
+
+return new LLMS_Admin_Tool_Wipe_Legacy_Account_Options();

--- a/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
+++ b/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
@@ -18,11 +18,18 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_Tool {
 
 	/**
-	 * Tool ID.
+	 * Tool ID
 	 *
 	 * @var string
 	 */
 	protected $id = 'wipe-legacy-account-options';
+
+	/**
+	 * Skip cache when checking if should load
+	 *
+	 * @var boolean
+	 */
+	private $skip_cache = false;
 
 	/**
 	 * Retrieve a description of the tool
@@ -105,6 +112,8 @@ class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_To
 			)
 		); // db call ok; no-cache ok.
 
+		$this->skip_cache = true;
+
 		return true;
 
 	}
@@ -119,6 +128,17 @@ class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_To
 	 * @return boolean Return `true` to load the tool and `false` to not load it.
 	 */
 	protected function should_load() {
+
+		if ( $this->skip_cache ) {
+			global $wpdb;
+
+			return ! empty(
+				$wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->options}
+				WHERE option_name='lifterlms_registration_generate_username'" )
+			);
+
+		}
+
 		return ( 'not-set' !== get_option( 'lifterlms_registration_generate_username', 'not-set' ) );
 
 	}

--- a/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
+++ b/includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php
@@ -41,7 +41,7 @@ class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_To
 	 * @return string
 	 */
 	protected function get_description() {
-		return __( 'Remove legacy pre LifterLMS 5.0 user information fields options.', 'lifterlms' );
+		return __( 'Removes all options used to control the visibility of user information fields prior to version 5.0. Since version 5.0 these options are only used when restoring forms to their original default values.', 'lifterlms' );
 	}
 
 	/**
@@ -54,7 +54,7 @@ class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_To
 	 * @return string
 	 */
 	protected function get_label() {
-		return __( 'Wipe Legacy User Information options', 'lifterlms' );
+		return __( 'Delete Legacy User Information Options', 'lifterlms' );
 	}
 
 	/**
@@ -65,7 +65,7 @@ class LLMS_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Abstract_Admin_To
 	 * @return string
 	 */
 	protected function get_text() {
-		return __( 'Wipe Legacy Options', 'lifterlms' );
+		return __( 'Delete Legacy Options', 'lifterlms' );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * Tests for the LLMS_Admin_Tool_Wipe_Legacy_Account_Options class
+ *
+ * @package LifterLMS/Tests/Admins/Tools
+ *
+ * @group admin
+ * @group admin_tools
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_UnitTestCase {
+
+	const LEGACY_OPTIONS = array(
+		'lifterlms_registration_generate_username',
+		'lifterlms_registration_password_strength',
+		'lifterlms_registration_password_min_strength',
+		'lifterlms_user_info_field_names_checkout_visibility',
+		'lifterlms_user_info_field_address_checkout_visibility',
+		'lifterlms_user_info_field_phone_checkout_visibility',
+		'lifterlms_user_info_field_email_confirmation_checkout_visibility',
+		'lifterlms_user_info_field_names_registration_visibility',
+		'lifterlms_user_info_field_address_registration_visibility',
+		'lifterlms_user_info_field_phone_registration_visibility',
+		'lifterlms_user_info_field_email_confirmation_registration_visibility',
+		'lifterlms_voucher_field_registration_visibility',
+		'lifterlms_user_info_field_names_account_visibility',
+		'lifterlms_user_info_field_address_account_visibility',
+		'lifterlms_user_info_field_phone_account_visibility',
+		'lifterlms_user_info_field_email_confirmation_account_visibility',
+	);
+
+	/**
+	 * Setup before class
+	 *
+	 * Include abstract class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php';
+
+	}
+
+	/**
+	 * Setup the test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$this->main = new LLMS_Admin_Tool_Wipe_Legacy_Account_Options();
+
+	}
+
+	/**
+	 * Tear Down
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+
+		parent::tearDown();
+		$this->delete_legacy_options();
+
+	}
+
+
+	/**
+	 * Test get_description()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_description() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_label()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_text()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_text() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test handle()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle() {
+
+		global $wpdb;
+
+		$sql = "
+		SELECT COUNT(*) FROM {$wpdb->options}
+		WHERE option_name IN (" . implode( ', ', array_fill( 0, count( self::LEGACY_OPTIONS ), '%s' ) ) . ')';
+
+		$query = $wpdb->prepare(
+			$sql,
+			self::LEGACY_OPTIONS
+		);
+
+		$this->assertEquals( 0, $wpdb->get_var( $query ) );
+
+		$this->add_legacy_options();
+
+		$this->assertEquals( count( self::LEGACY_OPTIONS ), $wpdb->get_var( $query ) );
+
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'handle' ) );
+
+		$this->assertEquals( 0, $wpdb->get_var( $query ) );
+
+	}
+
+	/**
+	 * Test can_load()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_load() {
+		$this->assertFalse(
+			LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' )
+		);
+
+		$this->add_legacy_options();
+
+		$this->assertTrue(
+			LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' )
+		);
+	}
+
+	/**
+	 * Add legacy options to the WP options table
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function add_legacy_options() {
+
+		array_map( 'add_option', self::LEGACY_OPTIONS, array_fill( 0, count( self::LEGACY_OPTIONS ), 'yes' ) );
+
+	}
+
+
+	/**
+	 * Remove legacy options to the WP options table
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function delete_legacy_options() {
+
+		array_map( 'delete_option', self::LEGACY_OPTIONS, array_fill( 0, count( self::LEGACY_OPTIONS ), 'yes' ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
@@ -171,6 +171,14 @@ class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_UnitTestCase
 		$this->assertTrue(
 			LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' )
 		);
+
+		// Check that the tool doesn't load after it has been handled.
+		LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+
+		$this->assertFalse(
+			LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' )
+		);
+
 	}
 
 	/**


### PR DESCRIPTION
## Description
Adds an admin tool to wipe all the legacy user information fields options pre 5.0

## How has this been tested?
manually and unit tests
~@thomasplevy for some reason though I get the tool loaded right after its execution... but if I refresh the page it correctly doesn't show up.~

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

