### PR TITLE
Add delta in test_llms_get_user_postmeta()

### DIFF
--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-user-postmeta.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-user-postmeta.php
@@ -164,19 +164,27 @@ class LLMS_Test_Functions_User_Postmeta extends LLMS_UnitTestCase {
 	}
 
 
+	/**
+	 * Test llms_get_user_postmeta().
+	 *
+	 * @since 3.21.0
+	 * @since [version] Add delta when comparing enrollment date with updated date.
+	 */
 	public function test_llms_get_user_postmeta() {
 
 		$this->assertEquals( 'enrolled', llms_get_user_postmeta( $this->student_id, $this->course_id, '_status' ) );
 		$this->assertEquals( '', llms_get_user_postmeta( $this->student_id, $this->course_id, '_fake' ) );
 		$this->assertEquals( 3, count( llms_get_user_postmeta( $this->student_id, $this->course_id ) ) );
 
-		// test serialized values
+		// Test serialized values.
 		$data = range( 1, 5 );
 		llms_update_user_postmeta( $this->student_id, $this->course_id, '_test_serialized_data', $data );
 		$this->assertEquals( $data, llms_get_user_postmeta( $this->student_id, $this->course_id, '_test_serialized_data' ) );
 
-		// try updated date return
-		$this->assertEquals( $this->student->get_enrollment_date( $this->course_id, 'enrolled', 'Y-m-d H:i:s' ), llms_get_user_postmeta( $this->student_id, $this->course_id, '_status', true, 'updated_date' ) );
+		// Test updated date.
+		$enrollment_date = $this->student->get_enrollment_date( $this->course_id, 'enrolled', 'Y-m-d H:i:s' );
+		$updated_date    = llms_get_user_postmeta( $this->student_id, $this->course_id, '_status', true, 'updated_date' );
+		$this->assertEqualsWithDelta( $enrollment_date, $updated_date, 2 );
 
 	}
 


### PR DESCRIPTION
## Description
Added 2 seconds of delta allowance when comparing enrollment date with updated date in `test_llms_get_user_postmeta()`.

Fixes #1793.

BTW, the `$delta` parameter in the PHPUnit `assertEquals()` method was deprecated in [v7.5.0](https://github.com/sebastianbergmann/phpunit/blob/7.5.0/ChangeLog-7.5.md) and removed in v9.0.0 in favor of the new `assertEqualsWithDelta()` and `assertNotEqualsWithDelta()` methods.


## How has this been tested?
Ran automatic tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] My code has been tested.
- [X] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

