### PR TITLE
Deprecate LLMS_Frontend_Assets::enqueue_inline_pw_script().

### DIFF
--- a/.changelogs/deprecate-enqueue-inline-pw-script.yml
+++ b/.changelogs/deprecate-enqueue-inline-pw-script.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: deprecated
+entry: Deprecated `LLMS_Frontend_Assets::enqueue_inline_pw_script()` with no replacement.

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 5.6.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,6 +21,7 @@ defined( 'ABSPATH' ) || exit;
  *              Method `is_inline_script_enqueued()` is deprecated in favor of `LLMS_Frontend_Assets::is_inline_enqueued()`.
  *              Private properties `$enqueued_inline_scripts` and `$inline_scripts` have been removed.
  *              Removed private methods `get_inline_scripts()` and `output_inline_scripts()`.
+ * @since [version] Deprecated `LLMS_Frontend_Assets::enqueue_inline_pw_script()` with no replacement.
  */
 class LLMS_Frontend_Assets {
 
@@ -136,10 +137,13 @@ class LLMS_Frontend_Assets {
 	 * Output the inline PW Strength meter script
 	 *
 	 * @since 3.4.1
+	 * @deprecated [version] There is not a replacement.
 	 *
 	 * @return void
 	 */
 	public static function enqueue_inline_pw_script() {
+
+		llms_deprecated_function( __CLASS__, '[version]' );
 		llms()->assets->enqueue_inline(
 			'llms-pw-strength',
 			'window.LLMS.PasswordStrength = window.LLMS.PasswordStrength || {};window.LLMS.PasswordStrength.get_minimum_strength = function() { return "' . llms_get_minimum_password_strength() . '"; };',

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -143,7 +143,7 @@ class LLMS_Frontend_Assets {
 	 */
 	public static function enqueue_inline_pw_script() {
 
-		llms_deprecated_function( __CLASS__, '[version]' );
+		llms_deprecated_function( __METHOD__, '[version]' );
 		llms()->assets->enqueue_inline(
 			'llms-pw-strength',
 			'window.LLMS.PasswordStrength = window.LLMS.PasswordStrength || {};window.LLMS.PasswordStrength.get_minimum_strength = function() { return "' . llms_get_minimum_password_strength() . '"; };',


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Deprecated `LLMS_Frontend_Assets::enqueue_inline_pw_script()` with no replacement.

This is the last crusty code to deprecate before the LifterLMS 5.7.0 release. It fell through the cracks in issue #1886.

## How has this been tested?
phpunit


## Types of changes
Deprecate unused code that itself uses a deprecated function.
Warned developers about the deprecation with `llms_deprecated_function()`.

## Checklist:
- [x] My code has been tested.
- [X] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [X] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

