### PR TITLE
BUild a tool to help identify orders potentially affected by payment plan changes in 5.3.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -881,20 +881,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/gocodebox/lifterlms-tests.git",
-                "reference": "2e73516d7cd3fefa576be0ef325b4d08151c7ccb"
+                "reference": "472c5a286e9f65e2be0c1d6b7edd8d5340d052ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/gocodebox/lifterlms-tests/zipball/2e73516d7cd3fefa576be0ef325b4d08151c7ccb",
-                "reference": "2e73516d7cd3fefa576be0ef325b4d08151c7ccb",
+                "url": "https://api.github.com/repos/gocodebox/lifterlms-tests/zipball/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed",
+                "reference": "472c5a286e9f65e2be0c1d6b7edd8d5340d052ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
                 "phpunit/phpunit": "^7.5",
                 "wp-cli/extension-command": "^2.1.0",
-                "wp-cli/wp-cli-tests": "^3.0.15",
-                "yoast/phpunit-polyfills": "^1.0"
+                "wp-cli/wp-cli-tests": "^3.0.15"
             },
             "default-branch": true,
             "bin": [
@@ -902,6 +901,11 @@
                 "bin/llms-env"
             ],
             "type": "library",
+            "extra": {
+                "llms": {
+                    "version": "2.1.0"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "LifterLMS\\Tests\\": "src/"
@@ -922,7 +926,7 @@
                 "issues": "https://github.com/gocodebox/lifterlms-tests/issues",
                 "source": "https://github.com/gocodebox/lifterlms-tests/tree/trunk"
             },
-            "time": "2021-08-06T18:15:42+00:00"
+            "time": "2021-08-26T17:24:44+00:00"
         },
         {
             "name": "mustache/mustache",

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * LLMS_Admin_Tool_Limited_Billing_Order_Locator class
+ *
+ * @package LifterLMS/Admin/Tools/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin tool which generates a report of limited billing orders affected by order end changes
+ *
+ * @since [version]
+ * 
+ * @link https://github.com/gocodebox/lifterlms/pull/1744
+ */
+class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_Tool {
+
+	/**
+	 * Tool ID.
+	 *
+	 * @var string
+	 */
+	protected $id = 'limited-billing-order-locator';
+
+	/**
+	 * Query the database for orders that may be affected by the change
+	 *
+	 * @since [version]
+	 *
+	 * @return array[] Returns an array of arrays where each array represents a line in the generated CSV file.
+	 */
+	protected function generate_csv() {
+
+		$csv = array();
+
+		$orders = new WP_Query( array(
+			'post_type'      => 'llms_order',
+			'post_status'    => array( 'llms-active', 'llms-on-hold' ),
+			'posts_per_page' => -1,
+			'meta_query'     => array(
+				array(
+					'key'     => '_llms_billing_length',
+					'value'   => 1,
+					'compare' => '>=',
+				),
+			),
+		) );
+
+		foreach ( $orders->posts as $order ) {
+
+			$order = llms_get_post( $order );
+			if ( ! $order || ! is_a( $order, 'LLMS_Order' ) ) {
+				continue;
+			}
+
+			$csv[] = $this->get_order_csv( $order );
+
+		}
+
+		return array_filter( $csv );
+
+	}
+
+	/**
+	 * Create a csv "file" via output buffering and return it as a string
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_csv_file() {
+
+		$csv = $this->get_csv();
+
+		// Add header row.
+		array_unshift( $csv, array(
+			'Order ID',
+			'Expected Payments',
+			'Total Payments',
+			'Successful Payments',
+			'Refunded Payments',
+			'Edit Link',
+		) );
+
+		// Create the CSV file.
+		ob_start();
+		$fh = fopen( 'php://output', 'w' );
+		foreach ( $csv as $line ) {
+			fputcsv( $fh, $line );
+		}
+		fclose( $fh );
+
+		return ob_get_clean();
+
+	}
+
+	/**
+	 * Retrieve a description of the tool
+	 *
+	 * This is displayed on the right side of the tool's list before the button.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_description() {
+
+		$count = count( $this->get_csv() );
+
+		$desc  = sprintf(
+			// Translators: %1$s = opening anchor link to documentation; %2$s = closing anchor link.
+			__( 'The method used to determine when a limited-billing recurring order has completed its payment plan changed during version 5.3.0. This tool provides a report of orders which may been affected by this change. %1$sRead more%2$s about this change.', 'lifterlms' ),
+			'<a href="https://lifterlms.com/docs/###" target="_blank">',
+			'</a>'
+		);
+		$desc .= ' ';
+		// Translators: %d = the number of pending batches.
+		$desc .= sprintf(
+			_n(
+				'There is %d order that should be reviewed.',
+				'There are %d orders that should be reviewed.',
+				$count,
+				'lifterlms'
+			),
+			$count
+		);
+
+		return $desc;
+
+	}
+
+	/**
+	 * Retrieve the tool's label
+	 *
+	 * The label is the tool's title. It's displayed in the left column on the tool's list.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_label() {
+		return __( 'Limited Billing Orders', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieves an array representing a line in generated CSV for the given order
+	 *
+	 * An order is considered to be affected by the change if either of the following conditions are true:
+	 *
+	 *   + Any number of refunds exist for the order. Since we are now counting refunds towards the billing limit
+	 *     an active order with any number of refunds should be reviewed by the admin.
+	 *
+	 *   + The plan is marked as "ended" and the total number of successful payments is not equal to the billing length.
+	 *     In this scenario admins will likely want to add additional payments and start the order again.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order The order object.
+	 * @return array Array of information on the order to be stored in the generated CSV or an empty array of the order
+	 *               was not affected by the change.
+	 */
+	protected function get_order_csv( $order ) {
+
+		$refunds   = $this->get_txn_count_by_status( $order, 'llms-txn-refunded' );
+		$successes = $this->get_txn_count_by_status( $order, 'llms-txn-succeeded' );
+		$total     = $refunds + $successes;
+
+		$ended     = llms_parse_bool( $order->get( 'plan_ended' ) );
+		$expected  = $order->get( 'billing_length' );
+
+		if ( $refunds >= 1 || ( $ended && $total !== $expected ) ) {
+
+			$id   = $order->get( 'id' );
+			$link = get_edit_post_link( $id );
+			return array( $id, $expected, $total, $successes, $refunds, $link );
+
+		}
+
+		return array();
+
+	}
+
+	/**
+	 * Helper to get the number of transactions on an order for a given status
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order  The order object.
+	 * @param string     $status Transaction post status to query by.
+	 * @return int Number of transactions for the requested status.
+	 */
+	protected function get_txn_count_by_status( $order, $status ) {
+
+		$txns = $order->get_transactions(
+			array(
+				'per_page' => 1,
+				'status'   => array( $status ),
+				'type'     => array( 'recurring', 'single' ), // If a manual payment is recorded it's counted a single payment and that should count.
+			)
+		);
+
+		return $txns['total'];
+
+	}
+
+	/**
+	 * Retrieve the tool's button text
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_text() {
+		return __( 'Download CSV', 'lifterlms' );
+	}
+
+	/**
+	 * Retrieve a list of orders
+	 *
+	 * @since [version]
+	 *
+	 * @return int[]
+	 */
+	protected function get_csv() {
+
+		$csv = wp_cache_get( $this->id, 'llms_tool_data' );
+		if ( ! $csv ) {
+			$csv = $this->generate_csv();
+			wp_cache_set( $this->id, $csv, 'llms_tool_data' );
+		}
+
+		return $csv;
+
+	}
+
+	/**
+	 * Schedules payments and expiration for an order
+	 *
+	 * Retrieves orders from the `get_orders()` method and schedules a recurring payment
+	 * and expiration action based on its existing calculated order data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function handle() {
+
+		$file = $this->get_csv_file();
+
+		if ( ! headers_sent() ) { // This makes the method testable via phpunit.
+			header( 'Content-Type: text/csv' );
+			header( 'Content-Disposition: attachment; filename=orders.csv' );
+			header( 'Content-Length: '. strlen( $file ) );
+			nocache_headers();
+		}
+
+		llms_exit( $file );
+
+	}
+
+	/**
+	 * Conditionally load the tool
+	 *
+	 * This tool should only load if there are orders that can be handled by the tool.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean Return `true` to load the tool and `false` to not load it.
+	 */
+	protected function should_load() {
+		return count( $this->get_csv() ) > 0;
+	}
+
+}
+
+return new LLMS_Admin_Tool_Limited_Billing_Order_Locator();

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -48,6 +48,10 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 						'value'   => 1,
 						'compare' => '>=',
 					),
