### PR TITLE
Fix certificate print issue with genesis in 6.0

### DIFF
--- a/assets/scss/certificates.scss
+++ b/assets/scss/certificates.scss
@@ -56,6 +56,7 @@ body {
 	width: 100%;
 	height: 100%;
 	background-size: 100% 100% !important;
+	box-sizing: border-box; 
 
 	.wp-block-columns .wp-block-column > * {
 		margin-top: 0 !important;


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Fixes #1944 

## How has this been tested?
I tested it manually (after running npm run build:styles)

## Screenshots <!-- if applicable -->

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->
Bug fix: adds CSS under .llms-certificate-container.cert-template-v2 in assets/scss/certificates.scss


## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

