### PR TITLE
Fix closing <p> tag.

### DIFF
--- a/includes/admin/views/access-plans/metabox.php
+++ b/includes/admin/views/access-plans/metabox.php
@@ -5,7 +5,8 @@
  * @package  LifterLMS/Admin/Views
  *
  * @since 3.0.0
- * @version 3.29.0
+ * @since [version] Fix closing tag inside the `llms-no-plans-msg` div element.
+ * @version [version]
  *
  * @var LLMS_Course $course
  * @var array $checkout_redirection_types checkout redirect setting options.
@@ -18,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<section class="llms-collapsible-group llms-access-plans" id="llms-access-plans">
 		<div class="llms-no-plans-msg">
-			<p><?php printf( __( 'Access plans define the payment options and access time-periods available for this %s.', 'lifterlms' ), strtolower( $product->get_post_type_label( 'singular_name' ) ) ); ?></h3>
+			<p><?php printf( __( 'Access plans define the payment options and access time-periods available for this %s.', 'lifterlms' ), strtolower( $product->get_post_type_label( 'singular_name' ) ) ); ?></p>
 			<p><?php printf( __( 'No access plans exist for your %s, click "Add New" to get started.', 'lifterlms' ), strtolower( $product->get_post_type_label( 'singular_name' ) ) ); ?></p>
 		</div>
 		<?php foreach ( $product->get_access_plans( false, false ) as $plan ) : ?>


### PR DESCRIPTION
## Description
Fix the closing `<p>` tag in the `llms-no-plans-msg` div element.

## How has this been tested?
Automated tests.


## Types of changes
Bug fix (non-breaking change which fixes an issue) 

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

