### PR TITLE
Adds a filter on the list of included libraries redux

### DIFF
--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -300,29 +300,41 @@ class LLMS_Loader {
 	 * @since 4.0.0
 	 * @since 4.9.0 Adds constants which can be used to identify when included libraries have been loaded.
 	 * @since 5.0.0 Load core libraries from new location, add WP Background Processing lib, add LLMS Helper.
+	 * @since [version] Add keys to the $libs array and pass them through a filter.
 	 *
 	 * @return void
 	 */
 	public function includes_libraries() {
 
 		$libs = array(
-			array(
+			'blocks' => array(
 				'const' => 'LLMS_BLOCKS_LIB',
 				'test'  => function_exists( 'has_blocks' ) && ! defined( 'LLMS_BLOCKS_VERSION' ),
 				'file'  => LLMS_PLUGIN_DIR . 'libraries/lifterlms-blocks/lifterlms-blocks.php',
 			),
-			array(
+			'rest' => array(
 				'const' => 'LLMS_REST_API_LIB',
 				'test'  => ! class_exists( 'LifterLMS_REST_API' ),
 				'file'  => LLMS_PLUGIN_DIR . 'libraries/lifterlms-rest/lifterlms-rest.php',
 			),
-			array(
+			'helper' => array(
 				'const' => 'LLMS_HELPER_LIB',
 				'test'  => ! class_exists( 'LifterLMS_Helper' ),
 				'file'  => LLMS_PLUGIN_DIR . 'libraries/lifterlms-helper/lifterlms-helper.php',
 			),
 		);
 
+		/**
+		 * Filters the list of LifterLMS libraries to be loaded.
+		 *
+		 * @since [version]
+		 *
+		 * @param array $libs Array of library data. Array key is a unique ID for the library and each array contains the following keys:
+		 *                    @type string $const Name of the constant used to identify if the library is loaded as a library.
+		 *                    @type bool   $test  A test which is evaluated to determine if the library should be loaded. Returning `false` causes the library not to load.
+		 *                    @type string $file  Path to the main library file's location in the LifterLMS core plugin.
+		 */
+		$libs = apply_filters( 'llms_included_libs', $libs );
 		foreach ( $libs as $lib ) {
 
 			if ( $lib['test'] ) {


### PR DESCRIPTION
## Description

Replaces #1725

Required by https://github.com/gocodebox/lifterlms-helper/pull/29

This fixes an issue encountered in phpunit test suites for our library add-ons (REST, Blocks, and Helper). Since the LifterLMS core is required by the add-ons and the PHP files are included slightly differently in the test suites than how it would be included in an actual WP site the tests that evaluate whether or not the lib should be loaded (because the plugin doesn't exist) will always show the library should be loaded in the phpunit environment.

This adds a filter which will allow us to force the library to not be loaded during testing.

The filter can also be leveraged by 3rd parties to disable the libraries in a different way (we currently have constants to allow this also so, slightly redundant but...)

## How has this been tested?

+ Manually
+ Unit tests (in the helper)

## Screenshots <!-- if applicable -->

## Types of changes

+ Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

