### PR TITLE
Fixed how protected properties are accessed.

### DIFF
--- a/.changelogs/access-protected-properties.yml
+++ b/.changelogs/access-protected-properties.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: fixed
+entry: >
+  + Fixed how the protected `LLMS_Notifications_Query::$found_results` property is accessed in `LLMS_Abstract_Notification_Controller::has_subscriber_received()`.
+  + Fixed how the protected `LLMS_Notifications_Query::$max_pages` property is accessed in `lifterlms_template_student_dashboard_my_notifications()`.

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -458,7 +458,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 			)
 		);
 
-		return (bool) $query->get_found_results();
+		return $query->has_results();
 
 	}
 

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.8.0
- * @version 5.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -440,6 +440,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 * Determine if the notification is a potential duplicate
 	 *
 	 * @since 3.11.0
+	 * @since [version] Fixed how the protected {@see LLMS_Notifications_Query::$found_results} property is accessed.
 	 *
 	 * @param string $type       Notification type id.
 	 * @param mixed  $subscriber WP User ID for the subscriber, email address, phone number, etc...
@@ -457,7 +458,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 			)
 		);
 
-		return $query->found_results ? true : false;
+		return (bool) $query->get_found_results();
 
 	}
 

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -717,6 +717,7 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard_my_notifications' 
 	 * @since 3.37.15 Use `in_array()`'s strict comparison.
 	 * @since 3.37.16 Fixed typo when comparing the current view.
 	 * @since [version] Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 *              Fix how the protected {@see LLMS_Notifications_Query::$max_pages} property is accessed.
 	 *
 	 * @return void
 	 */
@@ -762,7 +763,7 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard_my_notifications' 
 			);
 
 			$pagination = array(
-				'max'     => $notifications->max_pages,
+				'max'     => $notifications->get_max_pages(),
 				'current' => $page,
 			);
 


### PR DESCRIPTION
## Description
Replaced reading of protected properties with method calls.

## How has this been tested?
`composer run tests` and `composer check-cs-errors`.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

