### PR TITLE
Fixed get_the_excerpt filter hook missing second param

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @since [version]
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @version 4.10.0
+ * @since [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -402,6 +402,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 *
 	 * @since 3.34.0
 	 * @since 4.10.0 Add `post_name` as a property to skip scrubbing and add a filter on the list of properties to skip scrubbing.
+	 * @since [version] Pass second paramater to the `get_the_excerpt` filter hook (the WP_Post object), introduced in WordPress 4.5.0.
 	 *
 	 * @param string  $key The property key.
 	 * @param boolean $raw Optional. Whether or not we need to get the raw value. Default false.
@@ -430,7 +431,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 				case 'excerpt':
 					/* This is a WordPress filter. */
-					$val = $raw ? $this->post->$post_key : apply_filters( 'get_the_excerpt', $this->post->$post_key );
+					$val = $raw ? $this->post->$post_key : apply_filters( 'get_the_excerpt', $this->post->$post_key, $this->post );
 					break;
 
 				case 'ping_status':


### PR DESCRIPTION
## Description
We need to pass a second parameter to `get_the_excerpt` filter hook according to the [WP core filter definition.](https://developer.wordpress.org/reference/hooks/get_the_excerpt/)
The second parameter (the `$post`) has been added since wp 4.5.0.
Not passing it can cause fatal errors, as reported [here](https://github.com/gocodebox/lifterlms-rest/issues/233#issuecomment-888303723) - a conflict with the latest version of the Divi theme 4.10.0
So this...
Fixes https://github.com/gocodebox/lifterlms-rest/issues/233

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

