### PR TITLE
Fix certificate {sequential_id} only incremented when programmatically inserting an awarded certificate

### DIFF
--- a/includes/controllers/class-llms-controller-awards.php
+++ b/includes/controllers/class-llms-controller-awards.php
@@ -142,6 +142,10 @@ class LLMS_Controller_Awards {
 		 */
 		if ( ! $obj->is_awarded() ) {
 
+			if ( 'llms_my_certificate' === $post_type ) {
+				$obj->maybe_set_sequential_id();
+			}
+
 			LLMS_Engagement_Handler::create_actions(
 				self::strip_prefix( $post_type ),
 				$obj->get_user_id(),

--- a/includes/controllers/class-llms-controller-awards.php
+++ b/includes/controllers/class-llms-controller-awards.php
@@ -143,7 +143,7 @@ class LLMS_Controller_Awards {
 		if ( ! $obj->is_awarded() ) {
 
 			if ( 'llms_my_certificate' === $post_type ) {
-				$obj->maybe_set_sequential_id();
+				$obj->update_sequential_id();
 			}
 
 			LLMS_Engagement_Handler::create_actions(

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -106,18 +106,24 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 	}
 
 	/**
-	 * Maybe set this awarded certificate sequential id based on the parent's meta.
+	 * Set this awarded certificate sequential id based on the parent's meta.
 	 *
 	 * @since [version]
 	 *
-	 * @return void
+	 * @return int|false Returns the awarded certificate sequenatial id.
+	 *                   Returns false if the awarded certificate has no parent template.
 	 */
-	public function maybe_set_sequential_id() {
+	public function update_sequential_id() {
 
 		$parent = $this->get( 'parent' );
-		if ( $parent ) {
-			$this->set( 'sequential_id', llms_get_certificate_sequential_id( $parent, true ) );
+		if ( ! $parent ) {
+			return false;
 		}
+
+		$next_sequential_id = llms_get_certificate_sequential_id( $parent, true );
+		$this->set( 'sequential_id', $next_sequential_id );
+
+		return $next_sequential_id;
 
 	}
 

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -106,16 +106,19 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 	}
 
 	/**
-	 * Called immediately after creating / inserting a new post into the database
+	 * Maybe set this awarded certificate sequential id based on the parent's meta.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	protected function after_create() {
+	public function maybe_set_sequential_id() {
 
-		$this->set( 'sequential_id', llms_get_certificate_sequential_id( $this->get( 'parent' ), true ) );
-		parent::after_create();
+		$parent = $this->get( 'parent' );
+		if ( $parent ) {
+			$this->set( 'sequential_id', llms_get_certificate_sequential_id( $parent, true ) );
+		}
+
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
@@ -132,6 +132,28 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
+	 * Test update_sequential_id() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_sequential_id() {
+
+		$this->create();
+		// No parent.
+		$this->assertFalse( $this->obj->update_sequential_id() );
+
+		// Set a parent.
+		$template_id = $this->create_certificate_template();
+		update_post_meta( $template_id, '_llms_sequential_id', 25 );
+
+		$this->obj->set( 'parent', $template_id );
+		$this->assertEquals( 26, $this->obj->update_sequential_id() );
+
+	}
+
+	/**
 	 * Test creation of the model
 	 *
 	 * @since 4.5.0


### PR DESCRIPTION
## Description
Fixes #2021 

## How has this been tested?
manually and with unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

