### PR TITLE
Engagement opts

### DIFF
--- a/.changelogs/engagement-opts-1.yml
+++ b/.changelogs/engagement-opts-1.yml
@@ -1,0 +1,10 @@
+significance: minor
+type: deprecated
+entry: >
+  + The site options `lifterlms_certificate_bg_img_width`,
+  `lifterlms_certificate_bg_img_height`, and
+  `lifterlms_certificate_legacy_image_size` are now used only for certificates
+  and certificate templates created using the classic editor.
+    + The settings, found on the Engagements Settings screen, are hidden by default.
+    + During the database upgrade from versions earlier than 6.x, an site option, `llms_has_legacy_certificates`  is added when at least one certificate is found. This option will display the settings so they can continue to be used for legacy certificates.
+    + After migrating all certificates on a site, the settings will still display. In order to remove them from the screen a developer can either delete the option `llms_has_legacy_certificates` or return `false` from the filter `llms_has_legacy_certificates`.

--- a/.changelogs/engagement-opts.yml
+++ b/.changelogs/engagement-opts.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: added
+entry: >
+  + Added certificate global options for the default size of new certificates
+  and certificate templates.

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -173,7 +173,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			'certificates_options',
 			__( 'Certificate Settings', 'lifterlms' ),
 			'',
-			$settings,
+			$settings
 		);
 
 	}

--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -102,56 +102,78 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 	 * Retrieve fields for the certificates settings group.
 	 *
 	 * @since 3.37.3
-	 * @since [version] Add certificate background image option.
+	 * @since [version] Add background image options.
+	 *               Only load legacy certificate options when the legacy option is enabled.
 	 *
 	 * @return array[]
 	 */
 	protected function get_settings_group_certs() {
 
+		$settings = array(
+			array(
+				'title'    => __( 'Default Background Image', 'lifterlms' ),
+				'id'       => 'lifterlms_certificate_default_bg_img',
+				'type'     => 'image',
+				'value'    => llms()->certificates()->get_default_image( 0 ),
+				'autoload' => false,
+			),
+			array(
+				'title'    => __( 'Default Size', 'lifterlms' ),
+				'id'       => 'lifterlms_certificate_default_size',
+				'type'     => 'select',
+				'options'  => $this->get_certificate_size_opts(),
+				'default'  => 'LETTER',
+				'autoload' => false,
+			),
+
+		);
+
+		if ( $this->has_legacy_certificates() ) {
+
+			$settings = array_merge(
+				$settings,
+				array(
+					array(
+						'title' => __( 'Legacy Certificate Background Image Settings', 'lifterlms' ),
+						'type'  => 'subtitle',
+						'desc'  => __( 'Use these settings to determine the dimensions of legacy certificate background images created using the classic editor. These settings have no effect on certificates created using the block editor. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
+						'id'    => 'cert_bg_image_settings',
+					),
+					array(
+						'title'    => __( 'Image Width', 'lifterlms' ),
+						'desc'     => __( 'in pixels', 'lifterlms' ),
+						'id'       => 'lifterlms_certificate_bg_img_width',
+						'default'  => '800',
+						'type'     => 'number',
+						'autoload' => false,
+					),
+					array(
+						'title'    => __( 'Image Height', 'lifterlms' ),
+						'id'       => 'lifterlms_certificate_bg_img_height',
+						'desc'     => __( 'in pixels', 'lifterlms' ),
+						'default'  => '616',
+						'type'     => 'number',
+						'autoload' => false,
+					),
+					array(
+						'title'    => __( 'Legacy compatibility', 'lifterlms' ),
+						'desc'     => __( 'Use legacy certificate image sizes.', 'lifterlms' ) .
+										'<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
+						'id'       => 'lifterlms_certificate_legacy_image_size',
+						'default'  => 'no',
+						'type'     => 'checkbox',
+						'autoload' => false,
+					),
+				)
+			);
+
+		}
+
 		return $this->generate_settings_group(
 			'certificates_options',
 			__( 'Certificate Settings', 'lifterlms' ),
 			'',
-			array(
-				array(
-					'title' => __( 'Background Image Settings', 'lifterlms' ),
-					'type'  => 'subtitle',
-					'desc'  => __( 'Use these sizes to determine the dimensions of certificate background images. After changing these settings, you may need to <a href="http://wordpress.org/extend/plugins/regenerate-thumbnails/" target="_blank">regenerate your thumbnails</a>.', 'lifterlms' ),
-					'id'    => 'cert_bg_image_settings',
-				),
-				array(
-					'title'    => __( 'Default Background Image', 'lifterlms' ),
-					'id'       => 'lifterlms_certificate_default_bg_img',
-					'type'     => 'image',
-					'value'    => llms()->certificates()->get_default_image( 0 ),
-					'autoload' => false,
-				),
-				array(
-					'title'    => __( 'Image Width', 'lifterlms' ),
-					'desc'     => __( 'in pixels', 'lifterlms' ),
-					'id'       => 'lifterlms_certificate_bg_img_width',
-					'default'  => '800',
-					'type'     => 'number',
-					'autoload' => false,
-				),
-				array(
-					'title'    => __( 'Image Height', 'lifterlms' ),
-					'id'       => 'lifterlms_certificate_bg_img_height',
-					'desc'     => __( 'in pixels', 'lifterlms' ),
-					'default'  => '616',
-					'type'     => 'number',
-					'autoload' => false,
-				),
-				array(
-					'title'    => __( 'Legacy compatibility', 'lifterlms' ),
-					'desc'     => __( 'Use legacy certificate image sizes.', 'lifterlms' ) .
-									'<br><em>' . __( 'Enabling this will override the above dimension settings and set the image dimensions to match the dimensions of the uploaded image.', 'lifterlms' ) . '</em>',
-					'id'       => 'lifterlms_certificate_legacy_image_size',
-					'default'  => 'no',
-					'type'     => 'checkbox',
-					'autoload' => false,
-				),
-			)
+			$settings,
 		);
 
 	}
@@ -233,6 +255,74 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			'',
 			$services
 		);
