### PR TITLE
Fix white box while printing certificate

### DIFF
--- a/assets/scss/certificates.scss
+++ b/assets/scss/certificates.scss
@@ -112,14 +112,17 @@ body {
 		display: none !important;
 	}
 
-	/* make sure a .container parent doesn't shif the certificate see: https://github.com/gocodebox/lifterlms/issues/1163 */
+	/* make sure a .container parent doesn't shift the certificate see: https://github.com/gocodebox/lifterlms/issues/1163 */
+	.single-llms_my_certificate .container,
 	.single-llms_certificate .container {
 		width: 100%;
 	}
 
 	/* make only the certificate container and its children visible */
-	.llms-certificate-container, .llms-certificate-container * {
+	.llms-certificate-container,
+	.llms-certificate-container * {
 		visibility: visible !important;
+		background: transparent none;
 	}
 
 	/* position certificate absolutely and center horizontally */


### PR DESCRIPTION
## Description
Fixes #1635 
Of course this might introduce an issue for all of those who relied on the fact that the text in the certificate would have a white background...

(It also fixes #1163 when printing from the student dashboard... :/)


## How has this been tested?
Manually


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

