### PR TITLE
Allow template directory override when the block template comes from an add-on.

### DIFF
--- a/includes/functions/llms.functions.template.php
+++ b/includes/functions/llms.functions.template.php
@@ -259,7 +259,7 @@ function llms_get_template_override_directories() {
  *
  * @since 5.8.0
  *
- * @param string $template                    Template file name, without extension.
+ * @param string $template                    Template file name.
  * @param string $template_directory          Template directory relative to the plugin base directory.
  * @param bool   $template_directory_absolute Whether the template directory is absolute or not.
  * @return string

--- a/tests/phpunit/unit-tests/class-llms-test-block-templates.php
+++ b/tests/phpunit/unit-tests/class-llms-test-block-templates.php
@@ -7,11 +7,12 @@
  * @group block_templates
  *
  * @since 5.8.0
+ * @since [version] Added more tests.
  */
 class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 
 	/**
-	 * Setup the test case
+	 * Setup the test case.
 	 *
 	 * @since 5.8.0
 	 *
@@ -25,7 +26,7 @@ class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test __construct()
+	 * Test __construct().
 	 *
 	 * @since 5.8.0
 	 *
@@ -50,6 +51,406 @@ class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 		$this->assertEquals( 10, has_filter( 'get_block_templates', array( $this->main, 'add_llms_block_templates' ) ) );
 		$this->assertEquals( 10, has_filter( 'pre_get_block_file_template', array( $this->main, 'maybe_return_blocks_template' ) ) );
 		$this->assertEquals( 9999, has_action( 'admin_enqueue_scripts', array( $this->main, 'localize_blocks' ) ) );
+
+	}
+
+	/**
+	 * Test configure_block_templates().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_configure_block_templates() {
+
+		// Reset data.
+		LLMS_Unit_Test_Util::set_private_property( $this->main, 'block_templates_config', null );
+		$this->assertNull( LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' ) );
+
+		// Run configurator.
+		$this->main->configure_block_templates();
+
+		$block_templates_config = array(
+			llms()->plugin_path() . '/templates/' . $this->main::LLMS_BLOCK_TEMPLATES_DIRECTORY_NAME => array(
+				'slug_prefix'       => $this->main::LLMS_BLOCK_TEMPLATES_PREFIX,
+				'namespace'         => $this->main::LLMS_BLOCK_TEMPLATES_NAMESPACE,
+				'blocks_dir'        => $this->main::LLMS_BLOCK_TEMPLATES_DIRECTORY_NAME, // Relative to the plugin's templates directory.
+				'admin_blocks_l10n' => LLMS_Unit_Test_Util::call_method( $this->main, 'block_editor_l10n' ),
+				'template_titles'   => LLMS_Unit_Test_Util::call_method( $this->main, 'template_titles' ),
+			),
+		);
+
+		$this->assertNotNull( LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' ) );
+		$this->assertEquals(
+			$block_templates_config,
+			LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' )
+		);
+
+		// Check that the configuration can be extended through a filter
+		$additional_configuration = array(
+			'/some/path/to' => array(
+				'slug_prefix'       => 'some-slug-prefix_',
+				'namespace'         => 'some/namespace',
+				'blocks_dir'        => 'blocks-dir', // Relative to the plugin's templates directory.
+				'admin_blocks_l10n' => array( 'string-1' => 'String 1' ),
+				'template_titles'   => array( 'some-archive' => 'Some Archive title' ),
+			),
+		);
+		$add_configuration_cb = function( $config ) use ( $additional_configuration ) {
+			return array_merge( $config, $additional_configuration );
+		};
+		add_filter( 'llms_block_templates_config', $add_configuration_cb );
+
+		// Run configurator again.
+		$this->main->configure_block_templates();
+		remove_filter( 'llms_block_templates_config', $add_configuration_cb );
+
+		$this->assertNotNull( LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' ) );
+		$this->assertEquals(
+			array_merge( $block_templates_config, $additional_configuration ),
+			LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' )
+		);
+
+		// Run configurator again, without the filter, to reinit the configuration.
+		$this->main->configure_block_templates();
+		$this->assertEquals(
+			$block_templates_config,
+			LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' )
+		);
+
+	}
+
+	/**
+	 * Test generate_template_slug_from_path().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_template_slug_from_path() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+		$this->assertNotEmpty( reset( $block_templates_config )['slug_prefix'] );
+
+		// Expecting the slug to be the template name, without the extension, plus the configured slug prefix.
+		$this->assertEquals(
+			reset( $block_templates_config )['slug_prefix'] . 'template',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_slug_from_path',
+				array(
+					key( $block_templates_config ) . '/template.html',
+				)
+			)
+		);
+
+		// This util is pretty dumb, it expects the block file extension to be 5 chars, dot included, otherwise...
+		$this->assertEquals(
+			reset( $block_templates_config )['slug_prefix'] . 'templat',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_slug_from_path',
+				array(
+					key( $block_templates_config ) . '/template.htm',
+				)
+			)
+		);
+
+		$this->assertEquals(
+			reset( $block_templates_config )['slug_prefix'] . 'template',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_slug_from_path',
+				array(
+					key( $block_templates_config ) . '/template12345',
+				)
+			)
+		);
+
+		// If you pass a path which is not in the configuration I expect an empty slug.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_slug_from_path',
+				array(
+					'/whateverpath/template.html',
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Test generate_template_namespace_from_path().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_template_namespace_from_path() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+		$this->assertNotEmpty( reset( $block_templates_config )['namespace'] );
+
+		// Expecting the namespace to be the class constant LLMS_BLOCK_TEMPLATES_NAMESPACE.
+		$this->assertEquals(
+			$this->main::LLMS_BLOCK_TEMPLATES_NAMESPACE,
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_namespace_from_path',
+				array(
+					key( $block_templates_config ) . '/template.html',
+				)
+			)
+		);
+
+		// If you pass a path which is not in the configuration I expect an empty namespace.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_namespace_from_path',
+				array(
+					'/whateverpath/template.html',
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Test generate_template_prefix_from_path().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_template_prefix_from_path() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+		$this->assertNotEmpty( reset( $block_templates_config )['slug_prefix'] );
+
+		// Expecting the prefix to be the class constant LLMS_BLOCK_TEMPLATES_DIRECTORY_NAME.
+		$this->assertEquals(
+			$this->main::LLMS_BLOCK_TEMPLATES_DIRECTORY_NAME ,
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_blocks_dir_from_path',
+				array(
+					key( $block_templates_config ) . '/template.html',
+				)
+			)
+		);
+
+		// If you pass a path which is not in the configuration I expect an empty blocks directory.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_blocks_dir_from_path',
+				array(
+					'/whateverpath/template.html',
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Test generate_template_prefix_from_path().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_blocks_dir_from_path() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+		$this->assertNotEmpty( reset( $block_templates_config )['blocks_dir'] );
+
+		// Expecting the prefix to be the class constant LLMS_BLOCK_TEMPLATES_PREFIX
+		$this->assertEquals(
+			$this->main::LLMS_BLOCK_TEMPLATES_PREFIX ,
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_prefix_from_path',
+				array(
+					key( $block_templates_config ) . '/template.html',
+				)
+			)
+		);
+
+		// If you pass a path which is not in the configuration I expect an empty prefix.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'generate_template_prefix_from_path',
+				array(
+					'/whateverpath/template.html',
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Test block_template_config_property_from_path().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_block_template_config_property_from_path() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+
+		// Non-existent property for an existent path => empty string.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'block_template_config_property_from_path',
+				array(
+					key( $block_templates_config ) . '/some/block/template.html',
+					'this-property-does-not-exist'
+				)
+			)
+		);
+
+		// Non-existent property for a non-existent path => empty string.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'block_template_config_property_from_path',
+				array(
+					'/some/block/template.html',
+					'this-property-does-not-exist'
+				)
+			)
+		);
+
+		// Existent property for non-existent path => empty string.
+		$this->assertEquals(
+			'',
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'block_template_config_property_from_path',
+				array(
+					'/some/block/template.html',
+					'slug_prefix'
+				)
+			)
+		);
+
+		// Existent property for existent path => property value.
+		$this->assertEquals(
+			reset( $block_templates_config )['slug_prefix'],
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'block_template_config_property_from_path',
+				array(
+					key( $block_templates_config ) . '/some/block/template.html',
+					'slug_prefix'
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Test convert_slug_to_title().
+	 *
+	 * @since [version]
+	 *
+	 * @return string Human friendly title converted from the slug.
+	 */
+	public function test_convert_slug_to_title() {
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+
+		// Existent slugs.
+		$titles = reset( $block_templates_config )['template_titles'];
+		foreach ( $titles as $slug => $title ) {
+			$this->assertEquals(
+				$title,
+				LLMS_Unit_Test_Util::call_method(
+					$this->main,
+					'convert_slug_to_title',
+					array(
+						$slug,
+					)
+				),
+				$slug
+			);
+		}
+
+		// Non-existent slug.
+		$this->assertEquals(
+			"This Slug Does Not Exist",
+			LLMS_Unit_Test_Util::call_method(
+				$this->main,
+				'convert_slug_to_title',
+				array(
+					'this-slug-does-not-exist',
+				)
+			),
+			$slug
+		);
+
+	}
+
+	/**
+	 * Test localize_blocks().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_localize_blocks() {
+		global $wp_scripts;
+
+		$block_templates_config = LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'block_templates_config' );
+		$this->assertNotNull( $block_templates_config );
+
+		// Add a fake llms-blocks-editor script.
+		$wp_scripts->registered['llms-blocks-editor'] = new _WP_Dependency(
+			'llms-blocks-editor',
+			'/fake/',
+			array(),
+			'ver',
+			array()
+		);
+
+		// Check localization went through.
+		$this->assertTrue( $this->main->localize_blocks() );
+
+		// Check localization is what we expect.
+		$this->assertEquals(
+			sprintf(
+				'var %1$s = %2$s;',
+				'llmsBlockTemplatesL10n',
+				wp_json_encode(
+					array_map(
+						function( $value ) {
+							return html_entity_decode( (string) $value, ENT_QUOTES, 'UTF-8' );
+						},
+						array_merge( ...array_column( $block_templates_config, 'admin_blocks_l10n' ) )
+					)
+				)
+			),
+
+			$wp_scripts->get_data( 'llms-blocks-editor', 'data' ),
+
+		);
 
 	}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
@@ -8,6 +8,7 @@
  * @group functions_template
  *
  * @since 4.8.0
+ * @since [version] Added tests on llms_template_file_path().
  */
 class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
@@ -17,10 +18,11 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	);
 
 	/**
-	 * Setup test cases
+	 * Setup test cases.
 	 *
 	 * @since 4.8.0
 	 * @since 5.3.3 Renamed from `setUp()` for compat with WP core changes.
+	 * @since [version] Clean theme overrides directories cache.
 	 *
 	 * @return void
 	 */