+
+	}
+
+	/**
+	 * Retrieves the options array for the `lifterlms_certificate_default_size` option.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	private function get_certificate_size_opts() {
+
+		$units = llms_get_certificate_units();
+
+		$sizes = array();
+
+		foreach ( llms_get_certificate_sizes() as $size_id => $data ) {
+
+			$unit = $units[ $data['unit'] ] ?? '';
+
+			$sizes[ $size_id ] = sprintf(
+				'%1$s (%2$s%4$s x %3$s%4$s)',
+				$data['name'],
+				$data['width'],
+				$data['height'],
+				$unit['symbol'] ?? ''
+			);
+
+		}
+
+		return $sizes;
+
+	}
+
+	/**
+	 * Determines if legacy certificate options should be displayed.
+	 *
+	 * The option used to determine if there are certificates is set during a migration to version from versions
+	 * earlier than 6.0.0. During the migration if at least one certificate template is migrated, the option
+	 * is set and the legacy options will be displayed.
+	 *
+	 * Even after all certificates have been individually migrated the option will still be set and should be
+	 * deleted via the db, set to 'no' via the options.php screen or disabled by returning `false` from the short
+	 * circuit filter {@see llms_has_legacy_certificates}.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	private function has_legacy_certificates() {
+
+		/**
+		 * Short-circuits the legacy certificates check preventing a database call.
+		 *
+		 * This can be used to force-enable or force-disable legacy certificate settings regardless
+		 * of the value found in the database option.
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $has_legacy_certificates Return `true` to force legacy certificate settings on
+		 *                                         and `false` to force them off.
+		 */
+		$pre = apply_filters( 'llms_has_legacy_certificates', null );
+		if ( ! is_null( $pre ) ) {
+			return $pre;
+		}
+
+		return llms_parse_bool( get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 
 	}
 

