### PR TITLE
Remove trailing comma in function call for compatibility with PHP < 8.0.

### DIFF
--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms-dynamic-fields.php
@@ -512,7 +512,7 @@ class LLMS_Test_Forms_Dynamic_fields extends LLMS_UnitTestCase {
 						array(
 							$id,
 							$blocks
-						),
+						)
 					),
 					"{$location}:{$id}"
 				);


### PR DESCRIPTION
## Description
Removed unnecessary [trailing comma from a function argument list](https://www.php.net/manual/en/functions.arguments.php#functions.variable-arg-list) that breaks compatibility with PHP < 8.0.

Partially fixes #1740.

## How has this been tested?
Ran LifterLMS unit tests with PHP 7.2.

## Types of changes
No changes in test behavior, other than being able to run on PHP 7.2.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

