### PR TITLE
Fix typos in comments and non-global variable names.

### DIFF
--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -279,7 +279,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @param string $key Key to translate.
 	 * @return void
 	 */
-	public function _e( $key ) { // phpcs:ignore -- This is to mimick localization functions.
+	public function _e( $key ) { // phpcs:ignore -- This is to mimic localization functions.
 		echo $this->translate( $key );
 	}
 
@@ -354,7 +354,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @return void
 	 */
 	public function export() {
-		// If post type doesnt support exporting don't proceed.
+		// If post type doesn't support exporting don't proceed.
 		if ( ! $this->is_exportable() ) {
 			return;
 		}
@@ -402,7 +402,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 *
 	 * @since 3.34.0
 	 * @since 4.10.0 Add `post_name` as a property to skip scrubbing and add a filter on the list of properties to skip scrubbing.
-	 * @since 5.1.2 Pass second paramater to the `get_the_excerpt` filter hook (the WP_Post object), introduced in WordPress 4.5.0.
+	 * @since 5.1.2 Pass second parameter to the `get_the_excerpt` filter hook (the WP_Post object), introduced in WordPress 4.5.0.
 	 *
 	 * @param string  $key The property key.
 	 * @param boolean $raw Optional. Whether or not we need to get the raw value. Default false.
@@ -465,7 +465,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 			return $this->$key;
 		}
 
-		// If we found a valid, apply default llms get get filter and return the value.
+		// If we found a value, apply default llms get filter and return the value.
 		if ( isset( $val ) ) {
 
 			/**
@@ -620,8 +620,8 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	/**
 	 * Retrieve URL for an image associated with the post
 	 *
-	 * Currently only retrieves the featured image if the post type supports it
-	 * in the future this will allow retrieval of custom post images as well.
+	 * Currently, only retrieves the featured image if the post type supports it.
+	 * In the future, this will allow retrieval of custom post images as well.
 	 *
 	 * @since 3.3.0
 	 * @since 3.8.0 Unknown.
@@ -679,7 +679,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 *
 	 * @since 3.0.0
 	 * @since 3.7.0 Unknown.
-	 * @since 4.8.0 Use strict type comparision where possibile.
+	 * @since 4.8.0 Use strict type comparison where possible.
 	 *
 	 * @param string $key        Property key.
 	 * @param array  $price_args Optional. Array of arguments that can be passed to llms_price(). Default is empty array.
@@ -765,7 +765,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * This *should* be overridden by child classes.
 	 *
 	 * @since 3.0.0
-	 * @since 3.18.0 Uknown.
+	 * @since 3.18.0 Unknown.
 	 *
 	 * @param array $args Args of data to be passed to wp_insert_post.
 	 * @return array
@@ -1076,7 +1076,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * This is automatically called by set() method before anything is actually set.
 	 *
 	 * @since 3.0.0
-	 * @since 3.16.0 Uknown.
+	 * @since 3.16.0 Unknown.
 	 *
 	 * @param string $key Property key.
 	 * @param mixed  $val Property value.
@@ -1184,7 +1184,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @since 3.30.3 Use `wp_slash()` when setting properties.
 	 * @since 3.34.0 Turned to be only a wrapper for the set_bulk() method.
 	 *
-	 * @param string|array $key_or_array Key of the property or a an associative array of key/val pairs.
+	 * @param string|array $key_or_array Key of the property or an associative array of key/val pairs.
 	 * @param mixed        $val          Optional. Value to set the property with. Default empty string.
 	 *                                   This parameter will be ignored when the first parameter is an associative array of key/val pairs.
 	 * @return boolean true on success, false on error or if the submitted value is the same as what's in the database
@@ -1214,7 +1214,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @param array $model_array Associative array of key/val pairs.
 	 * @param array $wp_error    Optional. Whether or not return a WP_Error. Default false.
 	 * @return boolean|WP_Error True on success. If the param $wp_error is set to false this will be false on error or if there was nothing to update.
-	 *                          Otherwise this will be a WP_Error object collecting all the errors encountered along the way.
+	 *                          Otherwise, this will be a WP_Error object collecting all the errors encountered along the way.
 	 */
 	public function set_bulk( $model_array, $wp_error = false ) {
 
@@ -1632,7 +1632,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 
 			// Skip registered fields or fields 3rd parties want to skip.
 			/**
-			 * Filters whether the custom field should be excluded in the array represantation of the post model
+			 * Filters whether the custom field should be excluded in the array representation of the post model
 			 *
 			 * The dynamic portion of this hook, `$this->model_post_type`, refers to the model's post type. For example "course",
 			 * "lesson", "membership", etc...

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -242,7 +242,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		/**
 		 * Filters the query HAVING clause
 		 *
-		 * @since Unknwon
+		 * @since Unknown
 		 *
 		 * @param string             $sql           The HAVING clause of the query.
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
@@ -272,9 +272,9 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		);
 
 		// Add the fields to the array of fields to select.
-		foreach ( $fields as $key => $statment ) {
+		foreach ( $fields as $key => $statement ) {
 			if ( $this->requires_field( $key ) ) {
-				$joins[] = $statment;
+				$joins[] = $statement;
 			}
 		}
 
@@ -337,7 +337,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	}
 
 	/**
-	 * Setup the SQL for the select statement
+	 * Set up the SQL for the select statement
 	 *
 	 * @since 3.13.0
 	 * @since 4.10.2 Drop usage of `this->get_filter( 'select' )` in favor of `'llms_student_query_select'`.
@@ -367,9 +367,9 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		);
 
 		// Add the fields to the array of fields to select.
-		foreach ( $fields as $key => $statment ) {
+		foreach ( $fields as $key => $statement ) {
 			if ( $this->requires_field( $key ) ) {
-				$selects[] = $statment;
+				$selects[] = $statement;
 			}
 		}
 

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -287,9 +287,9 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 		}
 
 		// add subscriber info if set
-		$subsciber = $this->get( 'subscriber' );
-		if ( $subsciber ) {
-			$where .= $wpdb->prepare( ' AND n.subscriber = %s', $subsciber );
+		$subscriber = $this->get( 'subscriber' );
+		if ( $subscriber ) {
+			$where .= $wpdb->prepare( ' AND n.subscriber = %s', $subscriber );
 		}
 
 		// add post and user id checks


### PR DESCRIPTION
## Description
Fix typos in comments and non-global variable names.

## How has this been tested?
`composer check-cs-errors`

## Types of changes
Typos in comments and non-global variable names.

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

