### PR TITLE
Replace calls to deprecated llms_mock_current_time() 

### DIFF
--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
@@ -344,7 +344,7 @@ class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 	public function test_create_model() {
 
 		$date = '2021-04-22 14:34:00';
-		llms_mock_current_time( $date );
+		llms_tests_mock_current_time( $date );
 
 		$this->create( '' );
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-transaction.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-transaction.php
@@ -60,7 +60,7 @@ class LLMS_Test_LLMS_Transaction extends LLMS_PostModelUnitTestCase {
 	 */
 	public function test_create_model() {
 
-		llms_mock_current_time( '2021-03-05 01:05:23' );
+		llms_tests_mock_current_time( '2021-03-05 01:05:23' );
 
 		$this->create( 123 );
 


### PR DESCRIPTION
## Description
Replace calls to deprecated llms_mock_current_time() with llms_tests_mock_current_time().

## How has this been tested?
With automated tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

