### PR TITLE
Rewrite student dashboard view order to use hooks and template functions

### DIFF
--- a/includes/class.llms.student.dashboard.php
+++ b/includes/class.llms.student.dashboard.php
@@ -340,9 +340,11 @@ class LLMS_Student_Dashboard {
 	/**
 	 * Endpoint to output orders content
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.8.0
+	 * @since 3.0.0
+	 * @since 3.8.0 Unknown.
+	 * @since [version] Use `llms_template_view_order()` in favor of including the template file directly.
+	 *
+	 * @return void
 	 */
 	public static function output_orders_content() {
 
@@ -352,28 +354,8 @@ class LLMS_Student_Dashboard {
 
 		if ( ! empty( $wp->query_vars['orders'] ) ) {
 
-			$order = new LLMS_Order( $wp->query_vars['orders'] );
-
-			// Ensure people can't locate other peoples orders by dropping numbers into the url bar.
-			if ( get_current_user_id() !== $order->get( 'user_id' ) ) {
-				$order        = false;
-				$transactions = array();
-			} else {
-				$transactions = $order->get_transactions(
-					array(
-						'per_page' => apply_filters( 'llms_student_dashboard_transactions_per_page', 20 ),
-						'paged'    => isset( $_GET['txnpage'] ) ? absint( $_GET['txnpage'] ) : 1,
-					)
-				);
-			}
-
-			llms_get_template(
-				'myaccount/view-order.php',
-				array(
-					'order'        => $order,
-					'transactions' => $transactions,
-				)
-			);
+			$order = llms_get_post( $wp->query_vars['orders'] );
+			llms_template_view_order( $order );
 
 		} else {
 

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Order view template functions.
+ *
+ * @package LifterLMS/Functions
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+if ( ! function_exists( 'llms_template_view_order' ) ) {
+
+	/**
+	 * Loads the template for a single order view on the student dashboard.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order The order to display.
+	 * @return void
+	 */
+	function llms_template_view_order( $order ) {
+
+		// Validate order object and only allow the order's user to view the order.
+		if ( ! $order instanceof LLMS_Order || get_current_user_id() !== $order->get( 'user_id' ) ) {
+			return _e( 'Invalid Order.', 'lifterlms' );
+		}
+
+		/**
+		 * Allows customization of the view order layout on the student dashboard.
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $use_stacked_layout If `true`, forces usage of the stacked layout instead of the default side-by-side layout.
+		 */
+		$layout_class = apply_filters( 'llms_sd_stacked_order_layout', false, $order ) ? 'llms-stack-cols' : '';
+
+		$transactions = _llms_template_view_order_get_transactions( $order );
+
+		llms_get_template( 'myaccount/view-order.php', compact( 'order', 'transactions', 'layout_class' ) );
+
+	}
+}
+
+if ( ! function_exists( 'llms_template_view_order_actions' ) ) {
+
+	/**
+	 * Loads the single order view actions sidebar on the student dashboard.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order The order to display.
+	 * @return void
+	 */
+	function llms_template_view_order_actions( $order ) {
+		llms_get_template( 'myaccount/view-order-actions.php', compact( 'order' ) );
+	}
+
+}
+
+if ( ! function_exists( 'llms_template_view_order_information' ) ) {
+
+	/**
+	 * Loads the single order view information main area on the student dashboard.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order The order to display.
+	 * @return void
+	 */
+	function llms_template_view_order_information( $order ) {
+		$gateway = $order->get_gateway();
+		llms_get_template( 'myaccount/view-order-information.php', compact( 'order', 'gateway' ) );
+	}
+}
+
+if ( ! function_exists( 'llms_template_view_order_transactions' ) ) {
+
+	/**
+	 * Loads the single order view transactions table on the student dashboard.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order        The order to display.
+	 * @param array      $transactions Result array from LLMS_Order::get_transactions(). If null, will load transactions from the order.
+	 * @param integer    $per_page     Number of results to display per page. Only used if `$transactions` is `null`.
+	 * @param integer    $page         Current results page to display. Only used if `$transactions` is `null`.
+	 * @return void
+	 */
+	function llms_template_view_order_transactions( $order, $transactions = null, $per_page = 20, $page = null ) {
+
+		if ( is_null( $transactions ) ) {
+			$transactions = _llms_template_view_order_get_transactions( $order, $per_page, $page );
+		}
+
+		llms_get_template(
+			'myaccount/view-order-transactions.php',
+			compact( 'transactions'	)
+		);
+
+	}
+}
+
+/**
+ * Loads transactions for the given order.
+ *
+ * @since [version]
+ *
+ * @access private
+ *
+ * @param LLMS_order $order    Order object.
+ * @param integer    $per_page Transactions to display per page.
+ * @param integer    $page     Results page.
+ * @return array Results from LLMS_Order::get_transactions().
+ */
+function _llms_template_view_order_get_transactions( $order, $per_page = 20, $page = null ) {
+
+	$page = is_null( $page ) ? absint( llms_filter_input( INPUT_GET, 'txnpage', FILTER_SANITIZE_NUMBER_INT ) ) : $page;
+
+	return $order->get_transactions(
+		array(
+			/**
+			 * Filters the number of transactions displayed on each page when viewing order details.
+			 *
+			 * @since Unknown
+			 *
+			 * @param integer $per_page Number of orders per page. Default: `20`.
+			 */
+			'per_page' => apply_filters( 'llms_student_dashboard_transactions_per_page', $per_page ),
+			'paged'    => $page ? $page : 1,
+		)
+	);
+
+}

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -31,7 +31,8 @@ if ( ! function_exists( 'llms_template_view_order' ) ) {
 		 *
 		 * @since [version]
 		 *
-		 * @param boolean $use_stacked_layout If `true`, forces usage of the stacked layout instead of the default side-by-side layout.
+		 * @param boolean    $use_stacked_layout If `true`, forces usage of the stacked layout instead of the default side-by-side layout.
+		 * @param LLMS_Order $order              The order to display.
 		 */
 		$layout_class = apply_filters( 'llms_sd_stacked_order_layout', false, $order ) ? 'llms-stack-cols' : '';
 
@@ -92,10 +93,11 @@ if ( ! function_exists( 'llms_template_view_order_transactions' ) ) {
 			$transactions = _llms_template_view_order_get_transactions( $order, $per_page, $page );
 		}
 
-		llms_get_template(
-			'myaccount/view-order-transactions.php',
-			compact( 'transactions' )
-		);
+		if ( empty( $transactions['transactions'] ) ) {
+			return;
+		}
+
+		llms_get_template( 'myaccount/view-order-transactions.php', compact( 'transactions' ) );
 
 	}
 }

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -54,7 +54,6 @@ if ( ! function_exists( 'llms_template_view_order_actions' ) ) {
 	function llms_template_view_order_actions( $order ) {
 		llms_get_template( 'myaccount/view-order-actions.php', compact( 'order' ) );
 	}
-
 }
 
 if ( ! function_exists( 'llms_template_view_order_information' ) ) {
@@ -94,7 +93,7 @@ if ( ! function_exists( 'llms_template_view_order_transactions' ) ) {
 
 		llms_get_template(
 			'myaccount/view-order-transactions.php',
-			compact( 'transactions'	)
+			compact( 'transactions' )
 		);
 
 	}

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -109,9 +109,9 @@ if ( ! function_exists( 'llms_template_view_order_transactions' ) ) {
  *
  * @access private
  *
- * @param LLMS_order $order    Order object.
- * @param integer    $per_page Transactions to display per page.
- * @param integer    $page     Results page.
+ * @param LLMS_order   $order    Order object.
+ * @param integer      $per_page Transactions to display per page.
+ * @param null|integer $page     Results page.
  * @return array Results from LLMS_Order::get_transactions().
  */
 function _llms_template_view_order_get_transactions( $order, $per_page = 20, $page = null ) {

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -22,7 +22,8 @@ if ( ! function_exists( 'llms_template_view_order' ) ) {
 
 		// Validate order object and only allow the order's user to view the order.
 		if ( ! $order instanceof LLMS_Order || get_current_user_id() !== $order->get( 'user_id' ) ) {
-			return _e( 'Invalid Order.', 'lifterlms' );
+			_e( 'Invalid Order.', 'lifterlms' );
+			return;
 		}
 
 		/**

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -15,6 +15,7 @@ require 'functions/llms-functions-conditional-tags.php';
 require 'functions/llms-functions-templates-courses.php';
 require 'functions/llms-functions-templates-memberships.php';
 require 'functions/llms-functions-templates-shared.php';
+require 'functions/llms-functions-template-view-order.php';
 
 require 'functions/llms.functions.templates.achievements.php';
 require 'functions/llms.functions.templates.certificates.php';

--- a/includes/llms.template.hooks.php
+++ b/includes/llms.template.hooks.php
@@ -171,6 +171,10 @@ add_action( 'lifterlms_student_dashboard_index', 'lifterlms_template_student_das
 
 add_action( 'llms_my_grades_course_table', 'lifterlms_template_student_dashboard_my_grades_table', 10, 2 );
 
+add_action( 'llms_view_order_information', 'llms_template_view_order_information', 10 );
+add_action( 'llms_view_order_actions', 'llms_template_view_order_actions', 10 );
+add_action( 'llms_view_order_transactions', 'llms_template_view_order_transactions', 10, 2 );
+
 add_action( 'lifterlms_after_student_dashboard', 'lifterlms_template_student_dashboard_wrapper_close', 10 );
 
 /**

--- a/templates/myaccount/view-order-actions.php
+++ b/templates/myaccount/view-order-actions.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Order information template part.
+ *
+ * @package LifterLMS/Templates
+ *
+ * @since [version]
+ * @version [version]
+ *
+ * @param LLMS_Order $order Current order object.
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<aside class="order-secondary">
+
+	<?php
+		/**
+		 * Action executed after opening the secondary order element.
+		 *
+		 * @since [version]
+		 *
+		 * @param LLMS_Order $order The current order object.
+		 */
+		do_action( 'llms_view_order_before_secondary', $order );
+	?>
+
+	<?php if ( $order->is_recurring() ) : ?>
+
+		<?php if ( isset( $_GET['confirm-switch'] ) || 'llms-active' === $order->get( 'status' ) || $order->can_resubscribe() ) : ?>
+
+			<?php
+			llms_get_template(
+				'checkout/form-switch-source.php',
+				array(
+					'confirm' => llms_filter_input_sanitize_string( INPUT_GET, 'confirm-switch' ),
+					'order'   => $order,
+				)
+			);
+			?>
+
+		<?php endif; ?>
+
+		<?php if ( apply_filters( 'llms_allow_subscription_cancellation', true, $order ) && in_array( $order->get( 'status' ), array( 'llms-active', 'llms-on-hold' ) ) ) : ?>
+
+			<form action="" id="llms-cancel-subscription-form" method="POST">
+
+				<?php
+				llms_form_field(
+					array(
+						'columns'     => 12,
+						'classes'     => 'llms-button-secondary',
+						'id'          => 'llms_cancel_subscription',
+						'value'       => __( 'Cancel Subscription', 'lifterlms' ),
+						'last_column' => true,
+						'required'    => false,
+						'type'        => 'submit',
+					)
+				);
+				?>
+
+				<?php wp_nonce_field( 'llms_cancel_subscription', '_cancel_sub_nonce' ); ?>
+				<input name="order_id" type="hidden" value="<?php echo $order->get( 'id' ); ?>">
+
+			</form>
+
+		<?php endif; ?>
+
+	<?php endif; ?>
+
+	<?php
+		/**
+		 * Action executed before closing the secondary order element.
+		 *
+		 * @since [version]
+		 *
+		 * @param LLMS_Order $order The current order object.
+		 */
+		do_action( 'llms_view_order_after_secondary', $order );
+	?>
+
+</aside>

--- a/templates/myaccount/view-order-actions.php
+++ b/templates/myaccount/view-order-actions.php
@@ -42,7 +42,7 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php endif; ?>
 
-		<?php if ( apply_filters( 'llms_allow_subscription_cancellation', true, $order ) && in_array( $order->get( 'status' ), array( 'llms-active', 'llms-on-hold' ) ) ) : ?>
+		<?php if ( apply_filters( 'llms_allow_subscription_cancellation', true, $order ) && in_array( $order->get( 'status' ), array( 'llms-active', 'llms-on-hold' ), true ) ) : ?>
 
 			<form action="" id="llms-cancel-subscription-form" method="POST">
 

--- a/templates/myaccount/view-order-actions.php
+++ b/templates/myaccount/view-order-actions.php
@@ -7,7 +7,7 @@
  * @since [version]
  * @version [version]
  *
- * @param LLMS_Order $order Current order object.
+ * @var LLMS_Order $order Current order object.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -128,7 +128,16 @@ defined( 'ABSPATH' ) || exit;
 					<?php else : ?>
 						<?php echo $gateway->get_title(); ?>
 					<?php endif; ?>
-					<?php do_action( 'lifterlms_view_order_after_payment_method', $order ); ?>
+					<?php
+						/**
+						 * Action run immediately after the payment method is output within the view order information template.
+						 *
+						 * @since Unknown
+						 *
+						 * @param LLMS_Order $order Order object.
+						 */
+						do_action( 'lifterlms_view_order_after_payment_method', $order );
+					?>
 				</td>
 			</tr>
 
@@ -163,7 +172,16 @@ defined( 'ABSPATH' ) || exit;
 			</tr>
 			<?php endif; ?>
 
-			<?php do_action( 'lifterlms_view_order_table_body', $order ); ?>
+			<?php
+				/**
+				 * Action run before the closing of the `<tbody>` element on the view orders information table.
+				 *
+				 * @since Unknown
+				 *
+				 * @param LLMS_Order $order Order object.
+				 */
+				do_action( 'lifterlms_view_order_table_body', $order );
+			?>
 		</tbody>
 	</table>
 </section>

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -7,7 +7,9 @@
  * @since [version]
  * @version [version]
  *
- * @param LLMS_Order $order Current order object.
+ * @var LLMS_Order                    $order   Current order object.
+ * @var LLMS_Payment_Gateway|WP_Error $gateway Instance of the LLMS_Payment_Gateway extending class used for the payment.
+ *                                             WP_Error if the gateway cannot be located, e.g. because it's no longer enabled.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Order information template part.
+ *
+ * @package LifterLMS/Templates
+ *
+ * @since [version]
+ * @version [version]
+ *
+ * @param LLMS_Order $order Current order object.
+ */
+
+defined( 'ABSPATH' ) || exit;
+?>
+
+<section class="order-primary">
+
+	<table class="orders-table">
+		<tbody>
+			<tr>
+				<th><?php _e( 'Status', 'lifterlms' ); ?></th>
+				<td><?php echo $order->get_status_name(); ?></td>
+			</tr>
+
+			<tr>
+				<th><?php _e( 'Access Plan', 'lifterlms' ); ?></th>
+				<td><?php echo $order->get( 'plan_title' ); ?></td>
+			</tr>
+
+			<tr>
+				<th><?php _e( 'Product', 'lifterlms' ); ?></th>
+				<td>
+				<?php if ( llms_get_post( $order->get( 'product_id' ) ) ) : ?>
+					<a href="<?php echo get_permalink( $order->get( 'product_id' ) ); ?>"><?php echo $order->get( 'product_title' ); ?></a>
+				<?php else : ?>
+					<?php echo __( '[DELETED]', 'lifterlms' ) . ' ' . $order->get( 'product_title' ); ?>
+				<?php endif; ?>
+				</td>
+			</tr>
+			<?php if ( $order->has_trial() ) : ?>
+				<?php if ( $order->has_coupon() && $order->get( 'coupon_amount_trial' ) ) : ?>
+					<tr>
+						<th><?php _e( 'Original Total', 'lifterlms' ); ?></th>
+						<td><?php echo $order->get_price( 'trial_original_total' ); ?></td>
+					</tr>
+
+					<tr>
+						<th><?php _e( 'Coupon Discount', 'lifterlms' ); ?></th>
+						<td>
+							<?php echo $order->get_coupon_amount( 'trial' ); ?>
+							(<?php echo llms_price( $order->get_price( 'coupon_value_trial', array(), 'float' ) * - 1 ); ?>)
+							[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
+						</td>
+					</tr>
+				<?php endif; ?>
+
+				<tr>
+					<th><?php _e( 'Trial Total', 'lifterlms' ); ?></th>
+					<td>
+						<?php echo $order->get_price( 'trial_total' ); ?>
+						<?php printf( _n( 'for %1$d %2$s', 'for %1$d %2$ss', $order->get( 'trial_length' ), 'lifterlms' ), $order->get( 'trial_length' ), $order->get( 'trial_period' ) ); ?>
+					</td>
+				</tr>
+			<?php endif; ?>
+
+			<?php if ( $order->has_discount() ) : ?>
+				<tr>
+					<th><?php _e( 'Original Total', 'lifterlms' ); ?></th>
+					<td><?php echo $order->get_price( 'original_total' ); ?></td>
+				</tr>
+
+				<?php if ( $order->has_sale() ) : ?>
+					<tr>
+						<th><?php _e( 'Sale Discount', 'lifterlms' ); ?></th>
+						<td>
+							<?php echo $order->get_price( 'sale_price' ); ?>
+							(<?php echo llms_price( $order->get_price( 'sale_value', array(), 'float' ) * -1 ); ?>)
+						</td>
+					</tr>
+				<?php endif; ?>
+
+				<?php if ( $order->has_coupon() ) : ?>
+					<tr>
+						<th><?php _e( 'Coupon Discount', 'lifterlms' ); ?></th>
+						<td>
+							<?php echo $order->get_coupon_amount( 'regular' ); ?>
+							(<?php echo llms_price( $order->get_price( 'coupon_value', array(), 'float' ) * - 1 ); ?>)
+							[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
+						</td>
+					</tr>
+				<?php endif; ?>
+			<?php endif; ?>
+
+			<tr>
+				<th><?php _e( 'Total', 'lifterlms' ); ?></th>
+				<td>
+					<?php echo $order->get_price( 'total' ); ?>
+					<?php if ( $order->is_recurring() ) : ?>
+						<?php
+						// phpcs:disable WordPress.WP.I18n.MissingSingularPlaceholder -- We don't output the number in the singular so it throws a CS error but it's working as we want it to.
+						printf( _n( 'Every %2$s', 'Every %1$d %2$ss', $order->get( 'billing_frequency' ), 'lifterlms' ), $order->get( 'billing_frequency' ), $order->get( 'billing_period' ) );
+						// phpcs:enable WordPress.WP.I18n.MissingSingularPlaceholder
+						?>
+						<?php if ( $order->get( 'billing_cycle' ) > 0 ) : ?>
+							<?php printf( _n( 'for %1$d %2$s', 'for %1$d %2$ss', $order->get( 'billing_cycle' ), 'lifterlms' ), $order->get( 'billing_cycle' ), $order->get( 'billing_period' ) ); ?>
+						<?php endif; ?>
+					<?php else : ?>
+						<?php _e( 'One-time', 'lifterlms' ); ?>
+					<?php endif; ?>
+				</td>
+			</tr>
+
+			<tr>
+				<th><?php _e( 'Payment Method', 'lifterlms' ); ?></th>
+				<td>
+					<?php if ( is_wp_error( $gateway ) ) : ?>
+						<?php echo $order->get( 'payment_gateway' ); ?>
+					<?php else : ?>
+						<?php echo $gateway->get_title(); ?>
+					<?php endif; ?>
+					<?php do_action( 'lifterlms_view_order_after_payment_method', $order ); ?>
+				</td>
+			</tr>
+
+			<tr>
+				<th><?php _e( 'Start Date', 'lifterlms' ); ?></th>
+				<td><?php echo $order->get_date( 'date', 'F j, Y' ); ?></td>
+			</tr>
+			<?php if ( $order->is_recurring() ) : ?>
+				<tr>
+					<th><?php _e( 'Last Payment Date', 'lifterlms' ); ?></th>
+					<td><?php echo $order->get_last_transaction_date( 'llms-txn-succeeded', 'any', 'F j, Y' ); ?></td>
+				</tr>
+
+				<?php if ( 'llms-pending-cancel' !== $order->get( 'status' ) ) : ?>
+					<tr>
+						<th><?php _e( 'Next Payment Date', 'lifterlms' ); ?></th>
+						<td>
+							<?php if ( $order->has_scheduled_payment() ) : ?>
+								<?php echo $order->get_next_payment_due_date( 'F j, Y' ); ?>
+							<?php else : ?>
+								&ndash;
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endif; ?>
+			<?php endif; ?>
+
+			<?php if ( ! $order->is_recurring() || 'lifetime' !== $order->get( 'access_expiration' ) || 'llms-pending-cancel' === $order->get( 'status' ) ) : ?>
+			<tr>
+				<th><?php _e( 'Expiration Date', 'lifterlms' ); ?></th>
+				<td><?php echo $order->get_access_expiration_date( 'F j, Y' ); ?></td>
+			</tr>
+			<?php endif; ?>
+
+			<?php do_action( 'lifterlms_view_order_table_body', $order ); ?>
+		</tbody>
+	</table>
+</section>

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -97,9 +97,17 @@ defined( 'ABSPATH' ) || exit;
 					<?php echo $order->get_price( 'total' ); ?>
 					<?php if ( $order->is_recurring() ) : ?>
 						<?php
-						// phpcs:disable WordPress.WP.I18n.MissingSingularPlaceholder -- We don't output the number in the singular so it throws a CS error but it's working as we want it to.
-						printf( _n( 'Every %2$s', 'Every %1$d %2$ss', $order->get( 'billing_frequency' ), 'lifterlms' ), $order->get( 'billing_frequency' ), $order->get( 'billing_period' ) );
-						// phpcs:enable WordPress.WP.I18n.MissingSingularPlaceholder
+						printf(
+							// Translators: %1$d = the billing frequency; %2$s = the billing period.
+							_n( // phpcs:ignore: WordPress.WP.I18n.MismatchedPlaceholders -- It's not an error.
+								'Every %2$s', // phpcs:ignore: WordPress.WP.I18n.MissingSingularPlaceholder -- It works as expected despite the CS warning.
+								'Every %1$d %2$ss',
+								$order->get( 'billing_frequency' ),
+								'lifterlms'
+							),
+							$order->get( 'billing_frequency' ),
+							$order->get( 'billing_period' )
+						);
 						?>
 						<?php if ( $order->get( 'billing_cycle' ) > 0 ) : ?>
 							<?php printf( _n( 'for %1$d %2$s', 'for %1$d %2$ss', $order->get( 'billing_cycle' ), 'lifterlms' ), $order->get( 'billing_cycle' ), $order->get( 'billing_period' ) ); ?>

--- a/templates/myaccount/view-order-transactions.php
+++ b/templates/myaccount/view-order-transactions.php
@@ -22,17 +22,17 @@ if ( ! $transactions || ! $transactions['transactions'] ) {
 			<th><?php _e( 'Date', 'lifterlms' ); ?></th>
 			<th><?php _e( 'Amount', 'lifterlms' ); ?></th>
 			<th><?php _e( 'Method', 'lifterlms' ); ?></th>
-		<tr>
+		</tr>
 	</thead>
 	<tbody>
 	<?php foreach ( $transactions['transactions'] as $txn ) : ?>
 		<tr>
-			<th>
+			<td>
 				#<?php echo $txn->get( 'id' ); ?>
 				<span class="llms-status <?php echo $txn->get( 'status' ); ?>"><?php echo $txn->get_status_name(); ?></span>
-			</th>
-			<th><?php echo $txn->get_date( 'date' ); ?></th>
-			<th>
+			</td>
+			<td><?php echo $txn->get_date( 'date' ); ?></td>
+			<td>
 				<?php $refund_amount = $txn->get_price( 'refund_amount', array(), 'float' ); ?>
 				<?php if ( $refund_amount ) : ?>
 					<del><?php echo $txn->get_price( 'amount' ); ?></del>
@@ -40,8 +40,8 @@ if ( ! $transactions || ! $transactions['transactions'] ) {
 				<?php else : ?>
 					<?php echo $txn->get_price( 'amount' ); ?>
 				<?php endif; ?>
-			</th>
-			<th><?php echo $txn->get( 'gateway_source_description' ); ?></th>
+			</td>
+			<td><?php echo $txn->get( 'gateway_source_description' ); ?></td>
 		</tr>
 	<?php endforeach; ?>
 	</tbody>

--- a/templates/myaccount/view-order-transactions.php
+++ b/templates/myaccount/view-order-transactions.php
@@ -8,7 +8,7 @@
  * @since [version] Logic to return empty when no transactions present has been moved to the template function.
  * @version [version]
  *
- * @param array $transactions Result array from {@see LLMS_Order::get_transactions()}.
+ * @var array $transactions Result array from {@see LLMS_Order::get_transactions()}.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/view-order-transactions.php
+++ b/templates/myaccount/view-order-transactions.php
@@ -1,18 +1,17 @@
 <?php
 /**
- * View an Order
+ * Single order transactions table.
  *
  * @package LifterLMS/Templates
  *
- * @since    3.10.0
- * @version  3.10.0
+ * @since 3.10.0
+ * @since [version] Logic to return empty when no transactions present has been moved to the template function.
+ * @version [version]
+ *
+ * @param array $transactions Result array from {@see LLMS_Order::get_transactions()}.
  */
 
 defined( 'ABSPATH' ) || exit;
-
-if ( ! $transactions || ! $transactions['transactions'] ) {
-	return;
-}
 ?>
 
 <table class="orders-table transactions" id="llms-txns">

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -11,9 +11,9 @@
  * @since [version] Load sub-templates using hooks and template functions.
  * @version [version]
  *
- * @param LLMS_Order $order        Current order object.
- * @param array      $transactions Result array from {@see LLMS_Order::get_transactions()}.
- * @param string     $layout_class The view's layout classname. Either `llms-stack-cols` or an empty string for the default side-by-side layout.
+ * @var LLMS_Order $order        Current order object.
+ * @var array      $transactions Result array from {@see LLMS_Order::get_transactions()}.
+ * @var string     $layout_class The view's layout classname. Either `llms-stack-cols` or an empty string for the default side-by-side layout.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -11,254 +11,85 @@
  * @since [version] Stop using deprecated `FILTER_SANITIZE_STRING`.
  * @since [version] Add new hooks.
  * @version [version]
+ *
+ * @param LLMS_Order $order        Current order object.
+ * @param array      $transactions Result array from {@see LLMS_Order::get_transactions()}.
+ * @param string     $layout_class The view's layout classname. Either `llms-stack-cols` or an empty string for the default side-by-side layout.
  */
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! $order ) {
-	return _e( 'Invalid Order.', 'lifterlms' );
-}
-
-$gateway      = $order->get_gateway();
-$order_status = $order->get( 'status' );
+$classes = array_filter(
+	array_map(
+		'esc_attr',
+		array( 'llms-sd-section', 'llms-view-order', $layout_class )
+	)
+);
 
 llms_print_notices();
 ?>
 
-<div class="llms-sd-section llms-view-order<?php echo apply_filters( 'llms_sd_stacked_order_layout', false, $order ) ? ' llms-stack-cols' : ''; ?>">
+<div class="<?php echo implode( ' ', $classes ); ?>">
 
 	<h2 class="order-title">
 		<?php printf( __( 'Order #%d', 'lifterlms' ), $order->get( 'id' ) ); ?>
-		<span class="llms-status <?php echo $order_status; ?>"><?php echo $order->get_status_name(); ?></span>
+		<span class="llms-status <?php echo esc_attr( $order->get( 'status' ) ); ?>"><?php echo $order->get_status_name(); ?></span>
 	</h2>
 
-	<?php do_action( 'lifterlms_before_view_order_table', $order ); ?>
+	<?php
+		/**
+		 * Action run prior to the display of order information.
+		 *
+		 * @since Unknown
+		 *
+		 * @param LLMS_Order $order The order being displayed.
+		 */
+		do_action( 'lifterlms_before_view_order_table', $order );
 
-	<section class="order-primary">
+		/**
+		 * Displays information about the order.
+		 *
+		 * @hooked llms_template_view_order_information 10
+		 *
+		 * @since [version]
+		 *
+		 * @param LLMS_Order $order The order being displayed.
+		 */
+		do_action( 'llms_view_order_information', $order );
 
-		<table class="orders-table">
-			<tbody>
-				<tr>
-					<th><?php _e( 'Status', 'lifterlms' ); ?></th>
-					<td><?php echo $order->get_status_name(); ?></td>
-				</tr>
-
-				<tr>
-					<th><?php _e( 'Access Plan', 'lifterlms' ); ?></th>
-					<td><?php echo $order->get( 'plan_title' ); ?></td>
-				</tr>
-
-				<tr>
-					<th><?php _e( 'Product', 'lifterlms' ); ?></th>
-					<td>
-					<?php if ( llms_get_post( $order->get( 'product_id' ) ) ) : ?>
-						<a href="<?php echo get_permalink( $order->get( 'product_id' ) ); ?>"><?php echo $order->get( 'product_title' ); ?></a>
-					<?php else : ?>
-						<?php echo __( '[DELETED]', 'lifterlms' ) . ' ' . $order->get( 'product_title' ); ?>
-					<?php endif; ?>
-					</td>
-				</tr>
-				<?php if ( $order->has_trial() ) : ?>
-					<?php if ( $order->has_coupon() && $order->get( 'coupon_amount_trial' ) ) : ?>
-						<tr>
-							<th><?php _e( 'Original Total', 'lifterlms' ); ?></th>
-							<td><?php echo $order->get_price( 'trial_original_total' ); ?></td>
-						</tr>
-
-						<tr>
-							<th><?php _e( 'Coupon Discount', 'lifterlms' ); ?></th>
-							<td>
-								<?php echo $order->get_coupon_amount( 'trial' ); ?>
-								(<?php echo llms_price( $order->get_price( 'coupon_value_trial', array(), 'float' ) * - 1 ); ?>)
-								[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
-							</td>
-						</tr>
-					<?php endif; ?>
-
-					<tr>
-						<th><?php _e( 'Trial Total', 'lifterlms' ); ?></th>
-						<td>
-							<?php echo $order->get_price( 'trial_total' ); ?>
-							<?php printf( _n( 'for %1$d %2$s', 'for %1$d %2$ss', $order->get( 'trial_length' ), 'lifterlms' ), $order->get( 'trial_length' ), $order->get( 'trial_period' ) ); ?>
-						</td>
-					</tr>
-				<?php endif; ?>
-
-				<?php if ( $order->has_discount() ) : ?>
-					<tr>
-						<th><?php _e( 'Original Total', 'lifterlms' ); ?></th>
-						<td><?php echo $order->get_price( 'original_total' ); ?></td>
-					</tr>
-
-					<?php if ( $order->has_sale() ) : ?>
-						<tr>
-							<th><?php _e( 'Sale Discount', 'lifterlms' ); ?></th>
-							<td>
-								<?php echo $order->get_price( 'sale_price' ); ?>
-								(<?php echo llms_price( $order->get_price( 'sale_value', array(), 'float' ) * -1 ); ?>)
-							</td>
-						</tr>
-					<?php endif; ?>
-
-					<?php if ( $order->has_coupon() ) : ?>
-						<tr>
-							<th><?php _e( 'Coupon Discount', 'lifterlms' ); ?></th>
-							<td>
-								<?php echo $order->get_coupon_amount( 'regular' ); ?>
-								(<?php echo llms_price( $order->get_price( 'coupon_value', array(), 'float' ) * - 1 ); ?>)
-								[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
-							</td>
-						</tr>
-					<?php endif; ?>
-				<?php endif; ?>
-
-				<tr>
-					<th><?php _e( 'Total', 'lifterlms' ); ?></th>
-					<td>
-						<?php echo $order->get_price( 'total' ); ?>
-						<?php if ( $order->is_recurring() ) : ?>
-							<?php
-							// phpcs:disable WordPress.WP.I18n.MissingSingularPlaceholder -- We don't output the number in the singular so it throws a CS error but it's working as we want it to.
-							printf( _n( 'Every %2$s', 'Every %1$d %2$ss', $order->get( 'billing_frequency' ), 'lifterlms' ), $order->get( 'billing_frequency' ), $order->get( 'billing_period' ) );
-							// phpcs:enable WordPress.WP.I18n.MissingSingularPlaceholder
-							?>
-							<?php if ( $order->get( 'billing_cycle' ) > 0 ) : ?>
-								<?php printf( _n( 'for %1$d %2$s', 'for %1$d %2$ss', $order->get( 'billing_cycle' ), 'lifterlms' ), $order->get( 'billing_cycle' ), $order->get( 'billing_period' ) ); ?>
-							<?php endif; ?>
-						<?php else : ?>
-							<?php _e( 'One-time', 'lifterlms' ); ?>
-						<?php endif; ?>
-					</td>
-				</tr>
-
-				<tr>
-					<th><?php _e( 'Payment Method', 'lifterlms' ); ?></th>
-					<td>
-						<?php if ( is_wp_error( $gateway ) ) : ?>
-							<?php echo $order->get( 'payment_gateway' ); ?>
-						<?php else : ?>
-							<?php echo $gateway->get_title(); ?>
-						<?php endif; ?>
-						<?php do_action( 'lifterlms_view_order_after_payment_method', $order ); ?>
-					</td>
-				</tr>
-
-				<tr>
-					<th><?php _e( 'Start Date', 'lifterlms' ); ?></th>
-					<td><?php echo $order->get_date( 'date', 'F j, Y' ); ?></td>
-				</tr>
-				<?php if ( $order->is_recurring() ) : ?>
-					<tr>
-						<th><?php _e( 'Last Payment Date', 'lifterlms' ); ?></th>
-						<td><?php echo $order->get_last_transaction_date( 'llms-txn-succeeded', 'any', 'F j, Y' ); ?></td>
-					</tr>
-
-					<?php if ( 'llms-pending-cancel' !== $order_status ) : ?>
-						<tr>
-							<th><?php _e( 'Next Payment Date', 'lifterlms' ); ?></th>
-							<td>
-								<?php if ( $order->has_scheduled_payment() ) : ?>
-									<?php echo $order->get_next_payment_due_date( 'F j, Y' ); ?>
-								<?php else : ?>
-									&ndash;
-								<?php endif; ?>
-							</td>
-						</tr>
-					<?php endif; ?>
-				<?php endif; ?>
-
-				<?php if ( ! $order->is_recurring() || 'lifetime' !== $order->get( 'access_expiration' ) || 'llms-pending-cancel' === $order_status ) : ?>
-				<tr>
-					<th><?php _e( 'Expiration Date', 'lifterlms' ); ?></th>
-					<td><?php echo $order->get_access_expiration_date( 'F j, Y' ); ?></td>
-				</tr>
-				<?php endif; ?>
-
-				<?php do_action( 'lifterlms_view_order_table_body', $order ); ?>
-			</tbody>
-		</table>
-	</section>
-
-	<aside class="order-secondary">
-
-		<?php
-			/**
-			 * Action executed after opening the secondary order element.
-			 *
-			 * @since [version]
-			 *
-			 * @param LLMS_Order $order The current order object.
-			 */
-			do_action( 'llms_view_order_before_secondary', $order );
-		?>
-
-		<?php if ( $order->is_recurring() ) : ?>
-
-			<?php if ( isset( $_GET['confirm-switch'] ) || 'llms-active' === $order_status || $order->can_resubscribe() ) : ?>
-
-				<?php
-				llms_get_template(
-					'checkout/form-switch-source.php',
-					array(
-						'confirm' => llms_filter_input_sanitize_string( INPUT_GET, 'confirm-switch' ),
-						'order'   => $order,
-					)
-				);
-				?>
-
-			<?php endif; ?>
-
-			<?php if ( apply_filters( 'llms_allow_subscription_cancellation', true, $order ) && in_array( $order_status, array( 'llms-active', 'llms-on-hold' ) ) ) : ?>
-
-				<form action="" id="llms-cancel-subscription-form" method="POST">
-
-					<?php
-					llms_form_field(
-						array(
-							'columns'     => 12,
-							'classes'     => 'llms-button-secondary',
-							'id'          => 'llms_cancel_subscription',
-							'value'       => __( 'Cancel Subscription', 'lifterlms' ),
-							'last_column' => true,
-							'required'    => false,
-							'type'        => 'submit',
-						)
-					);
-					?>
-
-					<?php wp_nonce_field( 'llms_cancel_subscription', '_cancel_sub_nonce' ); ?>
-					<input name="order_id" type="hidden" value="<?php echo $order->get( 'id' ); ?>">
-
-				</form>
-
-			<?php endif; ?>
-
-		<?php endif; ?>
-
-		<?php
-			/**
-			 * Action executed before closing the secondary order element.
-			 *
-			 * @since [version]
-			 *
-			 * @param LLMS_Order $order The current order object.
-			 */
-			do_action( 'llms_view_order_after_secondary', $order );
-		?>
-
-	</aside>
+		/**
+		 * Displays user actions for the order.
+		 *
+		 * @hooked llms_template_view_order_information 10
+		 *
+		 * @since [version]
+		 *
+		 * @param LLMS_Order $order The order being displayed.
+		 */
+		do_action( 'llms_view_order_actions', $order );
+	?>
 
 	<div class="clear"></div>
 
 	<?php
-	llms_get_template(
-		'myaccount/view-order-transactions.php',
-		array(
-			'transactions' => $transactions,
-		)
-	);
-	?>
+		/**
+		 * Displays order transactions.
+		 *
+		 * @since Unknown
+		 *
+		 * @param LLMS_Order $order        The order being displayed.
+		 * @param array      $transactions Result array from {@see LLMS_Order::get_transactions()}.
+		 */
+		do_action( 'llms_view_order_transactions', $order, $transactions );
 
-	<?php do_action( 'lifterlms_after_view_order_table', $order ); ?>
+		/**
+		 * Action run after the display of order information.
+		 *
+		 * @since Unknown
+		 *
+		 * @param LLMS_Order $order The order being displayed.
+		 */
+		do_action( 'lifterlms_after_view_order_table', $order );
+	?>
 
 </div>

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -8,8 +8,7 @@
  * @since 3.33.0 Pass the current order object instance as param for all the actions and filters, plus redundant check on order existence removed.
  * @since 3.35.0 Access `$_GET` data via `llms_filter_input()`.
  * @since 5.4.0 Inform about deleted products.
- * @since [version] Stop using deprecated `FILTER_SANITIZE_STRING`.
- * @since [version] Add new hooks.
+ * @since [version] Load sub-templates using hooks and template functions.
  * @version [version]
  *
  * @param LLMS_Order $order        Current order object.

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-vier-order.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-vier-order.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Test certificate template functions
+ *
+ * @package LifterLMS/Tests/Functions
+ *
+ * @group functions
+ * @group functions_template
+ * @group functions_template_view_order
+ *
+ * @since [version]
+ */
+class LLMS_Test_Functions_Templates_View_Order extends LLMS_UnitTestCase {
+
+	/**
+	 * Utility used to get the number of times a set of actions has run.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	private function get_action_counts( $func ) {
+
+		switch ( $func ) {
+
+			case 'llms_template_view_order':
+				$list = array(
+					'lifterlms_before_view_order_table',
+					'llms_view_order_information',
+					'llms_view_order_actions',
+					'llms_view_order_transactions',
+					'lifterlms_after_view_order_table',
+				);
+				break;
+
+			case 'llms_template_view_order_actions':
+				$list = array(
+					'llms_view_order_before_secondary',
+					'llms_view_order_after_secondary',
+				);
+				break;
+
+			case 'llms_template_view_order_information':
+				$list = array(
+					'lifterlms_view_order_table_body',
+				);
+				break;
+
+		}
+
+		$actions = array_fill_keys( $list, 0 );
+		foreach ( $actions as $action => &$count ) {
+			$count = did_action( $action );
+		}
+
+		return $actions;
+
+	}
+
+	/**
+	 * Test llms_template_view_order() with invalid input.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_not_an_order() {
+
+		$post  = $this->factory->post->create_and_get( array( 'post_type' => 'course' ) );
+		$tests = array(
+			$post,
+			llms_get_post( $post ),
+			$post->ID,
+			false,
+			new stdClass(),
+		);
+		foreach ( $tests as $input ) {
+			$this->assertOutputEquals( 'Invalid Order.', 'llms_template_view_order', array( $input ) );
+		}
+
+		foreach ( $this->get_action_counts( 'llms_template_view_order' ) as $action => $count ) {
+			$this->assertSame( 0, $count, $action );
+		}
+
+
+	}
+
+	/**
+	 * Test llms_template_view_order() when accessed by another user.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_wrong_user() {
+
+		$order = $this->get_mock_order();
+		$this->assertOutputEquals( 'Invalid Order.', 'llms_template_view_order', array( $order ) );
+
+		foreach ( $this->get_action_counts( 'llms_template_view_order' ) as $action => $count ) {
+			$this->assertSame( 0, $count, $action );
+		}
+
+	}
+
+	/**
+	 * Test llms_template_view_order().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order() {
+
+		$actions = $this->get_action_counts( 'llms_template_view_order' );
+
+		$order = $this->get_mock_order();
+		wp_set_current_user( $order->get( 'user_id' ) );
+
+		$res = $this->get_output( 'llms_template_view_order', array( $order ) );
+
+		$this->assertStringContainsString( '<div class="llms-sd-section llms-view-order">', $res );
+		$this->assertStringContainsString( sprintf( 'Order #%d', $order->get( 'id' ) ), $res );
+
+		foreach ( $this->get_action_counts( 'llms_template_view_order' ) as $action => $count ) {
+			$this->assertEquals( $actions[ $action] + 1, $count, $action );
+		}
+
+	}
+
+	/**
+	 * Test llms_template_view_order_actions().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_actions() {
+
+		$actions = $this->get_action_counts( 'llms_template_view_order_actions' );
+
+		$order = $this->get_mock_order();
+
+		$res = $this->get_output( 'llms_template_view_order_actions', array( $order ) );
+
+		$this->assertStringContainsString( '<aside class="order-secondary">', $res );
+
+		foreach ( $this->get_action_counts( 'llms_template_view_order_actions' ) as $action => $count ) {
+			$this->assertEquals( $actions[ $action] + 1, $count, $action );
+		}
+
+	}
+
+	/**
+	 * Test llms_template_view_order_information().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_information() {
+
+		$actions = $this->get_action_counts( 'llms_template_view_order_information' );
+
+		$order = $this->get_mock_order();
+
+		$res = $this->get_output( 'llms_template_view_order_information', array( $order ) );
+
+		$this->assertStringContainsString( '<section class="order-primary">', $res );
+
+		foreach ( $this->get_action_counts( 'llms_template_view_order_information' ) as $action => $count ) {
+			$this->assertEquals( $actions[ $action] + 1, $count, $action );
+		}
+
+	}
+
+	/**
+	 * Test llms_template_view_order_transactions() for an order with no transactions.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_transactions_no_txns() {
+
+		$order = $this->get_mock_order();
+		$this->assertOutputEmpty( 'llms_template_view_order_transactions', array( $order ) );
+
+	}
+
+	/**
+	 * Test llms_template_view_order_transactions() for an order with no transactions.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_template_view_order_transactions() {
+
+		$order = $this->get_mock_order();
+		$order->record_transaction();
+
+		$res = $this->get_output( 'llms_template_view_order_transactions', array( $order ) );
+
+		$this->assertStringContainsString( '<table class="orders-table transactions" id="llms-txns">', $res );
+
+		// No pagination.
+		$this->assertStringNotContainsString( '<tfoot>', $res );
+
+		// Test pagination.
+		$order->record_transaction();
+		$order->record_transaction();
+
+		$filter = function( $count ) {
+			return 2;
+		};
+		add_filter( 'llms_student_dashboard_transactions_per_page', $filter );
+
+		$res = $this->get_output( 'llms_template_view_order_transactions', array( $order ) );
+
+		$this->assertStringContainsString( '<tfoot>', $res );
+		$this->assertStringContainsString( '<a class="llms-button-secondary small" href="?txnpage=2#llms-txns">Next</a>', $res );
+
+		// Two transactions in the table.
+		$dom = llms_get_dom_document( $res );
+		$this->assertEquals( 2, $dom->getElementsByTagName( 'tbody' )[0]->getElementsByTagName( 'tr' )->length );
+
+		// Go to page 2.
+		$this->mockGetRequest( array( 'txnpage' => 2 ) );
+		$res = $this->get_output( 'llms_template_view_order_transactions', array( $order ) );
+
+		$this->assertStringContainsString( '<tfoot>', $res );
+		$this->assertStringContainsString( '<a class="llms-button-secondary small" href="?txnpage=1#llms-txns">Back</a>', $res );
+
+		// One transaction in the table.
+		$dom = llms_get_dom_document( $res );
+		$this->assertEquals( 1, $dom->getElementsByTagName( 'tbody' )[0]->getElementsByTagName( 'tr' )->length );
+
+		remove_filter( 'llms_student_dashboard_transactions_per_page', $filter );
+
+	}
+
+}


### PR DESCRIPTION
## Description

This PR moves direct inclusion of view-order template files into hooks & template include functions.

The purpose of this change is, ultimately, provide greater extensibility to this area of the student dashboard. Most directly, this is useful in upcoming changes in our PDF add-on.

This also splits the view-order.php template file into several sub-templates

## How has this been tested?

+ Manually
+ I'll be coming back to this to add new tests for the template functions

## Screenshots <!-- if applicable -->

## Types of changes
+ Update

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

