### PR TITLE
Set specific typography and spacing for certificate default template

### DIFF
--- a/includes/schemas/llms-block-templates.php
+++ b/includes/schemas/llms-block-templates.php
@@ -15,13 +15,63 @@
 
 defined( 'ABSPATH' ) || exit;
 
+$styles = array(
+	'title' => array(
+		'typography' => array(
+			'fontSize'   => '90px',
+			'lineHeight' => '1.1',
+		),
+		'spacing'    => array(
+			'margin' => array(
+				'top'    => '40px',
+				'bottom' => '0px',
+			),
+		),
+	),
+	'h2'    => array(
+		'typography' => array(
+			'fontSize'   => '48px',
+			'lineHeight' => '1.3',
+		),
+		'spacing'    => array(
+			'margin' => array(
+				'top'    => '0px',
+				'bottom' => '0px',
+			),
+		),
+	),
+	'h3'    => array(
+		'typography' => array(
+			'fontSize'   => '32px',
+			'lineHeight' => '1.3',
+		),
+		'spacing'    => array(
+			'margin' => array(
+				'top'    => '0px',
+				'bottom' => '0px',
+			),
+		),
+	),
+	'p'     => array(
+		'typography' => array(
+			'fontSize'   => '18px',
+			'lineHeight' => '1.6',
+		),
+	),
+);
+
 /**
  * Shared block template for the `llms_certificate` and `llms_my_certificate` post types.
  *
  * @since [version]
  */
 $certificates = array(
-	array( 'llms/certificate-title' ),
+	array(
+		'llms/certificate-title',
+		array(
+			'style' => $styles['title'],
+		),
+	),
 	array(
 		'core/spacer',
 		array(
@@ -34,6 +84,7 @@ $certificates = array(
 			'content'   => __( 'Presented to', 'lifterlms' ),
 			'level'     => 3,
 			'textAlign' => 'center',
+			'style'     => $styles['h3'],
 		),
 	),
 	array(
@@ -42,6 +93,7 @@ $certificates = array(
 			'content'   => '[llms-user display_name]',
 			'level'     => 2,
 			'textAlign' => 'center',
+			'style'     => $styles['h2'],
 		),
 	),
 	array(
@@ -50,6 +102,7 @@ $certificates = array(
 			'content'   => __( 'for demonstration of excellence', 'lifterlms' ),
 			'level'     => 3,
 			'textAlign' => 'center',
+			'style'     => $styles['h3'],
 		),
 	),
 	array(
@@ -73,6 +126,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => '{current_date}',
+							'style'   => $styles['p'],
 						),
 					),
 					array(
@@ -86,6 +140,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => __( 'DATE', 'lifterlms' ),
+							'style'   => $styles['p'],
 						),
 					),
 				),
@@ -100,6 +155,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => '{site_title}',
+							'style'   => $styles['p'],
 						),
 					),
 					array(
@@ -113,6 +169,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => __( 'SIGNED', 'lifterlms' ),
+							'style'   => $styles['p'],
 						),
 					),
 				),

--- a/includes/schemas/llms-block-templates.php
+++ b/includes/schemas/llms-block-templates.php
@@ -15,50 +15,73 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$styles = array(
-	'title' => array(
-		'typography' => array(
-			'fontSize'   => '90px',
-			'lineHeight' => '1.1',
-		),
-		'spacing'    => array(
-			'margin' => array(
-				'top'    => '40px',
-				'bottom' => '0px',
+$blocks_styles = array(
+	'certificate' => array(
+		'title'  => array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'   => '90px',
+					'lineHeight' => '1.1',
+				),
+				'spacing'    => array(
+					'margin' => array(
+						'top'    => '40px',
+						'bottom' => '0px',
+					),
+				),
 			),
 		),
-	),
-	'h2'    => array(
-		'typography' => array(
-			'fontSize'   => '48px',
-			'lineHeight' => '1.3',
-		),
-		'spacing'    => array(
-			'margin' => array(
-				'top'    => '0px',
-				'bottom' => '0px',
+		'h2'     => array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'   => '48px',
+					'lineHeight' => '1.3',
+				),
+				'spacing'    => array(
+					'margin' => array(
+						'top'    => '0px',
+						'bottom' => '0px',
+					),
+				),
 			),
 		),
-	),
-	'h3'    => array(
-		'typography' => array(
-			'fontSize'   => '32px',
-			'lineHeight' => '1.3',
-		),
-		'spacing'    => array(
-			'margin' => array(
-				'top'    => '0px',
-				'bottom' => '0px',
+		'h3'     => array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'   => '32px',
+					'lineHeight' => '1.3',
+				),
+				'spacing'    => array(
+					'margin' => array(
+						'top'    => '0px',
+						'bottom' => '0px',
+					),
+				),
 			),
 		),
-	),
-	'p'     => array(
-		'typography' => array(
-			'fontSize'   => '18px',
-			'lineHeight' => '1.6',
+		'p'      => array(
+			'style' => array(
+				'typography' => array(
+					'fontSize'   => '18px',
+					'lineHeight' => '1.6',
+				),
+			),
+		),
+		'spacer' => array(
+			'height' => 100,
 		),
 	),
 );
