### PR TITLE
Syncing awarded certificates with their templates

### DIFF
--- a/assets/scss/admin.scss
+++ b/assets/scss/admin.scss
@@ -69,7 +69,7 @@
 @import "admin/metaboxes/llms-metabox";
 @import "admin/metaboxes/metabox-instructors";
 @import "admin/metaboxes/metabox-orders";
-@import "admin/metaboxes/metabox-award-engagement";
+@import "admin/metaboxes/metabox-engagements-type";
 @import "admin/metaboxes/metabox-product";
 @import "admin/metaboxes/metabox-students";
 @import "admin/metaboxes/metabox-field-repeater";

--- a/assets/scss/admin/metaboxes/_metabox-award-engagement.scss
+++ b/assets/scss/admin/metaboxes/_metabox-award-engagement.scss
@@ -1,4 +1,9 @@
 .llms-award-engagement-submitbox .llms-mb-list {
+	margin-bottom: 12px;
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+	&.sync-action,
 	&.student-info,
 	&.post_author_override label {
 		&:before {
@@ -11,7 +16,6 @@
 			vertical-align: top;
 			-webkit-font-smoothing: antialiased;
 			-moz-osx-font-smoothing: grayscale;
-			content: "\f110";
 			position: relative;
 			top: -1px;
 			color: #8c8f94;
@@ -19,6 +23,15 @@
 				color: currentColor; // Used when selecting a different admin color scheme from the default one.
 			}
 		}
+	}
+	&.student-info,
+	&.post_author_override label {
+		&:before {
+			content: '\f110';
+		}
+	}
+	&.sync-action:before {
+		content: '\f113'
 	}
 	&.post_author_override label {
 		display: inline-block;

--- a/assets/scss/admin/metaboxes/_metabox-engagements-type.scss
+++ b/assets/scss/admin/metaboxes/_metabox-engagements-type.scss
@@ -1,3 +1,4 @@
+.submitbox .llms-mb-section,
 .llms-award-engagement-submitbox .llms-mb-list {
 	margin-bottom: 12px;
 	&:last-of-type {

--- a/includes/admin/post-types/class.llms.meta.boxes.php
+++ b/includes/admin/post-types/class.llms.meta.boxes.php
@@ -202,15 +202,15 @@ class LLMS_Admin_Meta_Boxes {
 		}
 
 		$awarded_certificates_number = ( new LLMS_Awards_Query(
-			'certificates',
 			array(
-				'fields'         => 'ids',
-				'templates'      => $post->ID,
-				'posts_per_page' => 1,
-				'post_status'    => array(
+				'fields'    => 'ids',
+				'templates' => $post->ID,
+				'per_page'  => 1,
+				'status'    => array(
 					'publish',
 					'future',
 				),
+				'type'      => 'certificate',
 			)
 		) )->get_found_results();
 

--- a/includes/admin/post-types/class.llms.meta.boxes.php
+++ b/includes/admin/post-types/class.llms.meta.boxes.php
@@ -34,7 +34,7 @@ class LLMS_Admin_Meta_Boxes {
 	 * @since 1.0.0
 	 * @since 3.16.0 Unknown.
 	 * @since [version] Instantiate award engagement submit meta box.
-	 *
+	 *                  Add link to the certificate template submit box to sync awarded certificates.
 	 * @return void
 	 */
 	public function __construct() {
@@ -92,6 +92,7 @@ class LLMS_Admin_Meta_Boxes {
 		add_action( 'save_post', array( $this, 'save_meta_boxes' ), 10, 2 );
 
 		add_action( 'lifterlms_process_llms_voucher_meta', 'LLMS_Meta_Box_Voucher_Export::export', 10, 2 );
+		add_action( 'post_submitbox_misc_actions', array( $this, 'sync_awarded_certificates_action' ) );
 
 		// Error handling.
 		add_action( 'admin_notices', array( $this, 'display_errors' ) );
@@ -183,6 +184,67 @@ class LLMS_Admin_Meta_Boxes {
 		// Remove some defaults from the course.
 		remove_meta_box( 'postexcerpt', 'course', 'normal' );
 		remove_meta_box( 'tagsdiv-course_difficulty', 'course', 'side' );
+
+	}
+
+	/**
+	 * Sync awarded certificates action.
+	 *
+	 * @since [version]
+	 *
+	 * @param WP_Post $post The WP_Post instance of the certificate template.
+	 * @return void
+	 */
+	public function sync_awarded_certificates_action( $post ) {
+
+		if ( 'llms_certificate' !== $post->post_type ) {
+			return;
+		}
+
+		$number_awarded_certificates = 2;
+		/*
+		$number_awarded_certificates = ( new LLMS_Awards_Query(
+				'certificates',
+				array(
+					'templates'     => array( $post->ID ),
+					'no_found_rows' => true,
+					'per_page'      => -1,
+				)
+			) )->get_number_results();
+		*/
+
+		if ( ! $number_awarded_certificates ) {
+			return;
+		}
+
+		$base_url = remove_query_arg( 'action' ); // Current url without 'action' arg.
+		$sync_url = add_query_arg(
+			'action',
+			'sync_awarded_certificates',
+			wp_nonce_url( $base_url, 'llms-cert-sync-actions', '_llms_cert_sync_actions_nonce' )
+		);
+
+		// Translators: %1$d = Number of awarded certificates.
+		$sync_alert = sprintf(
+			__( 'This action will replace the current title, content, and the background of %1$d awarded certificates with the ones of this template.\nAre you sure you want to proceed?', 'lifterlms' ),
+			$number_awarded_certificates
+		);
+		$on_click   = "return confirm('${sync_alert}')";
+
+		printf(
+			'<div class="llms-mb-section misc-pub-section sync-action"> %1$s</div>',
+			// Translators: %1$s = Opening anchor tag, %2$d = Closing anchor tag, %3$d = Number of awarded certificates.
+			sprintf(
+				__( '%1$sSync%2$s %3$d awarded certificates', 'lifterlms' ),
+				sprintf(
+					'<a href="%1$s" onclick="%2$s">',
+					$sync_url,
+					$on_click
+				),
+				'</a>',
+				$number_awarded_certificates
+			)
+		);
 
 	}
 

--- a/includes/admin/post-types/class.llms.meta.boxes.php
+++ b/includes/admin/post-types/class.llms.meta.boxes.php
@@ -201,19 +201,20 @@ class LLMS_Admin_Meta_Boxes {
 			return;
 		}
 
-		$number_awarded_certificates = 2;
-		/*
-		$number_awarded_certificates = ( new LLMS_Awards_Query(
-				'certificates',
-				array(
-					'templates'     => array( $post->ID ),
-					'no_found_rows' => true,
-					'per_page'      => -1,
-				)
-			) )->get_number_results();
-		*/
+		$awarded_certificates_number = ( new LLMS_Awards_Query(
+			'certificates',
+			array(
+				'fields'         => 'ids',
+				'templates'      => $post->ID,
+				'posts_per_page' => 1,
+				'post_status'    => array(
+					'publish',
+					'future',
+				),
+			)
+		) )->get_found_results();
 
-		if ( ! $number_awarded_certificates ) {
+		if ( ! $awarded_certificates_number ) {
 			return;
 		}
 
@@ -227,7 +228,7 @@ class LLMS_Admin_Meta_Boxes {
 		// Translators: %1$d = Number of awarded certificates.
 		$sync_alert = sprintf(
 			__( 'This action will replace the current title, content, and the background of %1$d awarded certificates with the ones of this template.\nAre you sure you want to proceed?', 'lifterlms' ),
-			$number_awarded_certificates
+			$awarded_certificates_number
 		);
 		$on_click   = "return confirm('${sync_alert}')";
 
@@ -242,7 +243,7 @@ class LLMS_Admin_Meta_Boxes {
 					$on_click
 				),
 				'</a>',
-				$number_awarded_certificates
+				$awarded_certificates_number
 			)
 		);
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
@@ -60,7 +60,9 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 		$this->priority = 'high';
 
 		// Remove wp core post submit meta box.
-		remove_meta_box( 'submitdiv', $this->screens, 'side' );
+		if ( function_exists( 'remove_meta_box' ) ) { // When this class is instantiated at `wp` to show an error message, the message `remove_meta_box()` is not available.
+			remove_meta_box( 'submitdiv', $this->screens, 'side' );
+		}
 
 		add_filter( 'wp_redirect', array( $this, 'redirect_on_deletion' ) );
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
@@ -237,7 +237,7 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 			'sync_awarded_certificate',
 			wp_nonce_url( $base_url, 'llms-cert-sync-actions', '_llms_cert_sync_actions_nonce' )
 		);
-		$sync_alert = __( 'This action will replace the current title, content, and the background image with the template ones.\nAre you sure you want to preceed?', 'lifterlms' );
+		$sync_alert = __( 'This action will replace the current title, content, and the background image with the template ones.\nAre you sure you want to proceed?', 'lifterlms' );
 		$on_click   = "return confirm('${sync_alert}')";
 
 		return sprintf(

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
@@ -117,6 +117,7 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 		}
 
 		$fields .= $this->student_information();
+		$fields .= $this->sync_action();
 
 		return $fields;
 
@@ -214,6 +215,50 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 	}
 
 	/**
+	 * Sync action links html.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private function sync_action() {
+
+		if ( 'llms_my_certificate' !== get_post_type( $this->post->ID ) ) {
+			return;
+		}
+
+		$certificate_model = new $this->post_types['llms_my_certificate']['model']( $this->post->ID );
+		$template_id       = $certificate_model->get( 'certificate_template' );
+		$check             = LLMS_Engagement_Handler::check_post( $template_id, 'llms_certificate' );
+		if ( is_wp_error( $check ) ) {
+			return;
+		}
+
+		$base_url   = remove_query_arg( 'action' ); // Current url without 'action' arg.
+		$sync_url   = add_query_arg(
+			'action',
+			'sync_awarded_certificate',
+			wp_nonce_url( $base_url, 'llms-cert-sync-actions', '_llms_cert_sync_actions_nonce' )
+		);
+		$sync_alert = __( 'This action will replace the current title, content, and the background image with the template ones.\nAre you sure you want to preceed?', 'lifterlms' );
+		$on_click   = "return confirm('${sync_alert}')";
+
+		return sprintf(
+			'<li class="llms-mb-list sync-action"> <a href="%1$s" onclick="%2$s">%3$s</a> %4$s</li>',
+			$sync_url,
+			$on_click,
+			__( 'Sync', 'lifterlms' ),
+			sprintf(
+				// Tanslators: %1$s = Edit link to certificate template.
+				__( 'with its %1$stemplate%2$s', 'lifterlms' ),
+				'<a href="' . get_edit_post_link( $template_id ) . '" target="_blank">',
+				'</a>'
+			)
+		);
+
+	}
+
+	/**
 	 * Redirect on permanet deletion from the editor.
 	 *
 	 * @since [version]
@@ -304,7 +349,7 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 <script>
 	document.addEventListener("DOMContentLoaded", function(event) {
 		(function(){
-
+			// Localization.
 			const __ = window.wp.i18n.__;
 			const _i18n = {
 				'Publish on:': __( 'Award on:', 'lifterlms' ),
@@ -319,7 +364,6 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 					return text in _i18n ? _i18n[text] : translation;
 				}
 			);
-
 		})();
 	});
 </script>

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.award.engagement.submit.php
@@ -53,16 +53,11 @@ class LLMS_Meta_Box_Award_Engagement_Submit extends LLMS_Admin_Metabox {
 	 */
 	public function configure() {
 
-		$this->id       = 'submitdiv';
+		$this->id       = 'submitdiv'; // Overrides the WordPress core one.
 		$this->title    = __( 'Award', 'lifterlms' );
 		$this->screens  = array_keys( $this->post_types );
 		$this->context  = 'side';
 		$this->priority = 'high';
-
-		// Remove wp core post submit meta box.
-		if ( function_exists( 'remove_meta_box' ) ) { // When this class is instantiated at `wp` to show an error message, the message `remove_meta_box()` is not available.
-			remove_meta_box( 'submitdiv', $this->screens, 'side' );
-		}
 
 		add_filter( 'wp_redirect', array( $this, 'redirect_on_deletion' ) );
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.certificate.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Certificates meta box
+ * Certificates meta box.
  *
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Certificate template meta box class
+ * Certificate template meta box class.
  *
  * @since 1.0.0
  * @since 3.37.12 Allow the certificate title field to store text with quotes.

--- a/includes/admin/views/metaboxes/view-award-engagement-submit.php
+++ b/includes/admin/views/metaboxes/view-award-engagement-submit.php
@@ -9,11 +9,11 @@
  * @since [version]
  * @version [version]
  *
- * @property WP_Post $engagement     WP_Post instance of the engagement.
- * @property int     $engagement_id  WP_Post ID of the engagement.
- * @property string  $action         The action being performed.
- * @property bool    $can_publish    Whether the current user can publish the engagement.
- * @property string  $fields         Meta box fields such as student information ones.
+ * @property WP_Post $engagement    WP_Post instance of the engagement.
+ * @property int     $engagement_id WP_Post ID of the engagement.
+ * @property string  $action        The action being performed.
+ * @property bool    $can_publish   Whether the current user can publish the engagement.
+ * @property string  $fields        Meta box fields such as student information ones.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -453,7 +453,7 @@ class LLMS_Engagement_Handler {
 	 * @param int    $template_id WP_Post ID of the template post.
 	 * @return int WP_Post ID of the attachment or `0` when none found.
 	 */
-	private static function get_image_id( $type, $template_id ) {
+	public static function get_image_id( $type, $template_id ) {
 
 		$img_id = get_post_meta( $template_id, '_thumbnail_id', true );
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -197,18 +197,19 @@ class LLMS_Controller_Certificates {
 	 *
 	 * @since [version]
 	 *
-	 * @param int $cert_id Certificate template id.
+	 * @param int $certificate_template_id Certificate template id.
 	 * @return void
 	 */
-	private function sync_awarded_certificates( $cert_id ) {
+	private function sync_awarded_certificates( $certificate_template_id ) {
 
 		if ( ! current_user_can( get_post_type_object( 'llms_my_certificate' )->cap->edit_posts ) ) {
 			return;
 		}
 
-		$redirect_url = get_edit_post_link( $cert_id, 'raw' );
+		// Trigger background sync.
+		do_action( 'llms_do_awarded_certificates_bulk_sync', $certificate_template_id );
 
-		// TODO sync.
+		$redirect_url = get_edit_post_link( $certificate_template_id, 'raw' );
 		wp_safe_redirect( $redirect_url );
 		exit;
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -153,8 +153,17 @@ class LLMS_Controller_Certificates {
 		}
 
 		if ( 'sync_awarded_certificate' === $_GET['action'] ) {
-			( new LLMS_User_Certificate( $cert_id ) )->sync();
-			wp_safe_redirect( get_edit_post_link( $cert_id, 'raw' ) );
+			$sync = ( new LLMS_User_Certificate( $cert_id ) )->sync();
+
+			$redirect_url = get_edit_post_link( $cert_id, 'raw' );
+
+			if ( is_wp_error( $sync ) ) {
+				( new LLMS_Meta_Box_Award_Engagement_Submit() )->add_error( $sync->get_error_message() );
+			} else {
+				$redirect_url = add_query_arg( 'message', 1, $redirect_url );
+			}
+
+			wp_safe_redirect( $redirect_url );
 			exit;
 		}
 

--- a/includes/controllers/class.llms.controller.certificates.php
+++ b/includes/controllers/class.llms.controller.certificates.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Controller_Certificates {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @since 3.18.0
 	 * @since 3.37.4 Add filter hook for `lifterlms_register_post_type_llms_certificate`.
@@ -148,24 +148,69 @@ class LLMS_Controller_Certificates {
 
 		$cert_id = llms_filter_input( INPUT_GET, 'post', FILTER_SANITIZE_NUMBER_INT );
 
-		if ( empty( $cert_id ) || ! current_user_can( get_post_type_object( 'llms_my_certificate' )->cap->edit_post, $cert_id ) ) {
+		if ( empty( $cert_id ) ) {
 			return;
 		}
 
-		if ( 'sync_awarded_certificate' === $_GET['action'] ) {
-			$sync = ( new LLMS_User_Certificate( $cert_id ) )->sync();
-
-			$redirect_url = get_edit_post_link( $cert_id, 'raw' );
-
-			if ( is_wp_error( $sync ) ) {
-				( new LLMS_Meta_Box_Award_Engagement_Submit() )->add_error( $sync->get_error_message() );
-			} else {
-				$redirect_url = add_query_arg( 'message', 1, $redirect_url );
-			}
-
-			wp_safe_redirect( $redirect_url );
-			exit;
+		switch ( $_GET['action'] ) {
+			case 'sync_awarded_certificate':
+				$this->sync_awarded_certificate( $cert_id );
+				break;
+			case 'sync_awarded_certificates':
+				$this->sync_awarded_certificates( $cert_id );
+				break;
 		}
+
+	}
+
+	/**
+	 * Sync awarded certificate with its template.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $cert_id Awarded certificate id.
+	 * @return void
+	 */
+	private function sync_awarded_certificate( $cert_id ) {
+
+		if ( ! current_user_can( get_post_type_object( 'llms_my_certificate' )->cap->edit_post, $cert_id ) ) {
+			return;
+		}
+
+		$sync = ( new LLMS_User_Certificate( $cert_id ) )->sync();
+
+		$redirect_url = get_edit_post_link( $cert_id, 'raw' );
+
+		if ( is_wp_error( $sync ) ) {
+			( new LLMS_Meta_Box_Award_Engagement_Submit() )->add_error( $sync->get_error_message() );
+		} else {
+			$redirect_url = add_query_arg( 'message', 1, $redirect_url );
+		}
+
+		wp_safe_redirect( $redirect_url );
+		exit;
+
+	}
+
+	/**
+	 * Sync all the awarded certificates with their template.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $cert_id Certificate template id.
+	 * @return void
+	 */
+	private function sync_awarded_certificates( $cert_id ) {
+
+		if ( ! current_user_can( get_post_type_object( 'llms_my_certificate' )->cap->edit_posts ) ) {
+			return;
+		}
+
+		$redirect_url = get_edit_post_link( $cert_id, 'raw' );
+
+		// TODO sync.
+		wp_safe_redirect( $redirect_url );
+		exit;
 
 	}
 

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -406,8 +406,9 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 
 		$template = get_post( $template_id );
 
-		$this->set( 'title', $template->post_title );
+		$this->set( 'title', get_post_meta( $template_id, '_llms_certificate_title', true ) );
 		$this->set( 'content', $template->post_content );
+		update_post_meta( $this->get( 'id' ), '_thumbnail_id', LLMS_Engagement_Handler::get_image_id( 'certificate', $template_id ) );
 
 		// Save the fully merged content.
 		$this->set( 'content', $this->merge_content() );

--- a/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
+++ b/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
@@ -139,14 +139,16 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 				)
 			);
 
+			$this->clear_notices( $certificate_template_id );
+
 			LLMS_Admin_Notices::add_notice(
 				sprintf( 'awarded-certificates-sync-%1$d-started', $certificate_template_id ),
 				sprintf(
 					// Translators: %1$s Anchor opening tag linking to the certificate template, %2$s Certificate Template name, %3$d Certificate Template ID, %4s Anchor closing tag.
-					__( 'Awarded certificates sync sheduled for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
-					sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $args['query_args']['templates'] ) ),
-					get_the_title( $args['query_args']['templates'] ),
-					$args['query_args']['templates'],
+					__( 'Awarded certificates sync scheduled for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
+					sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $certificate_template_id ) ),
+					get_the_title( $certificate_template_id ),
+					$certificate_template_id,
 					'</a>'
 				),
 				array(
@@ -223,6 +225,25 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 				);
 			}
 		}
+
+	}
+
+	/**
+	 * Clear notices.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $certificate_template_id WP Post ID of the certificate template.
+	 * @return void
+	 */
+	private function clear_notices( $certificate_template_id ) {
+
+		LLMS_Admin_Notices::delete_notice(
+			sprintf( 'awarded-certificates-sync-%1$d-started', $certificate_template_id )
+		);
+		LLMS_Admin_Notices::delete_notice(
+			sprintf( 'awarded-certificates-sync-%1$d-done', $certificate_template_id )
+		);
 
 	}
 

--- a/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
+++ b/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
@@ -142,10 +142,11 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 			LLMS_Admin_Notices::add_notice(
 				sprintf( 'awarded-certificates-sync-%1$d-started', $certificate_template_id ),
 				sprintf(
-					// Translators: %1$s Certificate Template name, %2$d Certificate Template ID.
-					__( 'Awarded certificates sync scheduled for the template %1$s (#%2$d)', 'lifterlms' ),
-					get_the_title( $certificate_template_id ),
-					$certificate_template_id,
+					// Translators: %1$s Anchor opening tag linking to the certificate template, %2$s Certificate Template name, %3$d Certificate Template ID, %4s Anchor closing tag.
+					__( 'Awarded certificates sync sheduled for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
+					sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $args['query_args']['templates'] ) ),
+					get_the_title( $args['query_args']['templates'] ),
+					$args['query_args']['templates'],
 					'</a>'
 				),
 				array(
@@ -241,6 +242,10 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 				get_the_title( $args['query_args']['templates'] ),
 				$args['query_args']['templates']
 			)
+		);
+
+		LLMS_Admin_Notices::delete_notice(
+			sprintf( 'awarded-certificates-sync-%1$d-started', $args['query_args']['templates'] )
 		);
 
 		LLMS_Admin_Notices::add_notice(

--- a/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
+++ b/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
@@ -53,22 +53,23 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 		$this->cancel_process();
 
 		$args = array(
-			'templates'      => $certificate_template_id,
-			'posts_per_page' => 20,
-			'page'           => 1,
-			'post_status'    => array(
+			'templates' => $certificate_template_id,
+			'per_page'  => 20,
+			'page'      => 1,
+			'status'    => array(
 				'publish',
 				'future',
 			),
+			'type'      => 'certificate',
 		);
 
-		$query = new LLMS_Awards_Query( 'certificates', $args );
+		$query = new LLMS_Awards_Query( $args );
 
 		if ( ! $query->get_found_results() ) {
 			return;
 		}
 
-		while ( $args['page'] <= $query->get_total_pages() ) {
+		while ( $args['page'] <= $query->get_max_pages() ) {
 			$this->push_to_queue(
 				array(
 					'query_args' => $args,
@@ -145,7 +146,7 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 				sprintf( 'awarded-certificates-sync-%1$d-started', $certificate_template_id ),
 				sprintf(
 					// Translators: %1$s Anchor opening tag linking to the certificate template, %2$s Certificate Template name, %3$d Certificate Template ID, %4s Anchor closing tag.
-					__( 'Awarded certificates sync scheduled for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
+					__( 'Awarded certificates sync scheduled for the template %1$s%2$s (#%3$d)%4$s.', 'lifterlms' ),
 					sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $certificate_template_id ) ),
 					get_the_title( $certificate_template_id ),
 					$certificate_template_id,
@@ -186,10 +187,10 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 			return false;
 		}
 
-		$query = new LLMS_Awards_Query( 'certificates', $args['query_args'] );
+		$query = new LLMS_Awards_Query( $args['query_args'] );
 
 		if ( $query->has_results() ) {
-			$this->sync_awarded_certificates( $query->get_results(), $args['query_args']['templates'] );
+			$this->sync_awarded_certificates( $query->get_awards(), $args['query_args']['templates'] );
 		}
 
 		if ( $query->is_last_page() ) {
@@ -273,7 +274,7 @@ class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Proces
 			sprintf( 'awarded-certificates-sync-%1$d-done', $args['query_args']['templates'] ),
 			sprintf(
 				// Translators: %1$s Anchor opening tag linking to the certificate template, %2$s Certificate Template name, %3$d Certificate Template ID, %4s Anchor closing tag.
-				__( 'Awarded certificates sync completed for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
+				__( 'Awarded certificates sync completed for the template %1$s%2$s (#%3$d)%4$s.', 'lifterlms' ),
 				sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $args['query_args']['templates'] ) ),
 				get_the_title( $args['query_args']['templates'] ),
 				$args['query_args']['templates'],

--- a/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
+++ b/includes/processors/class.llms.processor.awarded.certificates.bulk.sync.php
@@ -1,0 +1,266 @@
+<?php
+/**
+ * Processor: Awarded Certificates Bulk Sync.
+ *
+ * @package LifterLMS/Processors/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Processor_Awarded_Certificates_Bulk_Sync class.
+ *
+ * @since [version]
+ */
+class LLMS_Processor_Awarded_Certificates_Bulk_Sync extends LLMS_Abstract_Processor {
+
+	/**
+	 * Unique identifier for the processor.
+	 *
+	 * @var string
+	 */
+	protected $id = 'awarded_certificates_bulk_sync';
+
+	/**
+	 * WP Cron Hook for scheduling the bg process.
+	 *
+	 * @var string
+	 */
+	private $schedule_hook = 'llms_awarded_certificates_bulk_sync';
+
+	/**
+	 * Action triggered to sync all the awarded certificate sthat need to be updated.
+	 *
+	 * @since [version]
+	 *
+	 * @param int certificate_template_id WP Post ID of the certificate template.
+	 * @return void
+	 */
+	public function dispatch_sync( $certificate_template_id ) {
+
+		$this->log(
+			sprintf(
+				'awarded certificates bulk sync dispatched for the certificate template %1$s (#%2$d)',
+				get_the_title( $certificate_template_id ),
+				$certificate_template_id
+			)
+		);
+
+		// Cancel process in case it's currently running.
+		$this->cancel_process();
+
+		$args = array(
+			'templates'      => $certificate_template_id,
+			'posts_per_page' => 20,
+			'page'           => 1,
+			'post_status'    => array(
+				'publish',
+				'future',
+			),
+		);
+
+		$query = new LLMS_Awards_Query( 'certificates', $args );
+
+		if ( ! $query->get_found_results() ) {
+			return;
+		}
+
+		while ( $args['page'] <= $query->get_total_pages() ) {
+			$this->push_to_queue(
+				array(
+					'query_args' => $args,
+				)
+			);
+
+			$args['page']++;
+		}
+
+		// Save queue and dispatch the process.
+		$this->save()->dispatch();
+
+	}
+
+	/**
+	 * Initializer.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function init() {
+
+		// For the cron.
+		add_action( $this->schedule_hook, array( $this, 'dispatch_sync' ), 10, 2 );
+
+		// For LifterLMS actions which trigger bulk enrollment.
+		$this->actions = array(
+			'llms_do_awarded_certificates_bulk_sync' => array(
+				'arguments' => 1,
+				'callback'  => 'schedule_sync',
+				'priority'  => 10,
+			),
+		);
+
+	}
+
+	/**
+	 * Schedule sync.
+	 *
+	 * This will schedule an event that will setup the queue of items for the background process.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $certificate_template_id WP Post ID of the certificate template.
+	 * @return void
+	 */
+	public function schedule_sync( $certificate_template_id ) {
+
+		$this->log(
+			sprintf(
+				'awarded certificates bulk sync for the certificate template %1$s (#%2$d)',
+				get_the_title( $certificate_template_id ),
+				$certificate_template_id
+			)
+		);
+
+		$args = array( $certificate_template_id );
+
+		if ( ! wp_next_scheduled( $this->schedule_hook, $args ) ) {
+
+			wp_schedule_single_event( time(), $this->schedule_hook, $args );
+			$this->log(
+				sprintf(
+					'awarded certificates bulk sync scheduled for the certificate template %1$s (#%2$d)',
+					get_the_title( $certificate_template_id ),
+					$certificate_template_id
+				)
+			);
+
+			LLMS_Admin_Notices::add_notice(
+				sprintf( 'awarded-certificates-sync-%1$d-started', $certificate_template_id ),
+				sprintf(
+					// Translators: %1$s Certificate Template name, %2$d Certificate Template ID.
+					__( 'Awarded certificates sync scheduled for the template %1$s (#%2$d)', 'lifterlms' ),
+					get_the_title( $certificate_template_id ),
+					$certificate_template_id,
+					'</a>'
+				),
+				array(
+					'dismissible'      => true,
+					'dismiss_for_days' => 0,
+				)
+			);
+
+		}
+
+	}
+
+	/**
+	 * Execute calculation for each item in the queue until all awarded certificates are synced.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of processing data.
+	 * @return boolean `true` to keep the item in the queue and process again.
+	 *                 `false` to remove the item from the queue.
+	 */
+	public function task( $args ) {
+
+		$this->log(
+			sprintf(
+				'awarded certificates bulk sync task started for the certificate template %1$s (#%2$d) - chunk %3$d',
+				get_the_title( $args['query_args']['templates'] ),
+				$args['query_args']['templates'],
+				$args['query_args']['page']
+			)
+		);
+
+		// Ensure the item has all the data we need to process it.
+		if ( empty( $args['query_args']['templates'] ) ) {
+			return false;
+		}
+
+		$query = new LLMS_Awards_Query( 'certificates', $args['query_args'] );
+
+		if ( $query->has_results() ) {
+			$this->sync_awarded_certificates( $query->get_results(), $args['query_args']['templates'] );
+		}
+
+		if ( $query->is_last_page() ) {
+			$this->process_completed( $args );
+		}
+
+		return false;
+
+	}
+
+	/**
+	 * Sync awarded certificates.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_User_Certificate[] $certificates Array of awarded certificates to sync.
+	 * @param int                     $template_id  Certificate template ID.
+	 * @return void
+	 */
+	private function sync_awarded_certificates( $certificates, $template_id ) {
+
+		foreach ( $certificates as $awarded_certificate ) {
+			$sync = $awarded_certificate->sync();
+			if ( is_wp_error( $sync ) ) {
+				$this->log(
+					sprintf(
+						'An error occurred while trying to sync awarded certificate %1$s (#%2$d) from template %3$s (#%4$d)',
+						$awarded_certificate->get( 'title' ),
+						$awarded_certificate->get( 'id' ),
+						get_the_title( $template_id ),
+						$template_id
+					)
+				);
+			}
+		}
+
+	}
+
+	/**
+	 * Perform actions when the process is completed.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of processing data.
+	 * @return void
+	 */
+	private function process_completed( $args ) {
+
+		$this->log(
+			sprintf(
+				'awarded certificate bulk sync completed for the certificate template %1$s (#%2$d)',
+				get_the_title( $args['query_args']['templates'] ),
+				$args['query_args']['templates']
+			)
+		);
+
+		LLMS_Admin_Notices::add_notice(
+			sprintf( 'awarded-certificates-sync-%1$d-done', $args['query_args']['templates'] ),
+			sprintf(
+				// Translators: %1$s Anchor opening tag linking to the certificate template, %2$s Certificate Template name, %3$d Certificate Template ID, %4s Anchor closing tag.
+				__( 'Awarded certificates sync completed for the template %1$s%2$s (#%3$d)%4$s', 'lifterlms' ),
+				sprintf( '<a href="%1$s" target="_blank">', get_edit_post_link( $args['query_args']['templates'] ) ),
+				get_the_title( $args['query_args']['templates'] ),
+				$args['query_args']['templates'],
+				'</a>'
+			),
+			array(
+				'dismissible'      => true,
+				'dismiss_for_days' => 0,
+			)
+		);
+
+	}
+
+}
+
+return new LLMS_Processor_Awarded_Certificates_Bulk_Sync();

--- a/includes/processors/class.llms.processors.php
+++ b/includes/processors/class.llms.processors.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Processors/Classes
  *
  * @since 3.15.0
- * @version 5.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,6 +19,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 5.0.0 Removed private method `includes()`.
  *              Stop loading removed processor "table_to_csv".
  * @since 5.3.0 Replace singleton code with `LLMS_Trait_Singleton`.
+ * @since [version] Added the awarded certificates bulk sync processor.
  */
 class LLMS_Processors {
 
@@ -34,6 +35,7 @@ class LLMS_Processors {
 	private $classes = array(
 		'course_data',
 		'membership_bulk_enroll',
+		'awarded_certificates_bulk_sync',
 	);
 
 	/**


### PR DESCRIPTION
## Description
Initial work on syncing awarded certificates with their templates

per https://github.com/gocodebox/lifterlms/pull/1771#issuecomment-966158070

## How has this been tested?
manually (for now) - unit tests about to come

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