+					array(
+						'key'     => '_llms_date_billing_end',
+						'compare' => 'EXISTS',
+					)
 				),
 			)
 		);
@@ -180,7 +184,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		if ( $refunds >= 1 || ( $ended && $total !== $expected ) ) {
 
 			$id   = $order->get( 'id' );
-			$link = get_edit_post_link( $id );
+			$link = get_edit_post_link( $id, 'raw' );
 			return array( $id, $expected, $total, $successes, $refunds, $link );
 
 		}

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -123,7 +123,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		$desc = sprintf(
 			// Translators: %1$s = opening anchor link to documentation; %2$s = closing anchor link.
 			__( 'The method used to determine when a limited-billing recurring order has completed its payment plan changed during version 5.3.0. This tool provides a report of orders which may been affected by this change. %1$sRead more%2$s about this change.', 'lifterlms' ),
-			'<a href="https://lifterlms.com/docs/###" target="_blank">',
+			'<a href="https://lifterlms.com/docs/payment-plan-orders-530/" target="_blank">',
 			'</a>'
 		);
 		$desc .= ' ';

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -247,7 +247,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Generate the CSV file an server it as a downloadable attachment
+	 * Generate the CSV file an serve it as a downloadable attachment
 	 *
 	 * @since [version]
 	 *

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * Admin tool which generates a report of limited billing orders affected by order end changes
  *
  * @since [version]
