### PR TITLE
Fix deprecation warning when editing an achievement

### DIFF
--- a/.changelogs/metabox.yml
+++ b/.changelogs/metabox.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+links:
+  - "#2016"
+entry: Added the ability to force an admin metabox field value through the new `meta` arg.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
@@ -73,7 +73,6 @@ class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 			'label'    => __( 'Achievement Content', 'lifterlms' ),
 			'desc'     => __( 'An optional short description of the achievement which will be shown to users', 'lifterlms' ),
 			'id'       => $this->prefix . 'achievement_content',
-			'default'  => '',
 			'type'     => 'textarea_w_tags',
 			'sanitize' => 'no_encode_quotes',
 			'cols'     => 80,

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.achievement.php
@@ -73,11 +73,12 @@ class LLMS_Meta_Box_Achievement extends LLMS_Admin_Metabox {
 			'label'    => __( 'Achievement Content', 'lifterlms' ),
 			'desc'     => __( 'An optional short description of the achievement which will be shown to users', 'lifterlms' ),
 			'id'       => $this->prefix . 'achievement_content',
+			'default'  => '',
 			'type'     => 'textarea_w_tags',
 			'sanitize' => 'no_encode_quotes',
 			'cols'     => 80,
 			'rows'     => 8,
-			'value'    => $this->post->post_content,
+			'meta'     => $this->post->post_content,
 		);
 
 		return array(

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.fields.php
@@ -42,13 +42,16 @@ abstract class LLMS_Metabox_Field {
 	 * @since unknown
 	 * @since 3.11.0 Unknown.
 	 * @since [version] Do not print empty labels; do not print the description block if both 'desc' and 'label' are empty.
-	 *
+	 *               Avoid retrieving the meta from the db if passed.
 	 * @return void
 	 */
 	public function output() {
 
 		global $post;
-		if ( ( ! metadata_exists( 'post', $post->ID, $this->field['id'] ) || 'auto-draft' === $post->post_status ) && ! empty( $this->field['default'] ) ) {
+
+		if ( isset( $this->field['meta'] ) ) {
+			$this->meta = $this->field['meta'];
+		} elseif ( ( ! metadata_exists( 'post', $post->ID, $this->field['id'] ) || 'auto-draft' === $post->post_status ) && ! empty( $this->field['default'] ) ) {
 			$this->meta = $this->field['default'];
 		} else {
 			$this->meta = self::get_post_meta( $post->ID, $this->field['id'] );

--- a/tests/phpunit/unit-tests/admin/post-types/meta-boxes/fields/class-llms-test-meta-box-textarea-tags.php
+++ b/tests/phpunit/unit-tests/admin/post-types/meta-boxes/fields/class-llms-test-meta-box-textarea-tags.php
@@ -33,11 +33,14 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test output when passing a custom value.
+	 * Test output when not passing a custom value.
+	 *
+	 * @since [version]
 	 *
 	 * @return void
 	 */
 	public function test_output_without_custom_value() {
+
 		// Set-up global post.
 		global $post;
 		$original_post = $post;
@@ -47,11 +50,11 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 
 		$field = new LLMS_Metabox_Textarea_W_Tags_Field(
 			array(
-				'type'       => 'textarea_w_tags',
-				'label'      => __( 'Test', 'lifterlms' ),
-				'id'         => 'without_custom_value',
-				'class'      => 'code input-full',
-				'value'      => '',
+				'type'  => 'textarea_w_tags',
+				'label' => __( 'Test', 'lifterlms' ),
+				'id'    => 'without_custom_value',
+				'class' => 'code input-full',
+				'value' => '',
 			),
 		);
 
@@ -67,11 +70,11 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 
 		$field = new LLMS_Metabox_Textarea_W_Tags_Field(
 			array(
-				'type'       => 'textarea_w_tags',
-				'label'      => __( 'Test', 'lifterlms' ),
-				'id'         => 'without_custom_value',
-				'class'      => 'code input-full',
-				'value'      => '',
+				'type'  => 'textarea_w_tags',
+				'label' => __( 'Test', 'lifterlms' ),
+				'id'    => 'without_custom_value',
+				'class' => 'code input-full',
+				'value' => '',
 			),
 		);
 		$this->assertOutputContains(
@@ -90,6 +93,8 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 	/**
 	 * Test output when passing a custom value.
 	 *
+	 * @since [version]
+	 *
 	 * @return void
 	 */
 	public function test_output_with_custom_value() {
@@ -103,11 +108,11 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 
 		$field = new LLMS_Metabox_Textarea_W_Tags_Field(
 			array(
-				'type'       => 'textarea_w_tags',
-				'label'      => __( 'Test', 'lifterlms' ),
-				'id'         => 'with_custom_value',
-				'class'      => 'code input-full',
-				'value'      => 'Custom Value',
+				'type'  => 'textarea_w_tags',
+				'label' => __( 'Test', 'lifterlms' ),
+				'id'    => 'with_custom_value',
+				'class' => 'code input-full',
+				'value' => 'Custom Value',
 			),
 		);
 
@@ -124,6 +129,47 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 
 	}
 
+
+	/**
+	 * Test output when forcing a meta.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output_with_meta_forced() {
+
+		// Set-up global post.
+		global $post;
+		$original_post = $post;
+
+		$post = $this->factory->post->create_and_get();
+		update_post_meta( $post->ID, 'with_custom_value', 'This should not show' );
+
+		$field = new LLMS_Metabox_Textarea_W_Tags_Field(
+			array(
+				'type'  => 'textarea_w_tags',
+				'label' => __( 'Test', 'lifterlms' ),
+				'id'    => 'with_custom_value',
+				'class' => 'code input-full',
+				'meta'  => 'Custom Value',
+			),
+		);
+
+		$this->assertOutputContains(
+			'>Custom Value</textarea>',
+			array(
+				$field,
+				'output'
+			)
+		);
+
+		// Reset global post.
+		$post = $original_post;
+
+	}
+
+
 	/**
 	 * Test output with rows and columns.
 	 *
@@ -139,10 +185,10 @@ class LLMS_Test_Metabox_Textarea_W_Tags_Field extends LLMS_Unit_Test_Case {
 		$post = $this->factory->post->create_and_get();
 
 		$args = array(
-			'type'       => 'textarea_w_tags',
-			'label'      => __( 'Test', 'lifterlms' ),
-			'id'         => 'without_custom_value',
-			'class'      => 'code input-full',
+			'type'  => 'textarea_w_tags',
+			'label' => __( 'Test', 'lifterlms' ),
+			'id'    => 'without_custom_value',
+			'class' => 'code input-full',
 		);
 
 		// Use defaults.


### PR DESCRIPTION
## Description
Fixes #2016 

This is fixed by "forcing" the `meta` value.
I previously used the `value` param for that purpose, but it didn't avoid the retrieving of the meta with key === field_id.
Also we cannot use the `value` param to force the field value, as historically that has been used for _different purposes_ see the checkbox field, or the search and the select meta boxes.

## How has this been tested?
manually & unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue) - kind of

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

