### PR TITLE
Block editor version compare

### DIFF
--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -454,7 +454,7 @@ function llms_get_certificate_title( $id = 0 ) {
 function llms_is_block_editor_supported_for_certificates() {
 
 	global $wp_version;
-	$is_supported = version_compare( $wp_version, '5.8', '>=' );
+	$is_supported = version_compare( $wp_version, '5.8-src', '>=' );
 
 	/**
 	 * Filters whether or not the block editor can be used for building certificates.

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
@@ -199,8 +199,8 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 			array( '5.8.1', true ),
 			array( '5.8.3', true ),
 			array( '5.9', true ),
-			array( '5.9-alpha.1', true ),
-			array( '5.9-RC.1', true ),
+			array( '5.9-alpha', true ),
+			array( '5.9-RC1', true ),
 			// Future versions?
 			array( '6.0', true ),
 			array( '6.0.1', true ),
@@ -209,6 +209,10 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 		foreach ( $tests as $test ) {
 			list( $wp_version, $expect ) = $test;
 			$this->assertEquals( $expect, llms_is_block_editor_supported_for_certificates(), $wp_version );
+
+			// Test "-src" version.
+			$wp_version .= '-src';
+			$this->assertEquals( $expect, llms_is_block_editor_supported_for_certificates(), $wp_version);
 		}
 
 		$wp_version = $orig;


### PR DESCRIPTION
## Description
This PR allows [`llms_is_block_editor_supported_for_certificates()`](https://github.com/gocodebox/lifterlms/blob/dev-600/includes/functions/llms.functions.certificate.php#L457) to work with WordPress version `5.8-src`.

Strings are handled by [version_compare](https://www.php.net/manual/en/function.version-compare.php) this way:
`any string not found in this list < dev < alpha = a < beta = b < RC = rc < # < pl = p`.

So 'src' is less than 'alpha'.

Another option is to string replace `-src` to empty string before comparing versions. That's what [WP-CLI](https://github.com/wp-cli/wp-cli/blob/master/php/utils.php#L284) does.

## How has this been tested?
development environment 5.8-src

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

