### PR TITLE
No certificate block template

### DIFF
--- a/includes/class-llms-block-templates.php
+++ b/includes/class-llms-block-templates.php
@@ -538,6 +538,7 @@ class LLMS_Block_Templates {
 	 * Add lifterlms blocks templates.
 	 *
 	 * @since 5.8.0
+	 * @since [versopm] Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
 	 *
 	 * @param WP_Block_Template[] $query_result Array of found block templates.
 	 * @param array               $query        {
@@ -552,7 +553,7 @@ class LLMS_Block_Templates {
 	public function add_llms_block_templates( $query_result, $query, $template_type = 'wp_template' ) {
 
 		// Bail it's not a block theme, or is being retrieved a non wp_template type requested.
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || 'wp_template' !== $template_type ) {
+		if ( ! llms_is_block_theme() || 'wp_template' !== $template_type ) {
 			return $query_result;
 		}
 

--- a/includes/class-llms-block-templates.php
+++ b/includes/class-llms-block-templates.php
@@ -538,7 +538,7 @@ class LLMS_Block_Templates {
 	 * Add lifterlms blocks templates.
 	 *
 	 * @since 5.8.0
-	 * @since [versopm] Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
+	 * @since [version] Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
 	 *
 	 * @param WP_Block_Template[] $query_result Array of found block templates.
 	 * @param array               $query        {

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -436,6 +436,8 @@ class LLMS_Template_Loader {
 	 * Filter blocks templates.
 	 *
 	 * @since 5.8.0
+	 * @since [version] Remove LifterLMS 6.0 version check about the certificate template.
+	 *               Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
 	 *
 	 * @param WP_Block_Template[] $result        Array of found block templates.
 	 * @param array               $query {
@@ -449,8 +451,8 @@ class LLMS_Template_Loader {
 	 */
 	public function block_template_loader( $result, $query, $template_type ) {
 
-		// Bail it's not a block theme, or is being retrieved a non wp_template file.
-		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() || 'wp_template' !== $template_type ) {
+		// Bail if it's not a block theme, or is being retrieved a non wp_template file.
+		if ( ! llms_is_block_theme() || 'wp_template' !== $template_type ) {
 			return $result;
 		}
 
@@ -460,15 +462,15 @@ class LLMS_Template_Loader {
 		 * Since LifterLMS 6.0.0 certificates have their own PHP template that do no depend on the theme.
 		 * This means that we can use the PHP template loaded in the method `LLMS_Template_Loader::template_loader()` below.
 		 */
-		$template_name = is_singular( array( 'llms_certificate', 'llms_my_certificate' ) ) && version_compare( '6.0.0-alpha.1', llms()->version, '<=' ) ? '' : $template_name;
+		$template_name = is_singular( array( 'llms_certificate', 'llms_my_certificate' ) ) ? '' : $template_name;
 
 		/**
 		 * Filters the block template to be loded forced.
 		 *
 		 * @since 5.8.0
 		 *
-		 * @param string $template_slug The template slug to be loaded forced.
-		 * @param string $template      The template name to be loaded forced.
+		 * @param string $template_slug The template slug to be force loaded.
+		 * @param string $template      The name of template to be force loaded.
 		 */
 		$template_slug = apply_filters( 'llms_forced_block_template_slug', $template_name ? LLMS_Block_Templates::LLMS_BLOCK_TEMPLATES_PREFIX . $template_name : '', $template_name );
 

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -591,11 +591,13 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard_my_grades' ) ) {
 				$course->get_quizzes()
 			);
 
-			$achievements = $student->get_achievements( array(
-				'related_posts' => $post_ids,
-				'per_page'      => 1,
-				'no_found_rows' => true,
-			) )->get_awards();
+			$achievements = $student->get_achievements(
+				array(
+					'related_posts' => $post_ids,
+					'per_page'      => 1,
+					'no_found_rows' => true,
+				)
+			)->get_awards();
 
 			$latest_achievement = $achievements ? $achievements[0] : false;
 

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -894,6 +894,26 @@ function llms_is_rest() {
 }
 
 /**
+ * Determine whether the current theme is a block theme.
+ *
+ * Just a wrapper for WordPress core `wp_is_block_theme()` so to filter for testing purposes.
+ *
+ * @since [version]
+ *
+ * @return string
+ */
+function llms_is_block_theme() {
+	/**
+	 * Filters whether the current theme is a block theme.
+	 *
+	 * @since [version]
+	 *
+	 * @param $is_block_theme Whether the current theme is a block theme.
+	 */
+	return apply_filters( 'llms_is_block_theme', function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() );
+}
+
+/**
  * Check if the home URL is https. If it is, we don't need to do things such as 'force ssl'.
  *
  * @thanks woocommerce <3.

--- a/templates/block-templates/single-certificate.html
+++ b/templates/block-templates/single-certificate.html
@@ -1,1 +1,0 @@
-<!-- wp:llms/php-template {"template":"single-certificate"} /-->


### PR DESCRIPTION
## Description
Remove the single certificate block template (html) for v6.0.0 as we don't want it to be modified, plus we serve the php file.
Some unit tests added.

## How has this been tested?
manually and with new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)/Improvement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

