### PR TITLE
Require a blank line before a @return line.

### DIFF
--- a/docs/documentation-standards.md
+++ b/docs/documentation-standards.md
@@ -195,14 +195,17 @@ When updating an existing element:
 #### 1. Parameters and Returns
 
 Functions and methods should define all parameter arguments and returns with the `@param` and `@return` tags.
+There should be a blank line before the first `@param` line and before the `@return` line.
 
 No HTML should be used in the descriptions for these tags, though limited Markdown can be used as necessary, such as for adding backticks around variables, e.g. `$variable`.
 
 All descriptions for any of these tags should be a full sentence ending with a full stop (a period, for example).
 
 ```
+ *
  * @param string $var1 Description of the argument.
  * @param bool $var2 Description of the argument.
+ *
  * @return string
  */
 function my_function( $var1, $var2 = false ) {
@@ -252,6 +255,7 @@ A function or method which throws an exception should document the thrown except
 When present, the `@throws` tag should be added to the end of the docblock below the `@return` tag. An empty line should separate the `@return` and `@throws` tag.
 
 ```
+ *
  * @return string
  *
  * @throws Exception A description of the raised exception.
@@ -286,6 +290,7 @@ Functions and class methods should be formatted as follows:
  *
  * @param type $var Description.
  * @param type $var Optional. Description. Default.
+ *
  * @return type Description.
  */
 ```


### PR DESCRIPTION
## Description
Documented the requirement of a blank line before a `@return` line in a DocBlock.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
Documentation standards.

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

