### PR TITLE
Rename llms_certificate and llms_my_certificate post type slugs

### DIFF
--- a/.changelogs/engagements-post-slug-1.yml
+++ b/.changelogs/engagements-post-slug-1.yml
@@ -1,0 +1,6 @@
+significance: minor
+type: changed
+entry: The URL of earned user certificates has been changed from
+  "my_certificate" to "certificate". Requests to the old url are automatically
+  redirected to the new url, including instances where the URL slug has been
+  translated.

--- a/.changelogs/engagements-post-slug.yml
+++ b/.changelogs/engagements-post-slug.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: changed
+entry: The URL of certificate temaplate previews has been changed from
+  "certificate" to "certificate-template".

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -406,7 +406,9 @@ class LLMS_Post_Types {
 	 * @since 5.5.0 Register all the post types using `self::register_post_type()`.
 	 * @since [version] Show `llms_my_certificate` ui (edit) only to who can `manage_lifterlms`.
 	 *             Register `llms_my_achievement` post type.
-	 *             Add thumbnail support for achievement and certificates (earned and template).
+	 *             Add thumbnail support for achievement and certificates (earned and template)
+	 *             Renames `llms_certificate` slug from `certificate` to `certificate-template`.
+	 *             Rename `llms_my_certificate` slug from `my_certificate` to `certificate`.
 	 *
 	 * @return void
 	 */
@@ -889,7 +891,7 @@ class LLMS_Post_Types {
 				'show_in_menu'        => 'edit.php?post_type=llms_engagement',
 				'hierarchical'        => false,
 				'rewrite'             => array(
-					'slug'       => untrailingslashit( _x( 'certificate', 'slug', 'lifterlms' ) ),
+					'slug'       => _x( 'certificate-template', 'slug', 'lifterlms' ),
 					'with_front' => false,
 					'feeds'      => true,
 				),
@@ -942,7 +944,7 @@ class LLMS_Post_Types {
 				'show_in_menu'        => ( current_user_can( apply_filters( 'lifterlms_admin_my_certificates_access', LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP ) ) ) ? 'edit.php?post_type=llms_engagement' : false,
 				'hierarchical'        => false,
 				'rewrite'             => array(
-					'slug'       => untrailingslashit( _x( 'my_certificate', 'slug', 'lifterlms' ) ),
+					'slug'       => _x( 'certificate', 'slug', 'lifterlms' ),
 					'with_front' => false,
 					'feeds'      => true,
 				),

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -300,11 +300,10 @@ class LLMS_Query {
 
 		global $wp, $wp_query;
 
-		$url = home_url( $wp->request );
-		$old = sprintf( '/%s/', _x( 'my_certificate', 'slug', 'lifterlms' ) );
-		if ( $wp_query->is_404() && false !== strpos( $url, $old ) ) {
-
-			$slug     = str_replace( $old, '', wp_parse_url( $url, PHP_URL_PATH ) );
+		$old  = sprintf( '/%s/', _x( 'my_certificate', 'slug', 'lifterlms' ) );
+		$path = wp_parse_url( home_url( $wp->request ), PHP_URL_PATH );
+		if ( $wp_query->is_404() && 0 === strpos( $path, $old ) ) {
+			$slug     = str_replace( $old, '', $path );
 			$new_post = get_page_by_path( $slug, 'OBJECT', 'llms_my_certificate' );
 			if ( $new_post ) {
 				llms_redirect_and_exit( get_permalink( $new_post->ID ) );

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -302,7 +302,7 @@ class LLMS_Query {
 
 		$url = home_url( $wp->request );
 		$old = sprintf( '/%s/', _x( 'my_certificate', 'slug', 'lifterlms' ) );
-		if ( $wp_query->is_404() && str_contains( $url, $old ) ) {
+		if ( $wp_query->is_404() && false !== strpos( $url, $old ) ) {
 
 			$slug     = str_replace( $old, '', wp_parse_url( $url, PHP_URL_PATH ) );
 			$new_post = get_page_by_path( $slug, 'OBJECT', 'llms_my_certificate' );

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -36,6 +36,7 @@ class LLMS_Query {
 	 *               so to avoid conflicts with the Divi theme whose callback runs at `10`,
 	 *               but since themes are loaded after plugins it overrode our one.
 	 * @since 4.5.0 Added action to serve 404s on unviewable certificates.
+	 * @since [version] Add callback to redirect old `llms_my_certificates` requests to the new url.
 	 */
 	public function __construct() {
 
@@ -46,6 +47,7 @@ class LLMS_Query {
 			add_filter( 'query_vars', array( $this, 'set_query_vars' ), 0 );
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'wp', array( $this, 'maybe_404_certificate' ), 50 );
+			add_action( 'wp', array( $this, 'maybe_redirect_certificate' ), 50 );
 
 		}
 
@@ -276,6 +278,38 @@ class LLMS_Query {
 				nocache_headers();
 
 			}
+		}
+
+	}
+
+	/**
+	 * Redirect requests to old llms_my_certificate URLs to the new url.
+	 *
+	 * Redirects `/my_certificate/slug` to `/certificate/slug` maintaining
+	 * translations.
+	 *
+	 * This will only redirect if `$wp_query` detects a 404 and a certificate
+	 * exists with the parsed slug. This check is important to prevent against
+	 * collisions which are theoretically possible, though probably unlikely.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function maybe_redirect_certificate() {
+
+		global $wp, $wp_query;
+
+		$url = home_url( $wp->request );
+		$old = sprintf( '/%s/', _x( 'my_certificate', 'slug', 'lifterlms' ) );
+		if ( $wp_query->is_404() && str_contains( $url, $old ) ) {
+
+			$slug     = str_replace( $old, '', wp_parse_url( $url, PHP_URL_PATH ) );
+			$new_post = get_page_by_path( $slug, 'OBJECT', 'llms_my_certificate' );
+			if ( $new_post ) {
+				llms_redirect_and_exit( get_permalink( $new_post->ID ) );
+			}
+
 		}
 
 	}

--- a/includes/class.llms.query.php
+++ b/includes/class.llms.query.php
@@ -309,7 +309,6 @@ class LLMS_Query {
 			if ( $new_post ) {
 				llms_redirect_and_exit( get_permalink( $new_post->ID ) );
 			}
-
 		}
 
 	}


### PR DESCRIPTION
## Description

Based on @eri-trabiccolo's proposed solution here: https://github.com/gocodebox/lifterlms/pull/1771#issuecomment-966107495

Instead of storing an option and putting a lifespan on the redirect I've opted to handle requests to the old URL and redirect them. If we store an option based on whether or not any shared certificates exist we run into an issue where bookmarks *might exist* for users that aren't sharing them (but have them saved somewhere for their own private purposes). 

This just performs a pretty safe redirect when a 404 is encountered, the URL contains `/my_certificate/` (or the equivalent transation), and an earned certificate exists for the slug (parsed from the url).

This should just do the job. In the scenario where someone has changed the slug via a filter this *will not work* but in that scenario we wouldn't want it to anyway since it's already been customized.

## How has this been tested?

+ Manually 
+ New PHPUnit tests

## Screenshots <!-- if applicable -->

## Types of changes
+ New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

