### PR TITLE
Exclude library pot files from distributions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
       "!/libraries",
       "/libraries/README.md",
       "/libraries/**/composer.*",
+      "/libraries/**/i18n",
 
       "/vendor/bin",
       "/vendor/**/**/composer.*",


### PR DESCRIPTION
## Description

Excludes the `i18n` directories of the included libraries (lifterlms-rest, etc...). These language files are only required by the libraries when running as standalone plugins so when included they can (and should?) be excluded.

This prevents the confusing warning message output by Loco Translate as a result of the plugin having superfluous pot files included within it.

As an aside: the strings included in libraries are pulled into the core pot file when the core's pot file is generated so the libraries *remain* translatable (as expected) regardless of the inclusion of the pot file from the lib.

Fixes #1753 

## How has this been tested?

+ Manually: installed a distribution of LifterLMS on top of an existing one (simulating an update) and the loco translate message identified in #1753 goes away.

## Screenshots <!-- if applicable -->

## Types of changes

+ Conflict fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

