### PR TITLE
Disable composer timeout when running unit tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,8 +111,14 @@
       "@tests-remove",
       "@tests-install"
     ],
-    "tests": "\"vendor/bin/phpunit\"",
-    "tests-run": "\"vendor/bin/phpunit\"",
+    "tests": [
+      "Composer\\Config::disableProcessTimeout",
+      "\"vendor/bin/phpunit\""
+    ],
+    "tests-run": [
+      "Composer\\Config::disableProcessTimeout",
+      "\"vendor/bin/phpunit\""
+    ],
     "install-php8": "composer install --ignore-platform-reqs"
   },
   "extra": {


### PR DESCRIPTION
## Description
Composer defaults to a 5-minute timeout when running scripts. This PR disables the timeout when running unit tests.

https://getcomposer.org/doc/06-config.md#process-timeout

## How has this been tested?

On an aging 4-core CPU.

## Types of changes

Remove time limit when running phpunit via composer.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

