### PR TITLE
Create llms_my_certificates with a non-numeric unique post slug

### DIFF
--- a/.changelogs/certificate-non-numeric-slug.yml
+++ b/.changelogs/certificate-non-numeric-slug.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: The `post_name` of earned certificate posts will be generated with a
+  randomized 3+ character string in favor of relying on sequential numbers.

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -210,12 +210,15 @@ class LLMS_Engagement_Handler {
 	 */
 	private static function create( $type, $user_id, $template_id, $related_id = '', $engagement_id = null ) {
 
+		$title = get_post_meta( $template_id, "_llms_{$type}_title", true );
+
 		// Setup args, ultimately passed to `wp_insert_post()`.
 		$post_args = array(
 			'post_title'   => get_post_meta( $template_id, "_llms_{$type}_title", true ),
 			'post_content' => self::get_unmerged_template_content( $template_id, $type ),
 			'post_status'  => 'publish',
 			'post_author'  => $user_id,
+			'post_name'    => llms()->certificates()->get_unique_slug( $title ),
 			'meta_input'   => array(
 				'_thumbnail_id'          => self::get_image_id( $type, $template_id ),
 				"_llms_{$type}_template" => $template_id,

--- a/includes/class.llms.certificates.php
+++ b/includes/class.llms.certificates.php
@@ -318,6 +318,47 @@ class LLMS_Certificates {
 	}
 
 	/**
+	 * Create a unique slug for earned certificates.
+	 *
+	 * When relying only on `wp_unique_post_slug()`, predictable URLs are created for earned certificates,
+	 * such as "certificate-of-completion-1", "certificate-of-completion-2", etc... this method creates
+	 * an obtuse and randomized suffix and appends it to the post slug.
+	 *
+	 * The unique suffix will be a randomized string at least 3 characters long and made up of lowercase letters and numbers.
+	 *
+	 * When ensuring uniqueness of the generated suffix, the length of the string will be increased by one for every 5
+	 * encountered collisions.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $title The title of the certificate being created.
+	 * @return string
+	 */
+	public function get_unique_slug( $title ) {
+
+		$title = sanitize_title( $title ) . '-';
+
+		/**
+		 * Filters the minimum length of the suffix used to create a unique earned certificate slug.
+		 *
+		 * @since [version]
+		 *
+		 * @param int $min_strlen The minimum desired suffix string length.
+		 */
+		$min_strlen = apply_filters( 'llms_certificate_unique_slug_suffix_min_length', 3 );
+
+		$i = 0;
+		do {
+			$length = $min_strlen + floor( $i / 5 );
+			$slug   = $title . strtolower( wp_generate_password( absint( $length ), false ) );
+			$i++;
+		} while ( wp_unique_post_slug( $slug, 0, 'publish', 'llms_my_certificate', 0 ) !== $slug );
+
+		return $slug;
+
+	}
+
+	/**
 	 * Modify the HTML using DOMDocument.
 	 *
 	 * Preparations include:

--- a/tests/phpunit/unit-tests/class-llms-test-certificates.php
+++ b/tests/phpunit/unit-tests/class-llms-test-certificates.php
@@ -192,7 +192,7 @@ class LLMS_Test_Certificates extends LLMS_UnitTestCase {
 		$this->assertEquals( 11, strlen( $post->post_name ) );
 		$this->assertEquals( 'a-title-aaa', $post->post_name );
 
-		// This request will result find '-aaa' as a collision and then try 4 more times and then increase to 4 characters.s
+		// This request will result find '-aaa' as a collision and then try 4 more times and then increase to 4 characters.
 		$this->assertEquals( 12, strlen( llms()->certificates()->get_unique_slug( 'A Title' ) ) );
 
 	}


### PR DESCRIPTION
## Description

Solves part 2 of https://github.com/gocodebox/lifterlms/pull/1771#issuecomment-965878426

Adds a function that generates a 3+ lowercase + numeric suffix to append to post slugs (in favor of `-1`, `-2`, etc...)

 For a certificate with the title of "Certificate of Completion" the generated slug might look like this:

 `certificate-of-completion-a3x` 
 `certificate-of-completion-10p`
 `certificate-of-completion-pya` 
etc... 

This only applies when a `llms_my_certificate` is awarded via an engagement trigger. If the certificate is created manually on the admin panel (or an existing certificate is edited) this will *not* run. The idea here is that the admin awarding the certificate manually should choose a unique slug (should they desire one) and then when updating a slug it should already be unique and if an admin chooses to change it that's on them.

`wp_unique_post_slug()` will still do it's thing, which could result in a slug like:  `certificate-of-completion-a3x-1` if the slug was updated manually to be a randomly generated slug that already exists.

The function will automatically increase the length of the random string as collisions are encountered while generating a string. 

There's a filter to customize the minimum length of the string. A very large site could conceivably run out of unique 3 digit strings and wish to speed things up (reduce DB queries found in wp_unique_post_slug()) by increasing the minimum length by reducing collisions.

Also there are 46,656 permutations of the dictionary when using 3 characters, 1,679,616 permutations when using 4. I think the default of 3 is good but I could be convinced to increase it to 4.

## How has this been tested?

+ Manually
+ New unit tests


## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

