### PR TITLE
Fix return type in `preprare_query()` DocBlock.

### DIFF
--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -282,8 +282,7 @@ abstract class LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 3.8.0
-	 *
-	 * @return void
+	 * @return string
 	 */
 	abstract protected function preprare_query();
 
@@ -434,7 +433,7 @@ abstract class LLMS_Database_Query {
 			 *
 			 * @since 4.5.1
 			 *
-			 * @param array               $ars           The query parse arguents.
+			 * @param array               $ars           The query parse arguments.
 			 * @param LLMS_Database_Query $db_query      The LLMS_Database_Query instance.
 			 * @param array               $original_args Original arguments before merging with defaults.
 			 * @param array               $default_args  Default arguments before merging with original.

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -282,6 +282,7 @@ abstract class LLMS_Database_Query {
 	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.8.0
+	 *
 	 * @return string
 	 */
 	abstract protected function preprare_query();

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -279,7 +279,7 @@ abstract class LLMS_Database_Query {
 	abstract protected function parse_args();
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.8.0
 	 * @return string

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -132,7 +132,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.36.0
 	 * @since 4.7.0 Use `$this->sql_select_columns({columns})` to determine the columns to select.

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -136,6 +136,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 *
 	 * @since 3.36.0
 	 * @since 4.7.0 Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -136,7 +136,6 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 *
 	 * @since 3.36.0
 	 * @since 4.7.0 Use `$this->sql_select_columns({columns})` to determine the columns to select.
-	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -136,7 +136,6 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	 * Prepare the SQL for the query
 	 *
 	 * @since 3.16.0
-	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -136,6 +136,7 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.16.0
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -133,7 +133,7 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.16.0
 	 * @return string

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -198,9 +198,8 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	/**
 	 * Prepare the SQL for the query
 	 *
-	 * @return   void
-	 * @since    3.15.0
-	 * @version  3.15.0
+	 * @since 3.15.0
+	 * @return string
 	 */
 	protected function preprare_query() {
 

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -199,6 +199,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.15.0
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -196,7 +196,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.15.0
 	 * @return string

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -150,7 +150,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.4.0
 	 * @since 3.13.0 Unknown.

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -155,6 +155,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 * @since 3.4.0
 	 * @since 3.13.0 Unknown.
 	 * @since 4.10.2 Demands to `$this->sql_select()` to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -155,8 +155,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 * @since 3.4.0
 	 * @since 3.13.0 Unknown.
 	 * @since 4.10.2 Demands to `$this->sql_select()` to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
-	 *
-	 * @return void
+	 * @return string
 	 */
 	protected function preprare_query() {
 

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -191,7 +191,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Prepare the SQL for the query
+	 * Prepare the SQL for the query.
 	 *
 	 * @since 3.8.0
 	 * @since 3.9.4 Unknown.

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -195,6 +195,7 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 *
 	 * @since 3.8.0
 	 * @since 3.9.4 Unknown.
+	 *
 	 * @return string
 	 */
 	protected function preprare_query() {

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -195,7 +195,6 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 *
 	 * @since 3.8.0
 	 * @since 3.9.4 Unknown.
-	 *
 	 * @return string
 	 */
 	protected function preprare_query() {


### PR DESCRIPTION
## Description
Fix return type in preprare_query() DocBlock.

## How has this been tested?
`composer check-cs-errors`

## Types of changes
Coding documentation improvements.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

