### PR TITLE
Include the LLMS-CLI as a core library

### DIFF
--- a/.changelogs/include-cli.yml
+++ b/.changelogs/include-cli.yml
@@ -1,0 +1,7 @@
+significance: minor
+type: added
+entry: >
+  + Includes the LLMS-CLI, a set of WP-CLI commands for LifterLMS and LifterLMS
+  add-ons, as part of the core plugin.
+
+  + To get started, run `wp llms --help` in your terminal or read the [online command documentation](https://developer.lifterlms.com/cli/commands/llms/).

--- a/.changelogs/include-cli.yml
+++ b/.changelogs/include-cli.yml
@@ -1,7 +1,7 @@
 significance: minor
 type: added
-entry: >
-  + Includes the LLMS-CLI, a set of WP-CLI commands for LifterLMS and LifterLMS
-  add-ons, as part of the core plugin.
-
-  + To get started, run `wp llms --help` in your terminal or read the [online command documentation](https://developer.lifterlms.com/cli/commands/llms/).
+entry: |
+  + Includes the LLMS-CLI beta, a set of WP-CLI commands for LifterLMS and LifterLMS add-ons, as part of the core plugin:
+    + To get started, run `wp llms --help` in your terminal or read the [online command documentation](https://developer.lifterlms.com/cli/commands/llms/).
+    + Please note that the LLMS-CLI is included as a public beta feature. The command API is in a pre-release state and, as such, is subject to change without warning.
+    + If you encounter any issues or wish to provide feedback on the LLMS-CLI please get in touch at [https://github.com/gocodebox/lifterlms-cli](https://github.com/gocodebox/lifterlms-cli).

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,10 @@
     "composer/installers": "~1.9.0",
     "deliciousbrains/wp-background-processing": "1.0.2",
     "lifterlms/lifterlms-blocks": "2.2.1",
+    "lifterlms/lifterlms-cli": "0.0.3",
+    "lifterlms/lifterlms-helper": "3.4.1",
     "lifterlms/lifterlms-rest": "1.0.0-beta.20",
-    "woocommerce/action-scheduler": "3.3.0",
-    "lifterlms/lifterlms-helper": "3.4.1"
+    "woocommerce/action-scheduler": "3.3.0"
   },
   "require-dev": {
     "lifterlms/lifterlms-tests": "^3.1.0",
@@ -117,6 +118,7 @@
     "installer-paths": {
       "libraries/{$name}": [
         "lifterlms/lifterlms-blocks",
+        "lifterlms/lifterlms-cli",
         "lifterlms/lifterlms-helper",
         "lifterlms/lifterlms-rest"
       ],

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 5.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -308,6 +308,7 @@ class LLMS_Loader {
 	 * @since 4.9.0 Adds constants which can be used to identify when included libraries have been loaded.
 	 * @since 5.0.0 Load core libraries from new location, add WP Background Processing lib, add LLMS Helper.
 	 * @since 5.1.3 Add keys to the $libs array and pass them through a filter.
+	 * @since [version] Add LLMS-CLI to the list of included libraries.
 	 *
 	 * @return void
 	 */
@@ -318,6 +319,11 @@ class LLMS_Loader {
 				'const' => 'LLMS_BLOCKS_LIB',
 				'test'  => function_exists( 'has_blocks' ) && ! defined( 'LLMS_BLOCKS_VERSION' ),
 				'file'  => LLMS_PLUGIN_DIR . 'libraries/lifterlms-blocks/lifterlms-blocks.php',
+			),
+			'cli'    => array(
+				'const' => 'LLMS_CLI_LIB',
+				'test'  => ! function_exists( 'llms_cli' ),
+				'file'  => LLMS_PLUGIN_DIR . 'libraries/lifterlms-cli/lifterlms-cli.php',
 			),
 			'rest'   => array(
 				'const' => 'LLMS_REST_API_LIB',
@@ -336,10 +342,13 @@ class LLMS_Loader {
 		 *
 		 * @since 5.1.3
 		 *
-		 * @param array $libs Array of library data. Array key is a unique ID for the library and each array contains the following keys:
-		 *                    @type string $const Name of the constant used to identify if the library is loaded as a library.
-		 *                    @type bool   $test  A test which is evaluated to determine if the library should be loaded. Returning `false` causes the library not to load.
-		 *                    @type string $file  Path to the main library file's location in the LifterLMS core plugin.
+		 * @param array $libs {
+		 *     Array of library data. Each array key serves as a unique ID for the library.
+		 *
+		 *     @type string $const Name of the constant used to identify if the library is loaded as a library.
+		 *     @type bool   $test  A test which is evaluated to determine if the library should be loaded. Returning `false` causes the library not to load.
+		 *     @type string $file  Path to the main library file's location in the LifterLMS core plugin.
+		 * }
 		 */
 		$libs = apply_filters( 'llms_included_libs', $libs );
 		foreach ( $libs as $lib ) {

--- a/tests/phpunit/unit-tests/class-llms-test-cli.php
+++ b/tests/phpunit/unit-tests/class-llms-test-cli.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test inclusion and initialization of the LLMS-CLI library
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group cli
+ * @group packages
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_CLI extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Test rest package exists and is loaded.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_cli_package_exists() {
+		$this->assertTrue( function_exists( 'llms_cli' ) );
+	}
+
+}


### PR DESCRIPTION
## Description

Closes gocodebox/lifterlms-cli#4

Includes the (beta) LLMS-CLI as a library plugin to expose all existing LLMS-CLI commands.

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes

+ new feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

