### PR TITLE
Certs wp version support

### DIFF
--- a/.changelogs/cert-block-editor.yml
+++ b/.changelogs/cert-block-editor.yml
@@ -1,7 +1,7 @@
 significance: minor
 type: added
 entry: >
-  + The block editor is now enabled by default for certificates.
+  + The block editor is now enabled by default for certificates when using WordPress versions 5.8 and later.
     + Existing certificates are marked as "legacy" and will continue to use the classic editor until migrated.
     + To migrate a certificate, click the "Migrate Certificate" button. This will force the certificate's content into blocks.
   + A number of new settings are available to certificates when using the block editor:

--- a/.github/workflow-matrix.yml
+++ b/.github/workflow-matrix.yml
@@ -9,3 +9,5 @@ Test PHPUnit:
   __delete:
     # Remove the LLMS Nightly job (intended for add-ons).
     - include[2]
+    # Can be removed when default LLMS job matrix drops support for 5.4.
+    - WP[4] # WP 5.4.

--- a/.github/workflow-matrix.yml
+++ b/.github/workflow-matrix.yml
@@ -11,3 +11,5 @@ Test PHPUnit:
     - include[2]
     # Can be removed when default LLMS job matrix drops support for 5.4.
     - WP[4] # WP 5.4.
+    # Can be removed when default job matrix drops support for PHP 7.3.
+    - PHP[2] # PHP 7.3

--- a/.github/workflows/workflow-matrix.yml
+++ b/.github/workflows/workflow-matrix.yml
@@ -1,3 +1,0 @@
-Test PHPUnit:
-  __delete:
-    - WP[4] # WP 5.4.

--- a/.github/workflows/workflow-matrix.yml
+++ b/.github/workflows/workflow-matrix.yml
@@ -1,0 +1,3 @@
+Test PHPUnit:
+  __delete:
+    - WP[4] # WP 5.4.

--- a/includes/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
+++ b/includes/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
@@ -38,7 +38,7 @@ class LLMS_Admin_Post_Table_Certificates {
 		}
 
 		$post_types = array( 'llms_certificate', 'llms_my_certificate' );
