### PR TITLE
llms_load_processors

### DIFF
--- a/includes/processors/class.llms.processors.php
+++ b/includes/processors/class.llms.processors.php
@@ -103,7 +103,7 @@ class LLMS_Processors {
 		 *
 		 * @param string[] $classes A list of processor class ids/slugs.
 		 */
-		$classes = apply_filters( 'llms_load_processors', $this->classes );
+		$this->classes = apply_filters( 'llms_load_processors', $this->classes );
 
 		foreach ( $this->classes as $name ) {
 

--- a/includes/processors/class.llms.processors.php
+++ b/includes/processors/class.llms.processors.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Processors/Classes
  *
  * @since 3.15.0
- * @version 5.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -84,16 +84,17 @@ class LLMS_Processors {
 	}
 
 	/**
-	 * Load all processors
+	 * Load all processors.
 	 *
 	 * @since 3.15.0
+	 * @since [version] Use the value from the `llms_load_processors` filter.
 	 *
 	 * @return void
 	 */
 	private function load_all() {
 
 		/**
-		 * Filter the list of available processors to be loaded
+		 * Filter the list of available processors to be loaded.
 		 *
 		 * Third parties can use this filter to load custom processors.
 		 *
@@ -103,9 +104,9 @@ class LLMS_Processors {
 		 *
 		 * @param string[] $classes A list of processor class ids/slugs.
 		 */
-		$this->classes = apply_filters( 'llms_load_processors', $this->classes );
+		$classes = apply_filters( 'llms_load_processors', $this->classes );
 
-		foreach ( $this->classes as $name ) {
+		foreach ( $classes as $name ) {
 
 			$class = $this->load_processor( $name );
 


### PR DESCRIPTION
## Description
The result of the `llms_load_processors` filter in [`LLMS_Processors::load_all()](https://github.com/gocodebox/lifterlms/blob/5.7.0/includes/processors/class.llms.processors.php#L106) was not used.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