+
+
+/**
+ * Filters the template blocks styling.
+ *
+ * @since [version]
+ *
+ * @param array $blocks_styles Array of blocks styles.
+ */
+$blocks_styles = apply_filters( 'llms_block_templates_styling', $blocks_styles );
 
 /**
  * Shared block template for the `llms_certificate` and `llms_my_certificate` post types.
@@ -69,13 +92,13 @@ $certificates = array(
 	array(
 		'llms/certificate-title',
 		array(
-			'style' => $styles['title'],
+			'style' => $blocks_styles['certificate']['title']['style'],
 		),
 	),
 	array(
 		'core/spacer',
 		array(
-			'height' => 100,
+			'height' => $blocks_styles['certificate']['spacer']['height'],
 		),
 	),
 	array(
@@ -84,7 +107,7 @@ $certificates = array(
 			'content'   => __( 'Presented to', 'lifterlms' ),
 			'level'     => 3,
 			'textAlign' => 'center',
-			'style'     => $styles['h3'],
+			'style'     => $blocks_styles['certificate']['h3']['style'],
 		),
 	),
 	array(
@@ -93,7 +116,7 @@ $certificates = array(
 			'content'   => '[llms-user display_name]',
 			'level'     => 2,
 			'textAlign' => 'center',
-			'style'     => $styles['h2'],
+			'style'     => $blocks_styles['certificate']['h2']['style'],
 		),
 	),
 	array(
@@ -102,13 +125,13 @@ $certificates = array(
 			'content'   => __( 'for demonstration of excellence', 'lifterlms' ),
 			'level'     => 3,
 			'textAlign' => 'center',
-			'style'     => $styles['h3'],
+			'style'     => $blocks_styles['certificate']['h3']['style'],
 		),
 	),
 	array(
 		'core/spacer',
 		array(
-			'height' => 100,
+			'height' => $blocks_styles['certificate']['spacer']['height'],
 		),
 	),
 	array(
@@ -126,7 +149,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => '{current_date}',
-							'style'   => $styles['p'],
+							'style'   => $blocks_styles['certificate']['p']['style'],
 						),
 					),
 					array(
@@ -140,7 +163,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => __( 'DATE', 'lifterlms' ),
-							'style'   => $styles['p'],
+							'style'   => $blocks_styles['certificate']['p']['style'],
 						),
 					),
 				),
@@ -155,7 +178,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => '{site_title}',
-							'style'   => $styles['p'],
+							'style'   => $blocks_styles['certificate']['p']['style'],
 						),
 					),
 					array(
@@ -169,7 +192,7 @@ $certificates = array(
 						array(
 							'align'   => 'center',
 							'content' => __( 'SIGNED', 'lifterlms' ),
-							'style'   => $styles['p'],
+							'style'   => $blocks_styles['certificate']['p']['style'],
 						),
 					),
 				),


### PR DESCRIPTION
## Description

Fixes #1954 

I thought a bit about that and I thought that:
1) we were fighting with the fact that gutenberg is not a WYSIWYG despite it should
2) we would suffer compatibility issues with a bunch of themes so...
I thought that the best approach was to set the default template to be as much as possible identical (in terms of sizing, yeah the size also depends on the font-family, the font-weight, but this is a good balance to me) across the various themes. User can change the default sizing from within the editor, and of course create their own titles and ps with the sizes they want.
Do you agree with this approach?


## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

