### PR TITLE
Cert back btn

### DIFF
--- a/assets/scss/certificates.scss
+++ b/assets/scss/certificates.scss
@@ -69,6 +69,7 @@ body {
  */
 .llms-print-certificate {
 	margin-top: 40px;
+	margin-bottom: 40px;
 	text-align: center;
 
 	form {

--- a/includes/functions/llms.functions.templates.certificates.php
+++ b/includes/functions/llms.functions.templates.certificates.php
@@ -81,7 +81,7 @@ function llms_certificate_actions( $certificate ) {
 	$back_link = $cert_ep_enabled ? llms_get_endpoint_url( 'view-certificates', '', $dashboard_url ) : $dashboard_url;
 	$back_text = $cert_ep_enabled ? __( 'All certificates', 'lifterlms' ) : __( 'Dashboard', 'lifterlms' );
 
- 	$is_template        = 'llms_certificate' === $certificate->get( 'type' );
+	$is_template        = 'llms_certificate' === $certificate->get( 'type' );
 	$is_sharing_enabled = $certificate->is_sharing_enabled();
 	llms_get_template(
 		'certificates/actions.php',

--- a/includes/functions/llms.functions.templates.certificates.php
+++ b/includes/functions/llms.functions.templates.certificates.php
@@ -81,10 +81,11 @@ function llms_certificate_actions( $certificate ) {
 	$back_link = $cert_ep_enabled ? llms_get_endpoint_url( 'view-certificates', '', $dashboard_url ) : $dashboard_url;
 	$back_text = $cert_ep_enabled ? __( 'All certificates', 'lifterlms' ) : __( 'Dashboard', 'lifterlms' );
 
+ 	$is_template        = 'llms_certificate' === $certificate->get( 'type' );
 	$is_sharing_enabled = $certificate->is_sharing_enabled();
 	llms_get_template(
 		'certificates/actions.php',
-		compact( 'certificate', 'back_link', 'back_text', 'is_sharing_enabled' )
+		compact( 'certificate', 'back_link', 'back_text', 'is_sharing_enabled', 'is_template' )
 	);
 
 }

--- a/includes/functions/llms.functions.templates.certificates.php
+++ b/includes/functions/llms.functions.templates.certificates.php
@@ -75,10 +75,16 @@ function llms_certificate_actions( $certificate ) {
 		return;
 	}
 
+	$dashboard_url   = get_permalink( llms_get_page_id( 'myaccount' ) );
+	$cert_ep_enabled = LLMS_Student_Dashboard::is_endpoint_enabled( 'view-certificates' );
+
+	$back_link = $cert_ep_enabled ? llms_get_endpoint_url( 'view-certificates', '', $dashboard_url ) : $dashboard_url;
+	$back_text = $cert_ep_enabled ? __( 'All certificates', 'lifterlms' ) : __( 'Dashboard', 'lifterlms' );
+
 	$is_sharing_enabled = $certificate->is_sharing_enabled();
 	llms_get_template(
 		'certificates/actions.php',
-		compact( 'certificate', 'is_sharing_enabled' )
+		compact( 'certificate', 'back_link', 'back_text', 'is_sharing_enabled' )
 	);
 
 }

--- a/templates/certificates/actions.php
+++ b/templates/certificates/actions.php
@@ -11,13 +11,16 @@
  * @param string                $back_link         URL for the back link.
  * @param string                $back_text         Text for the back link anchor.
  * @param boolean               $is_shaing_enabled Whether or not sharing is enabled for the certificate.
+ * @param boolean               $is_template       Whether or not a certificate template is being displayed.
  */
 
 defined( 'ABSPATH' ) || exit;
 ?>
 <div class="llms-print-certificate no-print" id="llms-print-certificate">
 
-	<a class="llms-cert-return-link" href="<?php echo esc_url( $back_link ); ?>">&larr; <?php echo $back_text; ?></a>
+	<?php if ( ! $is_template ) : ?>
+		<a class="llms-cert-return-link" href="<?php echo esc_url( $back_link ); ?>">&larr; <?php echo $back_text; ?></a>
+	<?php endif; ?>
 
 	<button class="llms-button-secondary" onClick="window.print()" type="button">
 		<?php echo _e( 'Print', 'lifterlms' ); ?>
@@ -25,11 +28,13 @@ defined( 'ABSPATH' ) || exit;
 	</button>
 
 	<form action="" method="POST">
+
 		<button class="llms-button-secondary" type="submit" name="llms_generate_cert">
-		<?php echo _e( 'Save', 'lifterlms' ); ?>
+			<?php echo _e( 'Save', 'lifterlms' ); ?>
 			<i class="fa fa-cloud-download" aria-hidden="true"></i>
 		</button>
-		<?php if ( get_post_type( $certificate->get( 'id' ) ) === $certificate->get( 'db_post_type' ) ) : ?>
+
+		<?php if ( ! $is_template ) : ?>
 			<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing" value="<?php echo ! $is_sharing_enabled; ?>">
 			<?php echo ( $is_sharing_enabled ? _e( 'Disable sharing', 'lifterlms' ) : _e( 'Enable sharing', 'lifterlms' ) ); ?>
 				<i class="fa fa-share-alt" aria-hidden="true"></i>
@@ -38,5 +43,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<input type="hidden" name="certificate_id" value="<?php echo get_the_ID(); ?>">
 		<?php wp_nonce_field( 'llms-cert-actions', '_llms_cert_actions_nonce' ); ?>
+
 	</form>
+
 </div>

--- a/templates/certificates/actions.php
+++ b/templates/certificates/actions.php
@@ -14,6 +14,9 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 <div class="llms-print-certificate no-print" id="llms-print-certificate">
+
+	<a href="<?php echo esc_url( llms_get_endpoint_url( 'my-certificates', '', get_permalink( llms_get_page_id( 'myaccount' ) ) ) ); ?>">&larr; <?php echo _e( 'All certificates', 'lifterlms' ); ?></a>
+
 	<button class="llms-button-secondary" onClick="window.print()" type="button">
 		<?php echo _e( 'Print', 'lifterlms' ); ?>
 		<i class="fa fa-print" aria-hidden="true"></i>

--- a/templates/certificates/actions.php
+++ b/templates/certificates/actions.php
@@ -8,6 +8,8 @@
  * @version [version]
  *
  * @param LLMS_User_Certificate $certificate       Certificate object.
+ * @param string                $back_link         URL for the back link.
+ * @param string                $back_text         Text for the back link anchor.
  * @param boolean               $is_shaing_enabled Whether or not sharing is enabled for the certificate.
  */
 
@@ -15,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div class="llms-print-certificate no-print" id="llms-print-certificate">
 
-	<a href="<?php echo esc_url( llms_get_endpoint_url( 'my-certificates', '', get_permalink( llms_get_page_id( 'myaccount' ) ) ) ); ?>">&larr; <?php echo _e( 'All certificates', 'lifterlms' ); ?></a>
+	<a class="llms-cert-return-link" href="<?php echo esc_url( $back_link ); ?>">&larr; <?php echo $back_text; ?></a>
 
 	<button class="llms-button-secondary" onClick="window.print()" type="button">
 		<?php echo _e( 'Print', 'lifterlms' ); ?>

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
@@ -141,6 +141,44 @@ class LLMS_Test_Functions_Templates_Certificates extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Test llms_certificate_actions().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_certificate_actions_backlink() {
+
+		$cert = $this->get_cert();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->assertOutputContains(
+			'<a class="llms-cert-return-link" ',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		$this->assertOutputContains(
+			'All certificates</a>',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		update_option( 'lifterlms_myaccount_certificates_endpoint', '' );
+
+		$this->assertOutputContains(
+			'<a class="llms-cert-return-link" ',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		$this->assertOutputContains(
+			'Dashboard</a>',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		update_option( 'lifterlms_myaccount_certificates_endpoint', 'my-certificates' );
+
+	}
+
 	// public function test_llms_get_certificate_preview() {}
 	// public function test_llms_the_certificate_preview() {}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
@@ -17,11 +17,13 @@ class LLMS_Test_Functions_Templates_Certificates extends LLMS_UnitTestCase {
 	 *
 	 * @since [version]
 	 *
-	 * @param array $args Certificate creation arguments.
+	 * @param array $args     Certificate creation arguments.
+	 * @parak bool  $template If `true` retrieves a certificate template object in favor of an awarded certificate.
 	 * @return LLMS_User_Certificate
 	 */
-	private function get_cert( $args = array() ) {
-		return llms_get_certificate( $this->factory->post->create( wp_parse_args( $args, array( 'post_type' => 'llms_my_certificate' ) ) ) );
+	private function get_cert( $args = array(), $template = false ) {
+		$post_type = $template ? 'llms_certificate' : 'llms_my_certificate';
+		return llms_get_certificate( $this->factory->post->create( wp_parse_args( $args, compact( 'post_type' ) ) ), $template );
 	}
 
 	/**
@@ -136,6 +138,67 @@ class LLMS_Test_Functions_Templates_Certificates extends LLMS_UnitTestCase {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 		$this->assertOutputContains(
 			'<div class="llms-print-certificate no-print" id="llms-print-certificate">',
+			'llms_certificate_actions', array( $cert )
+		);
+
+
+		// Back link.
+		$this->assertOutputContains(
+			'<a class="llms-cert-return-link" ',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		// Print button.
+		$this->assertOutputContains(
+			'<button class="llms-button-secondary" type="submit" name="llms_generate_cert">',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		// Sharing button.
+		$this->assertOutputContains(
+			'<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing"',
+			'llms_certificate_actions', array( $cert )
+		);
+
+	}
+
+	/**
+	 * Test llms_certificate_actions().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_certificate_actions_template() {
+
+		$cert = $this->get_cert( array(), true );
+
+		// Cannot manage.
+		wp_set_current_user( null );
+		$this->assertOutputEmpty( 'llms_certificate_actions', array( $cert ) );
+
+		// Can manage.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertOutputContains(
+			'<div class="llms-print-certificate no-print" id="llms-print-certificate">',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		// No backlink.
+		$this->assertOutputNotContains(
+			'<a class="llms-cert-return-link" ',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		// Print button.
+		$this->assertOutputContains(
+			'<button class="llms-button-secondary" type="submit" name="llms_generate_cert">',
+			'llms_certificate_actions', array( $cert )
+		);
+
+		// Sharing button.
+		$this->assertOutputNotContains(
+			'<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing"',
 			'llms_certificate_actions', array( $cert )
 		);
 


### PR DESCRIPTION
## Description

Closes #1959

![Screenshot_2022-01-28_11-12-19](https://user-images.githubusercontent.com/1290739/151600560-a4d41fb9-7edf-4222-aff8-d2bee52fc873.png)

Added a text-link (not a button) on the bottom left. This returns users to the "My Certificates" endpoint on the student dashboard if it's enabled and returns to the student dashboard (main page) if the cert endpoint is not enabled.

Language says "Dashboard" instead of "All Certificates" if the endpoint is disabled.

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

## Types of changes
+Update

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

