### PR TITLE
Addon uninstall method

### DIFF
--- a/includes/models/model.llms.add-on.php
+++ b/includes/models/model.llms.add-on.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.22.0
- * @version 4.21.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -448,6 +448,40 @@ class LLMS_Add_On {
 		}
 
 		return false;
+
+	}
+
+	/**
+	 * Uninstall an add-on
+	 *
+	 * @since [version]
+	 *
+	 * @return string|WP_Error
+	 */
+	public function uninstall() {
+
+		$ret = sprintf( __( '%s was successfully uninstalled.', 'lifterlms' ), $this->get( 'title' ) );
+
+		if ( ! $this->is_installed() ) {
+			$ret = new WP_Error( 'not-installed', sprintf( __( '%s is not installed.', 'lifterlms' ), $this->get( 'title' ) ) );
+		} elseif ( $this->is_active() ) {
+			$ret = new WP_Error( 'uninstall-active', sprintf( __( '%s is active and cannot be uninstalled.', 'lifterlms' ), $this->get( 'title' ) ) );
+		} else {
+
+			$type = $this->get_type();
+			$file = $this->get( 'update_file' );
+			if ( 'plugin' === $type ) {
+				uninstall_plugin( $file );
+				$del = delete_plugins( array( $file ) );
+				$ret = is_wp_error( $del ) ? $del : $ret;
+			} elseif ( 'theme' === $type ) {
+				$del = delete_theme( $file );
+				$ret = is_wp_error( $del ) ? $del : $ret;
+			}
+
+		}
+
+		return $ret;
 
 	}
 

