### PR TITLE
Fix MySQL error when course has no lessons

### DIFF
--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -164,6 +164,14 @@ class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 
 		$lessons = implode( ',', $this->post->get_lessons( 'ids' ) );
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		// It is possible to create a course but not have any lessons yet. Return zero now
+		// instead of causing a MySQL error by leaving "post_id IN ( {$lessons} )"
+		// blank in the query.
+		if(empty($lessons)){
+			return 0;
+		}
+
 		return $wpdb->get_var(
 			$wpdb->prepare(
 				"


### PR DESCRIPTION
## Description
If a course does not have any lessons yet, the `get_lesson_completions` method would cause a MySQL error.  With this change, the method will return zero if no lessons exist.

## How has this been tested?
Tested on our production site.  The MySQL error no longer occurs and the course report overview shows "0" for lesson completions instead of nothing.

Because this change is so small and the simple, I have not created a test environment and run automated tests.

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

