### PR TITLE
Fix checkout form with no (visible) fields and always require email fields in checkout/registration

### DIFF
--- a/includes/class.llms.person.handler.php
+++ b/includes/class.llms.person.handler.php
@@ -320,7 +320,7 @@ class LLMS_Person_Handler {
 	 *
 	 * @since Unknown
 	 * @since 5.0.0 Get fields from the checkout or registration forms before falling back to default fields.
-	 *               Changed filter on return from "lifterlms_lost_password_fields" to "llms_password_reset_fields".
+	 *              Changed filter on return from "lifterlms_lost_password_fields" to "llms_password_reset_fields".
 	 *
 	 * @param string $key User password reset key, usually populated via $_GET vars.
 	 * @param string $login User login (username), usually populated via $_GET vars.
@@ -367,12 +367,12 @@ class LLMS_Person_Handler {
 		 *
 		 * @since 5.0.0
 		 *
-		 * @param array[] $fields Array of form field arrays.
-		 * @param string $key User password reset key, usually populated via $_GET vars.
-		 * @param string $login User login (username), usually populated via $_GET vars.
-		 * @param string $location Location where the fields were retrieved from. Either "checkout", "registration", or "fallback".
-		 *                         Fallback denotes that no password field was located in either of the previous forms so a default
-		 *                         set of fields is generated programmatically.
+		 * @param array[] $fields   Array of form field arrays.
+		 * @param string  $key      User password reset key, usually populated via $_GET vars.
+		 * @param string  $login    User login (username), usually populated via $_GET vars.
+		 * @param string  $location Location where the fields were retrieved from. Either "checkout", "registration", or "fallback".
+		 *                          Fallback denotes that no password field was located in either of the previous forms so a default
+		 *                          set of fields is generated programmatically.
 		 */
 		return apply_filters( 'llms_password_reset_fields', $fields, $key, $login, $location );
 

--- a/includes/forms/class-llms-form-field.php
+++ b/includes/forms/class-llms-form-field.php
@@ -2,7 +2,7 @@
 /**
  * Setup and render form fields.
  *
- * @package  LifterLMS/Classes
+ * @package LifterLMS/Classes
  *
  * @since 5.0.0
  * @version 5.0.0

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -308,7 +308,7 @@ class LLMS_Form_Handler {
 	 * Form submission handler
 	 *
 	 * @since 5.0.0
-	 * @since [version] Remove invisible fields from when loading the form.
+	 * @since [version] Remove invisible fields from when loading the checkout form.
 	 *
 	 * @param array  $posted_data User-submitted form data.
 	 * @param string $location    Form location ID.
@@ -320,10 +320,14 @@ class LLMS_Form_Handler {
 		// Determine the user action to perform.
 		$action = get_current_user_id() ? 'update' : 'registration';
 
-		// Load the form, filtering out invisible fields.
-		add_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
+		// Load the form, filtering out invisible fields, only for checkout form.
+		if ( 'checkout' === $location ) {
+			add_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
+		}
 		$fields = $this->get_fields( $action, $location, $args );
-		remove_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
+		if ( 'checkout' === $location ) {
+			remove_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
+		}
 
 		if ( is_wp_error( $fields ) ) {
 			return $this->submit_error( $fields, $posted_data, $action );

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -340,6 +340,7 @@ class LLMS_Form_Handler {
 	 * Form fields submission
 	 *
 	 * @since 5.0.0
+	 * @since [version] Added "lifterlms_user_${action}_required_data" filter, to filter the required fields validity of the form submission.
 	 *
 	 * @param array   $posted_data User-submitted form data.
 	 * @param string  $location    Form location ID.

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -124,6 +124,7 @@ class LLMS_Form_Handler {
 	 * Modify LifterLMS Fields prior to performing submit handler validations.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Do not allow submitting a password change without providing a `password_current`
 	 *
 	 * @param array   $posted_data User submitted form data (passed by reference).
 	 * @param string  $location    Form location ID.
@@ -140,12 +141,24 @@ class LLMS_Form_Handler {
 		 * If email address and passwords aren't submitted we can mark them as "optional" fields.
 		 *
 		 * These fields are dynamically toggled and disabled if they're not modified.
+		 * Process `password_current` as last as it depends on `password` field submission.
 		 */
 		foreach ( array( 'email_address', 'password', 'password_current' ) as $field_id ) {
 
 			// If the field exists and it's not included (or empty) in the posted data.
 			$index = LLMS_Forms::instance()->get_field_by( $fields, 'id', $field_id, 'index' );
 			if ( false !== $index && empty( $posted_data[ $fields[ $index ]['name'] ] ) ) {
+
+				// When updating a password, the `password_current` is mandatory.
+				if ( 'account' === $location && 'password_current' === $field_id ) {
+					// Get `password` field.
+					$password_index = LLMS_Forms::instance()->get_field_by( $fields, 'id', 'password', 'index' );
+					// If a `passowrd` feld has been submitted then the `password_current` cannot be skipped.
+					if ( false !== $password_index &&
+							! empty( $posted_data[ $fields[ $password_index ]['name'] ] ) ) {
+						continue;
+					}
+				}
 
 				// Remove the field so we don't accidentally save an empty value later.
 				unset( $posted_data[ $fields[ $index ]['name'] ] );

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -5,7 +5,7 @@
  * @package  LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -308,6 +308,7 @@ class LLMS_Form_Handler {
 	 * Form submission handler
 	 *
 	 * @since 5.0.0
+	 * @since [version] Remove invisible fields from when loading the form.
 	 *
 	 * @param array  $posted_data User-submitted form data.
 	 * @param string $location    Form location ID.

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -320,9 +320,9 @@ class LLMS_Form_Handler {
 		$action = get_current_user_id() ? 'update' : 'registration';
 
 		// Load the form, filtering out invisible fields.
-		add_filter( 'llms_filter_out_invisible_field', '__return_true', 999 );
+		add_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
 		$fields = $this->get_fields( $action, $location, $args );
-		remove_filter( 'llms_filter_out_invisible_field', '__return_true', 999 );
+		remove_filter( 'llms_forms_remove_invisible_field', '__return_true', 999 );
 
 		if ( is_wp_error( $fields ) ) {
 			return $this->submit_error( $fields, $posted_data, $action );

--- a/includes/forms/class-llms-form-handler.php
+++ b/includes/forms/class-llms-form-handler.php
@@ -319,8 +319,11 @@ class LLMS_Form_Handler {
 		// Determine the user action to perform.
 		$action = get_current_user_id() ? 'update' : 'registration';
 
-		// Load the form.
+		// Load the form, filtering out invisible fields.
+		add_filter( 'llms_filter_out_invisible_field', '__return_true', 999 );
 		$fields = $this->get_fields( $action, $location, $args );
+		remove_filter( 'llms_filter_out_invisible_field', '__return_true', 999 );
+
 		if ( is_wp_error( $fields ) ) {
 			return $this->submit_error( $fields, $posted_data, $action );
 		}
@@ -333,6 +336,7 @@ class LLMS_Form_Handler {
 	}
 
 	/**
+	 * Form fields submission
 	 *
 	 * @since 5.0.0
 	 *
@@ -351,9 +355,9 @@ class LLMS_Form_Handler {
 		 *
 		 * @since 3.0.0
 		 * @since 5.0.0 Moved from `LLMS_Person_Handler::update()` & LLMS_Person_Handler::register().
-		 *               Added parameters `$fields` and `$args`.
-		 *               Triggered by `do_action_ref_array()` instead of `do_action()` allowing modification
-		 *               of `$posted_data` and `$fields` via hooks.
+		 *              Added parameters `$fields` and `$args`.
+		 *              Triggered by `do_action_ref_array()` instead of `do_action()` allowing modification
+		 *              of `$posted_data` and `$fields` via hooks.
 		 *
 		 * @param array   $posted_data Array of user-submitted data (passed by reference).
 		 * @param string  $location    Form location.

--- a/includes/forms/class-llms-form-templates.php
+++ b/includes/forms/class-llms-form-templates.php
@@ -94,11 +94,12 @@ class LLMS_Form_Templates {
 	 * Locates an existing wp_block post by field id
 	 *
 	 * @since 5.0.0
+	 * @since [version] Method access changed from private to public.
 	 *
 	 * @param string $field_id The field's identifier as found in the block schema list returned by LLMS_Form_Templates::get_reusable_block_schema().
 	 * @return WP_Post|boolean Returns the post object or false if not found.
 	 */
-	private static function find_reusable_block( $field_id ) {
+	public static function find_reusable_block( $field_id ) {
 
 		$query = new WP_Query(
 			array(

--- a/includes/forms/class-llms-form-templates.php
+++ b/includes/forms/class-llms-form-templates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/forms/class-llms-form-templates.php
+++ b/includes/forms/class-llms-form-templates.php
@@ -121,13 +121,14 @@ class LLMS_Form_Templates {
 	 * block modified by legacy options for the given location when `$reusable` is `false`.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Method access set to public.
 	 *
 	 * @param string  $field_id The field's identifier as found in the block schema list returned by LLMS_Form_Templates::get_reusable_block_schema().
 	 * @param string  $location Form location. Accepts "checkout", "registration", or "account".
 	 * @param boolean $reusable Whether or not a reusable block should be retrieved.
 	 * @return array
 	 */
-	private static function get_block( $field_id, $location, $reusable ) {
+	public static function get_block( $field_id, $location, $reusable ) {
 
 		if ( $reusable ) {
 			return self::get_reusable_block( $field_id );

--- a/includes/forms/class-llms-form-validator.php
+++ b/includes/forms/class-llms-form-validator.php
@@ -384,7 +384,7 @@ class LLMS_Form_Validator {
 	 */
 	public function validate_fields( $posted_data, $fields ) {
 
-		if ( empty( $posted_data ) && ! empty( $fields )  ) {
+		if ( empty( $posted_data ) && ! empty( $fields ) ) {
 			return new WP_Error( 'llms-form-no-input', __( 'Cannot validate a form with no user input.', 'lifterlms' ) );
 		}
 

--- a/includes/forms/class-llms-form-validator.php
+++ b/includes/forms/class-llms-form-validator.php
@@ -376,6 +376,7 @@ class LLMS_Form_Validator {
 	 * Validate submitted field values.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Don't validate form with no user input only if the form is not empty itself (e.g. contains only invisible fields).
 	 *
 	 * @param array   $posted_data Array of posted data.
 	 * @param array[] $fields      Array of LifterLMS Form Fields.
@@ -383,7 +384,7 @@ class LLMS_Form_Validator {
 	 */
 	public function validate_fields( $posted_data, $fields ) {
 
-		if ( empty( $posted_data ) ) {
+		if ( empty( $posted_data ) && ! empty( $fields )  ) {
 			return new WP_Error( 'llms-form-no-input', __( 'Cannot validate a form with no user input.', 'lifterlms' ) );
 		}
 

--- a/includes/forms/class-llms-form-validator.php
+++ b/includes/forms/class-llms-form-validator.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -280,15 +280,18 @@ class LLMS_Forms_Dynamic_Fields {
 		$blocks_to_add = array();
 		foreach ( $fields_to_require as $field_id => $block_to_add ) {
 			// If a reusable block exists for the field, use it. Otherwise use a dynamically generated block from the template schema.
-			$use_reusable = LLMS_Form_Templates::find_reusable_block( $block_to_add ) ? true : false;
-			$block_to_add = LLMS_Form_Templates::get_block( $block_to_add, $location, $use_reusable );
-			// Make sure the reusable block is visible.
-			$blocks_to_add[] = $use_reusable ? $this->make_all_visible( $block_to_add ) : $block_to_add;
+			$use_reusable    = LLMS_Form_Templates::find_reusable_block( $block_to_add ) ? true : false;
+			$blocks_to_add[] = LLMS_Form_Templates::get_block( $block_to_add, $location, $use_reusable );
 		}
+
+		// Load reusable.
+		$blocks_to_add = LLMS_Forms::instance()->load_reusable_blocks( $blocks_to_add );
+		// Make blocks to add visible.
+		$blocks_to_add = 'checkout' === $location ? array_map( array( $this, 'make_all_visible' ), $blocks_to_add ) : $blocks_to_add;
 
 		return array_merge(
 			$blocks,
-			LLMS_Forms::instance()->load_reusable_blocks( $blocks_to_add )
+			$blocks_to_add
 		);
 
 	}
@@ -410,10 +413,10 @@ class LLMS_Forms_Dynamic_Fields {
 				$block['innerBlocks'][ $index ] = $this->make_all_visible( $inner_block );
 			}
 		}
-
 		$block['attrs']['llms_visibility'] = '';
 
 		return $block;
+
 	}
 
 	/**

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -262,12 +262,12 @@ class LLMS_Forms_Dynamic_Fields {
 			}
 		}
 
-		// Maybe add field blocks.
+		$_blocks = array();
 		foreach ( $fields_to_require as $field_id => $block_to_add ) {
-			array_push( $blocks, LLMS_Form_Templates::get_block( $block_to_add, $location, false ) );
+			$_blocks[] = LLMS_Form_Templates::get_block( $block_to_add, $location, true );
 		}
 
-		return $blocks;
+		return empty( $_blocks ) ? $blocks : array_merge( $blocks, LLMS_Forms::instance()->load_reusable_blocks( $_blocks ) );
 
 	}
 

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -171,7 +171,7 @@ class LLMS_Forms_Dynamic_Fields {
 
 		if (
 			( ! is_user_logged_in() && in_array( $location, array( 'checkout', 'registration' ), true ) ) ||
-			( is_user_logged_in() && 'account' === $location ) ) {
+				( is_user_logged_in() && 'account' === $location ) ) {
 			$fields = array(
 				// Field ID => block name.
 				'email_address' => 'email',
@@ -268,7 +268,8 @@ class LLMS_Forms_Dynamic_Fields {
 			$block = $this->find_block( $field_id, $blocks );
 
 			if ( ! empty( $block ) ) {
-				$blocks = $this->make_block_visible( $block[1], $blocks, $block[0] );
+				// Fields in non checkout forms are always visible - see LLMS_Forms::get_form_html().
+				$blocks = 'checkout' === $location ? $this->make_block_visible( $block[1], $blocks, $block[0] ) : $blocks;
 
 				unset( $fields_to_require[ $field_id ] );
 				if ( empty( $fields_to_require ) ) { // All the required blocks are present.
@@ -300,7 +301,6 @@ class LLMS_Forms_Dynamic_Fields {
 	 * @param array[] $blocks      Array of parsed WP_Block arrays.
 	 * @param int     $block_index Index of the block within the `$blocks` list.
 	 *                             If the block is in a group, this is the the index of the item's parent.
-	 *
 	 * @return array[]
 	 */
 	private function make_block_visible( $block, $blocks, $block_index ) {

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -283,12 +283,12 @@ class LLMS_Forms_Dynamic_Fields {
 	 *
 	 * @param array   $block       Parsed WP_Block array.
 	 * @param array[] $blocks      Array of parsed WP_Block arrays.
-	 * @param int     $block_index Optional. Index of the block withing the `$blocks` list. Default is 0.
+	 * @param int     $block_index Optional. Index of the block within the `$blocks` list. Default is 0.
 	 * @return array[]
 	 */
 	private function make_block_visible( $block, $blocks, $block_index = 0 ) {
 
-		if ( LLMS_Forms::instance()->is_block_visible( $block ) ) {
+		if ( LLMS_Forms::instance()->is_block_visible_in_list( $block, array( $blocks[ $block_index ] ) ) ) {
 			return $blocks;
 		}
 

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -341,10 +341,9 @@ class LLMS_Forms_Dynamic_Fields {
 		foreach ( $blocks as $index => $block ) {
 
 			if ( $block['innerBlocks'] ) {
-				if ( 'llms/form-field-confirm-group' === $block['blockName'] ) {
-					if ( $this->find_block( $id, $block['innerBlocks'] ) ) {
-						return $block;
-					}
+				if ( ( 'llms/form-field-confirm-group' === $block['blockName'] ) &&
+						$this->find_block( $id, $block['innerBlocks'] ) ) {
+					return $block;
 				}
 				$inner = $this->get_confirm_group( $id, $block['innerBlocks'] );
 				if ( false !== $inner ) {

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -228,8 +228,8 @@ class LLMS_Forms_Dynamic_Fields {
 			return $blocks;
 		}
 
-		foreach ( $this->get_field_blocks( $blocks ) as $field_block ) {
-			if ( isset( $field_block['attrs']['id'] ) && 'email_address' === $field_block['attrs']['id'] && LLMS_Forms::$instance()->is_block_visible( $field_block ) ) {
+		foreach ( LLMS_Forms::instance()->get_field_blocks( $blocks ) as $field_block ) {
+			if ( isset( $field_block['attrs']['id'] ) && 'email_address' === $field_block['attrs']['id'] && LLMS_Forms::instance()->is_block_visible( $field_block ) ) {
 				return $blocks; // All good.
 			}
 		}

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -268,7 +268,6 @@ class LLMS_Forms_Dynamic_Fields {
 			$block = $this->find_block( $field_id, $blocks );
 
 			if ( ! empty( $block ) ) {
-
 				$blocks = $this->make_block_visible( $block[1], $blocks, $block[0] );
 
 				unset( $fields_to_require[ $field_id ] );
@@ -299,10 +298,12 @@ class LLMS_Forms_Dynamic_Fields {
 	 *
 	 * @param array   $block       Parsed WP_Block array.
 	 * @param array[] $blocks      Array of parsed WP_Block arrays.
-	 * @param int     $block_index Optional. Index of the block within the `$blocks` list. Default is 0.
+	 * @param int     $block_index Index of the block within the `$blocks` list.
+	 *                             If the block is in a group, this is the the index of the item's parent.
+	 *
 	 * @return array[]
 	 */
-	private function make_block_visible( $block, $blocks, $block_index = 0 ) {
+	private function make_block_visible( $block, $blocks, $block_index ) {
 
 		if ( LLMS_Forms::instance()->is_block_visible_in_list( $block, array( $blocks[ $block_index ] ) ) ) {
 			return $blocks;
@@ -315,8 +316,14 @@ class LLMS_Forms_Dynamic_Fields {
 		// Make the block and its children visible.
 		$block_to_add = $this->make_all_visible( $block_to_add );
 
-		// Replace the invisible with the visible block.
-		array_splice( $blocks, $block_index, 1, array( $block_to_add ) );
+		// Insert the visible block before the invisible one if the block is in a group,
+		// so to avoid the replacement of the whole group which might contain other required fields.
+		// But replace the invisible with the visible if otherwise.
+		if ( $block === $blocks[ $block_index ] ) {
+			$replace = true;
+		}
+
+		array_splice( $blocks, $block_index, (int) ( ! empty( $replace ) ), array( $block_to_add ) );
 
 		return $blocks;
 

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -389,6 +389,7 @@ class LLMS_Forms_Dynamic_Fields {
 		foreach ( $parent['innerContent'] as $chunk_index => $chunk ) {
 			if ( ! is_string( $chunk ) && $inner_block_index === $inner_block_in_content_index++ ) {
 				array_splice( $parent['innerContent'], $chunk_index, 1 ); // Remove and re-index.
+				break;
 			}
 		}
 

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -351,8 +351,8 @@ class LLMS_Forms_Dynamic_Fields {
 					return $inner;
 				}
 			}
-
 		}
+
 		return false;
 	}
 

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -171,8 +171,7 @@ class LLMS_Forms_Dynamic_Fields {
 
 		if (
 			( ! is_user_logged_in() && in_array( $location, array( 'checkout', 'registration' ), true ) ) ||
-			( is_user_logged_in() && 'account' === $location ) )
-		{
+			( is_user_logged_in() && 'account' === $location ) ) {
 			$fields = array(
 				// Field ID => block name.
 				'email_address' => 'email',

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -977,12 +977,11 @@ class LLMS_Forms {
 						}
 					}
 					// Re-index.
-					$_block['innerContent'] = array_values( $_block[ 'innerContent' ] );
+					$_block['innerContent'] = array_values( $_block['innerContent'] );
 				}
 
 				return array( $_block );
 			}
-
 		}
 
 		return array();

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -1020,7 +1020,7 @@ class LLMS_Forms {
 	}
 
 	/**
-	 * Maybe add the required email block to a given form
+	 * Maybe add the required email block to a form
 	 *
 	 * That's for checkout or registration forms for non logged in users.
 	 *

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -327,11 +327,12 @@ class LLMS_Forms {
 	 *
 	 * @since 5.0.0
 	 * @since [version] First check block's innerBlock attribute exists when checking for inner blocks.
+	 *              Also made the access visibility public.
 	 *
 	 * @param array $blocks Array of WP Block arrays from `parse_blocks()`.
 	 * @return array
 	 */
-	private function get_field_blocks( $blocks ) {
+	public function get_field_blocks( $blocks ) {
 
 		$fields = array();
 
@@ -801,11 +802,12 @@ class LLMS_Forms {
 	 * Determine if a block is visible based on LifterLMS Visibility Settings.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Changed access visibility to public.
 	 *
 	 * @param array $block Parsed block array.
 	 * @return bool
 	 */
-	private function is_block_visible( $block ) {
+	public function is_block_visible( $block ) {
 
 		// Make the block return `true` if it's visible, it will already automatically return an empty string if it's invisible.
 		add_filter( 'render_block', '__return_true', 5 );

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -936,7 +936,6 @@ class LLMS_Forms {
 
 				}
 			}
-
 		}
 
 		// Block not found in the list.

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -895,7 +895,7 @@ class LLMS_Forms {
 	 * @param array   $block      Parsed block array.
 	 * @param array[] $block_list The list of WP Block array `$block` comes from.
 	 * @param int     $iterations Stores the number of iterations.
-	 * @return array[] List of WP_Block arrays describing or an empty array if $block cannot be found within $block_list
+	 * @return array[] List of WP_Block arrays or an empty array if $block cannot be found within $block_list
 	 */
 	private function get_block_path( $block, $block_list, $iterations = 0 ) {
 

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -879,11 +879,12 @@ class LLMS_Forms {
 	 * from it's reference post.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Access turned to public.
 	 *
 	 * @param array[] $blocks List of WP_Block arrays.
 	 * @return array[]
 	 */
-	private function load_reusable_blocks( $blocks ) {
+	public function load_reusable_blocks( $blocks ) {
 
 		$loaded = array();
 

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -327,8 +327,9 @@ class LLMS_Forms {
 	 * Searches innerBlocks arrays recursively.
 	 *
 	 * @since 5.0.0
+	 * @since [version] First check block's innerBlock attribute exists when checking for inner blocks.
 	 *
-	 * @param  array $blocks Array of WP Block arrays from `parse_blocks()`.
+	 * @param array $blocks Array of WP Block arrays from `parse_blocks()`.
 	 * @return array
 	 */
 	private function get_field_blocks( $blocks ) {
@@ -337,7 +338,7 @@ class LLMS_Forms {
 
 		foreach ( $blocks as $block ) {
 
-			if ( $block['innerBlocks'] ) {
+			if ( ! empty( $block['innerBlocks'] ) ) {
 				$fields = array_merge( $fields, $this->get_field_blocks( $block['innerBlocks'] ) );
 			} elseif ( false !== strpos( $block['blockName'], 'llms/form-field-' ) ) {
 				$fields[] = $block;
@@ -442,6 +443,7 @@ class LLMS_Forms {
 	public function get_form_fields( $location, $args = array() ) {
 
 		$blocks = $this->get_form_blocks( $location, $args );
+
 		if ( false === $blocks ) {
 			return false;
 		}
@@ -1042,7 +1044,7 @@ class LLMS_Forms {
 		}
 
 		// Add email block.
-		array_unshift( $blocks, LLMS_Form_Templates::get_block( 'email', $location, true ) );
+		array_unshift( $blocks, LLMS_Form_Templates::get_block( 'email', $location, false ) );
 
 		return $blocks;
 

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -54,7 +54,6 @@ class LLMS_Forms {
 	 * Private Constructor
 	 *
 	 * @since 5.0.0
-	 * @since [version] Added logic to make sure checkout and registration forms for logged out users always have the email block.
 	 *
 	 * @return void
 	 */
@@ -65,7 +64,6 @@ class LLMS_Forms {
 		add_filter( 'render_block', array( $this, 'render_field_block' ), 10, 2 );
 		add_filter( 'llms_get_form_post', array( $this, 'maybe_load_preview' ) );
 
-		add_filter( 'llms_get_form_blocks', array( $this, 'maybe_add_required_email_field_block' ), 999, 3 );
 	}
 
 	/**
@@ -126,6 +124,7 @@ class LLMS_Forms {
 	 * Converts a block to settings understandable by `llms_form_field()`
 	 *
 	 * @since 5.0.0
+	 * @since [version] Added logic to remove invisible fields.
 	 *
 	 * @param array $block A WP Block array.
 	 * @return array
@@ -141,7 +140,7 @@ class LLMS_Forms {
 		 *
 		 * @param $filter Whether or not invisible fields should be included. Default is `false`.
 		 */
-		if ( ! $is_visible && apply_filters( 'llms_filter_out_invisible_field', false ) ) {
+		if ( ! $is_visible && apply_filters( 'llms_forms_remove_invisible_field', false ) ) {
 			return array();
 		}
 
@@ -1016,37 +1015,6 @@ class LLMS_Forms {
 		$attrs = $this->block_to_field_settings( $block );
 
 		return llms_form_field( $attrs, false );
-
-	}
-
-	/**
-	 * Maybe add the required email block to a form
-	 *
-	 * That's for checkout or registration forms for non logged in users.
-	 *
-	 * @since [version]
-	 *
-	 * @param array[] $blocks   Array of parsed WP_Block arrays.
-	 * @param string  $location The request form location ID.
-	 * @param array   $args     Additional arguments passed to the short-circuit filter.
-	 * @return array[]
-	 */
-	public function maybe_add_required_email_field_block( $blocks, $location, $args ) {
-
-		if ( is_user_logged_in() || ! in_array( $location, array( 'checkout', 'registration' ), true ) ) {
-			return $blocks;
-		}
-
-		foreach ( $this->get_field_blocks( $blocks ) as $field_block ) {
-			if ( isset( $field_block['attrs']['id'] ) && 'email_address' === $field_block['attrs']['id'] && $this->is_block_visible( $field_block ) ) {
-				return $blocks; // All good.
-			}
-		}
-
-		// Add email block.
-		array_unshift( $blocks, LLMS_Form_Templates::get_block( 'email', $location, false ) );
-
-		return $blocks;
 
 	}
 

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -138,7 +138,9 @@ class LLMS_Forms {
 		 * If the block is not visible (according to LLMS block-level visibility settings)
 		 * it will return an empty array (signaling the field to be removed).
 		 *
-		 * @param $filter Whether or not invisible fields should be included. Default is `false`.
+		 * @since [version]
+		 *
+		 * @param boolean $filter Whether or not invisible fields should be included. Default is `false`.
 		 */
 		if ( ! $is_visible && apply_filters( 'llms_forms_remove_invisible_field', false ) ) {
 			return array();

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -895,7 +895,7 @@ class LLMS_Forms {
 	 * @param array   $block      Parsed block array.
 	 * @param array[] $block_list The list of WP Block array `$block` comes from.
 	 * @param int     $iterations Stores the number of iterations.
-	 * @return bool
+	 * @return array[] List of WP_Block arrays describing or an empty array if $block cannot be found within $block_list
 	 */
 	private function get_block_path( $block, $block_list, $iterations = 0 ) {
 

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Shortcodes/Classes
  *
  * @since 1.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -273,9 +273,10 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Setup attributes for plan and form information.
+	 * Setup attributes for plan and form information
 	 *
 	 * @since 5.0.0
+	 * @since [version] Properly detect empty form fields when the html is only composed of blanks and empty paragraphs.
 	 *
 	 * @param int   $plan_id LLMS_Access_Plan post id.
 	 * @param array $atts Existing attributes.
@@ -291,9 +292,27 @@ class LLMS_Shortcode_Checkout {
 
 		$atts['form_location'] = 'checkout';
 		$atts['form_title']    = llms_get_form_title( $atts['form_location'], array( 'plan' => $plan ) );
-		$atts['form_fields']   = llms_get_form_html( $atts['form_location'], array( 'plan' => $plan ) );
+		$atts['form_fields']   = self::clean_form_fields( llms_get_form_html( $atts['form_location'], array( 'plan' => $plan ) ) );
 
 		return $atts;
 	}
 
+	/**
+	 * Clean form fields html
+	 *
+	 * Properly detects empty form fields when the html is only composed of blanks and empty paragraphs.
+	 * In this case the form fields html is turned into an empty string.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $fields Form Fields.
+	 * @return array
+	 */
+	private static function clean_form_fields( $fields_html ) {
+		// If fields html has only blanks and emoty paragraphs (autop?), clean it.
+		if ( empty( preg_replace( '/(\s)*(<p><\/p>)*/m', '', $fields_html ) ) ) {
+			$fields_html = '';
+		}
+		return $fields_html;
+	}
 }

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -305,7 +305,7 @@ class LLMS_Shortcode_Checkout {
 	 *
 	 * @since [version]
 	 *
-	 * @param array $fields Form Fields.
+	 * @param array $fields_html Form Fields.
 	 * @return array
 	 */
 	private static function clean_form_fields( $fields_html ) {

--- a/tests/phpunit/unit-tests/forms/class-llms-test-form-handler.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-form-handler.php
@@ -8,7 +8,7 @@
  * @group form_handler
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 class LLMS_Test_Form_Handler extends LLMS_UnitTestCase {
 
@@ -295,7 +295,7 @@ class LLMS_Test_Form_Handler extends LLMS_UnitTestCase {
 	 * Test successful submission for a new users.
 	 *
 	 * @since 5.0.0
-	 *
+	 * @since [version] Provide `password_current` when updating the `password`.
 	 * @return void
 	 */
 	public function test_submit_success() {
@@ -324,6 +324,8 @@ class LLMS_Test_Form_Handler extends LLMS_UnitTestCase {
 		wp_set_current_user( $ret );
 		$args['first_name'] = 'Maude';
 		$args['display_name'] = $user->display_name;
+		// Current password is required when updating the password.
+		$args['password_current'] = $args['password'];
 		$this->assertSame( $ret, $this->handler->submit( $args, 'account' ) );
 		$this->assertEquals( $args['first_name'], $user->first_name );
 

--- a/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
@@ -8,7 +8,7 @@
  * @group form_validator
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 
@@ -147,15 +147,21 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	 * Test validate_fields() when no user input is supplied.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Added test when the form field is not empty.
 	 *
 	 * @return void
 	 */
 	public function test_validate_fields_empty_input() {
 
+		// Empty input - empty form => validates.
 		$res = $this->main->validate_fields( array(), array() );
+		$this->assertTrue( $res );
 
+		// Empty input - not empty form => doesn't validate.
+		$res = $this->main->validate_fields( array(), array( $this->get_field_arr( 'text' ) ) );
 		$this->assertIsWPError( $res );
 		$this->assertWPErrorCodeEquals( 'llms-form-no-input', $res );
+
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -308,11 +308,11 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_maybe_add_required_block_fields_check_not_dupes() {
+	public function test_maybe_add_required_block_fields_check_no_dupes() {
 
 		foreach ( array( 'email_address', 'password' ) as $id ) {
 			foreach ( array( 'checkout', 'registration', 'account' ) as $location ) {
-				$this->forms->create( $location, false );
+				$this->forms->create( $location, true );
 				$blocks = $this->forms->get_form_blocks( $location );
 				$block  = LLMS_Unit_Test_Util::call_method(
 					$this->main,

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -310,10 +310,16 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 	 */
 	public function test_maybe_add_required_block_fields_check_no_dupes() {
 
-		foreach ( array( 'email_address', 'password' ) as $id ) {
-			foreach ( array( 'checkout', 'registration', 'account' ) as $location ) {
-				$this->forms->create( $location, true );
-				$blocks = $this->forms->get_form_blocks( $location );
+		foreach ( array( 'checkout', 'registration', 'account' ) as $location ) {
+			if ( 'account' === $location ) {
+				wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+			}
+
+			$this->forms->create( $location, true );
+			$blocks = $this->forms->get_form_blocks( $location );
+
+			foreach ( array( 'email_address', 'password' ) as $id ) {
+
 				$block  = LLMS_Unit_Test_Util::call_method(
 					$this->main,
 					'find_block',
@@ -328,7 +334,7 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 				);
 
 				// Check again for dupes.
-				array_splice( $blocks, $block[0], 1 ); // Remove just found block.
+				array_splice( $blocks, $block[0], 1); // Remove just found block.
 
 				$this->assertEmpty(
 					LLMS_Unit_Test_Util::call_method(
@@ -341,8 +347,14 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 					),
 					"{$location}:{$id}"
 				);
-
 			}
+
+			if ( 'account' === $location ) {
+				wp_set_current_user( null );
+			}
+
 		}
+
 	}
+
 }

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -238,16 +238,16 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 		wp_set_current_user( null );
 
 		// Email field not added to forms which are not checkout or registration.
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'account', array() ) );
 
 		// Email field added to checkout form.
-		$checkout_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() );
+		$checkout_blocks = $this->main->maybe_add_required_email_field_block( array(), 'checkout', array() );
 		$this->assertNotEmpty( $checkout_blocks );
 		$this->assertEquals( 'email_address', $checkout_blocks[0]['attrs']['id'] );
 
 		// Email field added to registration form.
-		$registration_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() );
+		$registration_blocks = $this->main->maybe_add_required_email_field_block( array(), 'registration', array() );
 		$this->assertNotEmpty( $registration_blocks );
 		$this->assertEquals( 'email_address', $registration_blocks[0]['attrs']['id'] );
 
@@ -255,10 +255,10 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 
 		// Email field not added to any forms for logged in users.
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'account', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'registration', array() ) );
 
 		// Make sure no user is logged in.
 		wp_set_current_user( null );

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -8,6 +8,7 @@
  * @group forms_dynamic_fields
  *
  * @since 5.0.0
+ * @version [version]
  */
 class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 
@@ -221,6 +222,46 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 		$res = $this->main->modify_account_form( $fields, 'account' );
 
 		// @todo.
+
+	}
+
+	/**
+	 * Test required email field block added to form blocks
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_add_required_email_field_block() {
+
+		// Make sure no user is logged in.
+		wp_set_current_user( null );
+
+		// Email field not added to forms which are not checkout or registration.
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
+
+		// Email field added to checkout form.
+		$checkout_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() );
+		$this->assertNotEmpty( $checkout_blocks );
+		$this->assertEquals( 'email_address', $checkout_blocks[0]['attrs']['id'] );
+
+		// Email field added to registration form.
+		$registration_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() );
+		$this->assertNotEmpty( $registration_blocks );
+		$this->assertEquals( 'email_address', $registration_blocks[0]['attrs']['id'] );
+
+		// Log in.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Email field not added to any forms for logged in users.
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() ) );
+
+		// Make sure no user is logged in.
+		wp_set_current_user( null );
 
 	}
 

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -357,4 +357,62 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test remove_block
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_remove_block() {
+
+		$this->forms->create( 'checkout', true );
+		$blocks = $this->forms->get_form_blocks( 'checkout' );
+
+		// Remove a field block, e.g. the email one
+		//$email_field = $this->forms->get_field_by( $this->forms->get_form_fields( 'checkout' ), 'email_address' );
+		$email_field_block = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'find_block',
+			array(
+				'email_address',
+				$blocks
+			)
+		)[1];
+
+		$removed = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'remove_block',
+			array(
+				$email_field_block,
+				&$blocks
+			)
+		);
+
+		$this->assertTrue( $removed );
+
+		$this->assertFalse(
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'find_block',
+				array(
+					'email_address',
+					$blocks
+				)
+			)
+		);
+
+		$this->assertFalse(
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'remove_block',
+				array(
+					$email_field_block,
+					&$blocks
+				)
+			)
+		);
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -23,7 +23,7 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 
 		parent::setUp();
 		$this->main = new LLMS_Forms_Dynamic_fields();
-
+		$this->forms = LLMS_Forms::instance();
 	}
 
 	/**
@@ -226,43 +226,123 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test required email field block added to form blocks
+	 * Test required fields block added to form blocks
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_maybe_add_required_email_field_block() {
+	public function test_maybe_add_required_block_fields() {
 
 		// Make sure no user is logged in.
 		wp_set_current_user( null );
 
-		// Email field not added to forms which are not checkout or registration.
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'account', array() ) );
+		// Email and pw fields not added to forms which are not checkout or registration.
+		$this->assertEmpty( $this->main->maybe_add_required_block_fields( array(), 'what', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_block_fields( array(), 'account', array() ) );
 
-		// Email field added to checkout form.
-		$checkout_blocks = $this->main->maybe_add_required_email_field_block( array(), 'checkout', array() );
-		$this->assertNotEmpty( $checkout_blocks );
-		$this->assertEquals( 'email_address', $checkout_blocks[0]['attrs']['id'] );
+		// Email and pw fields added to checkout form.
+		$checkout_blocks = $this->main->maybe_add_required_block_fields( array(), 'checkout', array() );
+		foreach ( array( 'email_address', 'password' ) as $id ) {
+			$this->assertNotEmpty(
+				LLMS_Unit_Test_Util::call_method(
+					$this->main,
+					'find_block',
+					array(
+						$id,
+						$checkout_blocks
+					)
+				),
+				$id
+			);
+		}
 
-		// Email field added to registration form.
-		$registration_blocks = $this->main->maybe_add_required_email_field_block( array(), 'registration', array() );
-		$this->assertNotEmpty( $registration_blocks );
-		$this->assertEquals( 'email_address', $registration_blocks[0]['attrs']['id'] );
+		// Email and pw fields added to registration form.
+		$registration_blocks = $this->main->maybe_add_required_block_fields( array(), 'registration', array() );
+		foreach ( array( 'email_address', 'password' ) as $id ) {
+			$this->assertNotEmpty(
+				LLMS_Unit_Test_Util::call_method(
+					$this->main,
+					'find_block',
+					array(
+						$id,
+						$registration_blocks
+					)
+				),
+				$id
+			);
+		}
 
 		// Log in.
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 
-		// Email field not added to any forms for logged in users.
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'account', array() ) );
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
-		$this->assertEmpty( $this->main->maybe_add_required_email_field_block( array(), 'registration', array() ) );
+		// Email and pw field not added to any forms except account for logged in users.
+		$this->assertEmpty( $this->main->maybe_add_required_block_fields( array(), 'what', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_block_fields( array(), 'checkout', array() ) );
+		$this->assertEmpty( $this->main->maybe_add_required_block_fields( array(), 'registration', array() ) );
+
+		$account_blocks = $this->main->maybe_add_required_block_fields( array(), 'account', array() );
+		foreach ( array( 'email_address', 'password' ) as $id ) {
+			$this->assertNotEmpty(
+				LLMS_Unit_Test_Util::call_method(
+					$this->main,
+					'find_block',
+					array(
+						$id,
+						$account_blocks
+					)
+				),
+				$id
+			);
+		}
 
 		// Make sure no user is logged in.
 		wp_set_current_user( null );
 
 	}
 
+	/**
+	 * Test required fields blocks not added to form blocks if they already have them.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_add_required_block_fields_check_not_dupes() {
+
+		foreach ( array( 'email_address', 'password' ) as $id ) {
+			foreach ( array( 'checkout', 'registration', 'account' ) as $location ) {
+				$this->forms->create( $location, false );
+				$blocks = $this->forms->get_form_blocks( $location );
+				$block  = LLMS_Unit_Test_Util::call_method(
+					$this->main,
+					'find_block',
+					array(
+						$id,
+						$blocks
+					)
+				);
+				$this->assertNotEmpty(
+					$block,
+					"{$location}:{$id}"
+				);
+
+				// Check again for dupes.
+				array_splice( $blocks, $block[0], 1 ); // Remove just found block.
+
+				$this->assertEmpty(
+					LLMS_Unit_Test_Util::call_method(
+						$this->main,
+						'find_block',
+						array(
+							$id,
+							$blocks
+						),
+					),
+					"{$location}:{$id}"
+				);
+
+			}
+		}
+	}
 }

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
@@ -927,7 +927,7 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 	/**
 	 * Test is_block_visible_in_list()
 	 *
-	 * This additionally covers conditions in get_block_path()
+	 * This additionally covers conditions in get_block_path().
 	 *
 	 * @since [version]
 	 *

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
@@ -7,7 +7,6 @@
  * @group forms
  *
  * @since 5.0.0
- * @version [version]
  */
 class LLMS_Test_Forms extends LLMS_UnitTestCase {
 
@@ -1124,46 +1123,6 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 		$expected = ob_get_clean();
 
 		$this->assertEquals( $expected, $this->forms->render_field_block( '', $blocks[0] ) );
-
-	}
-
-	/**
-	 * Test required email field block added to form blocks
-	 *
-	 * @since [version]
-	 *
-	 * @return void
-	 */
-	public function test_maybe_add_required_email_field_block() {
-
-		// Make sure no user is logged in.
-		wp_set_current_user( null );
-
-		// Email field not added to forms which are not checkout or registration.
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
-
-		// Email field added to checkout form.
-		$checkout_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() );
-		$this->assertNotEmpty( $checkout_blocks );
-		$this->assertEquals( 'email_address', $checkout_blocks[0]['attrs']['id'] );
-
-		// Email field added to registration form.
-		$registration_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() );
-		$this->assertNotEmpty( $registration_blocks );
-		$this->assertEquals( 'email_address', $registration_blocks[0]['attrs']['id'] );
-
-		// Log in.
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-
-		// Email field not added to any forms for logged in users.
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
-		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() ) );
-
-		// Make sure no user is logged in.
-		wp_set_current_user( null );
 
 	}
 

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
@@ -7,7 +7,7 @@
  * @group forms
  *
  * @since 5.0.0
- * @version 5.0.0
+ * @version [version]
  */
 class LLMS_Test_Forms extends LLMS_UnitTestCase {
 
@@ -1127,8 +1127,44 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test required email field block added to form blocks
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_add_required_email_field_block() {
+
+		// Make sure no user is logged in.
+		wp_set_current_user( null );
+
+		// Email field not added to forms which are not checkout or registration.
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
+
+		// Email field added to checkout form.
+		$checkout_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() );
+		$this->assertNotEmpty( $checkout_blocks );
+		$this->assertEquals( 'email_address', $checkout_blocks[0]['attrs']['id'] );
+
+		// Email field added to registration form.
+		$registration_blocks = $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() );
+		$this->assertNotEmpty( $registration_blocks );
+		$this->assertEquals( 'email_address', $registration_blocks[0]['attrs']['id'] );
+
+		// Log in.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Email field not added to any forms for logged in users.
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'what', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'account', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'checkout', array() ) );
+		$this->assertEmpty( $this->forms->maybe_add_required_email_field_block( array(), 'registration', array() ) );
+
+		// Make sure no user is logged in.
+		wp_set_current_user( null );
+
+	}
+
 }
-
-
-
-

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
@@ -925,6 +925,176 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test is_block_visible_in_list()
+	 *
+	 * This additionally covers conditions in get_block_path()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_is_block_visible_in_list() {
+
+		$hidden_json = '{"llms_visibility":"logged_in","llms_visibility_in":"any_course"}';
+
+		$visible = '<!-- wp:paragraph -->\n<p>Test</p>\n<!-- /wp:paragraph -->';
+		$hidden  = sprintf( '<!-- wp:paragraph %s -->\n<p>Test</p>\n<!-- /wp:paragraph -->', $hidden_json );
+
+		/**
+		 * List of tests to run
+		 *
+		 * @param array[] {
+		 *     @type string $0 Test description / message. Passed to the assertion for debugging failed tests.
+		 *     @type string $1 Block markup for the block being tested.
+		 *     @type string $2 List of blocks for use as second parameter. The HTML from $1 must be found in this list!
+		 *     @type bool   $3 The expected result of `is_block_visible_in_list()`.
+		 * }
+		 */
+		$tests = array(
+
+			array(
+				'Block not found in the list',
+				$visible,
+				$hidden,
+				false,
+			),
+
+			array(
+				'Empty list falls back to `is_block_visible()`: is visible',
+				$visible,
+				'',
+				true,
+			),
+
+			array(
+				'Empty list falls back to `is_block_visible()`: not visible',
+				$hidden,
+				'',
+				false,
+			),
+
+			array(
+				'Flat list: is visible',
+				$visible,
+				$hidden . $visible,
+				true,
+			),
+
+			array(
+				'Flat list: not visible',
+				$hidden,
+				$visible . $hidden,
+				false,
+			),
+
+			array(
+				'Visible in a group',
+				$visible,
+				sprintf( '<!-- wp:group -->\n<div class="wp-block-group">%s</div>\n<!-- /wp:group -->', $visible ),
+				true,
+			),
+
+			array(
+				'Hidden in a group',
+				$hidden,
+				sprintf( '<!-- wp:group -->\n<div class="wp-block-group">%s</div>\n<!-- /wp:group -->', $hidden ),
+				false,
+			),
+
+			array(
+				'Visible in a hidden group',
+				$visible,
+				sprintf( '<!-- wp:group %1$s -->\n<div class="wp-block-group">%2$s</div>\n<!-- /wp:group -->', $hidden_json, $visible ),
+				false,
+			),
+
+			array(
+				'Hidden in a hidden group',
+				$hidden,
+				sprintf( '<!-- wp:group %1$s -->\n<div class="wp-block-group">%2$s</div>\n<!-- /wp:group -->', $hidden_json, $hidden ),
+				false,
+			),
+
+			array(
+				'Multiple parents: visible -> visible -> visible',
+				$visible,
+				sprintf( '<!-- wp:columns -->\n<div class="wp-block-columns"><!-- wp:column -->\n<div class="wp-block-column">%s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $visible ),
+				true,
+			),
+
+			array(
+				'Multiple parents: hidden -> hidden -> hidden',
+				$hidden,
+				sprintf( '<!-- wp:columns %2$s -->\n<div class="wp-block-columns"><!-- wp:column %2$s -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $hidden, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Multiple parents: visible -> visible -> hidden',
+				$hidden,
+				sprintf( '<!-- wp:columns -->\n<div class="wp-block-columns"><!-- wp:column -->\n<div class="wp-block-column">%s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $hidden ),
+				false,
+			),
+
+			array(
+				'Multiple parents: visible -> hidden -> hidden',
+				$hidden,
+				sprintf( '<!-- wp:columns -->\n<div class="wp-block-columns"><!-- wp:column %2$s -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $hidden, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Multiple parents: hidden -> hidden -> visible',
+				$visible,
+				sprintf( '<!-- wp:columns %2$s -->\n<div class="wp-block-columns"><!-- wp:column %2$s -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $visible, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Multiple parents: hidden -> visible -> visible',
+				$visible,
+				sprintf( '<!-- wp:columns %2$s -->\n<div class="wp-block-columns"><!-- wp:column -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $visible, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Multiple parents: hidden -> visible -> hidden',
+				$hidden,
+				sprintf( '<!-- wp:columns %2$s -->\n<div class="wp-block-columns"><!-- wp:column -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $hidden, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Multiple parents: visible -> hidden -> visible',
+				$visible,
+				sprintf( '<!-- wp:columns -->\n<div class="wp-block-columns"><!-- wp:column %2$s -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $visible, $hidden_json ),
+				false,
+			),
+
+			array(
+				'Break Stuff',
+				$visible,
+				sprintf( '<!-- wp:columns -->\n<div class="wp-block-columns"><!-- wp:column %2$s -->\n<div class="wp-block-column">%1$s</div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->', $visible, $hidden_json ),
+				false,
+			),
+
+		);
+
+		foreach ( $tests as $data ) {
+
+			$msg    = $data[0];
+			$block  = parse_blocks( $data[1] )[0];
+			$list   = parse_blocks( $data[2] );
+			$expect = $data[3];
+
+			$this->assertEquals( $expect, $this->forms->is_block_visible_in_list( $block, $list ), $msg );
+
+		}
+
+
+	}
+
+	/**
 	 * Test is_location_valid()
 	 *
 	 * @since 5.0.0

--- a/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
+++ b/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Test the [lifterlms_checkout] Shortcode
+ *
+ * @group shortcodes
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
+
+	/**
+	 * Test shortcode registration
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_registration() {
+		$this->assertTrue( shortcode_exists( 'lifterlms_checkout' ) );
+	}
+
+	/**
+	 * Test clean_form_fields
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_clean_form_fields() {
+
+		$checks = array(
+			'<p></p>'               => '',
+			'<p>a</p>'              => '<p>a</p>',
+			"\n"                    => '',
+			"\t"                    => '',
+			"\n\r\t"                => '',
+			"<p></p>\n<p>a</p>\r\t" => "<p></p>\n<p>a</p>\r\t",
+		);
+
+		foreach ( $checks as $check => $expect ) {
+			$this->assertEquals( $expect, LLMS_Unit_Test_Util::call_method( 'LLMS_Shortcode_Checkout', 'clean_form_fields', array( $check ) ), $check );
+		}
+
+	}
+}

--- a/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
@@ -234,6 +234,7 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 	 *
 	 * @since 5.0.0
 	 * @since [version] Made sure no users are logged in before retrieving password reset fields.
+	 *               And avoid auto-adding of required fields like password/email when retrieving form's fields.
 	 *
 	 * @return void
 	 */
@@ -273,6 +274,7 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 	 * Test get_password_reset_fields() when "custom" password reset fields don't exist on checkout but do exist on reg form.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Avoid auto-adding of required fields like password/email when retrieving form's fields.
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
@@ -233,6 +233,7 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 	 * Test get_password_reset_fields() when "custom" password reset fields don't exist on checkout but do exist on reg form.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Made sure no users are logged in before retrieving password reset fields.
 	 *
 	 * @return void
 	 */
@@ -249,6 +250,9 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 			$this->assertEquals( 'registration', $location );
 			return $fields;
 		}, 10, 4 );
+
+		// Log out.
+		wp_set_current_user( null );
 
 		$expect = array(
 			'password',

--- a/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-person-handler.php
@@ -245,7 +245,8 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 		) );
 
 		LLMS_Forms::instance()->create( 'registration', true );
-
+		// Avoid auto adding of fields like password/email.
+		add_filter( 'llms_forms_required_block_fields', '__return_empty_array' );
 		add_filter( 'llms_password_reset_fields', function( $fields, $key, $login, $location ) {
 			$this->assertEquals( 'registration', $location );
 			return $fields;
@@ -264,6 +265,8 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 		);
 		$this->assertEquals( $expect, wp_list_pluck( LLMS_Person_Handler::get_password_reset_fields(), 'id' ) );
 
+		remove_filter( 'llms_forms_required_block_fields', '__return_empty_array' );
+
 	}
 
 	/**
@@ -275,6 +278,8 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 	 */
 	public function test_get_password_reset_fields_from_fallback() {
 
+		// Avoid auto adding of fields like password/email.
+		add_filter( 'llms_forms_required_block_fields', '__return_empty_array' );
 		add_filter( 'llms_password_reset_fields', function( $fields, $key, $login, $location ) {
 			$this->assertEquals( 'fallback', $location );
 			return $fields;
@@ -289,6 +294,8 @@ class LLMS_Test_Person_Handler extends LLMS_UnitTestCase {
 			'llms_reset_login',
 		);
 		$this->assertEquals( $expect, wp_list_pluck( LLMS_Person_Handler::get_password_reset_fields(), 'id' ) );
+
+		remove_filter( 'llms_forms_required_block_fields', '__return_empty_array' );
 
 	}
 


### PR DESCRIPTION
## Description
Fixes #1607 
Partial fix for #1589 (Only requires email address for checkout/registration fields).


## How has this been tested?
manually and with old and new unit tests (missing tests on the new `is_block_visible_in_list()`)

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

