### PR TITLE
LLMS_Admin_Tool_Limited_Billing_Order_Locator: retrieve order ordered by ID DESC.

### DIFF
--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * LLMS_Admin_Tool_Limited_Billing_Order_Locator class
+ * LLMS_Admin_Tool_Limited_Billing_Order_Locator class.
  *
  * @package LifterLMS/Admin/Tools/Classes
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin tool which generates a report of limited billing orders affected by order end changes
+ * Admin tool which generates a report of limited billing orders affected by order end changes.
  *
  * @since 5.3.0
  *
@@ -27,9 +27,10 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	protected $id = 'limited-billing-order-locator';
 
 	/**
-	 * Query the database for orders that may be affected by the change
+	 * Query the database for orders that may be affected by the change.
 	 *
 	 * @since 5.3.0
+	 * @since [version] Retrieve orders ordered by their unique ID (DESC) instead of the default `date_created`.
 	 *
 	 * @return array[] Returns an array of arrays where each array represents a line in the generated CSV file.
 	 */
@@ -42,6 +43,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 				'post_type'      => 'llms_order',
 				'post_status'    => array( 'llms-active', 'llms-on-hold' ),
 				'posts_per_page' => -1,
+				'orderby'        => 'ID',
 				'meta_query'     => array(
 					array(
 						'key'     => '_llms_billing_length',
@@ -72,7 +74,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Create a csv "file" via output buffering and return it as a string
+	 * Create a csv "file" via output buffering and return it as a string.
 	 *
 	 * @since 5.3.0
 	 *
@@ -108,7 +110,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Retrieve a description of the tool
+	 * Retrieve a description of the tool.
 	 *
 	 * This is displayed on the right side of the tool's list before the button.
 	 *
@@ -143,7 +145,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Retrieve the tool's label
+	 * Retrieve the tool's label.
 	 *
 	 * The label is the tool's title. It's displayed in the left column on the tool's list.
 	 *
@@ -156,7 +158,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Retrieves an array representing a line in generated CSV for the given order
+	 * Retrieves an array representing a line in generated CSV for the given order.
 	 *
 	 * An order is considered to be affected by the change if either of the following conditions are true:
 	 *
@@ -194,7 +196,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Helper to get the number of transactions on an order for a given status
+	 * Helper to get the number of transactions on an order for a given status.
 	 *
 	 * @since 5.3.0
 	 *
@@ -217,7 +219,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Retrieve the tool's button text
+	 * Retrieve the tool's button text.
 	 *
 	 * @since 5.3.0
 	 *
@@ -228,7 +230,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Retrieve a list of orders
+	 * Retrieve a list of orders.
 	 *
 	 * @since 5.3.0
 	 *
@@ -247,7 +249,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Generate the CSV file an serve it as a downloadable attachment
+	 * Generate the CSV file an serve it as a downloadable attachment.
 	 *
 	 * @since 5.3.0
 	 *
@@ -269,7 +271,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	}
 
 	/**
-	 * Conditionally load the tool
+	 * Conditionally load the tool.
 	 *
 	 * This tool should only load if there are orders that can be handled by the tool.
 	 *

--- a/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-limited-billing-order-locator.php
+++ b/tests/phpunit/unit-tests/admin/tools/class-llms-test-admin-tool-limited-billing-order-locator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the LLMS_Admin_Tool_Limited_Billing_Order_Locator class
+ * Tests for the LLMS_Admin_Tool_Limited_Billing_Order_Locator class.
  *
  * @package LifterLMS/Tests/Admins/Tools
  *
@@ -9,6 +9,7 @@
  * @group limited_billing
  *
  * @since 5.3.0
+ * @version [version]
  */
 class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool_Test_Case {
 
@@ -44,7 +45,7 @@ class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool
 	}
 
 	/**
-	 * Create mock orders
+	 * Create mock orders.
 	 *
 	 * @since 5.3.0
 	 *
@@ -64,7 +65,7 @@ class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool
 	}
 
 	/**
-	 * Test generate_csv()
+	 * Test generate_csv().
 	 *
 	 * @since 5.3.0
 	 *
@@ -89,7 +90,7 @@ class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool
 	}
 
 	/**
-	 * Test get_order_csv(): doesn't quality because the order hasn't ended and there's no refunds
+	 * Test get_order_csv(): doesn't quality because the order hasn't ended and there's no refunds.
 	 *
 	 * @since 5.3.0
 	 *
@@ -193,9 +194,10 @@ class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool
 	}
 
 	/**
-	 * Test handle()
+	 * Test handle().
 	 *
 	 * @since 5.3.0
+	 * @since [version] Made sure to compare the lists of orders with the same ordering.
 	 *
 	 * @return void
 	 */
@@ -223,6 +225,7 @@ class LLMS_Test_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Admin_Tool
 			$lines = explode( "\n", $csv );
 			$this->assertEquals( '"Order ID","Expected Payments","Total Payments","Successful Payments","Refunded Payments","Edit Link"', $lines[0] );
 			array_shift( $lines );
+			$orders = array_reverse( $orders ); // Orders affected by the change ($lines) are ordered by their `ID` `DESC`.
 
 			foreach ( $lines as $i => $line ) {
 				// Empty line at the end of the file.


### PR DESCRIPTION
## Description
Fixes the following random failing test:
https://github.com/gocodebox/lifterlms/pull/1748/checks?check_run_id=3859663078#step:4:62

Even if this mostly regarded to tests and could be resolved by "comparing sets" rather than ordered arrays, I preferred to change the the tool's query arguments as well, as I think that defining an actual unique ordering policy is a good practice that would avoid us problems like this.

## How has this been tested?
unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Test fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

