### PR TITLE
Change student registration date to be relative to the local time zone.

### DIFF
--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -25,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 4.0.0 Remove previously deprecated methods.
  * @since 4.2.0 The `$enrollment_trigger` parameter was added to the `'llms_user_enrollment_deleted'` action hook.
  *              Added new filter to allow customization of object completion data.
+ * @since [version] Changed the date to be relative to the local time zone in `get_registration_date`.
  */
 class LLMS_Student extends LLMS_Abstract_User_Data {
 
@@ -1145,12 +1146,13 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Retrieve the Students original registration date in chosen format
+	 * Retrieve the student's original registration date in the chosen format.
 	 *
-	 * @param    string $format  any date format that can be passed to date()
-	 * @return   string
-	 * @since    ??
-	 * @version  3.14.0
+	 * @since ??
+	 * @since [version] Changed the date to be relative to the local time zone.
+	 *
+	 * @param string $format Any date format that can be passed to date().
+	 * @return string
 	 */
 	public function get_registration_date( $format = '' ) {
 
@@ -1158,7 +1160,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			$format = get_option( 'date_format' );
 		}
 
-		return date_i18n( $format, strtotime( $this->get( 'user_registered' ) ) );
+		return wp_date( $format, strtotime( $this->get( 'user_registered' ) ) );
 
 	}
 

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1148,7 +1148,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	/**
 	 * Retrieve the student's original registration date in the chosen format.
 	 *
-	 * @since ??
+	 * @since unknown
 	 * @since [version] Changed the date to be relative to the local time zone.
 	 *
 	 * @param string $format Any date format that can be passed to date().

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1148,7 +1148,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 	/**
 	 * Retrieve the student's original registration date in the chosen format.
 	 *
-	 * @since unknown
+	 * @since Unknown
 	 * @since [version] Changed the date to be relative to the local time zone.
 	 *
 	 * @param string $format Any date format that can be passed to date().

--- a/tests/phpunit/unit-tests/user/class-llms-test-student.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-student.php
@@ -542,7 +542,7 @@ class LLMS_Test_Student extends LLMS_UnitTestCase {
 				'role'            => 'student',
 				'user_registered' => $test['user_registered'],
 			) );
-			$student = new LLMS_Student( $user_id );
+			$student = llms_get_student( $user_id );
 
 			# Test.
 			$actual_registration_date = $student->get_registration_date( 'Y-m-d' );

--- a/tests/phpunit/unit-tests/user/class-llms-test-student.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-student.php
@@ -5,6 +5,7 @@
  * @since 3.5.0
  * @since 3.33.0 Add delete enrollment tests.
  * @since 3.36.2 Added tests on membership enrollment with related courses enrollments deletion.
+ * @since [version] Added tests on `get_registration_date`.
  */
 class LLMS_Test_Student extends LLMS_UnitTestCase {
 
@@ -468,6 +469,84 @@ class LLMS_Test_Student extends LLMS_UnitTestCase {
 				$this->assertEquals( 60, $student->get_progress( $section_id, 'section' ) );
 			}
 
+		}
+
+	}
+
+	/**
+	 * Test LLMS_Student::get_registration_date().
+	 *
+	 * @since [version]
+	 */
+	public function test_get_registration_date() {
+
+		$tests = array(
+			'UTC@20' => array(
+				'timezone_string'            => 'UTC',
+				'user_registered'            => '2021-01-10 20:00:00',
+				'expected_registration_date' => '2021-01-10',
+			),
+			'UTC@04' => array(
+				'timezone_string'            => 'UTC',
+				'user_registered'            => '2021-01-10 04:00:00',
+				'expected_registration_date' => '2021-01-10',
+			),
+			'-5@20' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-06-10 20:00:00',
+				'expected_registration_date' => '2021-06-10',
+			),
+			'-5@04' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-06-10 04:00:00',
+				'expected_registration_date' => '2021-06-09',
+			),
+			'-5@05' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-06-10 05:00:00',
+				'expected_registration_date' => '2021-06-10',
+			),
+			'-6@20' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-01-10 20:00:00',
+				'expected_registration_date' => '2021-01-10',
+			),
+			'-6@04' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-01-10 04:00:00',
+				'expected_registration_date' => '2021-01-09',
+			),
+			'-6@06' => array(
+				'timezone_string'            => 'America/Chicago',
+				'user_registered'            => '2021-01-10 06:00:00',
+				'expected_registration_date' => '2021-01-10',
+			),
+			'+9@20' => array(
+				'timezone_string'            => 'Asia/Tokyo',
+				'user_registered'            => '2021-08-10 20:00:00',
+				'expected_registration_date' => '2021-08-11',
+			),
+			'+9@04' => array(
+				'timezone_string'            => 'Asia/Tokyo',
+				'user_registered'            => '2021-08-10 04:00:00',
+				'expected_registration_date' => '2021-08-10',
+			),
+		);
+
+		foreach ( $tests as $test_name => $test ) {
+			# Set the server's local time zone.
+			update_option( 'timezone_string', $test['timezone_string'] );
+
+			# Register a new student.
+			$user_id = $this->factory->user->create( array(
+				'role'            => 'student',
+				'user_registered' => $test['user_registered'],
+			) );
+			$student = new LLMS_Student( $user_id );
+
+			# Test.
+			$actual_registration_date = $student->get_registration_date( 'Y-m-d' );
+			$this->assertEquals( $test['expected_registration_date'], $actual_registration_date, $test_name );
 		}
 
 	}


### PR DESCRIPTION
## Description
Changed `LLMS_Student::get_registration_date` to return a date based on the server's local time zone setting instead of UTC.

Fixes #1559.

`LLMS_Student::get_registration_date` is used by:
* `templates/admin/reporting/tabs/students/information.php`
* `LLMS_Table_Students::get_data`

## How has this been tested?
Added `LLMS_Test_Student::test_get_registration_date`, which tests creating users with the server in different time zones before and after midnight.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

