### PR TITLE
Check for an empty sales page URL or ID.

### DIFF
--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
  * @since 4.0.0 Remove previously deprecated class methods.
+ * @since [version] Check for an empty sales page URL or ID.
  *
  * @property string $audio_embed                URL to an oEmbed enable audio URL.
  * @property float  $average_grade              Calculated value of the overall average grade of all *enrolled* students in the course..
@@ -651,17 +652,28 @@ implements LLMS_Interface_Post_Audio
 	}
 
 	/**
-	 * Determine if sales page redirection is enabled
+	 * Determine if sales page redirection is enabled.
 	 *
 	 * @since 3.20.0
 	 * @since 3.23.0 Unknown.
 	 * @since 4.12.0 Use strict `in_array()` comparison.
+	 * @since [version] Check for an empty sales page URL or ID.
 	 *
 	 * @return boolean
 	 */
 	public function has_sales_page_redirect() {
 
 		$type = $this->get( 'sales_page_content_type' );
+		switch ( $type ) {
+			case 'page':
+				$has_redirect = (bool) $this->get( 'sales_page_content_page_id' );
+				break;
+			case 'url':
+				$has_redirect = (bool) $this->get( 'sales_page_content_url' );
+				break;
+			default:
+				$has_redirect = false;
+		}
 
 		/**
 		 * Filters whether or not the course has a sales page redirect.
@@ -672,7 +684,7 @@ implements LLMS_Interface_Post_Audio
 		 * @param LLMS_Course $course       Course object.
 		 * @param string      $type         The course's sales page content type property value.
 		 */
-		return apply_filters( 'llms_course_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ), true ), $this, $type );
+		return apply_filters( 'llms_course_has_sales_page_redirect', $has_redirect, $this, $type );
 
 	}
 

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.36.3 Added `get_categories()`, `get_tags()` and `toArrayAfter()` methods.
  * @since 3.38.1 Added methods for retrieving posts associated with the membership.
  * @since 4.0.0 Added MySQL 8.0 compatibility.
+ * @since [version] Check for an empty sales page URL or ID.
  *
  * @property $auto_enroll (array) Array of course IDs users will be autoenrolled in upon successful enrollment in this membership
  * @property $instructors (array) Course instructor user information
@@ -304,16 +305,37 @@ implements LLMS_Interface_Post_Instructors, LLMS_Interface_Post_Sales_Page {
 	}
 
 	/**
-	 * Determine if sales page redirection is enabled
+	 * Determine if sales page redirection is enabled.
 	 *
 	 * @since 3.20.0
 	 * @since 3.38.1 Use strict array comparison.
+	 * @since [version] Check for an empty sales page URL or ID.
 	 *
 	 * @return string
 	 */
 	public function has_sales_page_redirect() {
 		$type = $this->get( 'sales_page_content_type' );
-		return apply_filters( 'llms_membership_has_sales_page_redirect', in_array( $type, array( 'page', 'url' ), true ), $this, $type );
+		switch ( $type ) {
+			case 'page':
+				$has_redirect = (bool) $this->get( 'sales_page_content_page_id' );
+				break;
+			case 'url':
+				$has_redirect = (bool) $this->get( 'sales_page_content_url' );
+				break;
+			default:
+				$has_redirect = false;
+		}
+
+		/**
+		 * Filters whether or not the course has a sales page redirect.
+		 *
+		 * @since Unknown.
+		 *
+		 * @param boolean         $has_redirect Whether or not the course has a sales page redirect.
+		 * @param LLMS_Membership $course       Course object.
+		 * @param string          $type         The course's sales page content type property value.
+		 */
+		return apply_filters( 'llms_membership_has_sales_page_redirect', $has_redirect, $this, $type );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -8,6 +8,7 @@
  * @since 3.4.0
  * @since 3.24.0 Add tests for the `get_available_points()` method.
  * @since 4.7.0 Add tests for `to_array_extra_blocks()` and `to_array_extra_images()`.
+ * @since [version] Add checks for empty URL and page ID in `test_has_sales_page_redirect()`.
  */
 class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
@@ -466,10 +467,10 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test the has_sales_page_redirect method
-	 * @return   void
-	 * @since    3.20.0
-	 * @version  3.20.0
+	 * Test the `has_sales_page_redirect` method.
+	 *
+	 * @since 3.20.0
+	 * @since [version] Add checks for empty URL and page ID.
 	 */
 	public function test_has_sales_page_redirect() {
 
@@ -484,9 +485,16 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		$this->assertEquals( false, $course->has_sales_page_redirect() );
 
 		$course->set( 'sales_page_content_type', 'url' );
+		$this->assertEquals( false, $course->has_sales_page_redirect() );
+
+		$course->set( 'sales_page_content_url', 'https://lifterlms.com' );
 		$this->assertEquals( true, $course->has_sales_page_redirect() );
 
 		$course->set( 'sales_page_content_type', 'page' );
+		$this->assertEquals( false, $course->has_sales_page_redirect() );
+
+		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
+		$course->set( 'sales_page_content_page_id', $page_id );
 		$this->assertEquals( true, $course->has_sales_page_redirect() );
 
 	}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-membership.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-membership.php
@@ -8,6 +8,7 @@
  * @since 3.20.0
  * @since 3.36.3 Remove redundant test method `test_get_sections()`,
  *               @see tests/unit-tests/models/class-llms-test-model-llms-course.php.
+ * @since [version] Add checks for empty URL and page ID in `test_has_sales_page_redirect()`.
  */
 class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 
@@ -356,29 +357,35 @@ class LLMS_Test_LLMS_Membership extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
-	 * Test the has_sales_page_redirect method.
+	 * Test the `has_sales_page_redirect` method.
 	 *
 	 * @since 3.20.0
-	 *
-	 * @return void
+	 * @since [version] Add checks for empty URL and page ID.
 	 */
 	public function test_has_sales_page_redirect() {
 
-		$course = new LLMS_Membership( 'new', 'Membership Title' );
+		$membership = new LLMS_Membership( 'new', 'Membership Title' );
 
-		$this->assertEquals( false, $course->has_sales_page_redirect() );
+		$this->assertEquals( false, $membership->has_sales_page_redirect() );
 
-		$course->set( 'sales_page_content_type', 'none' );
-		$this->assertEquals( false, $course->has_sales_page_redirect() );
+		$membership->set( 'sales_page_content_type', 'none' );
+		$this->assertEquals( false, $membership->has_sales_page_redirect() );
 
-		$course->set( 'sales_page_content_type', 'content' );
-		$this->assertEquals( false, $course->has_sales_page_redirect() );
+		$membership->set( 'sales_page_content_type', 'content' );
+		$this->assertEquals( false, $membership->has_sales_page_redirect() );
 
-		$course->set( 'sales_page_content_type', 'url' );
-		$this->assertEquals( true, $course->has_sales_page_redirect() );
+		$membership->set( 'sales_page_content_type', 'url' );
+		$this->assertEquals( false, $membership->has_sales_page_redirect() );
 
-		$course->set( 'sales_page_content_type', 'page' );
-		$this->assertEquals( true, $course->has_sales_page_redirect() );
+		$membership->set( 'sales_page_content_url', 'https://lifterlms.com' );
+		$this->assertEquals( true, $membership->has_sales_page_redirect() );
+
+		$membership->set( 'sales_page_content_type', 'page' );
+		$this->assertEquals( false, $membership->has_sales_page_redirect() );
+
+		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
+		$membership->set( 'sales_page_content_page_id', $page_id );
+		$this->assertEquals( true, $membership->has_sales_page_redirect() );
 
 	}
 


### PR DESCRIPTION
## Description
Added a check in `has_sales_page_redirect()` for an empty URL or an empty page ID.

Fixes #1546.

## How has this been tested?
Tested manually and with additional unit tests.

## Types of changes
If "Sales Page Redirect" is "Redirect to custom URL" and "Sales Page Redirect URL" is empty, viewing the page displays the page instead of a blank screen.

If "Sales Page Redirect" is "Redirect to WordPress Page" and "Select a Page" is empty, viewing the page displays the page instead of endlessly redirecting the web browser to the same page.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