-		if ( in_array( llms_filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), $post_types, true ) ) {
+		if ( in_array( llms_filter_input( INPUT_GET, 'post_type' ), $post_types, true ) ) {
 			add_filter( 'display_post_states', array( $this, 'add_states' ), 20, 2 );
 			add_filter( 'post_row_actions', array( $this, 'add_actions' ), 20, 2 );
 		}

--- a/includes/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
+++ b/includes/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
@@ -33,8 +33,12 @@ class LLMS_Admin_Post_Table_Certificates {
 	 */
 	public function __construct() {
 
+		if ( ! llms_is_block_editor_supported_for_certificates() ) {
+			return;
+		}
+
 		$post_types = array( 'llms_certificate', 'llms_my_certificate' );
-		if ( in_array( llms_filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_STRING ), $post_types, true ) ) {
+		if ( in_array( llms_filter_input( INPUT_GET, 'post_type', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), $post_types, true ) ) {
 			add_filter( 'display_post_states', array( $this, 'add_states' ), 20, 2 );
 			add_filter( 'post_row_actions', array( $this, 'add_actions' ), 20, 2 );
 		}

--- a/includes/class-llms-block-library.php
+++ b/includes/class-llms-block-library.php
@@ -39,15 +39,17 @@ class LLMS_Block_Library {
 	 */
 	private function get_blocks() {
 
-		$blocks = array(
-			'certificate-title' => array(
+		$blocks = array();
+
+		if ( llms_is_block_editor_supported_for_certificates() ) {
+			$blocks['certificate-title'] = array(
 				'path'       => null,
 				'post_types' => array(
 					'llms_certificate',
 					'llms_my_certificate',
 				),
-			),
-		);
+			);
+		}
 
 		// Add default path to all blocks.
 		foreach ( $blocks as $id => &$block ) {

--- a/includes/class-llms-rest-fields.php
+++ b/includes/class-llms-rest-fields.php
@@ -93,8 +93,12 @@ class LLMS_REST_Fields {
 	 */
 	public function register() {
 
-		$this->register_fields_for_certificates();
-		$this->register_fields_for_certificate_templates();
+		if ( llms_is_block_editor_supported_for_certificates() ) {
+
+			$this->register_fields_for_certificates();
+			$this->register_fields_for_certificate_templates();
+
+		}
 
 	}
 

--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -1176,7 +1176,7 @@ class LLMS_Post_Types {
 			'labels'              => wp_parse_args( $labels, $base_labels ),
 			'show_ui'             => $user_can,
 			'publicly_queryable'  => 'llms_certificate' === $post_type ? $user_can : true,
-			'show_in_rest'        => $user_can,
+			'show_in_rest'        => llms_is_block_editor_supported_for_certificates() && $user_can,
 			'public'              => true,
 			'hierarchical'        => false,
 			'exclude_from_search' => true,

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -442,6 +442,37 @@ function llms_get_certificate_title( $id = 0 ) {
 }
 
 /**
+ * Filters whether or not the block editor can be used to build certificates.
+ *
+ * The JS used for certificates in the block editor relies on WP functions and APIs available
+ * since WordPress 5.8. Earlier versions of WordPress won't work.
+ *
+ * @since [version]
+ *
+ * @param type $arg Description.
+ */
+function llms_is_block_editor_supported_for_certificates() {
+
+	global $wp_version;
+	$is_supported = version_compare( $wp_version, '5.8', '>=' );
+
+	/**
+	 * Filters whether or not the block editor can be used for building certificates.
+	 *
+	 * By default, `$is_supported` will be `true` for WordPress 5.8 or later and false for versions less than
+	 * 5.8.
+	 *
+	 * This filter may be used to disable the block editor on later versions.
+	 *
+	 * @since [version]
+	 *
+	 * @param boolean $is_supported Whether or not the block editor is supported.
+	 */
+	return apply_filters( 'llms_block_editor_supported_for_certificates', $is_supported );
+
+}
+
+/**
  * Register the custom "print_certificate" image size
  *
  * @since 2.2.0

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -442,14 +442,14 @@ function llms_get_certificate_title( $id = 0 ) {
 }
 
 /**
- * Filters whether or not the block editor can be used to build certificates.
+ * Determines whether or not the block editor can be used to build certificates.
  *
  * The JS used for certificates in the block editor relies on WP functions and APIs available
  * since WordPress 5.8. Earlier versions of WordPress won't work.
  *
  * @since [version]
  *
- * @param type $arg Description.
+ * @return boolean
  */
 function llms_is_block_editor_supported_for_certificates() {
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
@@ -67,8 +67,11 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 	 *
 	 * @return void
 	 */
-	public function test_block_editor_assets() {
+	public function test_block_editor_assets_for_certificates() {
 
+		if ( ! llms_is_block_editor_supported_for_certificates() ) {
+			$this->markTestSkipped( 'Block editor is not supported for certificates on this version of WordPress.' );
+		}
 
 		$handle    = 'llms-admin-certificate-editor';
 		$inline_id = 'llms-admin-certificate-settings';

--- a/tests/phpunit/unit-tests/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
+++ b/tests/phpunit/unit-tests/admin/post-types/post-tables/class-llms-admin-post-table-certificates.php
@@ -49,6 +49,10 @@ class LLMS_Test_Admin_Post_Table_Certificates extends LLMS_UnitTestCase {
 	 */
 	public function test_constructor() {
 
+		if ( ! llms_is_block_editor_supported_for_certificates() ) {
+			$this->markTestSkipped( 'No actions are registered for this version of WordPress.' );
+		}
+
 		// Wrong screen.
 		$this->assertFalse( has_filter( 'display_post_states', array( $this->main, 'add_states' ) ) );
 		$this->assertFalse( has_filter( 'post_row_actions', array( $this->main, 'add_actions' ) ) );

--- a/tests/phpunit/unit-tests/class-llms-test-block-library.php
+++ b/tests/phpunit/unit-tests/class-llms-test-block-library.php
@@ -20,6 +20,10 @@ class LLMS_Test_Block_Library extends LLMS_UnitTestCase {
 	 */
 	public function set_up() {
 
+		if ( ! llms_is_block_editor_supported_for_certificates() ) {
+			$this->markTestSkipped( 'No blocks supported on this version of WordPress.' );
+		}
+
 		parent::set_up();
 		$this->main     = new LLMS_Block_Library();
 		$this->registry = WP_Block_Type_Registry::get_instance();

--- a/tests/phpunit/unit-tests/class-llms-test-rest-fields.php
+++ b/tests/phpunit/unit-tests/class-llms-test-rest-fields.php
@@ -20,6 +20,10 @@ class LLMS_Test_REST_Fields extends LLMS_REST_Unit_Test_Case {
 	 */
 	public function test_register_fields_for_certificates() {
 
+		if ( ! llms_is_block_editor_supported_for_certificates() ) {
+			$this->markTestSkipped( 'REST endpoints are not supported for certificates on this version of WordPress.' );
+		}
+
 		foreach ( array( 'llms_certificate', 'llms_my_certificate' ) as $post_type ) {
 
 			unregister_post_type( $post_type );

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
@@ -208,7 +208,7 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 
 		foreach ( $tests as $test ) {
 			list( $wp_version, $expect ) = $test;
-			$this->assertEquals( $expect, llms_is_block_editor_supported_for_certificates() );
+			$this->assertEquals( $expect, llms_is_block_editor_supported_for_certificates(), $wp_version );
 		}
 
 		$wp_version = $orig;

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
@@ -173,4 +173,46 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test llms_is_block_editor_supported_for_certificates()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_is_block_editor_supported_for_certificates() {
+
+		global $wp_version;
+		$orig = $wp_version;
+
+		$tests = array(
+			// Unsupported versions.
+			array( '5.5.0', false ),
+			array( '5.6.0', false ),
+			array( '5.6.1', false ),
+			array( '5.7', false ),
+			array( '5.7.0', false ),
+			array( '5.7.5', false ),
+			// Supported versions.
+			array( '5.8', true ),
+			array( '5.8.0', true ),
+			array( '5.8.1', true ),
+			array( '5.8.3', true ),
+			array( '5.9', true ),
+			array( '5.9-alpha.1', true ),
+			array( '5.9-RC.1', true ),
+			// Future versions?
+			array( '6.0', true ),
+			array( '6.0.1', true ),
+		);
+
+		foreach ( $tests as $test ) {
+			list( $wp_version, $expect ) = $test;
+			$this->assertEquals( $expect, llms_is_block_editor_supported_for_certificates() );
+		}
+
+		$wp_version = $orig;
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-course.php
@@ -135,15 +135,24 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 	 *
 	 * @since 3.4.0
 	 * @since 4.10.0 Fix faulty tests, use assertSame in favor of assertEquals.
+	 * @since [version] Mock oembed results to prevent rate limiting issues causing tests to fail.
 	 *
 	 * @return void
 	 */
 	public function test_get_embeds() {
 
+		$iframe = '<iframe src="%s"></iframe>';
+
+		$handler = function( $html, $url ) use ( $iframe ) {
+			return sprintf( $iframe, $url );
+		};
+
+		add_filter( 'pre_oembed_result', $handler, 10, 2 );
+
 		$course = new LLMS_Course( 'new', 'Course With Embeds' );
 
-		$audio_url = 'https://open.spotify.com/track/1rNUOtuCWv1qswqsMFvzvz';
-		$video_url = 'https://www.youtube.com/watch?v=MhQlNwxn5oo';
+		$audio_url = 'http://example.tld/audio_embed';
+		$video_url = 'http://example.tld/video_embed';
 
 		// Empty string when none set.
 		$this->assertEmpty( $course->get_audio() );
@@ -156,8 +165,10 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 		$video_embed = $course->get_video();
 
 		// Should be an iframe for valid embeds.
-		$this->assertSame( 0, strpos( $audio_embed, '<iframe' ) );
-		$this->assertSame( 0, strpos( $video_embed, '<iframe' ) );
+		$this->assertEquals( sprintf( $iframe, $audio_url ),$audio_embed );
+		$this->assertEquals( sprintf( $iframe, $video_url ),$video_embed );
+
+		remove_filter( 'pre_oembed_result', $handler, 10, 2 );
 
 		// Fallbacks should be a link to the URL.
 		$not_embeddable_url = 'http://lifterlms.com/not/embeddable';
@@ -172,6 +183,7 @@ class LLMS_Test_LLMS_Course extends LLMS_PostModelUnitTestCase {
 
 		$this->assertStringContains( sprintf( 'href="%s"', $not_embeddable_url ), $audio_embed );
 		$this->assertStringContains( sprintf( 'href="%s"', $not_embeddable_url ), $video_embed );
+
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -203,15 +203,24 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 	 *
 	 * @since 3.14.8
 	 * @since 4.10.0 Fix faulty tests, use assertSame in favor of assertEquals.
+	 * @since [version] Mock oembed results to prevent rate limiting issues causing tests to fail.
 	 *
 	 * @return void
 	 */
 	public function test_get_embeds() {
 
+		$iframe = '<iframe src="%s"></iframe>';
+
+		$handler = function( $html, $url ) use ( $iframe ) {
+			return sprintf( $iframe, $url );
+		};
+
+		add_filter( 'pre_oembed_result', $handler, 10, 2 );
+
 		$lesson = new LLMS_Lesson( 'new', 'Lesson With Embeds' );
 
-		$audio_url = 'https://open.spotify.com/track/1rNUOtuCWv1qswqsMFvzvz';
-		$video_url = 'https://www.youtube.com/watch?v=MhQlNwxn5oo';
+		$audio_url = 'http://example.tld/audio_embed';
+		$video_url = 'http://example.tld/video_embed';
 
 		// Empty string when none set.
 		$this->assertEmpty( $lesson->get_audio() );
@@ -224,8 +233,10 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 		$video_embed = $lesson->get_video();
 
 		// Should be an iframe for valid embeds.
-		$this->assertSame( 0, strpos( $audio_embed, '<iframe' ) );
-		$this->assertSame( 0, strpos( $video_embed, '<iframe' ) );
+		$this->assertEquals( sprintf( $iframe, $audio_url ),$audio_embed );
+		$this->assertEquals( sprintf( $iframe, $video_url ),$video_embed );
+
+		remove_filter( 'pre_oembed_result', $handler, 10, 2 );
 
 		// Fallbacks should be a link to the URL.
 		$not_embeddable_url = 'http://lifterlms.com/not/embeddable';


### PR DESCRIPTION
## Description

This PR implements a version check against the WordPress core version and enables usage of the block editor for certificates for WordPress core 5.8 and later.

The reasoning for this restriction is that there are `@wordpress/*` pacakge apis/functions/etc used to build the block editor functionality that were introduced in version 5.8 of WordPress. I looked into what would be involved into updating the JS for earlier version support and decided that it would not be worth the effort. Additionally, we implemented a check like this on the introduction of forms block editor building (version 5.0) and no complaints about wanting to use the new functionality on an old version came to my attention. That doesn't mean no one complained, but the "Upgrade WP" response to "why can't I use the editor?" will likely be sufficient. I'm hoping.

On WP 5.7 and earlier, users will still be using the classic editor. They won't see the "Legacy" post status flag, nor will they have post action link to upgrade the template. Once upgraded to 5.8 all this functionality will be present and the block editor will become the default.

Additionally, this will add a simple flag for disabling the block editor on 5.8 or later: `add_filter( 'llms_block_editor_supported_for_certificates`, '__return_false' );`

There could be someone unhappy with the block editor that wants to stick on classic... and with this there's a simple way to allow that choice to be made.

## How has this been tested?

+ Manually tested WP 5.7 - 5.9.
+ Modified some unit tests to check for version support (some tests on 5.7 and lower were failing as a result of PHP function signatures that worked on 5.8 or later. These tests are now skipped on 5.7 and earlier)

