### PR TITLE
Delete empty notices and do not output them.

### DIFF
--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -290,6 +290,7 @@ class LLMS_Admin_Notices {
 	 * @since 3.0.0
 	 * @since 3.7.4 Unknown.
 	 * @since 5.2.0 Ensure `template_path` and `default_path` are properly passed to `llms_get_template()`.
+	 * @since [version] Delete empty notices and do not display them.
 	 *
 	 * @param string $notice_id Notice id.
 	 * @return void
@@ -300,14 +301,13 @@ class LLMS_Admin_Notices {
 
 			$notice = self::get_notice( $notice_id );
 
-			if ( empty( $notice ) ) {
-				return;
-			}
-
 			// Don't output those rogue empty notices I can't find.
 			// @todo find the source.
-			if ( empty( $notice['template'] ) && empty( $notice['html'] ) ) {
+			if ( empty( $notice ) || ( empty( $notice['template'] ) && empty( $notice['html'] ) ) ) {
 				self::delete_notice( $notice_id );
+
+				/** @noinspection PhpUnnecessaryStopStatementInspection */
+				return;
 			}
 			?>
 			<div class="notice notice-<?php echo $notice['type']; ?> llms-admin-notice" id="llms-notice<?php echo $notice_id; ?>" style="position:relative;">

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.0.0
- * @version 5.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -306,7 +306,6 @@ class LLMS_Admin_Notices {
 			if ( empty( $notice ) || ( empty( $notice['template'] ) && empty( $notice['html'] ) ) ) {
 				self::delete_notice( $notice_id );
 
-				/** @noinspection PhpUnnecessaryStopStatementInspection */
 				return;
 			}
 			?>

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -409,6 +409,41 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test output_notice().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output_notice() {
+
+		LLMS_Admin_Notices::init();
+
+		# Create a normal notice.
+		$notice_html = 'Have you heard of the band 999 MB? They haven\'t got a gig yet.';
+		$notice_id   = 'test-output-notice-normal';
+		LLMS_Admin_Notices::add_notice( $notice_id, $notice_html );
+		LLMS_Admin_Notices::save_notices();
+
+		# Test where current user does not have the 'manage_options' capability.
+		$this->assertOutputEmpty( array( 'LLMS_Admin_Notices', 'output_notice' ), array( $notice_id ) );
+
+		# Test where current user does have the 'manage_options' capability.
+		wp_set_current_user( 1 );
+		$this->assertOutputContains( $notice_html, array( 'LLMS_Admin_Notices', 'output_notice' ), array( $notice_id ) );
+
+		# Test where the notice does not exist.
+		$this->assertOutputEmpty( array( 'LLMS_Admin_Notices', 'output_notice' ), array( 'notice-does-not-exist' ) );
+
+		# Test where the notice html is empty.
+		$notice_id = 'test-output-notice-empty-html-empty-template';
+		LLMS_Admin_Notices::add_notice( $notice_id, '' );
+		LLMS_Admin_Notices::save_notices();
+		$this->assertOutputEmpty( array( 'LLMS_Admin_Notices', 'output_notice' ), array( $notice_id ) );
+
+	}
+
+	/**
 	 * Test save_notices()
 	 *
 	 * @since 4.13.0

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -429,7 +429,7 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 		$this->assertOutputEmpty( array( 'LLMS_Admin_Notices', 'output_notice' ), array( $notice_id ) );
 
 		# Test where current user does have the 'manage_options' capability.
-		wp_set_current_user( 1 );
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 		$this->assertOutputContains( $notice_html, array( 'LLMS_Admin_Notices', 'output_notice' ), array( $notice_id ) );
 
 		# Test where the notice does not exist.


### PR DESCRIPTION
## Description
Combined the checks for an empty notice array, empty html, and empty template file into one block that deletes the notice and returns without outputting a notice.

Fixes #1560.

## How has this been tested?
Wrote a new unit test for `LLMS_Admin_Notices->output_notice()`.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

