### PR TITLE
Fix typo.

### DIFF
--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -272,7 +272,7 @@ class LLMS_Engagement_Handler {
 		/**
 		 * Action run after a student has successfully earned an engagement.
 		 *
-		 * They dynamic portion of this hook, `{$type}`, refers to the engagement type,
+		 * The dynamic portion of this hook, `{$type}`, refers to the engagement type,
 		 * either "achievement" or "certificate".
 		 *
 		 * @since 1.0.0

--- a/includes/processors/class.llms.processor.membership.bulk.enroll.php
+++ b/includes/processors/class.llms.processor.membership.bulk.enroll.php
@@ -140,15 +140,16 @@ class LLMS_Processor_Membership_Bulk_Enroll extends LLMS_Abstract_Processor {
 	}
 
 	/**
-	 * Execute calculation for each item in the queue until all students
-	 * in the course have been polled
-	 * Stores the data in the postmeta table to be accessible via LLMS_Course
+	 * Execute calculation for each item in the queue until all students in the course have been polled.
 	 *
-	 * @param    array $item  array of processing data
-	 * @return   boolean          true to keep the item in the queue and process again
-	 *                            false to remove the item from the queue
-	 * @since    3.15.0
-	 * @version  3.26.1
+	 * Stores the data in the postmeta table to be accessible via LLMS_Course.
+	 *
+	 * @since 3.15.0
+	 * @since [version] Replaced access of LLMS_Student_Query::$found_results protected property with LLMS_Student_Query::has_results().
+	 *
+	 * @param array $item Array of processing data.
+	 * @return boolean True to keep the item in the queue and process again.
+	 *                 False to remove the item from the queue.
 	 */
 	public function task( $item ) {
 
@@ -168,7 +169,7 @@ class LLMS_Processor_Membership_Bulk_Enroll extends LLMS_Abstract_Processor {
 
 		$query = new LLMS_Student_Query( $item['query_args'] );
 
-		if ( $query->found_results ) {
+		if ( $query->has_results() ) {
 			foreach ( $query->get_students() as $student ) {
 				$student->enroll( $item['course_id'], $item['trigger'] );
 			}


### PR DESCRIPTION
## Description
Fix typo in the DocBlock of the `llms_user_earned_{$type}` hook.

Additionally, (this was supposed to be a separate PR),
Replaced access of LLMS_Student_Query::$found_results protected property with LLMS_Student_Query::has_results().

## How has this been tested?
Automated tests.

## Types of changes
DocBlock

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

