### PR TITLE
Fix select2 query posts (users) when the search terms contains quotes

### DIFF
--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * LifterLMS AJAX Event Handler
+ * LifterLMS AJAX Event Handler.
  *
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 4.21.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -329,7 +329,7 @@ class LLMS_AJAX_Handler {
 	}
 
 	/**
-	 * Retrieve Students
+	 * Retrieve Students.
 	 *
 	 * Used by Select2 AJAX functions to load paginated student results.
 	 * Also allows querying by:
@@ -339,13 +339,14 @@ class LLMS_AJAX_Handler {
 	 *
 	 * @since Unknown
 	 * @since 3.14.2 Unknown.
+	 * @since [version] Do not encode quotes when sanitizing search term.
 	 *
 	 * @return void
 	 */
 	public static function query_students() {
 
-		// grab the search term if it exists.
-		$term = array_key_exists( 'term', $_REQUEST ) ? llms_filter_input( INPUT_POST, 'term', FILTER_SANITIZE_STRING ) : '';
+		// Grab the search term if it exists.
+		$term = array_key_exists( 'term', $_REQUEST ) ? llms_filter_input( INPUT_POST, 'term', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES ) : '';
 
 		$page = array_key_exists( 'page', $_REQUEST ) ? llms_filter_input( INPUT_POST, 'page', FILTER_SANITIZE_NUMBER_INT ) : 0;
 
@@ -800,6 +801,7 @@ class LLMS_AJAX_Handler {
 	 * @since 3.32.0 Posts can be queried by post status(es) via the `$_POST['post_statuses']`.
 	 *               By default only the published posts will be queried.
 	 * @since 3.37.2 Posts can be 'filtered' by instructor via the `$_POST['instructor_id']`.
+	 * @since [version] Do not encode quotes when sanitizing search term.
 	 *
 	 * @return void
 	 */
@@ -807,10 +809,10 @@ class LLMS_AJAX_Handler {
 
 		global $wpdb;
 
-		// grab the search term if it exists.
-		$term = llms_filter_input( INPUT_POST, 'term', FILTER_SANITIZE_STRING );
+		// Grab the search term if it exists.
+		$term = llms_filter_input( INPUT_POST, 'term', FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
 
-		// get the page.
+		// Get the page.
 		$page = llms_filter_input( INPUT_POST, 'page', FILTER_SANITIZE_NUMBER_INT );
 
 		// Get post type(s).
@@ -830,7 +832,7 @@ class LLMS_AJAX_Handler {
 		}
 		$post_statuses = implode( ',', $post_statuses_array );
 
-		// filter posts (llms posts) by instructor ID.
+		// Filter posts (llms posts) by instructor ID.
 		$instructor_id = llms_filter_input( INPUT_POST, 'instructor_id', FILTER_SANITIZE_NUMBER_INT );
 		if ( ! empty( $instructor_id ) ) {
 			$serialized_iid = serialize(
@@ -872,8 +874,8 @@ class LLMS_AJAX_Handler {
 			 LIMIT %d, %d
 			",
 				$vars
-			)
-		);
+			) // phpcs:ignore -- The number of params is correct, $vars is an array of two elements.
+		);// no-cache ok.
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$items = array();
@@ -889,7 +891,7 @@ class LLMS_AJAX_Handler {
 
 			if ( $grouping ) {
 
-				// setup an object for the optgroup if it's not already set up.
+				// Setup an object for the optgroup if it's not already set up.
 				if ( ! isset( $items[ $post->post_type ] ) ) {
 					$obj                       = get_post_type_object( $post->post_type );
 					$items[ $post->post_type ] = array(

--- a/tests/phpunit/unit-tests/class-llms-test-ajax-handler.php
+++ b/tests/phpunit/unit-tests/class-llms-test-ajax-handler.php
@@ -10,6 +10,7 @@
  * @since 3.37.2 Added tests on querying courses/memberships filtererd by instructors.
  * @since 3.37.14 Added tests on persisting tracking events.
  * @since 3.37.15 Added tests for admin table methods.
+ * @since [version] Added tests on select2_query_posts when searching terms with quotes.
  */
 class LLMS_Test_AJAX_Handler extends LLMS_UnitTestCase {
 
@@ -354,6 +355,34 @@ class LLMS_Test_AJAX_Handler extends LLMS_UnitTestCase {
 		$this->assertSame( 'Memberships', $res['items']['llms_membership']['label'] );
 		$this->assertTrue( array_key_exists( 'items', $res['items']['llms_membership'] ) );
 		$this->assertSame( 2, count( $res['items']['llms_membership']['items'] ) );
+
+	}
+
+	/**
+	 * Test the select2_query_posts() ajax method with search term and quotes.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_select2_query_posts_search_term_quote() {
+
+		$course = $this->factory->post->create( array(
+			'post_title'  => 'search title with this quotes:\'" - :)',
+			'post_type'   => 'course',
+			'post_stauts' => 'publish',
+		));
+
+		$args = array(
+			'post_type'   => 'course',
+			'term'        => 'search title with this quotes:\'',
+		);
+
+		$res = $this->do_ajax( 'select2_query_posts', $args );
+		$this->assertSame( 1, count( $res['items'] ) );
+		$this->assertTrue( $res['success'] );
+		$this->assertSame( $course, (int) $res['items'][0]['id'] );
+		$this->assertSame( 'search title with this quotes:\'" - :)' .  " (ID# $course)", $res['items'][0]['name'] );
 
 	}
 


### PR DESCRIPTION

## Description

Fixes https://github.com/gocodebox/lifterlms-integration-woocommerce/issues/120
See also. this comment:
https://github.com/gocodebox/lifterlms-integration-woocommerce/issues/120#issuecomment-960594710

I went for the faster solution, assuming we'll going to tackle the php8.1 compatibility in the future. 

## How has this been tested?
Manually and new test (on the select2 query posts only).

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

