### PR TITLE
Set core/columns to not stack on mobile by default for certificate posts

### DIFF
--- a/includes/schemas/llms-block-templates.php
+++ b/includes/schemas/llms-block-templates.php
@@ -60,7 +60,9 @@ $certificates = array(
 	),
 	array(
 		'core/columns',
-		array(),
+		array(
+			'isStackedOnMobile' => false,
+		),
 		array(
 			array(
 				'core/column',

--- a/src/js/admin-certificate-editor/index.js
+++ b/src/js/admin-certificate-editor/index.js
@@ -6,6 +6,7 @@ import './editor';
 import './i18n';
 import './merge-codes';
 import './migrate';
+import './modify-blocks';
 import CertificateDocumentSettings from './document-settings';
 import CertificateResetTemplate from './reset-template';
 import CertificateUserSettings from './user-settings';

--- a/src/js/admin-certificate-editor/modify-blocks.js
+++ b/src/js/admin-certificate-editor/modify-blocks.js
@@ -1,7 +1,5 @@
-import classnames from 'classnames';
-
+// WP Deps.
 import { addFilter } from '@wordpress/hooks';
-import { cloneElement } from '@wordpress/element'
 
 /**
  * Modifies the registration of the core/columns block.
@@ -16,26 +14,23 @@ import { cloneElement } from '@wordpress/element'
  *
  * @since [version]
  *
- * @link https://github.com/gocodebox/lifterlms/issues/1972
+ * @see {@link https://github.com/gocodebox/lifterlms/issues/1972}
  *
  * @param {Object} settings  Block registration settings.
  * @param {string} blockName The block's name.
  * @return {Object} Block registration settings.
  */
 function modifyColumnsBlock( settings, blockName ) {
-
 	if ( 'core/columns' === blockName ) {
-
 		// Force all the existing columns block variation to have mobile stacking disabled by default.
 		settings.variations = settings.variations.map( ( variation ) => {
 			const { attributes = {} } = variation;
 			variation.attributes = {
 				...attributes,
-				isStackedOnMobile: false
+				isStackedOnMobile: false,
 			};
 			return variation;
 		} );
-
 	}
 
 	return settings;
@@ -45,4 +40,4 @@ addFilter(
 	'blocks.registerBlockType',
 	'llms/certificate-editor/columns-block',
 	modifyColumnsBlock,
-)
+);

--- a/src/js/admin-certificate-editor/modify-blocks.js
+++ b/src/js/admin-certificate-editor/modify-blocks.js
@@ -1,0 +1,48 @@
+import classnames from 'classnames';
+
+import { addFilter } from '@wordpress/hooks';
+import { cloneElement } from '@wordpress/element'
+
+/**
+ * Modifies the registration of the core/columns block.
+ *
+ * I cannot find a way to disable the toggle in the block's inspector panel, nor
+ * can I determine the proper way to simply define the block's default attribute value
+ * as `false`. By setting the variations to all have the default value it will
+ * ensure that any new columns added to a certificate will have mobile stacking disabled.
+ * Users will still be able to enable this via the admin UI but since there's no way
+ * to disable the toggle we'll have to accept that. Realistically it won't have much impact
+ * anyway but it would be good to be able to disable it.
+ *
+ * @since [version]
+ *
+ * @link https://github.com/gocodebox/lifterlms/issues/1972
+ *
+ * @param {Object} settings  Block registration settings.
+ * @param {string} blockName The block's name.
+ * @return {Object} Block registration settings.
+ */
+function modifyColumnsBlock( settings, blockName ) {
+
+	if ( 'core/columns' === blockName ) {
+
+		// Force all the existing columns block variation to have mobile stacking disabled by default.
+		settings.variations = settings.variations.map( ( variation ) => {
+			const { attributes = {} } = variation;
+			variation.attributes = {
+				...attributes,
+				isStackedOnMobile: false
+			};
+			return variation;
+		} );
+
+	}
+
+	return settings;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'llms/certificate-editor/columns-block',
+	modifyColumnsBlock,
+)


### PR DESCRIPTION
## Description

Closes #1972 

This PR modifies all `core/columns` block variations during block registration (client-side) to have `isStackedOnMobile` set to `false`.

Additionally passes this value in the default certificate block template.

This, effectively, makes it so that all columns added to a certificate will not stack by default until a user opts into stacking. They have the power to do so but they'll only do so if they choose.

I have tried ever filter found on [this page](https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/) to simply change the default value (via either PHP or JS) so that we don't need any fancy hacks but no combination I can find works without through a block validation error in the block editor. The validation error seems to be in error as the stored HTML is correct with most of the filters I've attempted. But... I can't figure out the chain of events that ultimately cause that validation error.

I cannot locate a way to disable the stacking toggle in the block's editor inspector. The only way I can figure out how to do it would be to redefine the `Edit()` element for the core block. This is possible but would make maintenance difficult long term. I'd rather avoid this.

I also tried creating a custom block (llms/certificate-columns) that leverages code from the core block (as we did for the lllms/certificate-title block, using the core/heading block as the base) but this block is quite a bit more complicated and I found myself having to copy too much logic again, making maintenance difficult.