@@ -29,6 +31,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 		foreach ( $this->themes as $theme ) {
 			$this->_delete_theme_override_directory( $theme );
 		}
+		wp_cache_delete( 'theme-override-directories', 'llms_template_functions' );
 	}
 
 	/**
@@ -38,7 +41,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lms_get_template_override_directories_only_parent_theme() {
+	public function test_llms_get_template_override_directories_only_parent_theme() {
 		$original_template = get_option( 'template', '' );
 		update_option( 'template', 'fake_parent' );
 		$this->_create_theme_override_directory( 'fake_parent' );
@@ -62,7 +65,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lms_get_template_override_directories_parent_and_child_theme() {
+	public function test_llms_get_template_override_directories_parent_and_child_theme() {
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
@@ -92,7 +95,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lms_get_template_override_directories_parent_and_child_theme_parent_overrides() {
+	public function test_llms_get_template_override_directories_parent_and_child_theme_parent_overrides() {
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
@@ -123,7 +126,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lms_get_template_override_directories_parent_and_child_theme_child_overrides() {
+	public function test_llms_get_template_override_directories_parent_and_child_theme_child_overrides() {
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
@@ -154,7 +157,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @return void
 	 */
-	public function test_lms_get_template_override_directories_parent_and_child_theme_no_override() {
+	public function test_llms_get_template_override_directories_parent_and_child_theme_no_override() {
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
@@ -178,20 +181,125 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Creates a theme and override lifterlms template diretoris
+	 * Test llms_template_file_path() passing an empty template file.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_file_path_empty_template_file_passed() {
+
+		$this->assertEquals(
+			llms()->plugin_path() . '/templates/',
+			llms_template_file_path( '' )
+		);
+
+		/**
+		 * Simulate the activation of a theme with the templates directory overridden.
+		 */
+		$original_template   = get_option( 'template', '' );
+		$original_stylesheet = get_option( 'stylesheet', '' );
+		wp_cache_delete( 'theme-override-directories', 'llms_template_functions' );
+		update_option( 'template', 'fake' );
+		update_option( 'stylesheet', 'fake' );
+		$this->_create_theme_override_directory( 'fake' );
+
+		$this->assertEquals(
+			get_theme_root() . '/fake/lifterlms/',
+			llms_template_file_path( '' )
+		);
+
+		$this->_delete_theme_override_directory( 'fake' );
+
+		update_option( 'template', $original_template );
+		update_option( 'stylesheet', $original_stylesheet );
+
+	}
+
+	/**
+	 * Test llms_template_file_path() passing a template file that doesn't exist in the theme.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_file_path_template_file_not_in_theme() {
+
+		/**
+		 * Simulate the activation of a theme with the templates directory overridden.
+		 */
+		$original_template   = get_option( 'template', '' );
+		$original_stylesheet = get_option( 'stylesheet', '' );
+		update_option( 'template', 'fake' );
+		update_option( 'stylesheet', 'fake' );
+		$this->_create_theme_override_directory( 'fake' );
+
+		$this->assertEquals(
+			llms()->plugin_path() . '/templates/single-certificate.php',
+			llms_template_file_path( 'single-certificate.php' )
+		);
+
+		$this->_delete_theme_override_directory( 'fake' );
+
+		update_option( 'template', $original_template );
+		update_option( 'stylesheet', $original_stylesheet );
+
+	}
+
+	/**
+	 * Test llms_template_file_path() when passing an absolute template directory (not relative to the plugin dir).
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_file_path_template_directory_absolute() {
+		$this->_delete_theme_override_directory( 'fake' );
+
+		$this->assertEquals(
+			'/path/to/absolute/single-certificate.php',
+			llms_template_file_path( 'single-certificate.php', 'path/to/absolute', true )
+		);
+
+		/**
+		 * Simulate the activation of a theme with the templates directory overridden.
+		 */
+		$original_template   = get_option( 'template', '' );
+		$original_stylesheet = get_option( 'stylesheet', '' );
+		update_option( 'template', 'fake' );
+		update_option( 'stylesheet', 'fake' );
+		$this->_create_theme_override_directory( 'fake' );
+		wp_cache_delete( 'theme-override-directories', 'llms_template_functions' );
+
+		$this->assertEquals(
+			get_theme_root() . '/fake/lifterlms/',
+			llms_template_file_path( '', 'path/to/absolute', true )
+		);
+
+		$this->_delete_theme_override_directory( 'fake' );
+
+		update_option( 'template', $original_template );
+		update_option( 'stylesheet', $original_stylesheet );
+
+	}
+
+	/**
+	 * Creates a theme and override lifterlms template directory.
 	 *
 	 * @since 4.8.0
+	 * @since [version] always remove the theme directory if it already exists.
 	 *
 	 * @param string $theme_dir_name Theme directory name.
 	 * @return void
 	 */
 	private function _create_theme_override_directory( $theme_dir_name ) {
 		$theme_root = get_theme_root();
+		$this->_delete_theme_override_directory( 'fake' );
 		mkdir( "{$theme_root}/{$theme_dir_name}/lifterlms", 0777, true );
 	}
 
 	/**
-	 * Deletes a theme and override lifterlms template diretoris
+	 * Deletes a theme and override lifterlms template directory.
 	 *
 	 * @since 4.8.0
 	 *

--- a/tests/phpunit/unit-tests/theme-support/class-llms-test-theme-support.php
+++ b/tests/phpunit/unit-tests/theme-support/class-llms-test-theme-support.php
@@ -8,6 +8,7 @@
  *
  * @since 3.37.0
  * @since 4.10.0 Added tests for Twenty Twenty-One theme.
+ * @since [version] Added tests for Twenty Twenty-Two
  */
 class LLMS_Test_Theme_Support extends LLMS_Unit_Test_Case {
 
@@ -19,9 +20,10 @@ class LLMS_Test_Theme_Support extends LLMS_Unit_Test_Case {
 	 * @var array
 	 */
 	protected $supported = array(
-		'twentynineteen' => 'LLMS_Twenty_Nineteen',
-		'twentytwenty' => 'LLMS_Twenty_Twenty',
+		'twentynineteen'  => 'LLMS_Twenty_Nineteen',
+		'twentytwenty'    => 'LLMS_Twenty_Twenty',
 		'twentytwentyone' => 'LLMS_Twenty_Twenty_One',
+		'twentytwentytwo' => 'LLMS_Twenty_Twenty_Two',
 	);
 
 	/**


### PR DESCRIPTION
## Description
Fixes an issue that prevented add-on block-template files to be overridden in a theme/childe-theme.
It adds further tests to the block templates logic (though they're not exhaustive yet).

## How has this been tested?
manually, and partially with new unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

