### PR TITLE
Add feature: content protection

### DIFF
--- a/.changelogs/copy-prevent.yml
+++ b/.changelogs/copy-prevent.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: Added an option to prevent users (by role) from copying site content and
+  saving local copies of images.

--- a/includes/admin/settings/class.llms.settings.general.php
+++ b/includes/admin/settings/class.llms.settings.general.php
@@ -147,11 +147,11 @@ class LLMS_Settings_General extends LLMS_Settings_Page {
 		);
 
 		$settings[] = array(
-			'title'    => __( 'Content Protection', 'lifterlms' ),
-			'desc'     => __( 'Prevent users from copying website content and downloading images.', 'lifterlms' ) . '<br><span class="description">' . __( 'Users with Unrestricted Preview Access will not be affected by this setting.', 'lifterlms' ) . '</span>' ,
-			'id'       => 'lifterlms_content_protection',
-			'default'  => 'no',
-			'type'     => 'checkbox',
+			'title'   => __( 'Content Protection', 'lifterlms' ),
+			'desc'    => __( 'Prevent users from copying website content and downloading images.', 'lifterlms' ) . '<br><span class="description">' . __( 'Users with Unrestricted Preview Access will not be affected by this setting.', 'lifterlms' ) . '</span>',
+			'id'      => 'lifterlms_content_protection',
+			'default' => 'no',
+			'type'    => 'checkbox',
 		);
 
 		$settings[] = array(

--- a/includes/admin/settings/class.llms.settings.general.php
+++ b/includes/admin/settings/class.llms.settings.general.php
@@ -44,6 +44,7 @@ class LLMS_Settings_General extends LLMS_Settings_Page {
 	 * @since 1.0.0
 	 * @since 3.13.0 Unknown.
 	 * @since [version] use LLMS_Roles::get_all_role_names() to retrieve the list of roles who can bypass enrollments.
+	 *              Add content protection setting.
 	 *
 	 * @return array
 	 */
@@ -143,6 +144,14 @@ class LLMS_Settings_General extends LLMS_Settings_Page {
 			),
 			'title'             => __( 'Unrestricted Preview Access', 'lifterlms' ),
 			'type'              => 'multiselect',
+		);
+
+		$settings[] = array(
+			'title'    => __( 'Content Protection', 'lifterlms' ),
+			'desc'     => __( 'Prevent users from copying website content and downloading images.', 'lifterlms' ) . '<br><span class="description">' . __( 'Users with Unrestricted Preview Access will not be affected by this setting.', 'lifterlms' ) . '</span>' ,
+			'id'       => 'lifterlms_content_protection',
+			'default'  => 'no',
+			'type'     => 'checkbox',
 		);
 
 		$settings[] = array(

--- a/packages/llms-e2e-test-utils/src/highlight-node.js
+++ b/packages/llms-e2e-test-utils/src/highlight-node.js
@@ -1,0 +1,36 @@
+/**
+ * Highlight (selects) the contents of a node.
+ *
+ * @since [version]
+ *
+ * @param {string}  selector      Query selector.
+ * @param {boolean} copySelection If `true`, copies the selected text and returns it.
+ *                                The browser clipboard-read permission must be granted in order to read from the clipboard.
+ * @return {boolean|string} Returns the copied text or `true` if `copySelection` is `false`.
+ */
+export async function highlightNode( selector, copySelection = false ) {
+	await page.waitForSelector( selector );
+
+	await page.evaluate( ( _selector ) => {
+		const range = document.createRange(),
+			// eslint-disable-next-line @wordpress/no-global-get-selection
+			selection = window.getSelection();
+
+		range.selectNodeContents( document.querySelector( _selector ) );
+
+		selection.removeAllRanges();
+
+		selection.addRange( range );
+	}, selector );
+
+	if ( copySelection ) {
+		await page.bringToFront();
+
+		return await page.evaluate( () => {
+			document.execCommand( 'copy' );
+			return window.navigator.clipboard.readText();
+		} );
+	}
+
+	return true;
+}

--- a/packages/llms-e2e-test-utils/src/index.js
+++ b/packages/llms-e2e-test-utils/src/index.js
@@ -18,6 +18,8 @@ export { enrollStudent } from './enroll-student';
 
 export { fillField } from './fill-field';
 
+export { highlightNode } from './highlight-node';
+
 export { importCourse } from './import-course';
 
 export { findElementByText } from './find-element-by-text';
@@ -29,6 +31,7 @@ export { registerStudent } from './register-student';
 export { runSetupWizard } from './run-setup-wizard';
 
 export { select2Select } from './select2-select';
+export { setCheckboxSetting } from './set-checkbox-setting';
 export { setSelect2Option } from './set-select2-option';
 
 export { toggleOpenRegistration } from './toggle-open-registration';

--- a/packages/llms-e2e-test-utils/src/logout-user.js
+++ b/packages/llms-e2e-test-utils/src/logout-user.js
@@ -13,8 +13,8 @@ const { clickAndWait } = require( './click-and-wait' );
  *
  * @since 3.37.8
  * @since 2.1.2 Wait 1 second before navigating to logout page.
- *
  * @since 3.0.0 Use `waitForTimeout()` in favor of deprecated `waitFor()`.
+ *
  * @return {void}
  */
 export async function logoutUser() {

--- a/packages/llms-e2e-test-utils/src/set-checkbox-setting.js
+++ b/packages/llms-e2e-test-utils/src/set-checkbox-setting.js
@@ -1,0 +1,26 @@
+// Internal dependencies.
+import { clickAndWait } from './click-and-wait';
+
+/**
+ * Toggles a LifterLMS checkbox setting.
+ *
+ * @since [version]
+ *
+ * @param {string}  selector Selector for the setting checkbox.
+ * @param {boolean} status   Requested setting status. Use `true` for checked and `false` for unchecked.
+ * @param {boolean} save     Whether or not to perform a save after updating the setting.
+ * @return {void}
+ */
+export async function setCheckboxSetting( selector, status = true, save = true ) {
+	await page.waitForSelector( selector );
+
+	const currStatus = await page.$eval( selector, ( el ) => el.checked );
+
+	if ( status !== currStatus ) {
+		await page.click( selector );
+
+		if ( save ) {
+			await clickAndWait( '.llms-save .llms-button-primary' );
+		}
+	}
+}

--- a/tests/bin/setup-e2e.sh
+++ b/tests/bin/setup-e2e.sh
@@ -14,6 +14,7 @@ $llmsenv wp plugin activate lifterlms
 $llmsenv wp user create voucher voucher@email.tld --role=student --user_pass=password
 
 # StudentDashboardLogin -> should allow a user with valid credentials to login
+# Settings/CopyPrevention -> StudentUser
 $llmsenv wp user create validcreds validcreds@email.tld --role=student --user_pass=password
 
 
@@ -21,3 +22,11 @@ $llmsenv wp user create validcreds validcreds@email.tld --role=student --user_pa
 #################
 
 $llmsenv wp option update can_compress_scripts 1
+
+
+# 4. Bootstrap posts
+####################
+
+# Settings/CopyPrevention
+COPY_TEST_ID=$( $llmsenv wp post create --post_type=page --post_title="Integrity-Test" --post_status=publish --porcelain )
+$llmsenv wp media import https://raw.githubusercontent.com/gocodebox/lifterlms/trunk/tests/assets/yura-timoshenko-R7ftweJR8ks-unsplash.jpeg --post_id=$COPY_TEST_ID --featured_image

--- a/tests/e2e/tests/settings/copy-prevention.test.js
+++ b/tests/e2e/tests/settings/copy-prevention.test.js
@@ -1,0 +1,121 @@
+/**
+ * Test the Setup Wizard
+ *
+ * @since 3.37.8
+ * @since 3.37.14 Fix package references.
+ * @since 4.5.0 Use package functions.
+ * @since 4.12.0 Added registration test with a voucher.
+ * @since 5.0.0 Added tests for form field localization (country, state, etc...).
+ * @since 5.5.0 Use `waitForTimeout()` in favor of deprecated `waitFor()`.
+ */
+
+import {
+	clickAndWait,
+	highlightNode,
+	logoutUser,
+	loginStudent,
+	setCheckboxSetting,
+	visitPage,
+	visitSettingsPage,
+} from '@lifterlms/llms-e2e-test-utils';
+
+import { switchUserToAdmin } from '@wordpress/e2e-test-utils';
+
+const context = browser.defaultBrowserContext();
+context.overridePermissions( process.env.WP_BASE_URL, [ 'clipboard-read' ] );
+
+/**
+ * Watch for an event to run.
+ *
+ * @since [version]
+ *
+ * @param {string} eventName The event name.
+ * @return {void}
+ */
+async function watchForEvent( eventName ) {
+	return await page.evaluate( ( _eventName ) => {
+		document.addEventListener( _eventName, ( event ) => window.watchCopyPreventionEvents( { eventName: _eventName, event } ) );
+	}, eventName );
+}
+
+describe( 'Setting/CopyPrevention', () => {
+
+	let caughtEvents = [];
+
+	beforeAll( async () => {
+		await visitSettingsPage();
+		await setCheckboxSetting( '#lifterlms_content_protection', true );
+		await page.exposeFunction( 'watchCopyPreventionEvents', ( event ) => {
+			caughtEvents.push( event );
+		} );
+	} );
+
+	afterAll( async () => {
+		await visitSettingsPage();
+		await setCheckboxSetting( '#lifterlms_content_protection', false );
+		await logoutUser();
+	} );
+
+	beforeEach( async () => {
+		await visitPage( 'integrity-test' );
+	} );
+
+	afterEach( () => {
+		caughtEvents = [];
+	} );
+
+	describe( 'AdminUser', () => {
+
+		beforeAll( async() => {
+			await switchUserToAdmin();
+		} );
+
+		it ( 'is allowed to copy content', async () => {
+
+			watchForEvent( 'llms-copy-prevented' );
+			expect( await highlightNode( 'h1.entry-title', true ) ).toBe( 'Integrity-Test' );
+			expect( caughtEvents.length ).toStrictEqual( 0 );
+
+		} );
+
+	} );
+
+	describe( 'StudentUser', () => {
+
+		beforeAll( async() => {
+
+			await logoutUser();
+			await loginStudent( 'validcreds@email.tld', 'password' );
+
+		} );
+
+		it ( 'is not allowed to copy content', async () => {
+
+			watchForEvent( 'llms-copy-prevented' );
+			expect( await highlightNode( 'h1.entry-title', true ) ).toBe( 'Copying is not allowed.' );
+			expect( caughtEvents[0].eventName ).toBe( 'llms-copy-prevented' );
+
+		} );
+
+	} );
+
+	describe( 'LoggedOutUser', () => {
+
+		beforeAll( async() => {
+
+			await logoutUser();
+			await visitPage( 'integrity-test' );
+
+		} );
+
+		it ( 'is not allowed to copy content', async () => {
+
+			await visitPage( 'integrity-test' );
+			watchForEvent( 'llms-copy-prevented' );
+			expect( await highlightNode( 'h1.entry-title', true ) ).toBe( 'Copying is not allowed.' );
+			expect( caughtEvents[0].eventName ).toBe( 'llms-copy-prevented' );
+
+		} );
+
+	} );
+} );

--- a/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
@@ -12,6 +12,54 @@
 class LLMS_Test_Frontend_Assets extends LLMS_UnitTestCase {
 
 	/**
+	 * Retrieves a list of enqueued inline scripts from the LLMS_Assets instance.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	private function get_inline_scripts() {
+		return LLMS_Unit_Test_Util::get_private_property_value( llms()->assets, 'inline' );
+	}
+
+	/**
+	 * Test enqueue_content_protection().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_content_protection() {
+
+		// Content protection off & user is logged out: no scripts loaded.
+		update_option( 'lifterlms_content_protection', 'no' );
+		LLMS_Frontend_Assets::enqueue_content_protection();
+		$this->assertEquals( array(), $this->get_inline_scripts() );
+
+		// Content protection is on and user is logged out: scripts are loaded.
+		update_option( 'lifterlms_content_protection', 'yes' );
+		LLMS_Frontend_Assets::enqueue_content_protection();
+		$this->assertArrayHasKey( 'llms-integrity', $this->get_inline_scripts() );
+
+		LLMS_Unit_Test_Util::set_private_property( llms()->assets, 'inline', array() );
+
+		// Admin can bypass restrictions, script is not loaded.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		LLMS_Frontend_Assets::enqueue_content_protection();
+		$this->assertEquals( array(), $this->get_inline_scripts() );
+
+		LLMS_Unit_Test_Util::set_private_property( llms()->assets, 'inline', array() );
+
+		// Student can't copy content.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'student' ) ) );
+		LLMS_Frontend_Assets::enqueue_content_protection();
+		$this->assertArrayHasKey( 'llms-integrity', $this->get_inline_scripts() );
+
+		LLMS_Unit_Test_Util::set_private_property( llms()->assets, 'inline', array() );
+
+	}
+
+	/**
 	 * Test inline script management functions
 	 *
 	 * @since 3.4.1
@@ -33,4 +81,5 @@ class LLMS_Test_Frontend_Assets extends LLMS_UnitTestCase {
 		$this->assertFalse( LLMS_Frontend_Assets::is_inline_script_enqueued( 'fake-id' ) );
 
 	}
+
 }


### PR DESCRIPTION
## Description

Adds a new site-wide option to prevent enable "Content Protection"

Content protection prevents users (without unrestricted preview access) from being able to copy content from the frontend of the site or download copies of images.

Additionally adds new utility functions to `@lifterlms/llms-e2e-test-utils` package (to facilitate new e2e tests)

## How has this been tested?

Manually
New unit tests
New e2e tests

Note: I cannot find a way to reliably test the contextmenu event in Puppeteer. From what I can find since the contextmenu itself exists *outside* of the browser (it exists on the OS level, I guess?) puppeteer does not provide an interface for interacting with it. I attempted to add actions to watch for the event (or lack there of) in the e2e tests but the `contextmenu` event never even fires in Puppeteer as far as I can tell. So testing this piece doesn't seem possible. I've tested this part manually.

## Screenshots <!-- if applicable -->

## Types of changes

New feature

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

