### PR TITLE
Update rest api to 1.0.0 beta.23

### DIFF
--- a/.changelogs/lifterlm-rest.yml
+++ b/.changelogs/lifterlm-rest.yml
@@ -1,3 +1,3 @@
 significance: minor
 type: changed
-entry: Updates LifterLMS REST to [v1.0.0-beta.22](https://make.lifterlms.com/2021/12/15/lifterlms-rest-api-version-1-0-0-beta-22/).
+entry: Updates LifterLMS REST to [v1.0.0-beta.23](https://make.lifterlms.com/2022/02/23/lifterlms-rest-api-version-1-0-0-beta-23/).

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "lifterlms/lifterlms-blocks": "2.3.2",
     "lifterlms/lifterlms-cli": "0.0.3",
     "lifterlms/lifterlms-helper": "3.4.1",
-    "lifterlms/lifterlms-rest": "1.0.0-beta.22",
+    "lifterlms/lifterlms-rest": "1.0.0-beta.23",
     "woocommerce/action-scheduler": "3.4.0"
   },
   "require-dev": {


### PR DESCRIPTION
requires [this](https://github.com/gocodebox/lifterlms-rest/pull/263) to be merged, and the release to be published.