- * 
+ *
  * @link https://github.com/gocodebox/lifterlms/pull/1744
  */
 class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_Tool {
@@ -37,18 +37,20 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 
 		$csv = array();
 
-		$orders = new WP_Query( array(
-			'post_type'      => 'llms_order',
-			'post_status'    => array( 'llms-active', 'llms-on-hold' ),
-			'posts_per_page' => -1,
-			'meta_query'     => array(
-				array(
-					'key'     => '_llms_billing_length',
-					'value'   => 1,
-					'compare' => '>=',
+		$orders = new WP_Query(
+			array(
+				'post_type'      => 'llms_order',
+				'post_status'    => array( 'llms-active', 'llms-on-hold' ),
+				'posts_per_page' => -1,
+				'meta_query'     => array(
+					array(
+						'key'     => '_llms_billing_length',
+						'value'   => 1,
+						'compare' => '>=',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		foreach ( $orders->posts as $order ) {
 
@@ -77,14 +79,17 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		$csv = $this->get_csv();
 
 		// Add header row.
-		array_unshift( $csv, array(
-			'Order ID',
-			'Expected Payments',
-			'Total Payments',
-			'Successful Payments',
-			'Refunded Payments',
-			'Edit Link',
-		) );
+		array_unshift(
+			$csv,
+			array(
+				'Order ID',
+				'Expected Payments',
+				'Total Payments',
+				'Successful Payments',
+				'Refunded Payments',
+				'Edit Link',
+			)
+		);
 
 		// Create the CSV file.
 		ob_start();
@@ -92,7 +97,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		foreach ( $csv as $line ) {
 			fputcsv( $fh, $line );
 		}
-		fclose( $fh );
+		fclose( $fh ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
 
 		return ob_get_clean();
 
@@ -111,7 +116,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 
 		$count = count( $this->get_csv() );
 
-		$desc  = sprintf(
+		$desc = sprintf(
 			// Translators: %1$s = opening anchor link to documentation; %2$s = closing anchor link.
 			__( 'The method used to determine when a limited-billing recurring order has completed its payment plan changed during version 5.3.0. This tool provides a report of orders which may been affected by this change. %1$sRead more%2$s about this change.', 'lifterlms' ),
 			'<a href="https://lifterlms.com/docs/###" target="_blank">',
@@ -169,8 +174,8 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		$successes = $this->get_txn_count_by_status( $order, 'llms-txn-succeeded' );
 		$total     = $refunds + $successes;
 
-		$ended     = llms_parse_bool( $order->get( 'plan_ended' ) );
-		$expected  = $order->get( 'billing_length' );
+		$ended    = llms_parse_bool( $order->get( 'plan_ended' ) );
+		$expected = $order->get( 'billing_length' );
 
 		if ( $refunds >= 1 || ( $ended && $total !== $expected ) ) {
 
@@ -254,7 +259,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		if ( ! headers_sent() ) { // This makes the method testable via phpunit.
 			header( 'Content-Type: text/csv' );
 			header( 'Content-Disposition: attachment; filename=orders.csv' );
-			header( 'Content-Length: '. strlen( $file ) );
+			header( 'Content-Length: ' . strlen( $file ) );
 			nocache_headers();
 		}
 

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -247,10 +247,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Schedules payments and expiration for an order
-	 *
-	 * Retrieves orders from the `get_orders()` method and schedules a recurring payment
-	 * and expiration action based on its existing calculated order data.
+	 * Generate the CSV file an server it as a downloadable attachment
 	 *
 	 * @since [version]
 	 *

--- a/includes/functions/llms-functions-wrappers.php
+++ b/includes/functions/llms-functions-wrappers.php
@@ -101,7 +101,7 @@ if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
 	 *
 	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L178-L199
 	 *
-	 * @param string $location Full URL to redirect to
+	 * @param string $location Full URL to redirect to.
 	 * @param array  $options  {
 	 *     Optional. Array of options. Default is empty array.
 	 *

--- a/includes/functions/llms-functions-wrappers.php
+++ b/includes/functions/llms-functions-wrappers.php
@@ -104,8 +104,10 @@ if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
 	 * @param string $location Full URL to redirect to
 	 * @param array  $options  {
 	 *     Optional. Array of options. Default is empty array.
+	 *
 	 *     @type int  $status HTTP status code of the redirect. Default: `302`.
 	 *     @type bool $safe   If true, use `wp_safe_redirect()` otherwise use `wp_redirect()`. Default: `true`.
+	 * }
 	 * @return void
 	 */
 	function llms_redirect_and_exit( $location, $options = array() ) {
@@ -119,7 +121,7 @@ if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
 		);
 
 		$func = $options['safe'] ? 'wp_safe_redirect' : 'wp_redirect';
-		call_user_func( $func, $location, $options['status'] );
+		$func( $location, $options['status'] );
 		exit();
 
 	}

--- a/includes/functions/llms-functions-wrappers.php
+++ b/includes/functions/llms-functions-wrappers.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Functions that wrap native PHP or WordPress core functions
+ *
+ * Most of these are pluggable primarily to allow easier testing when
+ * running phpunit.
+ *
+ * @package LifterLMS/Functions
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! function_exists( 'llms_current_time' ) ) {
+	/**
+	 * Retrieve the current time based on specified type.
+	 *
+	 * This is a wrapper for the WP Core current_time which can be plugged
+	 * We plug this during unit testing to allow mocking the current time.
+	 *
+	 * The 'mysql' type will return the time in the format for MySQL DATETIME field.
+	 * The 'timestamp' type will return the current timestamp.
+	 * Other strings will be interpreted as PHP date formats (e.g. 'Y-m-d').
+	 *
+	 * If $gmt is set to either '1' or 'true', then both types will use GMT time.
+	 * if $gmt is false, the output is adjusted with the GMT offset in the WordPress option.
+	 *
+	 * @since 3.4.0
+	 * @since [version] Moved location from `includes/llms.functions.core.php`.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/current_time/
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L2-L26
+	 *
+	 * @param string   $type Type of time to retrieve. Accepts 'mysql', 'timestamp', or PHP date format string (e.g. 'Y-m-d').
+	 * @param int|bool $gmt  Optional. Whether to use GMT timezone. Default false.
+	 * @return int|string Integer if $type is 'timestamp', string otherwise.
+	 */
+	function llms_current_time( $type, $gmt = 0 ) {
+		return current_time( $type, $gmt );
+	}
+}
+
+if ( ! function_exists( 'llms_exit' ) ) {
+	/**
+	 * Native php exit() wrapper
+	 *
+	 * This wrapper exists primarily to allow easy testing of code that calls exit().
+	 *
+	 * @since [version]
+	 *
+	 * @link https://www.php.net/manual/en/function.exit.php
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L164-L176
+	 *
+	 * @param int|string $status Exit status passed to `exit()`.
+	 * @return void
+	 */
+	function llms_exit( $status = null ) {
+		exit( $status );
+	}
+}
+
+if ( ! function_exists( 'llms_filter_input' ) ) {
+	/**
+	 * Gets a specific external variable by name and optionally filters it
+	 *
+	 * This is a pluggable wrapper around native `filter_input` which is plugged in the testing framework
+	 * to allow easy mocking of form variables when testing form controller functions and methods.
+	 *
+	 * @since 3.29.0
+	 * @since [version] Moved location from `includes/llms.functions.core.php`.
+	 *
+	 * @link https://www.php.net/manual/en/function.filter-input.php
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L113-L162
+	 *
+	 * @param int    $type          One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV.
+	 * @param string $variable_name Name of a variable to get.
+	 * @param int    $filter        Optional. The ID of the filter to apply. Default is `FILTER_DEFAULT`.
+	 * @param mixed  $options       Optional. Associative array of options or bitwise disjunction of flags. Default is empty array.
+	 *                              If filter accepts options, flags can be provided in "flags" field of array.
+	 * @return mixed  Value of the requested variable on success, FALSE if the filter fails, or NULL if
+	 *                the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used,
+	 *                it returns FALSE if the variable is not set and NULL if the filter fails.
+	 */
+	function llms_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = array() ) {
+		return filter_input( $type, $variable_name, $filter, $options );
+	}
+}
+
+if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
+	/**
+	 * Redirect and exit
+	 *
+	 * Wrapper for WP core redirects which automatically calls `exit();`.
+	 *
+	 * This function is redefined when running phpunit tests to make testing code that redirects (and exits).
+	 *
+	 * @since 3.19.4
+	 * @since [version] Moved location from `includes/llms.functions.core.php`.
+	 *
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L178-L199
+	 *
+	 * @param string $location Full URL to redirect to
+	 * @param array  $options  {
+	 *     Optional. Array of options. Default is empty array.
+	 *     @type int  $status HTTP status code of the redirect. Default: `302`.
+	 *     @type bool $safe   If true, use `wp_safe_redirect()` otherwise use `wp_redirect()`. Default: `true`.
+	 * @return void
+	 */
+	function llms_redirect_and_exit( $location, $options = array() ) {
+
+		$options = wp_parse_args(
+			$options,
+			array(
+				'status' => 302,
+				'safe'   => true,
+			)
+		);
+
+		$func = $options['safe'] ? 'wp_safe_redirect' : 'wp_redirect';
+		call_user_func( $func, $location, $options['status'] );
+		exit();
+
+	}
+}
+
+if ( ! function_exists( 'llms_setcookie' ) ) {
+	/**
+	 * Set a cookie.
+	 *
+	 * A pluggable wrapper for the native PHP function `set_cookie()`.
+	 *
+	 * The lifterlms-tests library plugs this function during unit testing so we can mock
+	 * the returns of methods that set cookies and write tests for those functions.
+	 *
+	 * @since 4.0.0
+	 * @since [version] Moved location from `includes/llms.functions.core.php`.
+	 *
+	 * @link https://www.php.net/manual/en/function.setcookie.php
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/trunk/framework/functions-llms-tests.php#L81-L111
+	 *
+	 * @param string $name     The name of the cookie.
+	 * @param string $value    The value of the cookie.
+	 * @param int    $expires  The time wehn the cookie expires as a Unix timestamp.
+	 * @param string $path     The path on the server where the cookie will be available.
+	 * @param string $domain   The (sub)domain that the cookie is available to.
+	 * @param bool   $secure   Indicates the cookie should only be transmitted over a secure HTTPS connection.
+	 * @param bool   $httponly When `true` the cookie will only be made accessible through the HTTP protocol,
+	 *                         preventing it from being accessed by scripting languages (such as Javascript).
+	 *
+	 * @return boolean
+	 */
+	function llms_setcookie( $name, $value = '', $expires = 0, $path = '', $domain = '', $secure = false, $httponly = false ) {
+		return setcookie( $name, $value, $expires, $path, $domain, $secure, $httponly );
+	}
+}
+

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,7 @@ require_once 'functions/llms-functions-locale.php';
 require_once 'functions/llms-functions-options.php';
 require_once 'functions/llms-functions-progression.php';
 require_once 'functions/llms-functions-user-information-fields.php';
+require_once 'functions/llms-functions-wrappers.php';
 
 require_once 'functions/llms.functions.access.php';
 require_once 'functions/llms.functions.certificate.php';
@@ -69,31 +70,6 @@ function llms_assoc_array_insert( $array, $after_key, $insert_key, $insert_item 
 
 	return $res;
 
-}
-
-/**
- * Retrieve the current time based on specified type.
- *
- * This is a wrapper for the WP Core current_time which can be plugged
- * We plug this during unit testing to allow mocking the current time.
- *
- * The 'mysql' type will return the time in the format for MySQL DATETIME field.
- * The 'timestamp' type will return the current timestamp.
- * Other strings will be interpreted as PHP date formats (e.g. 'Y-m-d').
- *
- * If $gmt is set to either '1' or 'true', then both types will use GMT time.
- * if $gmt is false, the output is adjusted with the GMT offset in the WordPress option.
- *
- * @since 3.4.0
- *
- * @param string   $type Type of time to retrieve. Accepts 'mysql', 'timestamp', or PHP date format string (e.g. 'Y-m-d').
- * @param int|bool $gmt  Optional. Whether to use GMT timezone. Default false.
- * @return int|string Integer if $type is 'timestamp', string otherwise.
- */
-if ( ! function_exists( 'llms_current_time' ) ) {
-	function llms_current_time( $type, $gmt = 0 ) {
-		return current_time( $type, $gmt );
-	}
 }
 
 /**
@@ -166,30 +142,6 @@ function llms_cleanup_tmp() {
 
 }
 add_action( 'llms_cleanup_tmp', 'llms_cleanup_tmp' );
-
-if ( ! function_exists( 'llms_filter_input' ) ) {
-
-	/**
-	 * Gets a specific external variable by name and optionally filters it
-	 *
-	 * This is a pluggable wrapper around native `filter_input` which is plugged in the testing framework
-	 * to allow easy mocking of form variables when testing form controller functions and methods.
-	 *
-	 * @since 3.29.0
-	 *
-	 * @param int    $type          One of INPUT_GET, INPUT_POST, INPUT_COOKIE, INPUT_SERVER, or INPUT_ENV.
-	 * @param string $variable_name Name of a variable to get.
-	 * @param int    $filter        Optional. The ID of the filter to apply. Default is `FILTER_DEFAULT`.
-	 * @param mixed  $options       Optional. Associative array of options or bitwise disjunction of flags. Default is empty array.
-	 *                              If filter accepts options, flags can be provided in "flags" field of array.
-	 * @return mixed  Value of the requested variable on success, FALSE if the filter fails, or NULL if
-	 *                the variable_name variable is not set. If the flag FILTER_NULL_ON_FAILURE is used,
-	 *                it returns FALSE if the variable is not set and NULL if the filter fails.
-	 */
-	function llms_filter_input( $type, $variable_name, $filter = FILTER_DEFAULT, $options = array() ) {
-		return filter_input( $type, $variable_name, $filter, $options );
-	}
-}
 
 /**
  * Retrieve an array of post types which can be completed by students
@@ -1082,91 +1034,6 @@ function llms_php_error_constant_to_code( $code ) {
 	return isset( $codes[ $code ] ) ? $codes[ $code ] : $code;
 
 }
-
-
-if ( ! function_exists( 'llms_exit' ) ) {
-	/**
-	 * Native php exit() wrapper
-	 *
-	 * This wrapper exists primarily to allow easy testing of code that calls exit().
-	 *
-	 * @since [version]
-	 *
-	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L164-L176
-	 *
-	 * @param int|string $status Exit status passed to `exit()`.
-	 * @return void
-	 */
-	function llms_exit( $status = null ) {
-		exit( $status );
-	}
-}
-
-if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
-	/**
-	 * Redirect and exit
-	 *
-	 * Wrapper for WP core redirects which automatically calls `exit();`.
-	 *
-	 * This function is redefined when running phpunit tests to make testing code that redirects (and exits).
-	 *
-	 * @since 3.19.4
-	 *
-	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L178-L199
-	 *
-	 * @param string $location Full URL to redirect to
-	 * @param array  $options  {
-	 *     Optional. Array of options. Default is empty array.
-	 *     @type int  $status HTTP status code of the redirect. Default: `302`.
-	 *     @type bool $safe   If true, use `wp_safe_redirect()` otherwise use `wp_redirect()`. Default: `true`.
-	 * @return void
-	 */
-	function llms_redirect_and_exit( $location, $options = array() ) {
-
-		$options = wp_parse_args(
-			$options,
-			array(
-				'status' => 302,
-				'safe'   => true,
-			)
-		);
-
-		$func = $options['safe'] ? 'wp_safe_redirect' : 'wp_redirect';
-		call_user_func( $func, $location, $options['status'] );
-		exit();
-
-	}
-}
-
-if ( ! function_exists( 'llms_setcookie' ) ) {
-	/**
-	 * Set a cookie.
-	 *
-	 * A pluggable wrapper for the native PHP function `set_cookie()`.
-	 *
-	 * The lifterlms-tests library plugs this function during unit testing so we can mock
-	 * the returns of methods that set cookies and write tests for those functions.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @link https://www.php.net/manual/en/function.setcookie.php
-	 *
-	 * @param string $name     The name of the cookie.
-	 * @param string $value    The value of the cookie.
-	 * @param int    $expires  The time wehn the cookie expires as a Unix timestamp.
-	 * @param string $path     The path on the server where the cookie will be available.
-	 * @param string $domain   The (sub)domain that the cookie is available to.
-	 * @param bool   $secure   Indicates the cookie should only be transmitted over a secure HTTPS connection.
-	 * @param bool   $httponly When `true` the cookie will only be made accessible through the HTTP protocol,
-	 *                         preventing it from being accessed by scripting languages (such as Javascript).
-	 *
-	 * @return boolean
-	 */
-	function llms_setcookie( $name, $value = '', $expires = 0, $path = '', $domain = '', $secure = false, $httponly = false ) {
-		return setcookie( $name, $value, $expires, $path, $domain, $secure, $httponly );
-	}
-}
-
 
 /**
  * Wrapper for set_time_limit to ensure it's enabled before calling

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -1083,21 +1083,44 @@ function llms_php_error_constant_to_code( $code ) {
 
 }
 
-/**
- * Redirect and exit
- *
- * Wrapper for WP core redirects which automatically calls `exit();`
- * and is pluggable (mainly for unit testing purposes).
- *
- * @since 3.19.4
- *
- * @param string $location Full URL to redirect to
- * @param array  $options  Optional. Array of options. Default is empty array.
- *                         $status int  HTTP status code of the redirect [default: 302].
- *                         $safe   bool If true, use `wp_safe_redirect()` otherwise use `wp_redirect()` [default: true],
- * @return void
- */
+
+if ( ! function_exists( 'llms_exit' ) ) {
+	/**
+	 * Native php exit() wrapper
+	 *
+	 * This wrapper exists primarily to allow easy testing of code that calls exit().
+	 *
+	 * @since [version]
+	 *
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L164-L176
+	 *
+	 * @param int|string $status Exit status passed to `exit()`.
+	 * @return void
+	 */
+	function llms_exit( $status = null ) {
+		exit( $status );
+	}
+}
+
 if ( ! function_exists( 'llms_redirect_and_exit' ) ) {
+	/**
+	 * Redirect and exit
+	 *
+	 * Wrapper for WP core redirects which automatically calls `exit();`.
+	 *
+	 * This function is redefined when running phpunit tests to make testing code that redirects (and exits).
+	 *
+	 * @since 3.19.4
+	 *
+	 * @link https://github.com/gocodebox/lifterlms-tests/blob/472c5a286e9f65e2be0c1d6b7edd8d5340d052ed/framework/functions-llms-tests.php#L178-L199
+	 *
+	 * @param string $location Full URL to redirect to
+	 * @param array  $options  {
+	 *     Optional. Array of options. Default is empty array.
+	 *     @type int  $status HTTP status code of the redirect. Default: `302`.
+	 *     @type bool $safe   If true, use `wp_safe_redirect()` otherwise use `wp_redirect()`. Default: `true`.
+	 * @return void
+	 */
 	function llms_redirect_and_exit( $location, $options = array() ) {
 
 		$options = wp_parse_args(

--- a/tests/phpunit/framework/class-llms-admin-tool-test-case.php
+++ b/tests/phpunit/framework/class-llms-admin-tool-test-case.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Admin Tool base test case
+ *
+ * @package LifterLMS/Tests/Framework
+ *
+ * @since [version]
+ */
+
+require_once 'class-llms-unit-test-case.php';
+
+class LLMS_Admin_Tool_Test_Case extends LLMS_UnitTestCase {
+
+	/**
+	 * Name of the class being tested.
+	 *
+	 * This must be added to extending classes.
+	 *
+	 * @var sting
+	 */
+	// const CLASS_NAME = 'LLMS_Admin_Tool_Class_Name';
+
+	/**
+	 * Setup before class
+	 *
+	 * Include abstract required classes.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function setUpBeforeClass() {
+
+		parent::setUpBeforeClass();
+
+		// Abstract tool.
+		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
+
+		// Include the tool itself.
+		$filename = 'class-' . str_replace( '_', '-', strtolower( static::CLASS_NAME ) ) . '.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/' . $filename;
+
+	}
+
+	/**
+	 * Setup test case
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+
+		parent::setUp();
+		$classname = static::CLASS_NAME;
+		$this->main = new $classname();
+
+	}
+
+	/**
+	 * Test get_description()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_description() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_label()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_label() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+	/**
+	 * Test get_text()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_text() {
+
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
+		$this->assertTrue( ! empty( $res ) );
+		$this->assertTrue( is_string( $res ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-batch-eraser.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-batch-eraser.php
@@ -6,28 +6,19 @@
  *
  * @group admin
  * @group admin_tools
+ * @group batch_eraser
  *
  * @since 3.37.19
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Batch_Eraser extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Batch_Eraser extends LLMS_Admin_Tool_Test_Case {
 
 	/**
-	 * Setup before class
+	 * Name of the class being tested.
 	 *
-	 * Include abstract class.
-	 *
-	 * @since 3.37.19
-	 *
-	 * @return void
+	 * @var sting
 	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-batch-eraser.php';
-
-	}
+	const CLASS_NAME = 'LLMS_Admin_Tool_Batch_Eraser';
 
 	/**
 	 * Teardown the test case.
@@ -52,65 +43,6 @@ class LLMS_Test_Admin_Tool_Batch_Eraser extends LLMS_UnitTestCase {
 	 */
 	private function clear_cache() {
 		wp_cache_delete( 'batch-eraser', 'llms_tool_data' );
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 3.37.19
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-
-		parent::setUp();
-
-		$this->main = new LLMS_Admin_Tool_Batch_Eraser();
-	}
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 3.37.19
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 3.37.19
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 3.37.19
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-clear-sessions.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-clear-sessions.php
@@ -6,87 +6,19 @@
  *
  * @group admin
  * @group admin_tools
+ * @group clear_sessions
  *
  * @since 4.0.0
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Clear_Sessions extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Clear_Sessions extends LLMS_Admin_Tool_Test_Case {
 
 	/**
-	 * Setup before class
+	 * Name of the class being tested.
 	 *
-	 * Include abstract class.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
+	 * @var sting
 	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-clear-sessions.php';
-
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-
-		parent::setUp();
-		$this->main = new LLMS_Admin_Tool_Clear_Sessions();
-
-	}
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 4.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
+	const CLASS_NAME = 'LLMS_Admin_Tool_Clear_Sessions';
 
 	/**
 	 * Test handle()

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-install-forms.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-install-forms.php
@@ -6,42 +6,19 @@
  *
  * @group admin
  * @group admin_tools
+ * @group install_forms
  *
  * @since 5.0.0
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Install_Forms extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Install_Forms extends LLMS_Admin_Tool_Test_Case {
 
 	/**
-	 * Setup before class
+	 * Name of the class being tested.
 	 *
-	 * Include abstract class.
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
+	 * @var sting
 	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-install-forms.php';
-
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-
-		parent::setUp();
-		$this->main = new LLMS_Admin_Tool_Install_Forms();
-
-	}
+	const CLASS_NAME = 'LLMS_Admin_Tool_Install_Forms';
 
 	/**
 	 * Retrieve a list of core reusable block post ids
@@ -72,51 +49,6 @@ class LLMS_Test_Admin_Tool_Install_Forms extends LLMS_UnitTestCase {
 
 		$forms = new WP_Query( array( 'post_type' => 'llms_form' ) );
 		return $forms->posts;
-
-	}
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-limited-billing-order-locator.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-limited-billing-order-locator.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Tests for the LLMS_Admin_Tool_Limited_Billing_Order_Locator class
+ *
+ * @package LifterLMS/Tests/Admins/Tools
+ *
+ * @group admin
+ * @group admin_tools
+ * @group limited_billing
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool_Test_Case {
+
+	/**
+	 * Name of the class being tested.
+	 *
+	 * @var sting
+	 */
+	const CLASS_NAME = 'LLMS_Admin_Tool_Limited_Billing_Order_Locator';
+
+	/**
+	 * Teardown the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		$this->clear_cache();
+	}
+
+	/**
+	 * Clear cached tool data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function clear_cache() {
+		wp_cache_delete( 'limited-billing-order-locator', 'llms_tool_data' );
+	}
+
+	/**
+	 * Create mock orders
+	 *
+	 * @since [version]
+	 *
+	 * @param int   $count Number of orders.
+	 * @param array $meta  Order meta data.
+	 * @param array $args  Additional args.
+	 * @return int[]
+	 */
+	private function create_mock_orders( $count, $meta = array(), $args = array() ) {
+
+		return $this->factory->post->create_many( $count, wp_parse_args( $args, array(
+			'post_type'   => 'llms_order',
+			'post_status' => 'llms-active',
+			'meta_input'  => $meta,
+		) ) );
+
+	}
+
+	/**
+	 * Test generate_csv()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_csv() {
+
+		$this->assertEquals( 0, count( LLMS_Unit_Test_Util::call_method( $this->main, 'generate_csv' ) ) );
+
+		// Not qualifying.
+		$this->create_mock_orders( 1 );
+		$this->assertEquals( 0, count( LLMS_Unit_Test_Util::call_method( $this->main, 'generate_csv' ) ) );
+
+		// Has length but wrong status.
+		$this->create_mock_orders( 1, array( '_llms_billing_length' => 2 ), array( 'post_status' => 'llms-cancelled' ) );
+		$this->assertEquals( 0, count( LLMS_Unit_Test_Util::call_method( $this->main, 'generate_csv' ) ) );
+
+		// Qualifying.
+		$this->create_mock_orders( 2, array( '_llms_billing_length' => 2, '_llms_plan_ended' => 'yes' ) );
+		$this->assertEquals( 2, count( LLMS_Unit_Test_Util::call_method( $this->main, 'generate_csv' ) ) );
+
+	}
+
+	/**
+	 * Test get_order_csv(): doesn't quality because the order hasn't ended and there's no refunds
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_order_csv_not_ended_no_refunds() {
+
+		$order = llms_get_post( $this->create_mock_orders( 1, array( '_llms_billing_length' => 2 ) )[0] );
+		$this->assertEquals( array(), LLMS_Unit_Test_Util::call_method( $this->main, 'get_order_csv', array( $order ) ) );
+
+	}
+
+	/**
+	 * Test get_order_csv(): Doesn't qualify because it has ended but has the expected number of payments.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_order_right_number_of_payments() {
+
+		$order = llms_get_post( $this->create_mock_orders( 1, array( '_llms_billing_length' => 2 ) )[0] );
+		$order->record_transaction();
+		$order->record_transaction();
+		$this->assertEquals( array(), LLMS_Unit_Test_Util::call_method( $this->main, 'get_order_csv', array( $order ) ) );
+
+	}
+
+	/**
+	 * Test get_order_csv(): Qualifies because it has ended and is missing a payment.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_order_missing_payments() {
+
+		$order_id = $this->create_mock_orders( 1, array( '_llms_billing_length' => 2, '_llms_plan_ended' => 'yes' ) )[0];
+		$order = llms_get_post( $order_id );
+		$expect = array( $order_id, 2, 1, 1, 0, get_edit_post_link( $order_id ) );
+		$order->record_transaction();
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::call_method( $this->main, 'get_order_csv', array( $order ) ) );
+
+	}
+
+	/**
+	 * Test get_order_csv(): Qualifies because it has a refund.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_order_has_refund() {
+
+		$order_id = $this->create_mock_orders( 1, array( '_llms_billing_length' => 5 ) )[0];
+		$order = llms_get_post( $order_id );
+		$expect = array( $order_id, 5, 1, 0, 1, get_edit_post_link( $order_id ) );
+		$order->record_transaction( array( 'status' => 'llms-txn-refunded' ) );
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::call_method( $this->main, 'get_order_csv', array( $order ) ) );
+
+	}
+
+	/**
+	 * Test get_csv() when there's nothing cached.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_csv_cache_miss() {
+
+		$this->clear_cache();
+
+		$this->create_mock_orders( 2, array( '_llms_billing_length' => 2, '_llms_plan_ended' => 'yes' ) );
+		$expect = LLMS_Unit_Test_Util::call_method( $this->main, 'generate_csv' );
+		$this->assertEquals( $expect, LLMS_Unit_Test_Util::call_method( $this->main, 'get_csv' ) );
+
+		// Should be cached.
+		$this->assertEquals( $expect, wp_cache_get( 'limited-billing-order-locator', 'llms_tool_data' ) );
+
+	}
+
+	/**
+	 * Test get_csv() when there's cached results.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_csv_cache_hit() {
+
+		wp_cache_set( 'limited-billing-order-locator', 'fake', 'llms_tool_data' );
+		$this->assertEquals( 'fake', LLMS_Unit_Test_Util::call_method( $this->main, 'get_csv' ) );
+
+	}
+
+	/**
+	 * Test handle()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle() {
+
+		$orders = $this->create_mock_orders( 3, array( '_llms_billing_length' => 2, '_llms_plan_ended' => 'yes' ) );
+
+		try {
+
+			LLMS_Unit_Test_Util::call_method( $this->main, 'handle' );
+
+		} catch ( LLMS_Unit_Test_Exception_Exit $exception ) {
+
+			$csv = $exception->get_status();
+
+			$this->assertTrue( is_string( $csv ) );
+
+			$lines = explode( PHP_EOL, $csv );
+			$this->assertEquals( '"Order ID","Expected Payments","Total Payments","Successful Payments","Refunded Payments","Edit Link"', $lines[0] );
+			array_shift( $lines );
+
+			foreach ( $lines as $i => $line ) {
+				// Empty line at the end of the file.
+				if ( 3 === $i ) {
+					$this->assertEmpty( $line );
+				} else {
+					$link = get_edit_post_link( $orders[ $i ] );
+					$this->assertEquals( "{$orders[ $i ]},2,0,0,0,{$link}", $line );
+				}
+			}
+
+
+
+		}
+
+
+
+	}
+
+	/**
+	 * Test should_load()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_load() {
+
+		// Shouldn't load.
+		$this->create_mock_orders( 1 );
+		$this->assertFalse( LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' ) );
+
+		// Should load.
+		$this->create_mock_orders( 1, array( '_llms_billing_length' => 2, '_llms_plan_ended' => 'yes' ) );
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $this->main, 'should_load' ) );
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-recurring-payment-rescheduler.php
@@ -6,28 +6,19 @@
  *
  * @group admin
  * @group admin_tools
+ * @group recurring_rescheduler
  *
  * @since 4.6.0
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Admin_Tool_Test_Case {
 
 	/**
-	 * Setup before class
+	 * Name of the class being tested.
 	 *
-	 * Include abstract class.
-	 *
-	 * @since 4.6.0
-	 *
-	 * @return void
+	 * @var sting
 	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php';
-
-	}
+	const CLASS_NAME = 'LLMS_Admin_Tool_Recurring_Payment_Rescheduler';
 
 	/**
 	 * Teardown the test case.
@@ -88,63 +79,6 @@ class LLMS_Test_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_UnitTestCa
 	private function clear_cache() {
 		wp_cache_delete( 'recurring-payment-rescheduler', 'llms_tool_data' );
 		wp_cache_delete( 'recurring-payment-rescheduler-total-results', 'llms_tool_data' );
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 4.6.0
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-		parent::setUp();
-		$this->main = new LLMS_Admin_Tool_Recurring_Payment_Rescheduler();
-	}
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 4.6.0
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 4.6.0
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 4.6.0
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-reset-automatic-payments.php
@@ -1,92 +1,24 @@
 <?php
 /**
- * Tests for the LLMS_Admin_Tool_Clear_Sessions class
+ * Tests for the LLMS_Admin_Tool_Reset_Automatic_Payments class
  *
  * @package LifterLMS/Tests/Admins/Tools
  *
  * @group admin
  * @group admin_tools
+ * @group reset_payments
  *
  * @since 4.13.0
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Reset_Automatic_Payments extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Reset_Automatic_Payments extends LLMS_Admin_Tool_Test_Case {
 
 	/**
-	 * Setup before class
+	 * Name of the class being tested.
 	 *
-	 * Include abstract class.
-	 *
-	 * @since 4.13.0
-	 *
-	 * @return void
+	 * @var sting
 	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-reset-automatic-payments.php';
-
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 4.13.0
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-
-		parent::setUp();
-		$this->main = new LLMS_Admin_Tool_Reset_Automatic_Payments();
-
-	}
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 4.13.0
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 4.13.0
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 4.13.0
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
+	const CLASS_NAME = 'LLMS_Admin_Tool_Reset_Automatic_Payments';
 
 	/**
 	 * Test handle()

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-wipe-legacy-account-options.php
@@ -6,10 +6,19 @@
  *
  * @group admin
  * @group admin_tools
+ * @group legacy_opts
  *
  * @since 5.0.0
+ * @since [version] Use `LLMS_Admin_Tool_Test_Case` and remove redundant methods/tests.
  */
-class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_UnitTestCase {
+class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_Admin_Tool_Test_Case {
+
+	/**
+	 * Name of the class being tested.
+	 *
+	 * @var sting
+	 */
+	const CLASS_NAME = 'LLMS_Admin_Tool_Wipe_Legacy_Account_Options';
 
 	const LEGACY_OPTIONS = array(
 		'lifterlms_registration_generate_username',
@@ -31,38 +40,6 @@ class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_UnitTestCase
 	);
 
 	/**
-	 * Setup before class
-	 *
-	 * Include abstract class
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public static function setUpBeforeClass() {
-
-		parent::setUpBeforeClass();
-
-		require_once LLMS_PLUGIN_DIR . 'includes/abstracts/llms-abstract-admin-tool.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php';
-
-	}
-
-	/**
-	 * Setup the test case
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-
-		parent::setUp();
-		$this->main = new LLMS_Admin_Tool_Wipe_Legacy_Account_Options();
-
-	}
-
-	/**
 	 * Tear Down
 	 *
 	 * @since 5.0.0
@@ -73,52 +50,6 @@ class LLMS_Test_Admin_Tool_Wipe_Legacy_Account_Options extends LLMS_UnitTestCase
 
 		parent::tearDown();
 		$this->delete_legacy_options();
-
-	}
-
-
-	/**
-	 * Test get_description()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_description() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_description' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_label()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_label() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_label' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
-
-	}
-
-	/**
-	 * Test get_text()
-	 *
-	 * @since 5.0.0
-	 *
-	 * @return void
-	 */
-	public function test_get_text() {
-
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'get_text' );
-		$this->assertTrue( ! empty( $res ) );
-		$this->assertTrue( is_string( $res ) );
 
 	}
 


### PR DESCRIPTION
## Description

Building on #1744

Adds a (conditionally loaded) tool to identify orders potentially affected by the changes to how an limited-billing recurring order is ended

Prior to #1744 these orders ended by a calculated date, now they end based on the number of successful (and refunded) payments.

This tool generates a CSV of affected active and on-hold orders with a billing length of at least one which meet one of the following criteria:

1. The order contains at least one refund
2. The order is marked as "ended" and has fewer successful transactions than the expected number (the billing length)

This tool does not take any actual action on the orders, it just generates a report that an admin should review and do what they like with. The main concern would be orders that ended incorrectly and need additional billing to be added. Admins can visit the order screen and update the remaining payments via the new interface should they disagree with the new rules.

This PR additionally introduces a pluggable wrapper for `exit()` that has been redefined in `lifterlms/lifterlms-tests` so that we can easily test methods that `exit()`.

It also updates other admin tool testing classes to consolidate redundant tests (mainly testing methods like `get_text()`...

And I moved all the pluggable wrappers from `includes/llms.functions.core.php` to their own function file.

## TODO

- [x] A piece of documentation needs to be written about this and then the tool description's link should be updated once the link exists. 

## How has this been tested?

+ Manually
+ New tests

## Screenshots <!-- if applicable -->

## Types of changes
+ New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

