### PR TITLE
Allow editing earned certificates and achievements

### DIFF
--- a/.changelogs/edit-earned-certificates-achievements.yml
+++ b/.changelogs/edit-earned-certificates-achievements.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added the ability for administrators and LMS managers to edit earned certificates/achievements from the students reporting screen.

--- a/.changelogs/edit-earned-certificates-achievements.yml
+++ b/.changelogs/edit-earned-certificates-achievements.yml
@@ -1,3 +1,3 @@
 significance: minor
 type: added
-entry: Added the ability for administrators and LMS managers to edit earned certificates/achievements from the students reporting screen.
+entry: Added the ability for administrators and LMS managers to edit earned certificates/achievements from the students reporting screen, as well as award new certificates/achievements to students.

--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -421,6 +421,7 @@ abstract class LLMS_Admin_Metabox {
 	 *               Return an `int` depending on return condition.
 	 *               Automatically add `FILTER_REQUIRE_ARRAY` flag when sanitizing a `multi` field.
 	 * @since 3.37.12 Move field sanitization and updates to the `save_field()` method.
+	 * @since [version] Allow skipping the saving of a field.
 	 *
 	 * @param int $post_id WP Post ID of the post being saved.
 	 * @return int `-1` When no user or user is missing required capabilities or when there's no or invalid nonce.
@@ -453,9 +454,8 @@ abstract class LLMS_Admin_Metabox {
 
 				// Loop through the fields.
 				foreach ( $data['fields'] as $field ) {
-
-					// Don't save things that don't have an ID.
-					if ( isset( $field['id'] ) ) {
+					// Don't save things that don't have an ID or that are set to be skipped.
+					if ( isset( $field['id'] ) && empty( $field['skip_save'] ) ) {
 						$this->save_field( $post_id, $field );
 					}
 				}

--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Admin Metabox Abstract
+ * Admin Metabox Abstract.
  *
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @version 3.37.19
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -104,9 +104,10 @@ class LLMS_Admin_Assets {
 	 * @since 4.3.3 Move logic for reporting/analytics scripts to `maybe_enqueue_reporting()`.
 	 * @since 4.4.0 Enqueue the main `llms` script.
 	 * @since 5.0.0 Clean up duplicate references to llms-select2 and register the script using `LLMS_Assets`.
-	 *               Remove topModal vendor dependency.
-	 *               Add `llms-admin-forms` on the forms post table screen.
+	 *              Remove topModal vendor dependency.
+	 *              Add `llms-admin-forms` on the forms post table screen.
 	 * @since [version] Use `LLMS_Assets` for the enqueue of `llms-admin-add-ons`.
+	 *              Enqueue certificate related js in `llms_my_certificate` post type as well.
 	 *
 	 * @return void
 	 */
@@ -176,7 +177,7 @@ class LLMS_Admin_Assets {
 			if ( 'lesson' == $post_type ) {
 				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 			}
-			if ( 'llms_certificate' == $post_type ) {
+			if ( in_array( $post_type, array( 'llms_certificate', 'llms_my_certificate' ), true ) ) {
 
 				wp_enqueue_script( 'llms-metabox-certificate', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-certificate' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 			}

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -107,7 +107,7 @@ class LLMS_Admin_Assets {
 	 *              Remove topModal vendor dependency.
 	 *              Add `llms-admin-forms` on the forms post table screen.
 	 * @since [version] Use `LLMS_Assets` for the enqueue of `llms-admin-add-ons`.
-	 *              Enqueue certificate related js in `llms_my_certificate` post type as well.
+	 *              Enqueue certificate and achievement related js in `llms_my_certificate`, `llms_my_achievement` post types as well.
 	 *
 	 * @return void
 	 */
@@ -181,7 +181,7 @@ class LLMS_Admin_Assets {
 
 				wp_enqueue_script( 'llms-metabox-certificate', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-certificate' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 			}
-			if ( 'llms_achievement' == $post_type ) {
+			if ( in_array( $post_type, array( 'llms_achievement', 'llms_my_achievement' ), true ) ) {
 
 				wp_enqueue_script( 'llms-metabox-achievement', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-achievement' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS()->version, true );
 			}

--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since Unknown
- * @version 4.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,10 +28,11 @@ class LLMS_Admin_Post_Types {
 	public function __construct() {
 
 		add_action( 'admin_init', array( $this, 'include_post_type_metabox_class' ) );
-		add_action( 'metabox_init', array( $this, 'meta_metabox_init' ) );
 
+		add_action( 'metabox_init', array( $this, 'meta_metabox_init' ) );
 		add_filter( 'post_updated_messages', array( $this, 'llms_post_updated_messages' ) );
 
+		add_action( 'load-edit.php', array( $this, 'disable_earned_engagements_post_types_list_tables' ) );
 	}
 
 	/**
@@ -122,6 +123,19 @@ class LLMS_Admin_Post_Types {
 		}
 
 		return $messages;
+	}
+
+	/**
+	 * Disable post list table for 'llms_my_certificate' and 'llms_my_achievement' post types.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function disable_earned_engagements_post_types_list_tables() {
+		if ( ! empty( $_REQUEST['post_type'] ) && in_array( $_REQUEST['post_type'], array( 'llms_my_certificate', 'llms_my_achievement' ), true ) ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended -- not needed.
+			wp_die( __( 'Listing this post type is disabled.', 'lifterlms' ) );
+		}
 	}
 
 }

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
@@ -21,6 +21,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 
+	use LLMS_Trait_Earned_Engagement_Meta_Box;
+
 	/**
 	 * Configure the metabox settings.
 	 *
@@ -49,53 +51,58 @@ class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 	 *
 	 * @since 3.0.0
 	 * @since 3.37.12 Allow some fields to store values with quotes.
+	 * @since [version] Handle specific fields for earned engaegments post types.
 	 *
 	 * @return array
 	 */
 	public function get_fields() {
 
+		$fields = array(
+			array(
+				'label'      => __( 'Achievement Title', 'lifterlms' ),
+				'desc'       => __( 'Enter a title for your achievement. IE: Achievement of Completion', 'lifterlms' ),
+				'id'         => $this->prefix . 'achievement_title',
+				'type'       => 'text',
+				'section'    => 'achievement_meta_box',
+				'class'      => 'code input-full',
+				'desc_class' => 'd-all',
+				'group'      => '',
+				'value'      => '',
+				'sanitize'   => 'no_encode_quotes',
+			),
+			// Achievement content textarea.
+			array(
+				'label'      => __( 'Achievement Content', 'lifterlms' ),
+				'desc'       => __( 'Enter any information you would like to display on the achievement.', 'lifterlms' ),
+				'id'         => $this->prefix . 'achievement_content',
+				'type'       => 'textarea_w_tags',
+				'section'    => 'achievement_meta_box',
+				'class'      => 'code input-full',
+				'desc_class' => 'd-all',
+				'group'      => '',
+				'value'      => '',
+				'sanitize'   => 'no_encode_quotes',
+			),
+			// Achievement background image.
+			array(
+				'label'      => __( 'Background Image', 'lifterlms' ),
+				'desc'       => __( 'Select an Image to use for the achievement.', 'lifterlms' ),
+				'id'         => $this->prefix . 'achievement_image',
+				'type'       => 'image',
+				'section'    => 'achievement_meta_box',
+				'class'      => 'achievement',
+				'desc_class' => 'd-all',
+				'group'      => '',
+				'value'      => '',
+			),
+		);
+
+		$fields = $this->add_earned_engagement_fields( $fields );
+
 		return array(
 			array(
-				'title'  => 'General',
-				'fields' => array(
-					array(
-						'label'      => __( 'Achievement Title', 'lifterlms' ),
-						'desc'       => __( 'Enter a title for your achievement. IE: Achievement of Completion', 'lifterlms' ),
-						'id'         => $this->prefix . 'achievement_title',
-						'type'       => 'text',
-						'section'    => 'achievement_meta_box',
-						'class'      => 'code input-full',
-						'desc_class' => 'd-all',
-						'group'      => '',
-						'value'      => '',
-						'sanitize'   => 'no_encode_quotes',
-					),
-					// Achievement content textarea.
-					array(
-						'label'      => __( 'Achievement Content', 'lifterlms' ),
-						'desc'       => __( 'Enter any information you would like to display on the achievement.', 'lifterlms' ),
-						'id'         => $this->prefix . 'achievement_content',
-						'type'       => 'textarea_w_tags',
-						'section'    => 'achievement_meta_box',
-						'class'      => 'code input-full',
-						'desc_class' => 'd-all',
-						'group'      => '',
-						'value'      => '',
-						'sanitize'   => 'no_encode_quotes',
-					),
-					// Achievement background image.
-					array(
-						'label'      => __( 'Background Image', 'lifterlms' ),
-						'desc'       => __( 'Select an Image to use for the achievement.', 'lifterlms' ),
-						'id'         => $this->prefix . 'achievement_image',
-						'type'       => 'image',
-						'section'    => 'achievement_meta_box',
-						'class'      => 'achievement',
-						'desc_class' => 'd-all',
-						'group'      => '',
-						'value'      => '',
-					),
-				),
+				'title'  => __( 'General', 'lifterlms' ),
+				'fields' => $fields,
 			),
 		);
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
- * @version 3.37.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,6 +25,7 @@ class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 	 * Configure the metabox settings.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Show metabox in `llms_my_achievement` post type as well.
 	 *
 	 * @return void
 	 */
@@ -34,6 +35,7 @@ class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 		$this->title    = __( 'Achievement Settings', 'lifterlms' );
 		$this->screens  = array(
 			'llms_achievement',
+			'llms_my_achievement',
 		);
 		$this->priority = 'high';
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
@@ -19,6 +19,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 
+	use LLMS_Trait_Earned_Engagement_Meta_Box;
+
 	/**
 	 * Configure the metabox settings.
 	 *
@@ -48,39 +50,44 @@ class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 	 * @since 1.0.0
 	 * @since 3.17.4 Unknown.
 	 * @since 3.37.12 Allow the certificate title field to store text with quotes.
+	 * @since [version] Handle specific fields for earned engaegments post types.
 	 *
 	 * @return array Array of metabox fields.
 	 */
 	public function get_fields() {
 
+		$fields = array(
+			array(
+				'label'      => __( 'Certificate Title', 'lifterlms' ),
+				'desc'       => __( 'Enter a title for your certificate. EG: Certificate of Completion', 'lifterlms' ),
+				'id'         => $this->prefix . 'certificate_title',
+				'type'       => 'text',
+				'section'    => 'certificate_meta_box',
+				'class'      => 'code input-full',
+				'desc_class' => 'd-all',
+				'group'      => '',
+				'value'      => '',
+				'sanitize'   => 'no_encode_quotes',
+			),
+			array(
+				'label'      => __( 'Background Image', 'lifterlms' ),
+				'desc'       => __( 'Select an Image to use for the certificate.', 'lifterlms' ),
+				'id'         => $this->prefix . 'certificate_image',
+				'type'       => 'image',
+				'section'    => 'certificate_meta_box',
+				'class'      => 'certificate',
+				'desc_class' => 'd-all',
+				'group'      => '',
+				'value'      => '',
+			),
+		);
+
+		$fields = $this->add_earned_engagement_fields( $fields );
+
 		return array(
 			array(
-				'title'  => 'General',
-				'fields' => array(
-					array(
-						'label'      => __( 'Certificate Title', 'lifterlms' ),
-						'desc'       => __( 'Enter a title for your certificate. EG: Certificate of Completion', 'lifterlms' ),
-						'id'         => $this->prefix . 'certificate_title',
-						'type'       => 'text',
-						'section'    => 'certificate_meta_box',
-						'class'      => 'code input-full',
-						'desc_class' => 'd-all',
-						'group'      => '',
-						'value'      => '',
-						'sanitize'   => 'no_encode_quotes',
-					),
-					array(
-						'label'      => __( 'Background Image', 'lifterlms' ),
-						'desc'       => __( 'Select an Image to use for the certificate.', 'lifterlms' ),
-						'id'         => $this->prefix . 'certificate_image',
-						'type'       => 'image',
-						'section'    => 'certificate_meta_box',
-						'class'      => 'certificate',
-						'desc_class' => 'd-all',
-						'group'      => '',
-						'value'      => '',
-					),
-				),
+				'title'  => __( 'General', 'lifterlms' ),
+				'fields' => $fields,
 			),
 		);
 	}

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
- * @version 3.37.12
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.17.4 Unknown.
  * @since 3.37.12 Allow the certificate title field to store text with quotes.
+ * @since [version] Show metabox in `llms_my_cetificate` post type as well.
  */
 class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 
@@ -32,6 +33,7 @@ class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 		$this->title    = __( 'Certificate Settings', 'lifterlms' );
 		$this->screens  = array(
 			'llms_certificate',
+			'llms_my_certificate',
 		);
 		$this->priority = 'high';
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
@@ -16,7 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  * @since 3.17.4 Unknown.
  * @since 3.37.12 Allow the certificate title field to store text with quotes.
- * @since [version] Show metabox in `llms_my_cetificate` post type as well.
  */
 class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 
@@ -24,6 +23,7 @@ class LLMS_Meta_Box_Certificate extends LLMS_Admin_Metabox {
 	 * Configure the metabox settings.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Show metabox in `llms_my_certificate` post type as well.
 	 *
 	 * @return void
 	 */

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Metabox_Field parent class
+ * Metabox_Field parent class.
  *
  * Contains base code for each of the Metabox Fields.
  *
@@ -21,14 +21,14 @@ defined( 'ABSPATH' ) || exit;
 abstract class LLMS_Metabox_Field {
 
 	/**
-	 * Global array used in class instance to store field information
+	 * Global array used in class instance to store field information.
 	 *
 	 * @var array
 	 */
 	public $field;
 
 	/**
-	 * Global variable to contain meta information about $field
+	 * Global variable to contain meta information about $field.
 	 *
 	 * @var object
 	 */
@@ -37,10 +37,13 @@ abstract class LLMS_Metabox_Field {
 	/**
 	 * Outputs the head for each of the field types.
 	 *
-	 * @todo  all the unset variables here should be defaulted somewhere else probably
+	 * @todo All the unset variables here should be defaulted somewhere else probably.
+	 *
 	 * @since unknown
 	 * @since 3.11.0 Unknown.
 	 * @since [version] Do not print empty labels; do not print the description block if both 'desc' and 'label' are empty.
+	 *
+	 * @return void
 	 */
 	public function output() {
 
@@ -77,19 +80,24 @@ abstract class LLMS_Metabox_Field {
 			<div class="description <?php echo $this->field['desc_class']; ?>">
 			<?php if ( ! empty( $this->field['label'] ) ) : ?>
 				<label for="<?php echo $this->field['id']; ?>"><?php echo $this->field['label']; ?></label>
-			<?php endif ?>
+			<?php endif; ?>
 				<?php echo $this->field['desc']; ?>
 				<?php
 				if ( isset( $this->field['required'] ) && $this->field['required'] ) :
 					?>
 					<em>(required)</em><?php endif; ?>
 			</div>
-		<?php endif; ?>
-		<?php
+			<?php
+			endif;
+
 	}
 
 	/**
-	 * outputs the tail for each of the field types
+	 * Outputs the tail for each of the field types
+	 *
+	 * @since unknown.
+	 *
+	 * @return void
 	 */
 	public function close_output() {
 
@@ -98,13 +106,14 @@ abstract class LLMS_Metabox_Field {
 	}
 
 	/**
-	 * Set the default meta value of a field
+	 * Set the default meta value of a field.
 	 *
-	 * @param    int    $post_id   WP Post ID
-	 * @param    string $field_id  ID/name of the field
-	 * @return   mixed
-	 * @since    1.0.0
-	 * @version  3.24.0
+	 * @since 1.0.0
+	 * @since 3.24.0 Unknown.
+	 *
+	 * @param int    $post_id  WP Post ID.
+	 * @param string $field_id ID/name of the field.
+	 * @return mixed
 	 */
 	public static function get_post_meta( $post_id, $field_id ) {
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Abstract Metabox_Field
+ * Abstract Metabox_Field.
  *
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
  *
- * @since ??
- * @version 3.24.0
+ * @since unknown
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Contains base code for each of the Metabox Fields.
  *
- * @since ??
+ * @since unknown
  * @since 3.24.0 Unknown.
  */
 abstract class LLMS_Metabox_Field {
@@ -35,11 +35,12 @@ abstract class LLMS_Metabox_Field {
 	public $meta;
 
 	/**
-	 * outputs the head for each of the field types
+	 * Outputs the head for each of the field types.
 	 *
 	 * @todo  all the unset variables here should be defaulted somewhere else probably
-	 * @since    ??
-	 * @version  3.11.0
+	 * @since unknown
+	 * @since 3.11.0 Unknown.
+	 * @since [version] Do not print empty labels; do not print the description block if both 'desc' and 'label' are empty.
 	 */
 	public function output() {
 
@@ -72,15 +73,19 @@ abstract class LLMS_Metabox_Field {
 
 		?>
 		<li class="<?php echo implode( ' ', $wrapper_classes ); ?>"<?php echo $controller . $controller_value; ?>>
+		<?php if ( ! empty( $this->field['desc'] ) || ! empty( $this->field['label'] ) ) : ?>
 			<div class="description <?php echo $this->field['desc_class']; ?>">
+			<?php if ( ! empty( $this->field['label'] ) ) : ?>
 				<label for="<?php echo $this->field['id']; ?>"><?php echo $this->field['label']; ?></label>
+			<?php endif ?>
 				<?php echo $this->field['desc']; ?>
 				<?php
 				if ( isset( $this->field['required'] ) && $this->field['required'] ) :
 					?>
 					<em>(required)</em><?php endif; ?>
 			</div>
-			<?php
+		<?php endif; ?>
+		<?php
 	}
 
 	/**

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
@@ -93,7 +93,7 @@ abstract class LLMS_Metabox_Field {
 	}
 
 	/**
-	 * Outputs the tail for each of the field types
+	 * Outputs the tail for each of the field types.
 	 *
 	 * @since unknown.
 	 *

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.hidden.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.hidden.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Meta box Field: Hidden.
+ *
+ * @package LifterLMS/Admin/PostTypes/MetaBoxes/Fields/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Metabox_Hidden_Field class.
+ *
+ * @since Unknown
+ */
+class LLMS_Metabox_Hidden_Field extends LLMS_Metabox_Field implements Meta_Box_Field_Interface {
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $_field Array containing information about field.
+	 */
+	public function __construct( $_field ) {
+
+		$this->field = $_field;
+	}
+
+	/**
+	 * Outputs the Html for the given field.
+	 *
+	 * @return void
+	 */
+	public function output() {
+
+		parent::output(); ?>
+
+		<input
+			name="<?php echo $this->field['id']; ?>"
+			id="<?php echo $this->field['id']; ?>"
+			type="hidden" value="<?php echo esc_attr( $this->field['value'] ); ?>">
+
+		<?php
+		parent::close_output();
+
+	}
+
+}

--- a/includes/admin/reporting/tables/llms.table.achievements.php
+++ b/includes/admin/reporting/tables/llms.table.achievements.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Table_Achievements extends LLMS_Admin_Table {
 
+	use LLMS_Trait_Earned_Engagement_Reporting_Table;
+
 	/**
 	 * Unique ID for the Table
 	 *

--- a/includes/admin/reporting/tables/llms.table.achievements.php
+++ b/includes/admin/reporting/tables/llms.table.achievements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
  * @since 3.2.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,16 +33,23 @@ class LLMS_Table_Achievements extends LLMS_Admin_Table {
 	protected $student = null;
 
 	/**
-	 * Get HTML for buttons in the actions cell of the table
+	 * Get HTML for buttons in the actions cell of the table.
 	 *
-	 * @param    int $achievement_id WP Post ID of the achievement post.
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 * @since [version] Show a button to edit earned achievements.
+	 *
+	 * @param int $achievement_id WP Post ID of the achievement post.
+	 * @return void
 	 */
 	private function get_actions_html( $achievement_id ) {
 		ob_start();
 		?>
+		<?php if ( get_edit_post_link( $achievement_id ) ) : ?>
+		<a class="llms-button-secondary small" href="<?php echo esc_url( get_edit_post_link( $achievement_id ) ); ?>">
+			<?php _e( 'Edit', 'lifterlms' ); ?>
+			<i class="fa fa-pencil" aria-hidden="true"></i>
+		</a>
+		<?php endif; ?>
 		<form action="" method="POST" style="display:inline;">
 
 			<button type="submit" class="llms-button-danger small" id="llms_delete_achievement" name="llms_delete_achievement">

--- a/includes/admin/reporting/tables/llms.table.certificates.php
+++ b/includes/admin/reporting/tables/llms.table.certificates.php
@@ -18,6 +18,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {
 
+	use LLMS_Trait_Earned_Engagement_Reporting_Table;
+
 	/**
 	 * Unique ID for the Table
 	 *

--- a/includes/admin/reporting/tables/llms.table.certificates.php
+++ b/includes/admin/reporting/tables/llms.table.certificates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
  * @since 3.2.0
- * @version 3.18.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,12 +33,13 @@ class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {
 	protected $student = null;
 
 	/**
-	 * Get HTML for buttons in the actions cell of the table
+	 * Get HTML for buttons in the actions cell of the table.
 	 *
-	 * @param    int $certificate_id  WP Post ID of the llms_my_certificate
-	 * @return   void
-	 * @since    3.18.0
-	 * @version  3.18.0
+	 * @since 3.18.0
+	 * @since [version] Show a butto to edit earned certificates.
+	 *
+	 * @param int $certificate_id  WP Post ID of the llms_my_certificate
+	 * @return void
 	 */
 	private function get_actions_html( $certificate_id ) {
 		ob_start();
@@ -47,7 +48,12 @@ class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {
 			<?php _e( 'View', 'lifterlms' ); ?>
 			<i class="fa fa-external-link" aria-hidden="true"></i>
 		</a>
-
+		<?php if ( get_edit_post_link( $certificate_id ) ) : ?>
+		<a class="llms-button-secondary small" href="<?php echo esc_url( get_edit_post_link( $certificate_id ) ); ?>" target="_blank" title="">
+			<?php _e( 'Edit', 'lifterlms' ); ?>
+			<i class="fa fa-pencil" aria-hidden="true"></i>
+		</a>
+		<?php endif; ?>
 		<form action="" method="POST" style="display:inline;">
 
 			<button type="submit" class="llms-button-secondary small" name="llms_generate_cert">

--- a/includes/admin/reporting/tables/llms.table.certificates.php
+++ b/includes/admin/reporting/tables/llms.table.certificates.php
@@ -36,7 +36,7 @@ class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {
 	 * Get HTML for buttons in the actions cell of the table.
 	 *
 	 * @since 3.18.0
-	 * @since [version] Show a butto to edit earned certificates.
+	 * @since [version] Show a button to edit earned certificates.
 	 *
 	 * @param int $certificate_id  WP Post ID of the llms_my_certificate
 	 * @return void
@@ -49,7 +49,7 @@ class LLMS_Table_Student_Certificates extends LLMS_Admin_Table {
 			<i class="fa fa-external-link" aria-hidden="true"></i>
 		</a>
 		<?php if ( get_edit_post_link( $certificate_id ) ) : ?>
-		<a class="llms-button-secondary small" href="<?php echo esc_url( get_edit_post_link( $certificate_id ) ); ?>" target="_blank" title="">
+		<a class="llms-button-secondary small" href="<?php echo esc_url( get_edit_post_link( $certificate_id ) ); ?>">
 			<?php _e( 'Edit', 'lifterlms' ); ?>
 			<i class="fa fa-pencil" aria-hidden="true"></i>
 		</a>

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -399,7 +399,7 @@ class LLMS_Engagement_Handler {
 			$is_duplicate = new WP_Error(
 				'llms-engagement--is-duplicate',
 				// Translators: %s = the WP_User ID.
-				sprintf( __( 'User "%" has already earned this engagement.', 'lifterlms' ), $user_id ),
+				sprintf( __( 'User "%s" has already earned this engagement.', 'lifterlms' ), $user_id ),
 				compact( 'type', 'user_id', 'template_id', 'related_id', 'engagement_id' )
 			);
 		}

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -368,7 +368,7 @@ class LLMS_Engagement_Handler {
 			array( $template_id, $user_id, $related_id ),
 			$type,
 			"llms_{$type}_has_user_earned",
-			"llms_earned_{$type}_dupcheck",
+			"llms_earned_{$type}_dupcheck"
 		);
 
 		/**

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -808,7 +808,7 @@ class LLMS_Post_Types {
 				'labels'              => array(
 					'name'               => __( 'Achievements', 'lifterlms' ),
 					'singular_name'      => __( 'Achievement', 'lifterlms' ),
-					'add_new'            => __( 'Add Achievement', 'lifterlms' ),
+					'add_new'            => __( 'Award Achievement', 'lifterlms' ),
 					'add_new_item'       => __( 'Add New Achievement', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
 					'edit_item'          => __( 'Edit Achievement', 'lifterlms' ),
@@ -892,7 +892,7 @@ class LLMS_Post_Types {
 				'labels'              => array(
 					'name'               => __( 'Certificates', 'lifterlms' ),
 					'singular_name'      => __( 'Certificate', 'lifterlms' ),
-					'add_new'            => __( 'Add Certificate', 'lifterlms' ),
+					'add_new'            => __( 'Award Certificate', 'lifterlms' ),
 					'add_new_item'       => __( 'Add New Certificate', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
 					'edit_item'          => __( 'Edit Certificate', 'lifterlms' ),

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -41,6 +41,8 @@ class LLMS_Post_Types {
 
 		add_action( 'after_setup_theme', array( __CLASS__, 'add_thumbnail_support' ), 777 );
 
+		add_action( 'admin_menu', array( __CLASS__, 'add_earned_egnagements_submenu_links' ) );
+
 	}
 
 	/**
@@ -768,22 +770,22 @@ class LLMS_Post_Types {
 			'llms_achievement',
 			array(
 				'labels'              => array(
-					'name'               => __( 'Achievements', 'lifterlms' ),
-					'singular_name'      => __( 'Achievement', 'lifterlms' ),
-					'add_new'            => __( 'Add Achievement', 'lifterlms' ),
-					'add_new_item'       => __( 'Add New Achievement', 'lifterlms' ),
+					'name'               => __( 'Achievement Templates', 'lifterlms' ),
+					'singular_name'      => __( 'Achievement Template', 'lifterlms' ),
+					'add_new'            => __( 'Add Achievement Template', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New Achievement Template', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
-					'edit_item'          => __( 'Edit Achievement', 'lifterlms' ),
-					'new_item'           => __( 'New Achievement', 'lifterlms' ),
-					'view'               => __( 'View Achievement', 'lifterlms' ),
-					'view_item'          => __( 'View Achievement', 'lifterlms' ),
-					'search_items'       => __( 'Search Achievement', 'lifterlms' ),
-					'not_found'          => __( 'No Achievement found', 'lifterlms' ),
-					'not_found_in_trash' => __( 'No Achievement found in trash', 'lifterlms' ),
-					'parent'             => __( 'Parent Achievement', 'lifterlms' ),
+					'edit_item'          => __( 'Edit Achievement Template', 'lifterlms' ),
+					'new_item'           => __( 'New Achievement Template', 'lifterlms' ),
+					'view'               => __( 'View Achievement Template', 'lifterlms' ),
+					'view_item'          => __( 'View Achievement Template', 'lifterlms' ),
+					'search_items'       => __( 'Search Achievement Templates', 'lifterlms' ),
+					'not_found'          => __( 'No Achievement Templates found', 'lifterlms' ),
+					'not_found_in_trash' => __( 'No Achievement Templates found in trash', 'lifterlms' ),
+					'parent'             => __( 'Parent Achievement Template', 'lifterlms' ),
 					'menu_name'          => _x( 'Achievements', 'Admin menu name', 'lifterlms' ),
 				),
-				'description'         => __( 'This is where achievements are stored.', 'lifterlms' ),
+				'description'         => __( 'This is where achievement templates are stored.', 'lifterlms' ),
 				'public'              => false,
 				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_achievements_access', 'manage_lifterlms' ) ) ) ? true : false,
 				'map_meta_cap'        => true,
@@ -804,20 +806,20 @@ class LLMS_Post_Types {
 			'llms_my_achievement',
 			array(
 				'labels'              => array(
-					'name'               => __( 'My Achievements', 'lifterlms' ),
-					'singular_name'      => __( 'My Achievement', 'lifterlms' ),
-					'add_new'            => __( 'Add My Achievement', 'lifterlms' ),
-					'add_new_item'       => __( 'Add New My Achievement', 'lifterlms' ),
+					'name'               => __( 'Achievements', 'lifterlms' ),
+					'singular_name'      => __( 'Achievement', 'lifterlms' ),
+					'add_new'            => __( 'Add Achievement', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New Achievement', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
-					'edit_item'          => __( 'Edit My Achievement', 'lifterlms' ),
-					'new_item'           => __( 'New My Achievement', 'lifterlms' ),
-					'view'               => __( 'View My Achievement', 'lifterlms' ),
-					'view_item'          => __( 'View My Achievement', 'lifterlms' ),
-					'search_items'       => __( 'Search My Achievements', 'lifterlms' ),
-					'not_found'          => __( 'No My Achievements found', 'lifterlms' ),
-					'not_found_in_trash' => __( 'No My Achievements found in trash', 'lifterlms' ),
-					'parent'             => __( 'Parent My Achievements', 'lifterlms' ),
-					'menu_name'          => _x( 'My Achievements', 'Admin menu name', 'lifterlms' ),
+					'edit_item'          => __( 'Edit Achievement', 'lifterlms' ),
+					'new_item'           => __( 'Award Achievement', 'lifterlms' ),
+					'view'               => __( 'View Achievement', 'lifterlms' ),
+					'view_item'          => __( 'View Achievement', 'lifterlms' ),
+					'search_items'       => __( 'Search Achievements', 'lifterlms' ),
+					'not_found'          => __( 'No Achievements found', 'lifterlms' ),
+					'not_found_in_trash' => __( 'No Achievements found in trash', 'lifterlms' ),
+					'parent'             => __( 'Parent Achievements', 'lifterlms' ),
+					'menu_name'          => _x( 'Award Achievement', 'Admin menu name', 'lifterlms' ),
 				),
 				'description'         => __( 'This is where you can view all of the achievements.', 'lifterlms' ),
 				'public'              => false,
@@ -849,19 +851,19 @@ class LLMS_Post_Types {
 			'llms_certificate',
 			array(
 				'labels'              => array(
-					'name'               => __( 'Certificates', 'lifterlms' ),
-					'singular_name'      => __( 'Certificate', 'lifterlms' ),
-					'add_new'            => __( 'Add Certificate', 'lifterlms' ),
-					'add_new_item'       => __( 'Add New Certificate', 'lifterlms' ),
+					'name'               => __( 'Certificate Templates', 'lifterlms' ),
+					'singular_name'      => __( 'Certificate Template', 'lifterlms' ),
+					'add_new'            => __( 'Add Certificate Template', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New Certificate Template', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
-					'edit_item'          => __( 'Edit Certificate', 'lifterlms' ),
-					'new_item'           => __( 'New Certificate', 'lifterlms' ),
-					'view'               => __( 'View Certificate', 'lifterlms' ),
-					'view_item'          => __( 'View Certificate', 'lifterlms' ),
-					'search_items'       => __( 'Search Certificates', 'lifterlms' ),
-					'not_found'          => __( 'No Certificates found', 'lifterlms' ),
-					'not_found_in_trash' => __( 'No Certificates found in trash', 'lifterlms' ),
-					'parent'             => __( 'Parent Certificates', 'lifterlms' ),
+					'edit_item'          => __( 'Edit Certificate Template', 'lifterlms' ),
+					'new_item'           => __( 'New Certificate Template', 'lifterlms' ),
+					'view'               => __( 'View Certificate Template', 'lifterlms' ),
+					'view_item'          => __( 'View Certificate Template', 'lifterlms' ),
+					'search_items'       => __( 'Search Certificate Templates', 'lifterlms' ),
+					'not_found'          => __( 'No Certificate Templates found', 'lifterlms' ),
+					'not_found_in_trash' => __( 'No Certificate Templates found in trash', 'lifterlms' ),
+					'parent'             => __( 'Parent Certificate Templates', 'lifterlms' ),
 					'menu_name'          => _x( 'Certificates', 'Admin menu name', 'lifterlms' ),
 				),
 				'description'         => __( 'This is where you can view all of the certificates.', 'lifterlms' ),
@@ -888,20 +890,20 @@ class LLMS_Post_Types {
 			'llms_my_certificate',
 			array(
 				'labels'              => array(
-					'name'               => __( 'My Certificates', 'lifterlms' ),
-					'singular_name'      => __( 'My Certificate', 'lifterlms' ),
-					'add_new'            => __( 'Add My Certificate', 'lifterlms' ),
-					'add_new_item'       => __( 'Add New My Certificate', 'lifterlms' ),
+					'name'               => __( 'Certificates', 'lifterlms' ),
+					'singular_name'      => __( 'Certificate', 'lifterlms' ),
+					'add_new'            => __( 'Add Certificate', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New Certificate', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
-					'edit_item'          => __( 'Edit My Certificate', 'lifterlms' ),
-					'new_item'           => __( 'New My Certificate', 'lifterlms' ),
-					'view'               => __( 'View My Certificate', 'lifterlms' ),
-					'view_item'          => __( 'View My Certificate', 'lifterlms' ),
-					'search_items'       => __( 'Search My Certificates', 'lifterlms' ),
-					'not_found'          => __( 'No My Certificates found', 'lifterlms' ),
-					'not_found_in_trash' => __( 'No My Certificates found in trash', 'lifterlms' ),
-					'parent'             => __( 'Parent My Certificates', 'lifterlms' ),
-					'menu_name'          => _x( 'My Certificates', 'Admin menu name', 'lifterlms' ),
+					'edit_item'          => __( 'Edit Certificate', 'lifterlms' ),
+					'new_item'           => __( 'New Certificate', 'lifterlms' ),
+					'view'               => __( 'View Certificate', 'lifterlms' ),
+					'view_item'          => __( 'View Certificate', 'lifterlms' ),
+					'search_items'       => __( 'Search Certificates', 'lifterlms' ),
+					'not_found'          => __( 'No Certificates found', 'lifterlms' ),
+					'not_found_in_trash' => __( 'No Certificates found in trash', 'lifterlms' ),
+					'parent'             => __( 'Parent Certificates', 'lifterlms' ),
+					'menu_name'          => _x( 'Award Certificate', 'Admin menu name', 'lifterlms' ),
 				),
 				'description'         => __( 'This is where you can view all of the certificates.', 'lifterlms' ),
 				'public'              => true,
@@ -936,19 +938,19 @@ class LLMS_Post_Types {
 			'llms_email',
 			array(
 				'labels'              => array(
-					'name'               => __( 'Emails', 'lifterlms' ),
-					'singular_name'      => __( 'Email', 'lifterlms' ),
-					'add_new'            => __( 'Add Email', 'lifterlms' ),
-					'add_new_item'       => __( 'Add New Email', 'lifterlms' ),
+					'name'               => __( 'Email Templates', 'lifterlms' ),
+					'singular_name'      => __( 'Email Template', 'lifterlms' ),
+					'add_new'            => __( 'Add Email Template', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New Email Template', 'lifterlms' ),
 					'edit'               => __( 'Edit', 'lifterlms' ),
-					'edit_item'          => __( 'Edit Email', 'lifterlms' ),
-					'new_item'           => __( 'New Email', 'lifterlms' ),
-					'view'               => __( 'View Email', 'lifterlms' ),
-					'view_item'          => __( 'View Email', 'lifterlms' ),
-					'search_items'       => __( 'Search Emails', 'lifterlms' ),
+					'edit_item'          => __( 'Edit Email Template', 'lifterlms' ),
+					'new_item'           => __( 'New Email Template', 'lifterlms' ),
+					'view'               => __( 'View Email Template', 'lifterlms' ),
+					'view_item'          => __( 'View Email Template', 'lifterlms' ),
+					'search_items'       => __( 'Search Email Templates', 'lifterlms' ),
 					'not_found'          => __( 'No Emails found', 'lifterlms' ),
 					'not_found_in_trash' => __( 'No Emails found in trash', 'lifterlms' ),
-					'parent'             => __( 'Parent Emails', 'lifterlms' ),
+					'parent'             => __( 'Parent Email Templates', 'lifterlms' ),
 					'menu_name'          => _x( 'Emails', 'Admin menu name', 'lifterlms' ),
 				),
 				'description'         => __( 'This is where emails are stored.', 'lifterlms' ),
@@ -1451,6 +1453,37 @@ class LLMS_Post_Types {
 			)
 		);
 
+	}
+
+	/**
+	 * Add submenu items for earned engagments post types (llms_my_certificate,llms_my_achievement).
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function add_earned_egnagements_submenu_links() {
+
+		$post_types = array(
+			'llms_my_certificate',
+			'llms_my_achievement',
+		);
+
+		foreach ( $post_types as $post_type ) {
+
+			$post_type_object = get_post_type_object( $post_type );
+			if ( empty( $post_type_object ) ) {
+				continue;
+			}
+
+			add_submenu_page(
+				'edit.php?post_type=llms_engagement',
+				$post_type_object->labels->menu_name,
+				$post_type_object->labels->menu_name,
+				LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+				admin_url( "post-new.php?post_type={$post_type}" )
+			);
+		}
 	}
 
 }

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -403,7 +403,7 @@ class LLMS_Post_Types {
 	 * @since 4.17.0 Add "llms-sales-page" feature to course and membership post types.
 	 * @since [version] Register all the post types using `self::register_post_type()`.
 	 *             Show `llms_my_certificate` ui (edit) only to who can `manage_lifterlms`.
-	 *             Register `llms_my_achievements` post type.
+	 *             Register `llms_my_achievement` post type.
 	 *
 	 * @return void
 	 */
@@ -830,7 +830,7 @@ class LLMS_Post_Types {
 				 *                      Default is `manage_earned_engagements`.
 				 */
 				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_achievements_access', LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP ) ) ) ? true : false,
-				'capabilities'        => self::get_post_type_caps( 'my_achievements' ),
+				'capabilities'        => self::get_post_type_caps( 'my_achievement' ),
 				'map_meta_cap'        => false,
 				'publicly_queryable'  => false,
 				'exclude_from_search' => true,

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -210,6 +210,7 @@ class LLMS_Post_Types {
 	 * See https://core.trac.wordpress.org/ticket/30991.
 	 *
 	 * @since 3.13.0
+	 * @since [version] Add specific case for `llms_my_achievements`, `llms_my_certificates` post types.
 	 *
 	 * @param string $post_type Post type name.
 	 * @return array
@@ -224,19 +225,10 @@ class LLMS_Post_Types {
 			$plural   = $post_type[1];
 		}
 
-		/**
-		 * Filter the list of post type capabilities for the given post type.
-		 *
-		 * The dynamic portion of this hook, `$singular` refers to the post type's
-		 * name, for example "course" or "llms_membership".
-		 *
-		 * @since 3.13.0
-		 *
-		 * @param array $caps Array of capabilities.
-		 */
-		return apply_filters(
-			"llms_get_{$singular}_post_type_caps",
-			array(
+		if ( in_array( $singular, array( 'my_achievement', 'my_certificate' ), true ) ) {
+			$caps = self::get_earned_engagements_post_type_caps();
+		} else {
+			$caps = array(
 
 				'read_post'              => sprintf( 'read_%s', $singular ),
 				'read_private_posts'     => sprintf( 'read_private_%s', $plural ),
@@ -257,7 +249,56 @@ class LLMS_Post_Types {
 
 				'create_posts'           => sprintf( 'create_%s', $plural ),
 
-			)
+			);
+		}
+
+		/**
+		 * Filter the list of post type capabilities for the given post type.
+		 *
+		 * The dynamic portion of this hook, `$singular` refers to the post type's
+		 * name, for example "course" or "llms_membership".
+		 *
+		 * @since 3.13.0
+		 *
+		 * @param array $caps Array of capabilities.
+		 */
+		return apply_filters(
+			"llms_get_{$singular}_post_type_caps",
+			$caps
+		);
+
+	}
+
+	/**
+	 * Get an array of capabilities for earned engagements post types.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public static function get_earned_engagements_post_type_caps() {
+
+		return array(
+
+			'read_post'              => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'read_private_posts'     => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+
+			'edit_post'              => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'edit_posts'             => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'edit_others_posts'      => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'edit_private_posts'     => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'edit_published_posts'   => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+
+			'publish_posts'          => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+
+			'delete_post'            => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'delete_posts'           => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'delete_private_posts'   => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'delete_published_posts' => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+			'delete_others_posts'    => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+
+			'create_posts'           => LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP,
+
 		);
 
 	}
@@ -786,10 +827,11 @@ class LLMS_Post_Types {
 				 * @since [version]
 				 *
 				 * @param bool $show_ui The needed capability to generate and allow a UI for managing `llms_my_achievement` post type in the admin.
-				 *                      Default is `manage_lifterlms`.
+				 *                      Default is `manage_earned_engagements`.
 				 */
-				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_achievements_access', 'manage_lifterlms' ) ) ) ? true : false,
-				'map_meta_cap'        => true,
+				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_achievements_access', LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP ) ) ) ? true : false,
+				'capabilities'        => self::get_post_type_caps( 'my_achievements' ),
+				'map_meta_cap'        => false,
 				'publicly_queryable'  => false,
 				'exclude_from_search' => true,
 				'show_in_menu'        => false,
@@ -869,10 +911,11 @@ class LLMS_Post_Types {
 				 * @since [version]
 				 *
 				 * @param bool $show_ui The needed capability to generate and allow a UI for managing `llms_my_certificate` post type in the admin.
-				 *                      Default is `manage_lifterlms`.
+				 *                      Default is `manage_earned_engagements`.
 				 */
-				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_certificates_access', 'manage_lifterlms' ) ) ) ? true : false,
-				'map_meta_cap'        => true,
+				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_certificates_access', LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP ) ) ) ? true : false,
+				'capabilities'        => self::get_post_type_caps( 'my_certificate' ),
+				'map_meta_cap'        => false,
 				'publicly_queryable'  => true,
 				'exclude_from_search' => true,
 				'show_in_menu'        => false,

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -362,6 +362,7 @@ class LLMS_Post_Types {
 	 * @since 4.17.0 Add "llms-sales-page" feature to course and membership post types.
 	 * @since [version] Register all the post types using `self::register_post_type()`.
 	 *             Show `llms_my_certificate` ui (edit) only to who can `manage_lifterlms`.
+	 *             Register `llms_my_achievements` post type.
 	 *
 	 * @return void
 	 */
@@ -779,6 +780,14 @@ class LLMS_Post_Types {
 				),
 				'description'         => __( 'This is where you can view all of the achievements.', 'lifterlms' ),
 				'public'              => false,
+				/**
+				 * Filters the needed capability to generate and allow a UI for managing `llms_my_achievement` post type in the admin.
+				 *
+				 * @since [version]
+				 *
+				 * @param bool $show_ui The needed capability to generate and allow a UI for managing `llms_my_achievement` post type in the admin.
+				 *                      Default is `manage_lifterlms`.
+				 */
 				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_achievements_access', 'manage_lifterlms' ) ) ) ? true : false,
 				'map_meta_cap'        => true,
 				'publicly_queryable'  => false,
@@ -854,6 +863,14 @@ class LLMS_Post_Types {
 				),
 				'description'         => __( 'This is where you can view all of the certificates.', 'lifterlms' ),
 				'public'              => true,
+				/**
+				 * Filters the needed capability to generate and allow a UI for managing `llms_my_certificate` post type in the admin.
+				 *
+				 * @since [version]
+				 *
+				 * @param bool $show_ui The needed capability to generate and allow a UI for managing `llms_my_certificate` post type in the admin.
+				 *                      Default is `manage_lifterlms`.
+				 */
 				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_certificates_access', 'manage_lifterlms' ) ) ) ? true : false,
 				'map_meta_cap'        => true,
 				'publicly_queryable'  => true,

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -757,6 +757,42 @@ class LLMS_Post_Types {
 			)
 		);
 
+		// Earned achievements.
+		self::register_post_type(
+			'llms_my_achievement',
+			array(
+				'labels'              => array(
+					'name'               => __( 'My Achievements', 'lifterlms' ),
+					'singular_name'      => __( 'My Achievement', 'lifterlms' ),
+					'add_new'            => __( 'Add My Achievement', 'lifterlms' ),
+					'add_new_item'       => __( 'Add New My Achievement', 'lifterlms' ),
+					'edit'               => __( 'Edit', 'lifterlms' ),
+					'edit_item'          => __( 'Edit My Achievement', 'lifterlms' ),
+					'new_item'           => __( 'New My Achievement', 'lifterlms' ),
+					'view'               => __( 'View My Achievement', 'lifterlms' ),
+					'view_item'          => __( 'View My Achievement', 'lifterlms' ),
+					'search_items'       => __( 'Search My Achievements', 'lifterlms' ),
+					'not_found'          => __( 'No My Achievements found', 'lifterlms' ),
+					'not_found_in_trash' => __( 'No My Achievements found in trash', 'lifterlms' ),
+					'parent'             => __( 'Parent My Achievements', 'lifterlms' ),
+					'menu_name'          => _x( 'My Achievements', 'Admin menu name', 'lifterlms' ),
+				),
+				'description'         => __( 'This is where you can view all of the achievements.', 'lifterlms' ),
+				'public'              => false,
+				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_achievements_access', 'manage_lifterlms' ) ) ) ? true : false,
+				'map_meta_cap'        => true,
+				'publicly_queryable'  => false,
+				'exclude_from_search' => true,
+				'show_in_menu'        => false,
+				'hierarchical'        => false,
+				'rewrite'             => false,
+				'show_in_nav_menus'   => false,
+				'has_archive'         => false,
+				'query_var'           => false,
+				'supports'            => array( 'title' ),
+			)
+		);
+
 		// Certificate.
 		self::register_post_type(
 			'llms_certificate',

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -361,6 +361,7 @@ class LLMS_Post_Types {
 	 * @since 4.5.1 Removed "excerpt" support for the course post type.
 	 * @since 4.17.0 Add "llms-sales-page" feature to course and membership post types.
 	 * @since [version] Register all the post types using `self::register_post_type()`.
+	 *             Show `llms_my_certificate` ui (edit) only to who can `manage_lifterlms`.
 	 *
 	 * @return void
 	 */
@@ -817,7 +818,7 @@ class LLMS_Post_Types {
 				),
 				'description'         => __( 'This is where you can view all of the certificates.', 'lifterlms' ),
 				'public'              => true,
-				'show_ui'             => true,
+				'show_ui'             => ( current_user_can( apply_filters( 'lifterlms_admin_my_certificates_access', 'manage_lifterlms' ) ) ) ? true : false,
 				'map_meta_cap'        => true,
 				'publicly_queryable'  => true,
 				'exclude_from_search' => true,

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.16.12
- * @version 5.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -90,6 +90,7 @@ class LLMS_Post_Relationships {
 	 *
 	 * @since 3.16.12
 	 * @since 5.4.0 Prevent course/membership with active subscriptions deletion.
+	 * @since [version] Added hook to force permanent deletion of some post types (`llms_my_certificate`, `llms_my_achievement`).
 	 *
 	 * @return void
 	 */
@@ -98,9 +99,96 @@ class LLMS_Post_Relationships {
 		add_action( 'delete_post', array( $this, 'maybe_update_relationships' ) );
 		add_action( 'pre_delete_post', array( __CLASS__, 'maybe_prevent_product_deletion' ), 10, 2 );
 
+		add_action( 'pre_trash_post', array( __CLASS__, 'force_permanent_deletion_of_post_types' ), 10, 2 );
+		add_action( 'before_delete_post', array( __CLASS__, 'maybe_clean_earned_engagments_related_user_post_meta' ) );
+
 	}
 
+	/**
+	 * Force deletion of some post types.
+	 *
+	 * @since [version]
+	 *
+	 * @param bool|null $trash Whether to go forward with trashing.
+	 * @param WP_Post   $post  Post object.
+	 * @return void
+	 */
+	public static function force_permanent_deletion_of_post_types( $trash, $post ) {
 
+		$post_types = array(
+			'llms_my_certificate',
+			'llms_my_achievement',
+		);
+
+		if ( in_array( get_post_type( $post ), $post_types, true ) ) {
+			return wp_delete_post( $post->ID, true );
+		}
+
+		return $trash;
+	}
+
+	/**
+	 * Maybe delete LifterLMS user post meta related to earned engagements.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	public static function maybe_clean_earned_engagments_related_user_post_meta( $post_id ) {
+
+		$post_types = array(
+			'llms_my_certificate',
+			'llms_my_achievement',
+		);
+		$post_type  = get_post_type( $post_id );
+
+		if ( ! in_array( $post_type, $post_types, true ) ) {
+			return;
+		}
+
+		$earned_engagement = 'llms_my_certificate' === $post_type ? new LLMS_User_Certificate( $post_id ) : new LLMS_User_Achievement( $post_id );
+
+		do_action_deprecated(
+			'llms_before_delete_' . str_replace( 'llms_my_', '', $post_type ),
+			array(
+				$earned_engagement,
+			),
+			'[version]',
+			'',
+			__( 'Use WordPress core  `before_delete_post` action hook', 'lifterlms' )
+		);
+
+		global $wpdb;
+		$wpdb->delete(
+			"{$wpdb->prefix}lifterlms_user_postmeta",
+			array(
+				'user_id'    => $earned_engagement->get_user_id(),
+				'meta_key'   => '_' . str_replace( 'llms_my_', '', $post_type ) . '_earned',
+				'meta_value' => $post_id,
+			),
+			array( '%d', '%s', '%d' )
+		); // no-cache ok.
+
+		add_action(
+			'after_delete_post',
+			function( $post_id ) use ( $earned_engagement, $post_type ) {
+
+				if ( $earned_engagement->get( 'id' ) === $post_id ) {
+					do_action_deprecated(
+						'llms_delete_' . str_replace( 'llms_my_', '', $post_type ),
+						array(
+							$earned_engagement,
+						),
+						'[version]',
+						'',
+						__( 'Use WordPress core `deleted_post` action hook.', 'lifterlms' )
+					);
+				}
+
+			}
+		);
+	}
 
 	/**
 	 * Determine whether a product deletion should take place.

--- a/includes/class.llms.post.relationships.php
+++ b/includes/class.llms.post.relationships.php
@@ -111,7 +111,7 @@ class LLMS_Post_Relationships {
 	 *
 	 * @param bool|null $trash Whether to go forward with trashing.
 	 * @param WP_Post   $post  Post object.
-	 * @return void
+	 * @return mixed
 	 */
 	public static function force_permanent_deletion_of_post_types( $trash, $post ) {
 

--- a/includes/class.llms.roles.php
+++ b/includes/class.llms.roles.php
@@ -5,17 +5,26 @@
  * @package LifterLMS/Classes
  *
  * @since 3.13.0
- * @version 4.21.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LifterLMS Custom Roles and Capabilities
+ * LifterLMS Custom Roles and Capabilities.
  *
  * @since 3.13.0
  */
 class LLMS_Roles {
+
+	/**
+	 * The capability name to manage earned engagament.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	const MANAGE_EARNED_ENGAGEMENT_CAP = 'manage_earned_engagement';
 
 	/**
 	 * Retrieve an array of all capabilities for a role
@@ -37,12 +46,13 @@ class LLMS_Roles {
 	}
 
 	/**
-	 * Get an array of registered core lifterlms caps
+	 * Get an array of registered core lifterlms caps.
 	 *
 	 * @since 3.13.0
 	 * @since 3.14.0 Add the `lifterlms_instructor` capability.
 	 * @since 3.34.0 Added capabilities for student management.
 	 * @since 4.21.2 Added the `view_grades` capability.
+	 * @since [version] Added `manage_earned_engagement` capability.
 	 *
 	 * @link https://lifterlms.com/docs/roles-and-capabilities/
 	 *
@@ -62,6 +72,7 @@ class LLMS_Roles {
 			array(
 				'lifterlms_instructor',
 				'manage_lifterlms',
+				self::MANAGE_EARNED_ENGAGEMENT_CAP,
 				'view_lifterlms_reports',
 				'view_others_lifterlms_reports',
 				'enroll',
@@ -84,6 +95,7 @@ class LLMS_Roles {
 	 * @since 3.13.0
 	 * @since 3.34.0 Added student management capabilities.
 	 * @since 4.21.2 Added 'view_grades' to the list of instructor/assistant caps which are not automatically available.
+	 * @since [version] Added `manage_earned_engagement` to the list of instructor/assistant caps which are not automatically available.
 	 *
 	 * @param string $role Name of the role.
 	 * @return string[]
@@ -101,6 +113,7 @@ class LLMS_Roles {
 					$caps['enroll'],
 					$caps['unenroll'],
 					$caps['manage_lifterlms'],
+					$caps[ self::MANAGE_EARNED_ENGAGEMENT_CAP ],
 					$caps['view_others_lifterlms_reports'],
 					$caps['create_students'],
 					$caps['view_others_students'],
@@ -137,7 +150,7 @@ class LLMS_Roles {
 	}
 
 	/**
-	 * Retrieve the post type specific capabilities for a give role
+	 * Retrieve the post type specific capabilities for a give role.
 	 *
 	 * @since 3.13.0
 	 * @since 4.21.2 Use strict comparisons for `in_array()`.

--- a/includes/controllers/class.llms.controller.achievements.php
+++ b/includes/controllers/class.llms.controller.achievements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.18.0
- * @version 3.35.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,7 +30,7 @@ class LLMS_Controller_Achievements {
 	}
 
 	/**
-	 * Handle certificate form actions to download (for students and admins) and to delete (admins only)
+	 * Handle achievement form actions to download (for students and admins) and to delete (admins only)
 	 *
 	 * @since 3.18.0
 	 * @since 3.35.0 Sanitize `$_POST` data.
@@ -50,21 +50,21 @@ class LLMS_Controller_Achievements {
 	}
 
 	/**
-	 * Delete a cert
+	 * Delete an achievement.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Permanently delete achievement via wp_delete_post().
 	 *
-	 * @param int $cert_id WP Post ID of the llms_my_certificate.
+	 * @param int $achievement_id WP Post ID of the llms_my_achievement.
 	 * @return void
 	 */
-	private function delete( $cert_id ) {
+	private function delete( $achievement_id ) {
 
 		if ( ! is_admin() ) {
 			return;
 		}
 
-		$cert = new LLMS_User_Achievement( $cert_id );
-		$cert->delete();
+		wp_delete_post( $achievement_id, true );
 
 	}
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -153,11 +153,12 @@ class LLMS_Controller_Certificates {
 	}
 
 	/**
-	 * Delete a certificate
+	 * Delete a certificate.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Permanently delete certificate via wp_delete_post().
 	 *
-	 * @param int $cert_id WP Post ID of the llms_my_certificate
+	 * @param int $cert_id WP Post ID of the llms_my_certificate.
 	 * @return void
 	 */
 	private function delete( $cert_id ) {
@@ -166,8 +167,7 @@ class LLMS_Controller_Certificates {
 			return;
 		}
 
-		$cert = new LLMS_User_Certificate( $cert_id );
-		$cert->delete();
+		wp_delete_post( $cert_id, true );
 
 	}
 

--- a/includes/models/model.llms.user.achievement.php
+++ b/includes/models/model.llms.user.achievement.php
@@ -71,4 +71,49 @@ class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 
 	}
 
+	/**
+	 * Get the WP Post ID of the post which triggered the earning of the achievement.
+	 *
+	 * This would be a lesson, course, section, track, etc...
+	 *
+	 * @since 3.8.0
+	 * @since [version] Return `null` if no post id set.
+	 *
+	 * @return int|null
+	 */
+	public function get_related_post_id() {
+		$meta = $this->get_user_postmeta();
+		return isset( $meta->post_id ) ? absint( $meta->post_id ) : null;
+	}
+
+	/**
+	 * Retrieve the user id of the user who earned the achievement
+	 *
+	 * @since 3.8.0
+	 * @since [version] Return `null` if no user set.
+	 *
+	 * @return int|null
+	 */
+	public function get_user_id() {
+		$meta = $this->get_user_postmeta();
+		return isset( $meta->user_id ) ? absint( $meta->user_id ) : null;
+	}
+
+	/**
+	 * Retrieve user postmeta data for the achievement
+	 *
+	 * @return   obj
+	 * @since    3.8.0
+	 * @version  3.8.0
+	 */
+	public function get_user_postmeta() {
+		global $wpdb;
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT user_id, post_id FROM {$wpdb->prefix}lifterlms_user_postmeta WHERE meta_value = %d AND meta_key = '_achievement_earned'",
+				$this->get( 'id' )
+			)
+		);
+	}
+
 }

--- a/includes/models/model.llms.user.achievement.php
+++ b/includes/models/model.llms.user.achievement.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.8.0
- * @version 3.18.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/models/model.llms.user.achievement.php
+++ b/includes/models/model.llms.user.achievement.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.8.0
- * @version [version]
+ * @version 3.18.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,7 +15,6 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.8.0
  * @since [version] Utilize `LLMS_Abstract_User_Engagement` abstract.
- *              Declare `achievement_title` and `achievement_content` properties.
  */
 class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 
@@ -23,9 +22,9 @@ class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 	protected $model_post_type = 'achievement';
 
 	protected $properties = array(
-		'achievement_title'    => 'string',
+		// 'achievement_title' => 'string', // use get( 'title' )
 		'achievement_image'    => 'absint',
-		'achievement_content'  => 'html',
+		// 'achievement_content' => 'html', // use get( 'content' )
 		'achievement_template' => 'absint',
 	);
 
@@ -69,51 +68,6 @@ class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 
 		return apply_filters( 'llms_achievement_get_image', $src, $this );
 
-	}
-
-	/**
-	 * Get the WP Post ID of the post which triggered the earning of the achievement.
-	 *
-	 * This would be a lesson, course, section, track, etc...
-	 *
-	 * @since 3.8.0
-	 * @since [version] Return `null` if no post id set.
-	 *
-	 * @return int|null
-	 */
-	public function get_related_post_id() {
-		$meta = $this->get_user_postmeta();
-		return isset( $meta->post_id ) ? absint( $meta->post_id ) : null;
-	}
-
-	/**
-	 * Retrieve the user id of the user who earned the achievement
-	 *
-	 * @since 3.8.0
-	 * @since [version] Return `null` if no user set.
-	 *
-	 * @return int|null
-	 */
-	public function get_user_id() {
-		$meta = $this->get_user_postmeta();
-		return isset( $meta->user_id ) ? absint( $meta->user_id ) : null;
-	}
-
-	/**
-	 * Retrieve user postmeta data for the achievement
-	 *
-	 * @return   obj
-	 * @since    3.8.0
-	 * @version  3.8.0
-	 */
-	public function get_user_postmeta() {
-		global $wpdb;
-		return $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT user_id, post_id FROM {$wpdb->prefix}lifterlms_user_postmeta WHERE meta_value = %d AND meta_key = '_achievement_earned'",
-				$this->get( 'id' )
-			)
-		);
 	}
 
 }

--- a/includes/models/model.llms.user.achievement.php
+++ b/includes/models/model.llms.user.achievement.php
@@ -15,6 +15,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 3.8.0
  * @since [version] Utilize `LLMS_Abstract_User_Engagement` abstract.
+ *              Declare `achievement_title` and `achievement_content` properties.
  */
 class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 
@@ -22,9 +23,9 @@ class LLMS_User_Achievement extends LLMS_Abstract_User_Engagement {
 	protected $model_post_type = 'achievement';
 
 	protected $properties = array(
-		// 'achievement_title' => 'string', // use get( 'title' )
+		'achievement_title'    => 'string',
 		'achievement_image'    => 'absint',
-		// 'achievement_content' => 'html', // use get( 'content' )
+		'achievement_content'  => 'html',
 		'achievement_template' => 'absint',
 	);
 

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * LifterLMS Eearned Engagements (Certificate/Achievement) Meta Box trait.
  *
- * **This trait should only be used by classes that extend from the {@see LLMS_Admin_Metabox} class.**
+ * This trait should only be used by classes that extend from the {@see LLMS_Admin_Metabox} class.
  *
  * @since [version]
  */
@@ -135,7 +135,7 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	}
 
 	/**
-	 * Wheter the user has earned the engagement.
+	 * Whether the user has earned the engagement.
 	 *
 	 * @since [version]
 	 *

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -27,8 +27,14 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	 * @var string[]
 	 */
 	private $allowed_post_types = array(
-		'llms_my_achievement',
-		'llms_my_certificate',
+		'llms_my_achievement' => array(
+			'model'                => 'LLMS_User_Achievement',
+			'user_postmeta_prefix' =>'_achievement',
+		),
+		'llms_my_certificate' => array(
+			'model' => 'LLMS_User_Certificate',
+			'user_postmeta_prefix' =>'_certificate',
+		),
 	);
 
 	/**
@@ -41,12 +47,13 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	 */
 	protected function add_earned_engagement_fields( $fields = array() ) {
 
-		if ( ! in_array( get_post_type(), $this->allowed_post_types, true ) ) {
+		$post_type = get_post_type();
+		if ( ! array_key_exists( $post_type, $this->allowed_post_types ) ) {
 			return $fields;
 		}
 
 		$student = ! empty( $_GET['sid'] ) ? llms_filter_input( INPUT_GET, 'sid', FILTER_SANITIZE_NUMBER_INT ) : false; // phpcs:ignore
-		$student = empty( $student ) ? ( new LLMS_User_Certificate( $this->post->ID ) )->get_user_id() : $student;
+		$student = empty( $student ) ? ( new $this->allowed_post_types[ $post_type ]['model']( $this->post->ID ) )->get_user_id() : $student;
 
 		if ( empty( $student ) ) {
 			$fields[] = array(
@@ -84,13 +91,87 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	 * @return boolean
 	 */
 	protected function save_field( $post_id, $field ) {
+
+		if ( $this->prefix . 'student' === $field['id'] && isset( $_POST[$field['id']] ) ) {
+			$this->log_earned_engament( llms_filter_input( INPUT_POST, $field['id'], FILTER_SANITIZE_NUMBER_INT ), $post_id );
+		}
+
 		/**
 		 * Skip saving _llms_student field, only used to award an engagement, it's not a post field.
 		 */
 		if ( isset( $field['id'] ) && $this->prefix . 'student' === $field['id'] ) {
 			return true;
 		}
+
 		parent::save_field( $post_id, $field );
+
+	}
+
+	/**
+	 * Wheter the user has earned the engagement.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $user_id The student's user id.
+	 * @param int $post_id The earned engagement id.
+	 */
+	private function has_user_earned( $user_id, $post_id ) {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"
+				SELECT COUNT( meta_id )
+				FROM {$wpdb->prefix}lifterlms_user_postmeta
+				WHERE user_id=%d
+				AND meta_value=%d
+				",
+				array(
+					$user_id,
+					$post_id
+				)
+			)
+		);
+	}
+
+	/**
+	 * Wheter the user has earned the engagement.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $user_id The student's user id.
+	 * @param int $post_id The earned engagement id.
+	 * @return void
+	 */
+	private function log_earned_engament( $user_id, $post_id ) {
+
+		// Log earned engagement.
+		if ( ! $this->has_user_earned( $user_id, $post_id ) ) { // We need a better LLMS_Achievement(Certificate)_User::has_user_earned() method.
+			$post_type = get_post_type();
+			$prefix    = $this->allowed_post_types[ $post_type ]['user_postmeta_prefix'];
+
+			// We need a better LLMS_User_Achievement(Certificate)::create() method.
+			global $wpdb;
+			$wpdb->insert(
+				"{$wpdb->prefix}lifterlms_user_postmeta",
+				array(
+					'user_id'      => $user_id,
+					'post_id'      => 0,
+					'meta_key'     => "{$prefix}_earned",
+					'meta_value'   => $post_id,
+					'updated_date' => current_time( 'mysql' ),
+				)
+			);
+
+			/**
+			 * Allow 3rd parties to hook into the generation of an achievement
+			 * Notifications uses this
+			 * note 3rd param $this->lesson_id is actually the related post id (but misnamed)
+			 */
+			do_action( "llms_user_earned$prefix" , $user_id, $post_id, 0 );
+
+		}
+
 	}
 
 }

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -32,7 +32,7 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 			'user_postmeta_prefix' => '_achievement',
 		),
 		'llms_my_certificate' => array(
-			'model' => 'LLMS_User_Certificate',
+			'model'                => 'LLMS_User_Certificate',
 			'user_postmeta_prefix' => '_certificate',
 		),
 	);

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -74,4 +74,23 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 		return $fields;
 	}
 
+	/**
+	 * Save a metabox field.
+	 *
+	 * @since [version]
+	 *
+	 * @param int   $post_id WP_Post ID.
+	 * @param array $field   Metabox field array.
+	 * @return boolean
+	 */
+	protected function save_field( $post_id, $field ) {
+		/**
+		 * Skip saving _llms_student field, only used to award an engagement, it's not a post field.
+		 */
+		if ( isset( $field['id'] ) && $this->prefix . 'student' === $field['id'] ) {
+			return true;
+		}
+		parent::save_field( $post_id, $field );
+	}
+
 }

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -29,11 +29,11 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	private $allowed_post_types = array(
 		'llms_my_achievement' => array(
 			'model'                => 'LLMS_User_Achievement',
-			'user_postmeta_prefix' =>'_achievement',
+			'user_postmeta_prefix' => '_achievement',
 		),
 		'llms_my_certificate' => array(
 			'model' => 'LLMS_User_Certificate',
-			'user_postmeta_prefix' =>'_certificate',
+			'user_postmeta_prefix' => '_certificate',
 		),
 	);
 
@@ -92,7 +92,7 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 	 */
 	protected function save_field( $post_id, $field ) {
 
-		if ( $this->prefix . 'student' === $field['id'] && isset( $_POST[$field['id']] ) ) {
+		if ( $this->prefix . 'student' === $field['id'] && isset( $_POST[ $field['id'] ] ) ) { //phpcs:ignore -- nonce already verified in `LLMS_Admin_Metabox::save`.
 			$this->log_earned_engament( llms_filter_input( INPUT_POST, $field['id'], FILTER_SANITIZE_NUMBER_INT ), $post_id );
 		}
 
@@ -128,7 +128,7 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 				",
 				array(
 					$user_id,
-					$post_id
+					$post_id,
 				)
 			)
 		);
@@ -168,7 +168,7 @@ trait LLMS_Trait_Earned_Engagement_Meta_Box {
 			 * Notifications uses this
 			 * note 3rd param $this->lesson_id is actually the related post id (but misnamed)
 			 */
-			do_action( "llms_user_earned$prefix" , $user_id, $post_id, 0 );
+			do_action( "llms_user_earned$prefix", $user_id, $post_id, 0 );
 
 		}
 

--- a/includes/traits/llms-trait-earned-engagement-meta-box.php
+++ b/includes/traits/llms-trait-earned-engagement-meta-box.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * LifterLMS Eearned Engagements (Certificate/Achievement) Meta Box trait.
+ *
+ * @package LifterLMS/Traits
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS Eearned Engagements (Certificate/Achievement) Meta Box trait.
+ *
+ * **This trait should only be used by classes that extend from the {@see LLMS_Admin_Metabox} class.**
+ *
+ * @since [version]
+ */
+trait LLMS_Trait_Earned_Engagement_Meta_Box {
+
+	/**
+	 * Allowed post types.
+	 *
+	 * @since [version]
+	 *
+	 * @var string[]
+	 */
+	private $allowed_post_types = array(
+		'llms_my_achievement',
+		'llms_my_certificate',
+	);
+
+	/**
+	 * Add earned engagement fields.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $fields  Array of metabox fields.
+	 * @return array
+	 */
+	protected function add_earned_engagement_fields( $fields = array() ) {
+
+		if ( ! in_array( get_post_type(), $this->allowed_post_types, true ) ) {
+			return $fields;
+		}
+
+		$student = ! empty( $_GET['sid'] ) ? llms_filter_input( INPUT_GET, 'sid', FILTER_SANITIZE_NUMBER_INT ) : false; // phpcs:ignore
+		$student = empty( $student ) ? ( new LLMS_User_Certificate( $this->post->ID ) )->get_user_id() : $student;
+
+		if ( empty( $student ) ) {
+			$fields[] = array(
+				'allow_null'      => false,
+				'class'           => 'llms-select2-student',
+				'data_attributes' => array(
+					'allow_clear' => false,
+					'placeholder' => __( 'Select a Student', 'lifterlms' ),
+				),
+				'id'              => $this->prefix . 'student',
+				'label'           => __( 'Select a Student', 'lifterlms' ),
+				'type'            => 'select',
+			);
+		} else {
+			array_unshift(
+				$fields,
+				array(
+					'id'    => $this->prefix . 'student',
+					'type'  => 'hidden',
+					'value' => $student,
+				)
+			);
+		}
+
+		return $fields;
+	}
+
+}

--- a/includes/traits/llms-trait-earned-engagement-reporting-table.php
+++ b/includes/traits/llms-trait-earned-engagement-reporting-table.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * LifterLMS Eearned Engagements (Certificate/Achievement) Reporting Table trait.
+ *
+ * @package LifterLMS/Traits
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS Eearned Engagements (Certificate/Achievement) Reporting Table trait.
+ *
+ * **This trait should only be used by classes that extend from the {@see LLMS_Admin_Table} class.**
+ *
+ * @since [version]
+ */
+trait LLMS_Trait_Earned_Engagement_Reporting_Table {
+
+	/**
+	 * Add award engaement button above the table.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_table_html() {
+
+		$table = parent::get_table_html();
+
+		$post_type = null;
+		if ( 'certificates' === $this->id ) {
+			$post_type = 'llms_my_certificate';
+		} elseif ( 'achievements' === $this->id ) {
+			$post_type = 'llms_my_achievement';
+		}
+		if ( empty( $post_type ) ) {
+			return $table;
+		}
+
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! current_user_can( $post_type_object->cap->edit_post ) ) {
+			return $table;
+		}
+
+		$student = false;
+		if ( ! empty( $this->student ) ) {
+			$student = $this->student->get_id();
+		} elseif ( ! empty( $_GET['student_id'] ) ) { //phpcs:ignore -- Nonce verification not needed.
+			$student = llms_filter_input( INPUT_GET, 'student_id', FILTER_SANITIZE_NUMBER_INT );
+		}
+
+		$post_new_file  = "post-new.php?post_type=$post_type";
+		$post_new_url   = esc_url( add_query_arg( 'sid', $student, admin_url( $post_new_file ) ) );
+		$add_new_button = '<a style="display:inline-block;margin-bottom:20px" href="' . $post_new_url . '" class="page-title-action">' . esc_html( $post_type_object->labels->add_new ) . '</a>';
+
+		return $add_new_button . $table;
+
+	}
+
+}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -83,6 +83,7 @@
 
 		<exclude-pattern>templates/*.php</exclude-pattern>
 		<exclude-pattern>templates/**/*.php</exclude-pattern>
+		<exclude-pattern>uninstall.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment">
 		<exclude-pattern>includes/admin/views/*.php</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -83,7 +83,6 @@
 
 		<exclude-pattern>templates/*.php</exclude-pattern>
 		<exclude-pattern>templates/**/*.php</exclude-pattern>
-		<exclude-pattern>uninstall.php</exclude-pattern>
 	</rule>
 	<rule ref="Squiz.Commenting.FileComment">
 		<exclude-pattern>includes/admin/views/*.php</exclude-pattern>

--- a/templates/achievements/template.php
+++ b/templates/achievements/template.php
@@ -5,7 +5,8 @@
  * @package LifterLMS/Templates
  *
  * @since 1.0.0
- * @version 3.14.6
+ * @since [version] Display the achievement_content post meta not the post content.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 	<h4 class="llms-achievement-title"><?php echo $achievement->get( 'achievement_title' ); ?></h4>
 
 	<div class="llms-achievement-info">
-		<div class="llms-achievement-content"><?php echo $achievement->get( 'content' ); ?></div>
+		<div class="llms-achievement-content"><?php echo $achievement->get( 'achievement_content' ); ?></div>
 		<div class="llms-achievement-date"><?php printf( _x( 'Awarded on %s', 'achievement earned date', 'lifterlms' ), $achievement->get_earned_date() ); ?></div>
 	</div>
 

--- a/tests/phpunit/unit-tests/class-llms-test-post-types.php
+++ b/tests/phpunit/unit-tests/class-llms-test-post-types.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for LifterLMS Custom Post Types
+ * Tests for LifterLMS Custom Post Types.
  *
  * @group LLMS_Post_Types
  *
@@ -9,6 +9,94 @@
  */
 class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 
+	/**
+	 * LifterLMS Custom Post Types.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	private $post_types = array(
+		'course',
+		'section',
+		'lesson',
+		'llms_membership',
+		'llms_engagement',
+		'llms_order',
+		'llms_transaction',
+		'llms_achievement',
+		'llms_my_achievement',
+		'llms_certificate',
+		'llms_my_certificate',
+		'llms_email',
+		'llms_quiz',
+		'llms_question',
+		'llms_coupon',
+		'llms_voucher',
+		'llms_review',
+		'llms_access_plan',
+		'llms_form'
+	);
+
+	/**
+	 * LifterLMS Custom Post Types for earned engagements.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	private $earned_engagements_post_types = array(
+		'llms_my_achievement',
+		'llms_my_certificate',
+	);
+
+	/**
+	 * LifterLMS Custom Taxonomies.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	private $taxonomies = array(
+		'course_cat',
+		'course_difficulty',
+		'course_tag',
+		'course_track',
+		'membership_cat',
+		'membership_tag',
+		'llms_product_visibility',
+		'llms_access_plan_visibility',
+	);
+
+	/**
+	 * LifterLMS Custom Post Statuses.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	private $post_statuses = array(
+		'llms-completed',
+		'llms-active',
+		'llms-expired',
+		'llms-on-hold',
+		'llms-pending',
+		'llms-cancelled',
+		'llms-refunded',
+		'llms-failed',
+		'llms-txn-failed',
+		'llms-txn-pending',
+		'llms-txn-refunded',
+		'llms-txn-succeeded',
+	);
+
+	/**
+	 * Test LLMS_Post_Types::deregister_sitemap_post_types( $mock ).
+	 *
+	 * @since 4.3.2
+	 *
+	 * @return void
+	 */
 	public function test_deregister_sitemap_post_types() {
 
 		$mock = array(
@@ -31,78 +119,56 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test register taxonomies.
+	 *
+	 * @since 3.13.0
+	 * @since [version] Use `$this->taxonomies` member.
+	 *
+	 * @return void
+	 */
 	public function test_register_post_taxonomies() {
 
 		LLMS_Post_Types::register_taxonomies();
 
-		$taxonomies = array(
-			'course_cat',
-			'course_difficulty',
-			'course_tag',
-			'course_track',
-			'membership_cat',
-			'membership_tag',
-			'llms_product_visibility',
-			'llms_access_plan_visibility',
-		);
-
-		foreach ( $taxonomies as $name ) {
+		foreach ( $this->taxonomies as $name ) {
 			// var_dump( sprintf( '%s: %s', $name, taxonomy_exists( $name ) ) );
 			$this->assertTrue( taxonomy_exists( $name ) );
 		}
 
 	}
 
+	/**
+	 * Test register post types.
+	 *
+	 * @since 3.13.0
+	 * @since [version] Use `$this->post_types` member.
+	 *
+	 * @return void
+	 */
 	public function test_register_post_types() {
 
 		LLMS_Post_Types::register_post_types();
 
-		$post_types = array(
-			'course',
-			'section',
-			'lesson',
-			'llms_membership',
-			'llms_engagement',
-			'llms_order',
-			'llms_transaction',
-			'llms_achievement',
-			'llms_certificate',
-			'llms_my_certificate',
-			'llms_email',
-			'llms_quiz',
-			'llms_question',
-			'llms_coupon',
-			'llms_voucher',
-			'llms_review',
-			'llms_access_plan',
-		);
-
-		foreach ( $post_types as $name ) {
+		foreach ( $this->post_types as $name ) {
 			$this->assertTrue( post_type_exists( $name ) );
 		}
 
 	}
 
+	/**
+	 * Test register post statusess.
+	 *
+	 * @since 3.13.0
+	 * @since [version] Use `$this->post_statuses` member.
+	 *
+	 * @return void
+	 */
 	public function test_register_post_statuses() {
 
 		LLMS_Post_Types::register_post_statuses();
 
-		$statuses = array(
-			'llms-completed',
-			'llms-active',
-			'llms-expired',
-			'llms-on-hold',
-			'llms-pending',
-			'llms-cancelled',
-			'llms-refunded',
-			'llms-failed',
-			'llms-txn-failed',
-			'llms-txn-pending',
-			'llms-txn-refunded',
-			'llms-txn-succeeded',
-		);
-
-		foreach ( $statuses as $name ) {
+		foreach ( $this->post_statuses as $name ) {
 			$this->assertTrue( ! is_null( get_post_status_object( $name ) ) );
 		}
 
@@ -118,6 +184,7 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 	 * @expectedDeprecated lifterlms_register_post_type_llms_achievement
 	 * @expectedDeprecated lifterlms_register_post_type_llms_certificate
 	 * @expectedDeprecated lifterlms_register_post_type_llms_my_certificate
+	 * @expectedDeprecated lifterlms_register_post_type_llms_my_achievement
 	 * @expectedDeprecated lifterlms_register_post_type_llms_email
 	 * @expectedDeprecated lifterlms_register_post_type_llms_quiz
 	 * @expectedDeprecated lifterlms_register_post_type_llms_question
@@ -125,6 +192,7 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 	 * @expectedDeprecated lifterlms_register_post_type_llms_voucher
 	 * @expectedDeprecated lifterlms_register_post_type_llms_review
 	 * @expectedDeprecated lifterlms_register_post_type_llms_access_plan
+	 * @expectedDeprecated lifterlms_register_post_type_llms_form
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -135,27 +203,7 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 	 */
 	public function test_deprecated_filters() {
 
-		$post_types = array(
-			'course',
-			'section',
-			'lesson',
-			'llms_membership',
-			'llms_engagement',
-			'llms_order',
-			'llms_transaction',
-			'llms_achievement',
-			'llms_certificate',
-			'llms_my_certificate',
-			'llms_email',
-			'llms_quiz',
-			'llms_question',
-			'llms_coupon',
-			'llms_voucher',
-			'llms_review',
-			'llms_access_plan',
-		);
-
-		foreach ( $post_types as $post_type ) {
+		foreach ( $this->post_types as $post_type ) {
 
 			unregister_post_type( $post_type );
 			add_filter( "lifterlms_register_post_type_${post_type}", '__return_empty_array' );
@@ -164,6 +212,121 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 
 		}
 
+	}
+
+	/**
+	 * Test LLMS_Post_Types::get_post_type_caps() when argument is an array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_post_type_caps_argument_as_array() {
+
+		foreach ( array_diff( $this->post_types, $this->earned_engagements_post_types ) as $post_type ) {
+			$post_type = str_replace( 'llms_', '', $post_type );
+			$singular  = $post_type;
+			$plural    = $post_type . '_plural';
+
+			$post_type = array(
+				$singular,
+				$plural,
+			);
+
+			$this->assertEquals(
+				LLMS_Post_Types::get_post_type_caps( $post_type ),
+				array(
+					'read_post'              => sprintf( 'read_%s', $singular ),
+					'read_private_posts'     => sprintf( 'read_private_%s', $plural ),
+
+					'edit_post'              => sprintf( 'edit_%s', $singular ),
+					'edit_posts'             => sprintf( 'edit_%s', $plural ),
+					'edit_others_posts'      => sprintf( 'edit_others_%s', $plural ),
+					'edit_private_posts'     => sprintf( 'edit_private_%s', $plural ),
+					'edit_published_posts'   => sprintf( 'edit_published_%s', $plural ),
+
+					'publish_posts'          => sprintf( 'publish_%s', $plural ),
+
+					'delete_post'            => sprintf( 'delete_%s', $singular ),
+					'delete_posts'           => sprintf( 'delete_%s', $plural ), // This is the core bug issue here.
+					'delete_private_posts'   => sprintf( 'delete_private_%s', $plural ),
+					'delete_published_posts' => sprintf( 'delete_published_%s', $plural ),
+					'delete_others_posts'    => sprintf( 'delete_others_%s', $plural ),
+
+					'create_posts'           => sprintf( 'create_%s', $plural ),
+				),
+				$post_type[0]
+			);
+		}
+
+		foreach ( $this->earned_engagements_post_types as $post_type ) {
+
+			$post_type = str_replace( 'llms_', '', $post_type );
+
+			$post_type = array(
+				$post_type,
+				$post_type . '_plural',
+			);
+
+			$this->assertEquals(
+				LLMS_Post_Types::get_post_type_caps( $post_type ),
+				LLMS_Post_Types::get_earned_engagements_post_type_caps(),
+			);
+
+		}
+	}
+
+
+	/**
+	 * Test LLMS_Post_Types::get_post_type_caps() when argument is a string.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_post_type_caps_argument_as_string() {
+
+		foreach ( array_diff( $this->post_types, $this->earned_engagements_post_types ) as $post_type ) {
+			$post_type = str_replace( 'llms_', '', $post_type );
+			$singular  = $post_type;
+			$plural    = $post_type . 's';
+
+			$this->assertEquals(
+				LLMS_Post_Types::get_post_type_caps( $post_type ),
+				array(
+					'read_post'              => sprintf( 'read_%s', $singular ),
+					'read_private_posts'     => sprintf( 'read_private_%s', $plural ),
+
+					'edit_post'              => sprintf( 'edit_%s', $singular ),
+					'edit_posts'             => sprintf( 'edit_%s', $plural ),
+					'edit_others_posts'      => sprintf( 'edit_others_%s', $plural ),
+					'edit_private_posts'     => sprintf( 'edit_private_%s', $plural ),
+					'edit_published_posts'   => sprintf( 'edit_published_%s', $plural ),
+
+					'publish_posts'          => sprintf( 'publish_%s', $plural ),
+
+					'delete_post'            => sprintf( 'delete_%s', $singular ),
+					'delete_posts'           => sprintf( 'delete_%s', $plural ), // This is the core bug issue here.
+					'delete_private_posts'   => sprintf( 'delete_private_%s', $plural ),
+					'delete_published_posts' => sprintf( 'delete_published_%s', $plural ),
+					'delete_others_posts'    => sprintf( 'delete_others_%s', $plural ),
+
+					'create_posts'           => sprintf( 'create_%s', $plural ),
+				),
+				$post_type[0]
+			);
+		}
+
+		foreach ( $this->earned_engagements_post_types as $post_type ) {
+
+			$post_type = str_replace( 'llms_', '', $post_type );
+
+			$this->assertEquals(
+				LLMS_Post_Types::get_post_type_caps( $post_type ),
+				LLMS_Post_Types::get_earned_engagements_post_type_caps(),
+			);
+
+		}
 	}
 
 }

--- a/tests/phpunit/unit-tests/class-llms-test-post-types.php
+++ b/tests/phpunit/unit-tests/class-llms-test-post-types.php
@@ -329,4 +329,36 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Check actual post types capabilities.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_post_type_capabilities() {
+		foreach (
+				array(
+					'course'              => 'course',
+					'lesson'              => 'lesson',
+					'llms_membership'     => 'membership',
+					'llms_quiz'           => array( 'quiz', 'quizzes' ),
+					'llms_question'       => 'question',
+					'llms_my_achievement' => 'my_achievement',
+					'llms_my_certificate' => 'my_certificate',
+				) as $post_type => $post_type_name_for_caps ) {
+
+			$post_type_object = get_post_type_object( $post_type );
+			$caps = (array) $post_type_object->cap;
+			unset( $caps['read'] );
+
+			$this->assertEquals(
+				$caps,
+				LLMS_Post_Types::get_post_type_caps( $post_type_name_for_caps ),
+			);
+
+		}
+
+	}
+
 }

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,11 +1,12 @@
 <?php
 /**
- * LifterLMS Uninstall
+ * LifterLMS Uninstall.
  *
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 4.5.0
+ * @since [version] Delete `llms_my_achievement` and `llms_form` post type when removing all data.
+ * @version [version]
  */
 
 // If uninstall not called from WordPress exit.
@@ -57,8 +58,8 @@ if ( defined( 'LLMS_REMOVE_ALL_DATA' ) && true === LLMS_REMOVE_ALL_DATA ) {
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}lifterlms_events" );
 	$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}lifterlms_events_open_sessions" );
 
-	// delete all post types & related meta data.
-	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'course', 'section', 'lesson', 'llms_quiz', 'llms_question', 'llms_membership', 'llms_engagement', 'llms_order', 'llms_transaction', 'llms_achievement', 'llms_certificate', 'llms_my_certificate', 'llms_email', 'llms_coupon', 'llms_voucher', 'llms_review', 'llms_access_plan' );" );
+	// Delete all post types & related meta data.
+	$wpdb->query( "DELETE FROM {$wpdb->posts} WHERE post_type IN ( 'course', 'section', 'lesson', 'llms_quiz', 'llms_question', 'llms_membership', 'llms_engagement', 'llms_order', 'llms_transaction', 'llms_achievement', 'llms_my_achievement', 'llms_certificate', 'llms_my_certificate', 'llms_email', 'llms_coupon', 'llms_voucher', 'llms_review', 'llms_access_plan', 'llms_form' );" );
 	$wpdb->query( "DELETE meta FROM {$wpdb->postmeta} meta LEFT JOIN {$wpdb->posts} posts ON posts.ID = meta.post_id WHERE posts.ID IS NULL;" );
 
 	// Delete terms if > WP 4.2 (term splitting was added in 4.2).

--- a/uninstall.php
+++ b/uninstall.php
@@ -5,7 +5,6 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @since [version] Delete `llms_my_achievement` and `llms_form` post type when removing all data.
  * @version [version]
  */
 


### PR DESCRIPTION
## Description
Allow editing earned certificates and achievements.

~Pondering on whether to extend this to achievements too: they are not `public` and they don't have a template, so to actual see the changes one should be the one who earned it or using an user switcher plugin...~

A couple of thoughts about the "my" achievements:

a) They don't have a public permalink, and I don't think we should introduce it just for the purpose of allowing seeing the published changes in an easy way: even if I guess it would be rare, we could generate some conflict with 3rd party code.
b) They could be previewed (Preview Changes button) BUT since most of the actual, and relevant, achievement data to be displayed are post meta (achievement_title, achievement_content, achievement_image), and as we know not already saved post metas are not available in the preview, I decided to leave the preview not available
c) They don't have a "single" template, which because of a) and b) I decided to not implement - although its implementation would be trivial.

If you think otherwise let's see what we can do. But I think that this PR can be merged as it is, and possible further improvements could be set to be done in the future.


## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

