### PR TITLE
Declare minimum node version requirements

### DIFF
--- a/.github/workflows/packages-test-and-lint.yml
+++ b/.github/workflows/packages-test-and-lint.yml
@@ -77,7 +77,7 @@ jobs:
         # uses: artiomtr/jest-coverage-report-action@v2.0-rc.6
         uses: gocodebox/jest-coverage-report-action@master
         with:
-          github-token: ${{ secrets.ORG_WORKFLOWS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-step: install
           threshold: 50
           test-script: npm run pkg:test -- --coverageReporters="text" --coverageReporters="text-summary"

--- a/.github/workflows/packages-test-and-lint.yml
+++ b/.github/workflows/packages-test-and-lint.yml
@@ -77,7 +77,7 @@ jobs:
         # uses: artiomtr/jest-coverage-report-action@v2.0-rc.6
         uses: gocodebox/jest-coverage-report-action@master
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ORG_WORKFLOWS }}
           skip-step: install
           threshold: 50
           test-script: npm run pkg:test -- --coverageReporters="text" --coverageReporters="text-summary"

--- a/packages/dev/.npmrc
+++ b/packages/dev/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+engine-strict=true

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -26,6 +26,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=14.14.0"
+  },
   "dependencies": {
     "chalk": "^4.1.2",
     "columnify": "^1.5.4",

--- a/packages/dev/test/utils/get-project-privacy.test.js
+++ b/packages/dev/test/utils/get-project-privacy.test.js
@@ -33,7 +33,7 @@ describe( 'getProjectPrivacy', () => {
 	const testData = [
 		[ 'Should return "public" for public repos', 'lifterlms', 'public', true ],
 		[ 'Should return "private" for private repos', 'lifterlms-groups', 'private', false ],
-		[ 'Should return "unknown" for invalid repos', 'fake-repo', 'unknown' ],
+		[ 'Should return "unknown" for invalid repos', 'fake-repo', 'unknown', undefined ],
 	];
 	it.each( testData )( '%s', ( name, slug, expected, isPublic ) => {
 		mockedApiReturn = getMockApiReturn( isPublic );
@@ -57,9 +57,9 @@ describe( 'isProjectPublic', () => {
 
 describe( 'isProjectPrivate', () => {
 	const testData = [
-		[ 'Should return false for public repos', 'lifterlms', false, false ],
-		[ 'Should return true for private repos', 'lifterlms-groups', true, true ],
-		[ 'Should return undefined for invalid repos', 'fake-repo', undefined ],
+		[ 'Should return false for public repos', 'lifterlms', false, true ],
+		[ 'Should return true for private repos', 'lifterlms-groups', true, false ],
+		[ 'Should return undefined for invalid repos', 'fake-repo', undefined, undefined ],
 	];
 	it.each( testData )( '%s', ( name, slug, expected, isPublic ) => {
 		mockedApiReturn = getMockApiReturn( isPublic );

--- a/packages/dev/test/utils/get-project-privacy.test.js
+++ b/packages/dev/test/utils/get-project-privacy.test.js
@@ -1,19 +1,42 @@
 jest.mock( '../../src/utils/get-project-slug' );
 
-const getProjectSlug = require( '../../src/utils/get-project-slug' ),
+// eslint-disable-next-line camelcase
+const child_procces = require( 'child_process' ),
+	getProjectSlug = require( '../../src/utils/get-project-slug' ),
 	{ getProjectPrivacy, isProjectPublic, isProjectPrivate } = require( '../../src/utils/get-project-privacy' );
 
-let mockedSlug;
+// Mocked return values.
+let mockedSlug,
+	mockedApiReturn;
+
+jest.mock( 'child_process' );
+child_procces.execSync.mockImplementation( () => mockedApiReturn );
 
 getProjectSlug.mockImplementation( () => mockedSlug );
 
+/**
+ * Mock the API return retrieved by `gh api...`.
+ *
+ * @since [version]
+ *
+ * @param {boolean} isPublic Whether or not the repo is public. Pass `undefined` to for an "unknown" return.
+ * @return {string|Object} A JSON string or object to be parsed. Returning an object causes an error for the test unknown responses.
+ */
+function getMockApiReturn( isPublic ) {
+	if ( undefined === isPublic ) {
+		return {}; // Causes an error which is enough to get the proper return.
+	}
+	return JSON.stringify( { private: ! isPublic } );
+}
+
 describe( 'getProjectPrivacy', () => {
 	const testData = [
-		[ 'Should return "public" for public repos', 'lifterlms', 'public' ],
-		[ 'Should return "private" for private repos', 'lifterlms-groups', 'private' ],
+		[ 'Should return "public" for public repos', 'lifterlms', 'public', true ],
+		[ 'Should return "private" for private repos', 'lifterlms-groups', 'private', false ],
 		[ 'Should return "unknown" for invalid repos', 'fake-repo', 'unknown' ],
 	];
-	it.each( testData )( '%s', ( name, slug, expected ) => {
+	it.each( testData )( '%s', ( name, slug, expected, isPublic ) => {
+		mockedApiReturn = getMockApiReturn( isPublic );
 		mockedSlug = slug;
 		expect( getProjectPrivacy() ).toBe( expected );
 	} );
@@ -26,6 +49,7 @@ describe( 'isProjectPublic', () => {
 		[ 'Should return undefined for invalid repos', 'fake-repo', undefined ],
 	];
 	it.each( testData )( '%s', ( name, slug, expected ) => {
+		mockedApiReturn = getMockApiReturn( expected );
 		mockedSlug = slug;
 		expect( isProjectPublic() ).toBe( expected );
 	} );
@@ -33,11 +57,12 @@ describe( 'isProjectPublic', () => {
 
 describe( 'isProjectPrivate', () => {
 	const testData = [
-		[ 'Should return false for public repos', 'lifterlms', false ],
-		[ 'Should return true for private repos', 'lifterlms-groups', true ],
+		[ 'Should return false for public repos', 'lifterlms', false, false ],
+		[ 'Should return true for private repos', 'lifterlms-groups', true, true ],
 		[ 'Should return undefined for invalid repos', 'fake-repo', undefined ],
 	];
-	it.each( testData )( '%s', ( name, slug, expected ) => {
+	it.each( testData )( '%s', ( name, slug, expected, isPublic ) => {
+		mockedApiReturn = getMockApiReturn( isPublic );
 		mockedSlug = slug;
 		expect( isProjectPrivate() ).toBe( expected );
 	} );


### PR DESCRIPTION
## Description

Declare node version 14.14.0 as the minimum supported node version for the package.

`rmSync` is only available since this version (and it's used)

## How has this been tested?

+ Rocco told me it works on 14.14.0

## Screenshots <!-- if applicable -->

## Types of changes

+Bug fix

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

