### PR TITLE
slash serialized block content to preserve charcter codes

### DIFF
--- a/includes/forms/class-llms-form-templates.php
+++ b/includes/forms/class-llms-form-templates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 5.1.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -62,6 +62,7 @@ class LLMS_Form_Templates {
 	 * if it already exists and will only create it if one isn't found.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Run serialized block content through `wp_slash()` to preserve special characters converted to character codes.
 	 *
 	 * @param string $field_id The field's identifier as found in the block schema list returned by LLMS_Form_Templates::get_reusable_block_schema().
 	 * @return int Returns the WP_Post ID of the the wp_block post type or `0` on failure.
@@ -77,7 +78,7 @@ class LLMS_Form_Templates {
 
 		$args = array(
 			'post_title'   => $block_data['title'],
-			'post_content' => serialize_blocks( $block_data['block'] ),
+			'post_content' => wp_slash( serialize_blocks( $block_data['block'] ) ),
 			'post_status'  => 'publish',
 			'post_type'    => 'wp_block',
 			'meta_input'   => array(


### PR DESCRIPTION
## Description

Slashes serialized reusable block for reusable blocks during installs / upgrades (or form re-installation) to preserve character codes for special characters.

Fixes #1700 

## How has this been tested?

Replaced "Email Address" in the user info schema with "Dirección de correo electrónico". When reinstalling user forms you'll see the bug identified in #1700. After inspecting the content of the created reusable block the label is converted to `Direcci\u00f3n de correo electr\u00f3nico` however the slashes are lost during `wp_insert_post()`.

The character codes I think are added by https://developer.wordpress.org/reference/functions/filter_block_content/ (or maybe actually `filter_block_kses()`.

Existing unit tests pass

Also manually tested reinstallation without translations and there's no regressions or new issues I can spot


## Types of changes

+ Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

