### PR TITLE
Minor updates to the dashboard grades table

### DIFF
--- a/assets/scss/frontend/_student-dashboard.scss
+++ b/assets/scss/frontend/_student-dashboard.scss
@@ -204,6 +204,12 @@
 // grades table for a single course
 .llms-table.llms-single-course-grades {
 
+	tbody {
+		tr:first-child td, tr:first-child th {
+			background-color: #eaeaea;
+		}
+	}
+
 	th {
 		font-weight: 400;
 	}

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -946,6 +946,8 @@ function llms_modify_dashboard_pagination_links( $link ) {
  */
 function llms_sd_my_grades_table_content( $id, $lesson, $student, $restrictions ) {
 
+	ob_start();
+
 	/**
 	 * Fires before the student dashboard my grades table cell content output
 	 *
@@ -1007,5 +1009,20 @@ function llms_sd_my_grades_table_content( $id, $lesson, $student, $restrictions 
 	 * @param array        $restrictions Restriction data from `llms_page_restricted()`.
 	 */
 	do_action( 'llms_sd_my_grades_table_content_' . $id, $lesson, $student, $restrictions );
+
+	$html = ob_get_clean();
+
+	/**
+	 * Filters the HTML returned by llms_sd_my_grades_table_content().
+	 *
+	 * @since [version]
+	 *
+	 * @param string       $html         The cell HTML.
+	 * @param string       $id           Key of the table cell.
+	 * @param LLMS_Lesson  $lesson       LLMS_Lesson.
+	 * @param LLMS_Student $student      LLMS_Student.
+	 * @param array        $restrictions Restriction data from `llms_page_restricted()`.
+	 */
+	return apply_filters( 'llms_sd_my_grades_table_content', $html, $id, $lesson, $student, $restrictions );
 
 }

--- a/templates/myaccount/my-grades-single-table.php
+++ b/templates/myaccount/my-grades-single-table.php
@@ -4,7 +4,7 @@
  *
  * @since 3.24.0
  * @since [version] Wrap each section in a <tbody> element.
- * @version 3.24.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/my-grades-single-table.php
+++ b/templates/myaccount/my-grades-single-table.php
@@ -2,8 +2,9 @@
 /**
  * My Grades Single Course Table Template
  *
- * @since    3.24.0
- * @version  3.24.0
+ * @since 3.24.0
+ * @since [version] Wrap each section in a <tbody> element.
+ * @version 3.24.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,43 +12,43 @@ defined( 'ABSPATH' ) || exit;
 
 <table class="llms-table llms-single-course-grades">
 <?php foreach ( $course->get_sections() as $section ) : ?>
-
-	<tr class="llms-section">
-		<th class="llms-section_title" colspan="2">
-			<?php printf( __( 'Section %1$d: %2$s', 'lifterlms' ), $section->get( 'order' ), $section->get( 'title' ) ); ?>
-		</th>
-		<?php foreach ( $section_headings as $id => $content ) : ?>
-			<th class="llms-<?php echo esc_attr( $id ); ?>">
-				<?php echo $content; ?>
+	<tbody>
+		<tr class="llms-section">
+			<th class="llms-section_title" colspan="2">
+				<?php printf( __( 'Section %1$d: %2$s', 'lifterlms' ), $section->get( 'order' ), $section->get( 'title' ) ); ?>
 			</th>
-		<?php endforeach; ?>
-	</tr>
-
-	<?php
-	foreach ( $section->get_lessons() as $lesson ) :
-		$restricted = llms_page_restricted( $lesson->get( 'id' ) );
-		$title      = $lesson->get( 'title' );
-		$url        = $restricted['is_restricted'] ? '#' : get_permalink( $lesson->get( 'id' ) );
-		$title      = sprintf( '<a href="%1$s">%2$s</a>', $url, $title );
-		?>
-		<tr>
-			<td class="llms-lesson_title" colspan="2">
-				<?php printf( __( 'Lesson %1$d: %2$s', 'lifterlms' ), $lesson->get( 'order' ), $title ); ?>
-				<?php if ( $restricted['is_restricted'] ) : ?>
-					<a data-tooltip-msg="<?php echo esc_attr( strip_tags( llms_get_restriction_message( $restricted ) ) ); ?>" href="#llms-lesson-locked">
-						<i class="fa fa-lock" aria-hidden="true"></i>
-					</a>
-				<?php endif; ?>
-			</td>
-
-			<?php foreach ( $section_headings as $id => $data ) : ?>
-				<td class="llms-<?php echo esc_attr( $id ); ?>">
-					<?php echo llms_sd_my_grades_table_content( $id, $lesson, $student, $restricted ); ?>
-				</td>
+			<?php foreach ( $section_headings as $id => $content ) : ?>
+				<th class="llms-<?php echo esc_attr( $id ); ?>">
+					<?php echo $content; ?>
+				</th>
 			<?php endforeach; ?>
-
 		</tr>
-	<?php endforeach; ?>
 
+		<?php
+		foreach ( $section->get_lessons() as $lesson ) :
+			$restricted = llms_page_restricted( $lesson->get( 'id' ) );
+			$title      = $lesson->get( 'title' );
+			$url        = $restricted['is_restricted'] ? '#' : get_permalink( $lesson->get( 'id' ) );
+			$title      = sprintf( '<a href="%1$s">%2$s</a>', $url, $title );
+			?>
+			<tr>
+				<td class="llms-lesson_title" colspan="2">
+					<?php printf( __( 'Lesson %1$d: %2$s', 'lifterlms' ), $lesson->get( 'order' ), $title ); ?>
+					<?php if ( $restricted['is_restricted'] ) : ?>
+						<a data-tooltip-msg="<?php echo esc_attr( strip_tags( llms_get_restriction_message( $restricted ) ) ); ?>" href="#llms-lesson-locked">
+							<i class="fa fa-lock" aria-hidden="true"></i>
+						</a>
+					<?php endif; ?>
+				</td>
+
+				<?php foreach ( $section_headings as $id => $data ) : ?>
+					<td class="llms-<?php echo esc_attr( $id ); ?>">
+						<?php echo llms_sd_my_grades_table_content( $id, $lesson, $student, $restricted ); ?>
+					</td>
+				<?php endforeach; ?>
+
+			</tr>
+		<?php endforeach; ?>
+	</tbody>
 <?php endforeach; ?>
 </table>


### PR DESCRIPTION
## Description

+Adds a filter on the return of [llms_sd_my_grades_table_content()](https://developer.lifterlms.com/?s=llms_sd_my_grades_table_content)
+ Wraps each section in the grades table in a `<tbody>` element. This makes the table a bit more accessible from a semantic perspective. Also darken the first row of each `<tbody>` to help the row stand out as the section header.

Theses changes primarily help the PDFs add-on v2 changes.

## How has this been tested?

+ Manually

