### PR TITLE
Engagement refactoring fix failing tests

### DIFF
--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -647,7 +647,9 @@ class LLMS_Engagements {
 	 */
 	public function unschedule_delayed_engagements( $post_id, $post = null ) {
 
+		// @todo Remove compatibility with WP < 5.5 when bumping the minimum WP required version to 5.5+
 		$post_type = $post ? $post->post_type : get_post_type( $post_id );
+
 		if ( 'llms_engagement' === $post_type ) {
 			as_unschedule_all_actions( '', array(), $this->get_delayed_group_id( $post_id ) );
 		}

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -637,15 +637,18 @@ class LLMS_Engagements {
 	 *
 	 * This is the callback function for deleted engagement posts.
 	 *
+	 * The `deleted_post` action param `$post` has been added since WordPress 5.5.0.
+	 *
 	 * @since [version]
 	 *
 	 * @param int          $post_id WP_Post ID.
 	 * @param WP_Post|null $post    Post object of the deleted post.
 	 * @return void
 	 */
-	public function unschedule_delayed_engagements( $post_id, $post ) {
+	public function unschedule_delayed_engagements( $post_id, $post = null ) {
 
-		if ( 'llms_engagement' === $post->post_type ) {
+		$post_type = $post ? $post->post_type : get_post_type( $post_id );
+		if ( 'llms_engagement' === $post_type ) {
 			as_unschedule_all_actions( '', array(), $this->get_delayed_group_id( $post_id ) );
 		}
 

--- a/tests/phpunit/framework/class-llms-settings-page-test-case.php
+++ b/tests/phpunit/framework/class-llms-settings-page-test-case.php
@@ -3,6 +3,7 @@
  * LifterLMS Unit Test Case Base class
  *
  * @since 3.37.3
+ * @version [version]
  */
 class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 
@@ -85,8 +86,9 @@ class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 	 * Ensure all editable settings exist in the settings array.
 	 *
 	 * @since 3.37.3
+	 * @since [version] Compare arrays without caring about order.
 	 *
-	 * @return [type]
+	 * @return void
 	 */
 	public function test_get_settings() {
 
@@ -98,7 +100,7 @@ class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 
 		$mock   = array_keys( $settings );
 		$actual = $this->get_settings_ids();
-		$this->assertEquals( $mock, $actual );
+		$this->assertEqualSets( $mock, $actual );
 
 	}
 

--- a/tests/phpunit/framework/class-llms-settings-page-test-case.php
+++ b/tests/phpunit/framework/class-llms-settings-page-test-case.php
@@ -3,7 +3,6 @@
  * LifterLMS Unit Test Case Base class
  *
  * @since 3.37.3
- * @version [version]
  */
 class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 
@@ -86,7 +85,6 @@ class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 	 * Ensure all editable settings exist in the settings array.
 	 *
 	 * @since 3.37.3
-	 * @since [version] Compare arrays without caring about order.
 	 *
 	 * @return void
 	 */
@@ -100,7 +98,7 @@ class LLMS_Settings_Page_Test_Case extends LLMS_Unit_Test_Case {
 
 		$mock   = array_keys( $settings );
 		$actual = $this->get_settings_ids();
-		$this->assertEqualSets( $mock, $actual );
+		$this->assertEquals( $mock, $actual );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -10,6 +10,7 @@
  *
  * @since 3.37.3
  * @since 3.40.0 Add tests for `get_settings_group_email_delivery()`.
+ * @version [version]
  */
 class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 
@@ -38,6 +39,7 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 	 * Return an array of mock settings and possible values.
 	 *
 	 * @since 3.37.3
+	 * @since [version] Update settings.
 	 *
 	 * @return void
 	 */
@@ -57,6 +59,12 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 			),
 			'lifterlms_email_footer_text' => array(
 				'footer text content',
+			),
+			'lifterlms_achievement_default_img' => array(
+				0
+			),
+			'lifterlms_certificate_default_bg_img' => array(
+				0
 			),
 			'lifterlms_certificate_bg_img_width' => array(
 				800,

--- a/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -10,7 +10,6 @@
  *
  * @since 3.37.3
  * @since 3.40.0 Add tests for `get_settings_group_email_delivery()`.
- * @version [version]
  */
 class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 


### PR DESCRIPTION
fixes some failing tests.

There are a bunch of other tests that are erroring because of the now missing `create_attachment()` test method, not sure what you want to do with it though, so I haven't looked for a solution. 