### PR TITLE
Allow LMS managers to get all lessons.

### DIFF
--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -166,14 +166,14 @@ class LLMS_Admin_Builder {
 	 * @since 3.14.8
 	 * @since 3.16.12 Unknown.
 	 * @since [version] Allow LMS managers to get all lessons. {@link https://github.com/gocodebox/lifterlms/issues/1849}.
+	 *              Removed unused `$course_id` parameter.
 	 *
-	 * @param int    $course_id   NOT USED. WP Post ID of the course, lesson or llms_quiz.
 	 * @param string $post_type   Optional. Search specific post type(s). By default searches for all post types.
 	 * @param string $search_term Optional. Search term (searches post_title). Default is empty string.
 	 * @param int    $page        Optional. Used when paginating search results. Default is `1`.
 	 * @return array
 	 */
-	private static function get_existing_posts( $course_id, $post_type = '', $search_term = '', $page = 1 ) {
+	private static function get_existing_posts( $post_type = '', $search_term = '', $page = 1 ) {
 
 		$args = array(
 			'order'          => 'ASC',
@@ -381,7 +381,7 @@ class LLMS_Admin_Builder {
 						$post_type = sanitize_text_field( $request['post_type'] );
 					}
 				}
-				wp_send_json( self::get_existing_posts( absint( $request['course_id'] ), $post_type, $term, $page ) );
+				wp_send_json( self::get_existing_posts( $post_type, $term, $page ) );
 				break;
 
 		}

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.13.0
- * @version 5.1.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -165,8 +165,9 @@ class LLMS_Admin_Builder {
 	 *
 	 * @since 3.14.8
 	 * @since 3.16.12 Unknown.
+	 * @since [version] Allow LMS managers to get all lessons. {@link https://github.com/gocodebox/lifterlms/issues/1849}.
 	 *
-	 * @param int    $course_id   WP Post ID of the course
+	 * @param int    $course_id   NOT USED. WP Post ID of the course, lesson or llms_quiz.
 	 * @param string $post_type   Optional. Search specific post type(s). By default searches for all post types.
 	 * @param string $search_term Optional. Search term (searches post_title). Default is empty string.
 	 * @param int    $page        Optional. Used when paginating search results. Default is `1`.
@@ -186,7 +187,7 @@ class LLMS_Admin_Builder {
 			$args['post_type'] = $post_type;
 		}
 
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! current_user_can( 'manage_lifterlms' ) ) {
 
 			$instructor = llms_get_instructor();
 			$parents    = $instructor->get( 'parent_instructors' );

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -117,7 +117,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 			$role = reset( $user->roles ); // We created users with only one role.
 
 			// Get lessons that the user can access.
-			$lesson_search    = LLMS_Unit_Test_Util::call_method( $this->main, 'get_existing_posts', array( null, 'lesson' ) );
+			$lesson_search    = LLMS_Unit_Test_Util::call_method( $this->main, 'get_existing_posts', array( 'lesson' ) );
 			$found_lesson_ids = array();
 			foreach ( $lesson_search['results'] as $result ) {
 				$found_lesson_ids[] = $result['id'];


### PR DESCRIPTION
## Description
Allow LMS managers to get all lessons, not just the ones that they have authored.

Fixes #1849.

## Documentation Suggestions
@willmiddleton-lifterlms, perhaps the language on [this knowledge base](https://lifterlms.com/docs/roles-and-capabilities/#instructors-assistant) should change from

> Instructor’s Assistants are similar to Instructors but they can only edit courses they’ve been assigned to.

to

> Instructor’s Assistants are similar to Instructors but they can only edit courses that are authored by the instructors they’ve been assigned to.

The knowledge base post links to a [table of roles and capabilities](https://lifterlms.com/docs/roles-and-capabilities/#table) that  may be difficult to read. [Here is another version](https://github.com/gocodebox/lifterlms/files/7877409/llms-roles-and-caps-table2.zip) with:
1. the columns and rows transposed
2. the capabilities displayed in groups


## How has this been tested?
I added unit tests that check what lessons users of different roles can use when building courses.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