--- a/includes/functions/updates/llms-functions-updates-600.php
+++ b/includes/functions/updates/llms-functions-updates-600.php
@@ -87,7 +87,7 @@ function migrate_award_templates() {
 		_migrate_image( $post->ID, llms_strip_prefixes( $post->post_type ) );
 		if ( 'llms_achievement' === $post->post_type ) {
 			_migrate_achievement_content( $post->ID );
-		} else if ( 'llms_certificate' === $post->post_type && ! $legacy_option_added ) {
+		} elseif ( 'llms_certificate' === $post->post_type && ! $legacy_option_added ) {
 			_add_legacy_opt();
 			$legacy_option_added = true;
 		}
@@ -164,7 +164,7 @@ function _migrate_awards( $type ) {
 	$query_args = array(
 		'orderby'        => array( 'ID' => 'ASC' ),
 		'post_type'      => "llms_my_{$type}",
-		// 'post_status'    => 'any',
+		'post_status'    => 'any',
 		'posts_per_page' => $per_page,
 		'no_found_rows'  => true, // We don't care about found rows since we'll run the query as many times as needed anyway.
 		'fields'         => 'ids', // We just need the ID for the updates we'll perform.
@@ -194,8 +194,6 @@ function _migrate_awards( $type ) {
 
 	$query = new \WP_Query( $query_args );
 
-
-
 	// Don't trigger deprecations.
 	remove_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
 
@@ -212,7 +210,6 @@ function _migrate_awards( $type ) {
 			_add_legacy_opt();
 			$legacy_option_added = true;
 		}
-
 	}
 	// Re-enable deprecations.
 	add_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );

--- a/includes/functions/updates/llms-functions-updates-600.php
+++ b/includes/functions/updates/llms-functions-updates-600.php
@@ -59,6 +59,7 @@ function migrate_award_templates() {
 	$query = new \WP_Query(
 		array(
 			'orderby'        => array( 'ID' => 'ASC' ),
+			'post_status'    => 'any',
 			'post_type'      => array( 'llms_achievement', 'llms_certificate' ),
 			'posts_per_page' => $per_page,
 			'no_found_rows'  => true, // We don't care about found rows since we'll run the query as many times as needed anyway.
@@ -80,10 +81,15 @@ function migrate_award_templates() {
 		)
 	);
 
+	$legacy_option_added = false;
+
 	foreach ( $query->posts as $post ) {
 		_migrate_image( $post->ID, llms_strip_prefixes( $post->post_type ) );
 		if ( 'llms_achievement' === $post->post_type ) {
 			_migrate_achievement_content( $post->ID );
+		} else if ( 'llms_certificate' === $post->post_type && ! $legacy_option_added ) {
+			_add_legacy_opt();
+			$legacy_option_added = true;
 		}
 	}
 
@@ -158,6 +164,7 @@ function _migrate_awards( $type ) {
 	$query_args = array(
 		'orderby'        => array( 'ID' => 'ASC' ),
 		'post_type'      => "llms_my_{$type}",
+		// 'post_status'    => 'any',
 		'posts_per_page' => $per_page,
 		'no_found_rows'  => true, // We don't care about found rows since we'll run the query as many times as needed anyway.
 		'fields'         => 'ids', // We just need the ID for the updates we'll perform.
@@ -187,14 +194,25 @@ function _migrate_awards( $type ) {
 
 	$query = new \WP_Query( $query_args );
 
+
+
 	// Don't trigger deprecations.
 	remove_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
 
 	// Don't trigger save hooks.
 	remove_action( "save_post_llms_my_{$type}", array( 'LLMS_Controller_Awards', 'on_save' ), 20 );
 
+	$legacy_option_added = false;
+
 	foreach ( $query->posts as $post_id ) {
+
 		_migrate_award( $post_id, $type );
+
+		if ( 'certificate' === $type && ! $legacy_option_added ) {
+			_add_legacy_opt();
+			$legacy_option_added = true;
+		}
+
 	}
 	// Re-enable deprecations.
 	add_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
@@ -298,4 +316,15 @@ function _migrate_image( $post_id, $type ) {
 
 	delete_post_meta( $post_id, "_llms_{$type}_image" );
 
+}
+
+/**
+ * Adds an option used to determine if the site has at least one legacy certificate template.
+ *
+ * @since [version]
+ *
+ * @return void
+ */
+function _add_legacy_opt() {
+	update_option( 'lifterlms_has_legacy_certificates', 'yes', 'no' );
 }

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -188,7 +188,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 	/**
 	 * Retrieve information about the certificate background image.
 	 *
-	 * This is a legacy function used for certificates using template version 1.
+	 * This function returns an array of information used for legacy certificates using the v1 template.
+	 *
+	 * When using the v2 template, only the `$src` value is utilized and the background image itself is
+	 * always set to 100% width and height of certificate as defined by the certificate's sizing settings.
 	 *
 	 * @since [version]
 	 *
@@ -205,7 +208,11 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 
 		$id     = $this->get( 'id' );
 		$img_id = get_post_thumbnail_id( $id );
-		$size   = llms_parse_bool( get_option( 'lifterlms_certificate_legacy_image_size', 'yes' ) ) ? 'full' : 'lifterlms_certificate_background';
+
+		$size = 'full';
+		if ( 1 === $this->get_template_version() ) {
+			$size = llms_parse_bool( get_option( 'lifterlms_certificate_legacy_image_size', 'yes' ) ) ? 'full' : 'lifterlms_certificate_background';
+		}
 
 		if ( ! $img_id ) {
 
@@ -218,6 +225,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 			/**
 			 * Filters the display height of the default certificate background image.
 			 *
+			 * This filter is used by legacy certificates only. If the certificate is utilizing
+			 * the block editor the filtered value does not affect the size of the background image as
+			 * the image is always set to fill the width and height of the certificate itself.
+			 *
 			 * @since 2.2.0
 			 *
 			 * @param int $height         Display height of the image, in pixels.
@@ -227,6 +238,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 
 			/**
 			 * Filters the display width of the default certificate background image.
+			 *
+			 * This filter is used by legacy certificates only. If the certificate is utilizing
+			 * the block editor the filtered value does not affect the size of the background image as
+			 * the image is always set to fill the width and height of the certificate itself.
 			 *
 			 * @since 2.2.0
 			 *
@@ -255,6 +270,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 			/**
 			 * Filters the display height of the certificate background image.
 			 *
+			 * This filter is used by legacy certificates only. If the certificate is utilizing
+			 * the block editor the filtered value does not affect the size of the background image as
+			 * the image is always set to fill the width and height of the certificate itself.
+			 *
 			 * @since 2.2.0
 			 *
 			 * @param int $height         Display height of the image, in pixels.
@@ -264,6 +283,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 
 			/**
 			 * Filters the display width of the certificate background image.
+			 *
+			 * This filter is used by legacy certificates only. If the certificate is utilizing
+			 * the block editor the filtered value does not affect the size of the background image as
+			 * the image is always set to fill the width and height of the certificate itself.
 			 *
 			 * @since 2.2.0
 			 *
@@ -492,7 +515,7 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 		$size  = $this->get_size();
 		$sizes = llms_get_certificate_sizes();
 		if ( ! $size || empty( $sizes[ $size ] ) ) {
-			$size = get_option( 'llms_certificate_default_size', 'LETTER' );
+			$size = get_option( 'lifterlms_certificate_default_size', 'LETTER' );
 		}
 
 		return $sizes[ $size ] ?? array_values( $sizes )[0];

--- a/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -35,6 +35,13 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 	protected $class_label = 'Engagements';
 
 	/**
+	 * Determines whether or not legacy setting should be added to the mock settings array.
+	 *
+	 * @var boolean
+	 */
+	private $expect_legacy_opts = false;
+
+	/**
 	 * Return an array of mock settings and possible values.
 	 *
 	 * @since 3.37.3
@@ -44,7 +51,7 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 	 */
 	protected function get_mock_settings() {
 
-		return array(
+		$settings = array(
 			'lifterlms_email_from_name' => array(
 				esc_attr( get_bloginfo( 'title' ) ),
 				'mock from name',
@@ -60,23 +67,57 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 				'footer text content',
 			),
 			'lifterlms_achievement_default_img' => array(
-				0
+				0,
+				25,
 			),
 			'lifterlms_certificate_default_bg_img' => array(
-				0
+				0,
+				32,
 			),
-			'lifterlms_certificate_bg_img_width' => array(
-				800,
-				1024,
-			),
-			'lifterlms_certificate_bg_img_height' => array(
-				616,
-				1200,
-			),
-			'lifterlms_certificate_legacy_image_size' => array(
-				'yes',
+			'lifterlms_certificate_default_size' => array(
+				'LETTER',
+				'A4'
 			),
 		);
+
+		if ( $this->expect_legacy_opts ) {
+			$settings = array_merge(
+				$settings,
+				array(
+					'lifterlms_certificate_bg_img_width' => array(
+						800,
+						1024,
+					),
+					'lifterlms_certificate_bg_img_height' => array(
+						616,
+						1200,
+					),
+					'lifterlms_certificate_legacy_image_size' => array(
+						'yes',
+					),
+				)
+			);
+		}
+
+		return $settings;
+
+	}
+
+	/**
+	 * Ensure all editable settings exist in the settings array when the legacy option is set.
+	 *
+	 * Calls the parent test method `test_get_setting()` after setting up data to enable legacy opts.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_with_legacy() {
+
+		update_option( 'lifterlms_has_legacy_certificates', 'yes' );
+		$this->expect_legacy_opts = true;
+		parent::test_get_settings();
+		$this->expect_legacy_opts = false;
 
 	}
 
@@ -132,5 +173,22 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 		remove_filter( 'llms_email_delivery_services', array( $this, 'get_mock_email_provider' ) );
 
 	}
+
+	/**
+	 * Test the save() method with legacy options enabled.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_with_legacy_opts() {
+
+		update_option( 'lifterlms_has_legacy_certificates', 'yes' );
+		$this->expect_legacy_opts = true;
+		parent::test_save();
+		$this->expect_legacy_opts = false;
+
+	}
+
 
 }

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
@@ -37,6 +37,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		parent::set_up();
 		add_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
+		delete_option( 'lifterlms_has_legacy_certificates' );
 
 	}
 
@@ -48,8 +49,11 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 * @return void
 	 */
 	public function tear_down() {
+
 		parent::tear_down();
 		remove_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
+		delete_option( 'lifterlms_has_legacy_certificates' );
+
 	}
 
 	/**
@@ -224,6 +228,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		foreach ( $tests as $type ) {
 
+			delete_option( 'lifterlms_has_legacy_certificates' );
+
 			$awards = $this->create_legacy_awards( 12, $type );
 
 			// Should run 3 times, the 3rd has fewer than max results so we're complete.
@@ -234,6 +240,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 			}
 
 			foreach ( $awards as $i => $award ) {
+
 				$post = get_post( $award['post_id'] );
 
 				// Everything is migrated.
@@ -255,9 +262,34 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 			}
 
+			$this->assertEquals( 'certificate' === $type ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+
 		}
 
 		remove_filter( 'llms_update_600_per_page', $per_page );
+
+	}
+
+	/**
+	 * Test the migrate_achievements() and migrate_certificates() functions when none exist to migrate.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_award_metas_none_found() {
+
+		$tests = array(
+			'achievement',
+			'certificate',
+		);
+
+		foreach ( $tests as $type ) {
+
+			$this->assertFalse( $this->call_ns_func( "migrate_{$type}s", array( $type ) ) );
+			$this->assertEquals( 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+
+		}
 
 	}
 
@@ -292,6 +324,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 			}
 
 		}
+
+		$this->assertEquals( 'yes', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 
 	}
 


### PR DESCRIPTION
Per #1908 

+ Add global options for something that I prepped an option for and never added the option.. something related to certificate defaults (it was the default certificate size)
+ Cleanup certificate global settings (legacy size options are now confusing and only used for legacy certs built with the classic ed)

---

Modifies the engagement options page to include default options for certificate sizing

Hides the <= 5.x certificate options for sizing when no legacy certificates are found on the site. I didn't build a way to *disable* this when all legacy certificates have been migrated.

The best I could come up with would be to execute a query every time a certificate is migrated which would count the remaining legacy certificates... however this would require us to query *all* the posts and then run `has_blocks()` on the post content. This is a pretty expensive query to run in order to hide some options.

I also considered running this on a cronjob so long as the option exists and then automatically removing the cron once the site is fully migrated and the option deleted

I also considered building an admin tool (conditionally displayed based on the presence of the option) which would run the (expensive) query

I also considered making the option a counter (of the number of legacy certs) and then decrementing that counter when a migration takes place. Once it gets to 0 we could delete the option (hiding the settings on the settings page) 

All of this felt like a bit of non-essential code... I think if anyone is ever truly bothered by the presence of these options we can A) Provide them the filter code to hide it 

```php
add_filter( 'llms_has_legacy_certificates', '__return_false' );
```

Or show them how to flip the option from 'yes' to 'no' via the wp-admin/options.php page