--- a/includes/models/model.llms.add-on.php
+++ b/includes/models/model.llms.add-on.php
@@ -486,16 +486,19 @@ class LLMS_Add_On {
 	private function uninstall_real() {
 
 		$type = $this->get_type();
+
+		if ( ! in_array( $type, array( 'plugin', 'theme' ), true ) ) {
+			// Translators: %s = add-on type.
+			return new WP_Error( 'uninstall-invalid-type', sprintf( __( 'Cannot uninstall "%s" type add-ons.', 'lifterlms' ), $type ) );
+		}
+
 		$file = $this->get( 'update_file' );
-		$del  = null;
+
 		if ( 'plugin' === $type ) {
 			uninstall_plugin( $file );
 			$del = delete_plugins( array( $file ) );
-		} elseif ( 'theme' === $type ) {
-			$del = delete_theme( $file );
 		} else {
-			// Translators: %s = add-on type.
-			return new WP_Error( 'uninstall-invalid-type', sprintf( __( 'Cannot uninstall "%s" type add-ons.', 'lifterlms' ), $type ) );
+			$del = delete_theme( $file );
 		}
 
 		if ( is_wp_error( $del ) ) {

--- a/includes/models/model.llms.add-on.php
+++ b/includes/models/model.llms.add-on.php
@@ -478,7 +478,6 @@ class LLMS_Add_On {
 				$del = delete_theme( $file );
 				$ret = is_wp_error( $del ) ? $del : $ret;
 			}
-
 		}
 
 		return $ret;

--- a/includes/models/model.llms.add-on.php
+++ b/includes/models/model.llms.add-on.php
@@ -452,7 +452,7 @@ class LLMS_Add_On {
 	}
 
 	/**
-	 * Uninstall an add-on
+	 * Uninstall an add-on and permanently deletes its files
 	 *
 	 * @since [version]
 	 *
@@ -470,14 +470,14 @@ class LLMS_Add_On {
 
 			$type = $this->get_type();
 			$file = $this->get( 'update_file' );
+			$del  = null;
 			if ( 'plugin' === $type ) {
 				uninstall_plugin( $file );
 				$del = delete_plugins( array( $file ) );
-				$ret = is_wp_error( $del ) ? $del : $ret;
 			} elseif ( 'theme' === $type ) {
 				$del = delete_theme( $file );
-				$ret = is_wp_error( $del ) ? $del : $ret;
 			}
+			$ret = is_wp_error( $del ) ? $del : $ret;
 		}
 
 		return $ret;

--- a/tests/assets/lifterlms-mock-addon.php
+++ b/tests/assets/lifterlms-mock-addon.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Plugin Name: LifterLMS Mock Add-on
+ * Plugin URI: https://lifterlms.com/
+ * Description: Mock add-on plugin for phpunit integration tests related to add-ons.
+ * Version: 1.0.0
+ * Author: LifterLMS
+ * Author URI: https://lifterlms.com/
+ * License: GPLv3
+ * License URI: https://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'LLMS_MOCK_PLUGIN_LOADED', true );

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-add-on.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-add-on.php
@@ -261,4 +261,20 @@ class LLMS_Test_Add_On extends LLMS_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Test uninstall() for an add-on that isn't installed
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_error_addon_not_installed() {
+
+		$addon = llms_get_add_on( 'lifterlms-groups', 'slug' );
+		$res   = $addon->uninstall();
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'not-installed', $res );
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-add-on.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-add-on.php
@@ -12,6 +12,36 @@
 class LLMS_Test_Add_On extends LLMS_Unit_Test_Case {
 
 	/**
+	 * Retrieve a mock plugin add-on for testing
+	 *
+	 * @since [version]
+	 *
+	 * @param boolean $install  If true, calls `install_mock_addon()` to physically install the mock plugin.
+	 * @param boolean $activate If true and `$install` is also true, activates the mock plugin following installation.
+	 * @return LLMS_Add_On
+	 */
+	private function get_mock_addon( $install = false, $activate = false ) {
+
+		$asset = 'lifterlms-mock-addon.php';
+		$dir   = 'lifterlms-mock-addon/';
+		$file  = $dir . $asset;
+		if ( $install ) {
+			LLMS_Unit_Test_Files::copy_asset( $asset, trailingslashit( WP_PLUGIN_DIR  ). $dir );
+			if ( $activate ) {
+				activate_plugin( $file );
+			}
+		}
+
+		return new LLMS_Add_On( array(
+			'title'       => 'LLMS Mock Add-on',
+			'update_file' => $file,
+			'id'          => 'lifterlms-com-mock-addon',
+			'type'        => 'plugin',
+		) );
+
+	}
+
+	/**
 	 * Test constructor with an addon array passed in.
 	 *
 	 * @since 4.21.3
@@ -277,4 +307,50 @@ class LLMS_Test_Add_On extends LLMS_Unit_Test_Case {
 
 	}
 
+	/**
+	 * Test uninstall() error for an active add-on.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_error_is_activate() {
+
+		$addon = $this->get_mock_addon( true, true );
+		$res   = $addon->uninstall();
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'uninstall-active', $res );
+
+	}
+
+	/**
+	 * Test uninstall() error for an invalid add-on type.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_real_error_invalid_type() {
+
+		$addon = new LLMS_Add_On( array( 'type' => 'fake' ) );
+		$res = LLMS_Unit_Test_Util::call_method( $addon, 'uninstall_real' );
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'uninstall-invalid-type', $res );
+
+	}
+
+	/**
+	 * Test uninstall() success for a plugin add-on
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_uninstall_plugin_real_success() {
+
+		$addon = $this->get_mock_addon( true, false );
+		$res   = LLMS_Unit_Test_Util::call_method( $addon, 'uninstall_real' );
+		$this->assertEquals( 'LLMS Mock Add-on was successfully uninstalled.', $res );
+
+	}
 }


### PR DESCRIPTION
## Description

Adds an "uninstall" method to the `LLMS_Add_On` class to enable programmatic uninstallation of add-on plugins and themes.

## How has this been tested?

+ Manually
+ Unit tests are not easy to write for this until we have the CLI finished (and included) in the core. Then we can bootstrap an add-on plugin into the test environment to do more thorough testing against. It's technically possible without the CLI but it'll be a lot easier to wait until the CLI is done.

## Screenshots <!-- if applicable -->

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

