### PR TITLE
Fix custom slugs with non-latin characters

### DIFF
--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 4.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -209,9 +209,10 @@ class LLMS_Admin_Settings {
 	 * @since 3.29.0 Unknown.
 	 * @since 3.34.4 Add "keyval" field for displaying custom html next to a setting key.
 	 * @since 3.37.9 Add option for fields to show an asterisk for required fields.
+	 * @since [version] Pass any option value sanitized as a "slug" through `urldecode()` prior to displaying it.
 	 *
-	 * @param    array $field  array of field settings
-	 * @return   void
+	 * @param array $field  array of field settings
+	 * @return void
 	 */
 	public static function output_field( $field ) {
 
@@ -379,6 +380,11 @@ class LLMS_Admin_Settings {
 
 				$secure_val   = isset( $field['secure_option'] ) ? llms_get_secure_option( $field['secure_option'], false ) : false;
 				$option_value = ( false !== $secure_val ) ? str_repeat( '*', strlen( $secure_val ) ) : $option_value;
+
+				// Ensure slugs with non-latin characters are not displayed as urlencoded strings.
+				if ( ! empty( $field['sanitize'] && 'slug' === $field['sanitize'] ) ) {
+					$option_value = urldecode( $option_value );
+				}
 
 				?>
 				<tr valign="top" class="<?php echo $disabled_class; ?>">

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -211,7 +211,7 @@ class LLMS_Admin_Settings {
 	 * @since 3.37.9 Add option for fields to show an asterisk for required fields.
 	 * @since [version] Pass any option value sanitized as a "slug" through `urldecode()` prior to displaying it.
 	 *
-	 * @param array $field  array of field settings
+	 * @param array $field Array of field settings.
 	 * @return void
 	 */
 	public static function output_field( $field ) {

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -382,7 +382,7 @@ class LLMS_Admin_Settings {
 				$option_value = ( false !== $secure_val ) ? str_repeat( '*', strlen( $secure_val ) ) : $option_value;
 
 				// Ensure slugs with non-latin characters are not displayed as urlencoded strings.
-				if ( ! empty( $field['sanitize'] && 'slug' === $field['sanitize'] ) ) {
+				if ( ! empty( $field['sanitize'] ) && 'slug' === $field['sanitize'] ) {
 					$option_value = urldecode( $option_value );
 				}
 

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -60,7 +60,7 @@ class LLMS_Query {
 	 *
 	 * @since 1.0.0
 	 * @since 3.28.2 Handle dashboard tab pagination via a rewrite rule.
-	 * @since [version] Add support for slugs with non-latin Characters.
+	 * @since [version] Add support for slugs with non-latin characters.
 	 *
 	 * @return void
 	 */
@@ -301,4 +301,3 @@ class LLMS_Query {
 }
 
 return new LLMS_Query();
-

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -1,29 +1,21 @@
 <?php
 /**
- * Query base class
- *
- * Handles queries and endpoints.
+ * LLMS_Query class file.
  *
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 4.5.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Query class.
+ * Query base class
+ *
+ * Handles queries and endpoints.
  *
  * @since 1.0.0
- * @since 3.31.0 Deprecated `add_query_vars() method and added sanitizing functions when accessing `$_GET` vars.
- * @since 3.33.0 Added catalog secondary sorting by `post_title` when the primary sort is `menu_order`.
- * @since 3.36.3 Changed `pre_get_posts` callback from `10 (default) to `15`,
- *               so to avoid conflicts with the Divi theme whose callback runs at `10`,
- *               but since themes are loaded after plugins it overrode our one.
- * @since 3.36.4 Don't remove `pre_get_posts` callback from within the callback itself.
- *               Rather use a static variable to make sure the business logic of the callback
- *               is executed only once.
  * @since 4.0.0 Remove previously deprecated methods.
  */
 class LLMS_Query {
@@ -68,20 +60,21 @@ class LLMS_Query {
 	 *
 	 * @since 1.0.0
 	 * @since 3.28.2 Handle dashboard tab pagination via a rewrite rule.
+	 * @since [version] Add support for slugs with non-latin Characters.
 	 *
 	 * @return void
 	 */
 	public function add_endpoints() {
 
 		foreach ( $this->get_query_vars() as $key => $var ) {
-			add_rewrite_endpoint( $var, EP_PAGES );
+			add_rewrite_endpoint( $var, EP_PAGES, $key );
 		}
 
 		global $wp_rewrite;
 		foreach ( LLMS_Student_Dashboard::get_tabs() as $id => $tab ) {
 			if ( ! empty( $tab['paginate'] ) ) {
-				$regex    = sprintf( '(.?.+?)/%1$s/%2$s/?([0-9]{1,})/?$', $tab['endpoint'], $wp_rewrite->pagination_base );
-				$redirect = sprintf( 'index.php?pagename=$matches[1]&%s=$matches[3]&paged=$matches[2]', $tab['endpoint'] );
+				$regex    = sprintf( '(.?.+?)/%1$s/%2$s/?([0-9]{1,})/?$', urldecode( $tab['endpoint'] ), $wp_rewrite->pagination_base );
+				$redirect = sprintf( 'index.php?pagename=$matches[1]&%s=$matches[3]&paged=$matches[2]', $id );
 				add_rewrite_rule( $regex, $redirect, 'top' );
 			}
 		}
@@ -102,7 +95,7 @@ class LLMS_Query {
 	/**
 	 * Get a taxonomy query that filters out courses & memberships based on catalog / search visibility settings
 	 *
-	 * @since    3.6.0
+	 * @since 3.6.0
 	 *
 	 * @param array $query Existing taxonomy query from the global $wp_query.
 	 * @return array

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -161,8 +161,8 @@ class LLMS_Query {
 		global $wp;
 
 		foreach ( $this->get_query_vars() as $key => $var ) {
-			if ( isset( $_GET[ $var ] ) ) {
-				$wp->query_vars[ $key ] = sanitize_text_field( wp_unslash( $_GET[ $var ] ) );
+			if ( isset( $_GET[ $var ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$wp->query_vars[ $key ] = sanitize_text_field( wp_unslash( $_GET[ $var ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			} elseif ( isset( $wp->query_vars[ $var ] ) ) {
 				$wp->query_vars[ $key ] = $wp->query_vars[ $var ];
 			}
@@ -244,10 +244,10 @@ class LLMS_Query {
 
 			}
 
-			// do it once.
+			// Do it once.
 			$done = true;
 
-		}// End if().
+		}
 
 		if ( $modify_tax_query ) {
 

--- a/tests/phpunit/unit-tests/class-llms-test-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-query.php
@@ -25,6 +25,136 @@ class LLMS_Test_Query extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Assertion helper to ensure that the `$wp_query->query` variables equal an expected array
+	 *
+	 * @since [version]
+	 *
+	 * @param array  $expected Expected query array.
+	 * @param string $message  Error message.
+	 * @return void
+	 */
+	private function assertQueryVarsEqual( $expected, $message = null ) {
+
+		global $wp_query;
+		$this->assertEquals( $expected, $wp_query->query, urldecode( $message ) );
+
+	}
+
+	/**
+	 * Tests the add_endpoints() method
+	 *
+	 * This is a large "integration" test that ensures that student dashboard
+	 * endpoints are properly added to the `$wp_rewrite` list.
+	 *
+	 * It does "real" tests by simulating a visit to the URL and testing that the expected
+	 * `$wp_query->query` variables are set.
+	 *
+	 * It runs tests with the default values of the endpoints, with custom translated values in various
+	 * languages (to ensure non-latin characters work in customized slugs) and finally adds a random string
+	 * of alphanumeric latin chars for testing.
+	 *
+	 * It additionally tests pagination for endpoints that utilize pagination work regardless of the customized
+	 * slug.
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms/issues/1639
+	 *
+	 * @return void
+	 */
+	public function test_add_endpoints() {
+
+		LLMS_Install::create_pages();
+
+		// Setup.
+		$temp = get_option( 'permalink_structure' );
+		update_option( 'permalink_structure', '/%postname%/' );
+
+		global $wp_rewrite;
+		$wp_rewrite->init();
+
+		$account_url = llms_get_page_url( 'myaccount' );
+		$options     = array(
+			'view-courses'      => 'lifterlms_myaccount_courses_endpoint',
+			'my-grades'         => 'lifterlms_myaccount_grades_endpoint',
+			'view-memberships'  => 'lifterlms_myaccount_memberships_endpoint',
+			'view-achievements' => 'lifterlms_myaccount_achievements_endpoint',
+			'view-certificates' => 'lifterlms_myaccount_certificates_endpoint',
+			'notifications'     => 'lifterlms_myaccount_notifications_endpoint',
+			'edit-account'      => 'lifterlms_myaccount_edit_account_endpoint',
+			'redeem-voucher'    => 'lifterlms_myaccount_redeem_vouchers_endpoint',
+			'orders'            => 'lifterlms_myaccount_orders_endpoint',
+		);
+
+		$non_latin = array(
+			'view-courses'      => 'ビューコース', // Japanese.
+			'my-grades'         => 'мои-оценки', // Russian.
+			'view-memberships'  => 'ਵੇਖੋ-ਸਦੱਸਤਾ', // Punjabi.
+			'view-achievements' => 'nailiyyətlər', // Azerbaijani.
+			'view-certificates' => 'ເບິ່ງໃບຢັ້ງຢືນ', // Lao.
+			'notifications'     => '通知', // Chinese (Simplified).
+			'edit-account'      => 'חשבון-עריכה', // Hebrew.
+			'redeem-voucher'    => 'چھڑانا', // Urdu.
+			'orders'            => 'आदेश', // Hindi.
+		);
+
+		foreach ( LLMS_Student_Dashboard::get_tabs() as $id => $tab ) {
+
+			if ( empty( $tab['endpoint'] ) ) {
+				continue;
+			}
+
+			$tests = array(
+				$tab['endpoint'],
+				wp_generate_password( 6, false, false ),
+				$non_latin[ $id ],
+			);
+
+			foreach ( $tests as $option ) {
+
+				update_option( $options[ $id ], urlencode( $option ) );
+				new LLMS_Student_Dashboard();
+				$this->main->add_endpoints();
+				flush_rewrite_rules();
+
+				$url = isset( $tab['url'] ) ? $tab['url'] : llms_get_endpoint_url( $id, null, $account_url );
+
+				$this->go_to( $url );
+
+				$expect = array(
+					'pagename' => 'dashboard',
+				);
+
+				if ( 'dashboard' === $id ) {
+					$expect['page'] = '';
+				} else {
+					$expect[ $id ] = '';
+				}
+
+				$this->assertQueryVarsEqual( $expect, $id . ' - ' . $url );
+
+				if ( ! empty( $tab['paginate'] ) ) {
+					$url .= 'page/1';
+					$this->go_to( $url );
+					$expect['paged'] = 1;
+					$this->assertQueryVarsEqual( $expect, $url );
+
+				}
+
+			}
+
+		}
+
+
+		$this->go_to( '' );
+
+		// Teardown.
+		update_option( 'permalink_structure', $temp );
+		$wp_rewrite->init();
+
+	}
+
+	/**
 	 * Test maybe_404_certificate()
 	 *
 	 * This test runs in a separate process because something before it is making it hard


### PR DESCRIPTION
## Description

Allows non-latin characters to be used in custom endpoint slugs

Fixes #1639 

## How has this been tested?

+ Manually
+ New tests

## Types of changes

Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

