### PR TITLE
Fix calculation of expected next payment time

### DIFF
--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -663,6 +663,7 @@ class LLMS_Order extends LLMS_Post_Model {
 				'ping_status'    => 'closed',
 				'post_author'    => 1,
 				'post_content'   => '',
+				'post_date'      => llms_current_time( 'mysql' ),
 				'post_excerpt'   => '',
 				'post_password'  => uniqid( 'order_' ),
 				'post_status'    => 'llms-' . apply_filters( 'llms_default_order_status', 'pending' ),

--- a/tests/phpunit/framework/class-llms-payment-gateway-mock.php
+++ b/tests/phpunit/framework/class-llms-payment-gateway-mock.php
@@ -70,8 +70,8 @@ class LLMS_Payment_Gateway_Mock extends LLMS_Payment_Gateway {
 	 *
 	 * @since 3.37.6
 	 *
-	 * @param obj $order Instance LLMS_Order for the order being processed.
-	 * @return mixed
+	 * @param LLMS_Order $order Instance LLMS_Order for the order being processed.
+	 * @return void
 	 */
 	public function handle_recurring_transaction( $order ) {
 

--- a/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
+++ b/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
@@ -150,6 +150,7 @@ class LLMS_Test_Payment_Gateway_Integrations extends LLMS_UnitTestCase {
 	 *
 	 * @since 3.37.6
 	 * @since 3.37.12 Added additional assertion message information to assist in debug chaos-related failures.
+	 * @since [version] If the chaos >= 0, calculate the expected next payment time based on the scheduled payment time.
 	 *
 	 * @param LLMS_Order $order Initialized order to run charges against.
 	 * @param int $num Number of charges to run.

--- a/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
+++ b/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
@@ -163,7 +163,7 @@ class LLMS_Test_Payment_Gateway_Integrations extends LLMS_UnitTestCase {
 		$i       = 2;
 		while ( $i <= $num + 1 && $elapsed <= $limit ) {
 
-			$scheduled_payment_time = $order->get_date( 'date_next_payment', 'U' );
+			$scheduled_payment_time = (int) $order->get_date( 'date_next_payment', 'U' );
 
 			// Run the recurring payment randomly between 12 hours before and 12 hours after the scheduled payment time.
 			$chaos = rand( 0, HOUR_IN_SECONDS * $chaos_hours ) * ( rand( 0, 1 ) ? -1 : 1 );

--- a/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
+++ b/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
@@ -169,7 +169,7 @@ class LLMS_Test_Payment_Gateway_Integrations extends LLMS_UnitTestCase {
 			$chaos = rand( 0, HOUR_IN_SECONDS * $chaos_hours ) * ( rand( 0, 1 ) ? -1 : 1 );
 
 			// Time travel.
-			llms_mock_current_time( $scheduled_payment_time + $chaos );
+			llms_tests_mock_current_time( $scheduled_payment_time + $chaos );
 
 			// Run the transaction.
 			$this->gateway->handle_recurring_transaction( $order );

--- a/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
+++ b/tests/phpunit/unit-tests/class-llms-test-payment-gateway-integrations.php
@@ -8,8 +8,14 @@
  * @since 3.37.12 Added additional assertion message information to assist in debug chaos-related failures.
  * @since 3.37.14 Reduce number of tests run for monthly and yearly chaotic simulations.
  * @since 4.3.1 Increased delta for `test_recurring_lifecycle_for_month_plan_with_chaos_and_frequency()` and `test_recurring_lifecycle_for_month_plan_with_chaos()`.
+ * @since [version] Declare the `$gateway` property.
  */
 class LLMS_Test_Payment_Gateway_Integrations extends LLMS_UnitTestCase {
+
+	/**
+	 * @var LLMS_Payment_Gateway|false
+	 */
+	protected $gateway;
 
 	/**
 	 * Before the class runs, register the mock gateway.


### PR DESCRIPTION
## Description
Calculation of the expected next payment time should be based on the scheduled payment time if the chaos seconds are >= 0. This is consistent with how `LLMS_Order->calculate_next_payment_date()` does it.

Fixes #1053.

## How has this been tested?
The "Steps to Reproduce" were used before and after the code changes.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

