### PR TITLE
Conditionally use the legacy default background image.

### DIFF
--- a/includes/admin/settings/class.llms.settings.engagements.php
+++ b/includes/admin/settings/class.llms.settings.engagements.php
@@ -322,7 +322,7 @@ class LLMS_Settings_Engagements extends LLMS_Settings_Page {
 			return $pre;
 		}
 
-		return llms_parse_bool( get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+		return llms_parse_bool( get_option( 'llms_has_certificates_with_legacy_default_image', 'no' ) );
 
 	}
 

--- a/includes/functions/updates/llms-functions-updates-600.php
+++ b/includes/functions/updates/llms-functions-updates-600.php
@@ -81,22 +81,21 @@ function migrate_award_templates() {
 		)
 	);
 
-	$legacy_certificates_option_added = false;
-	$legacy_achievements_option_added = false;
+	$legacy_option_added['achievement'] = false;
+	$legacy_option_added['certificate'] = false;
 
 	foreach ( $query->posts as $post ) {
-		_migrate_image( $post->ID, llms_strip_prefixes( $post->post_type ) );
 
-		if ( 'llms_achievement' === $post->post_type ) {
+		$type = llms_strip_prefixes( $post->post_type );
+		_migrate_image( $post->ID, $type );
+
+		if ( 'achievement' === $type ) {
 			_migrate_achievement_content( $post->ID );
+		}
 
-			if ( ! $legacy_achievements_option_added ) {
-				_add_legacy_opt( 'achievement' );
-				$legacy_achievements_option_added = true;
-			}
-		} elseif ( 'llms_certificate' === $post->post_type && ! $legacy_certificates_option_added ) {
-			_add_legacy_opt( 'certificate' );
-			$legacy_certificates_option_added = true;
+		if ( ! $legacy_option_added[ $type ] ) {
+			_add_legacy_opt( $type );
+			$legacy_option_added[ $type ] = true;
 		}
 	}
 
@@ -215,19 +214,14 @@ function _migrate_awards( $type ) {
 	// Don't trigger save hooks.
 	remove_action( "save_post_llms_my_{$type}", array( 'LLMS_Controller_Awards', 'on_save' ), 20 );
 
-	$legacy_certificates_option_added = false;
-	$legacy_achievements_option_added = false;
-
+	$legacy_option_added = false;
 	foreach ( $query->posts as $post_id ) {
 
 		_migrate_award( $post_id, $type );
 
-		if ( 'certificate' === $type && ! $legacy_certificates_option_added ) {
+		if ( ! $legacy_option_added ) {
 			_add_legacy_opt( $type );
-			$legacy_certificates_option_added = true;
-		} elseif ( 'achievement' === $type && ! $legacy_achievements_option_added ) {
-			_add_legacy_opt( $type );
-			$legacy_achievements_option_added = true;
+			$legacy_option_added = true;
 		}
 	}
 	// Re-enable deprecations.

--- a/includes/functions/updates/llms-functions-updates-600.php
+++ b/includes/functions/updates/llms-functions-updates-600.php
@@ -333,7 +333,8 @@ function _migrate_image( $post_id, $type ) {
 }
 
 /**
- * Adds an option used to determine if the site has at least one legacy achievement or certificate template or award.
+ * Adds an option used to determine if the site has at least one legacy achievement or certificate template or award
+ * that uses the default image.
  *
  * @since [version]
  *
@@ -341,5 +342,5 @@ function _migrate_image( $post_id, $type ) {
  * @return void
  */
 function _add_legacy_opt( $engagement_type ) {
-	update_option( "lifterlms_has_legacy_{$engagement_type}s", 'yes', 'no' );
+	update_option( "llms_has_{$engagement_type}s_with_legacy_default_image", 'yes', 'no' );
 }

--- a/includes/traits/llms-trait-award-default-images.php
+++ b/includes/traits/llms-trait-award-default-images.php
@@ -31,8 +31,8 @@ trait LLMS_Trait_Award_Default_Images {
 	 * images via the filter {@see llms_use_legacy_engagement_images}.
 	 *
 	 * The legacy default image URL is returned if the current certificate version is 1 and the
-	 * 'lifterlms_has_legacy_certificates' option is 'yes' or the type is achievement and the
-	 * 'lifterlms_has_legacy_achievements' option is 'yes. These options are set when LifterLMS is updated
+	 * 'llms_has_achievements_with_legacy_default_image' option is 'yes' or the type is achievement and the
+	 * 'llms_has_certificates_with_legacy_default_image' option is 'yes. These options are set when LifterLMS is updated
 	 * to 6.0.0 and there are legacy user engagements ({@see \LLMS\Updates\Version_6_0_0\_add_legacy_opt()}).
 	 *
 	 * @since [version]
@@ -46,12 +46,12 @@ trait LLMS_Trait_Award_Default_Images {
 
 		switch ( $this->award_type ) {
 			case 'achievement':
-				$use_legacy = llms_parse_bool( get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
+				$use_legacy = llms_parse_bool( get_option( 'llms_has_achievements_with_legacy_default_image', 'no' ) );
 				break;
 			case 'certificate':
 				$certificate = llms_get_certificate( null, true );
 				if ( $certificate && 1 === $certificate->get_template_version() ) {
-					$use_legacy = llms_parse_bool( get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+					$use_legacy = llms_parse_bool( get_option( 'llms_has_certificates_with_legacy_default_image', 'no' ) );
 				}
 				break;
 		}

--- a/includes/traits/llms-trait-award-default-images.php
+++ b/includes/traits/llms-trait-award-default-images.php
@@ -51,7 +51,7 @@ trait LLMS_Trait_Award_Default_Images {
 			case 'certificate':
 				$certificate = llms_get_certificate( null, true );
 				if ( $certificate && 1 === $certificate->get_template_version() ) {
-					$use_legacy = 'yes' === get_option( 'lifterlms_has_legacy_certificates', 'no' );
+					$use_legacy = llms_parse_bool( get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 				}
 				break;
 		}

--- a/includes/traits/llms-trait-award-default-images.php
+++ b/includes/traits/llms-trait-award-default-images.php
@@ -30,13 +30,31 @@ trait LLMS_Trait_Award_Default_Images {
 	 * were updated with the release of this method and allows usage of the previous version's
 	 * images via the filter {@see llms_use_legacy_engagement_images}.
 	 *
+	 * The legacy default image URL is returned if the current certificate version is 1 and the
+	 * 'lifterlms_has_legacy_certificates' option is 'yes' or the type is achievement and the
+	 * 'lifterlms_has_legacy_achievements' option is 'yes. These options are set when LifterLMS is updated
+	 * to 6.0.0 and there are legacy user engagements ({@see \LLMS\Updates\Version_6_0_0\_add_legacy_opt()}).
+	 *
 	 * @since [version]
 	 *
-	 * @return [type] [description]
+	 * @return string The URL to the default image.
 	 */
 	protected function get_default_default_image_src() {
 
-		$img = "default-{$this->award_type}.png";
+		$img        = "default-{$this->award_type}.png";
+		$use_legacy = false;
+
+		switch ( $this->award_type ) {
+			case 'achievement':
+				$use_legacy = 'yes' === get_option( 'lifterlms_has_legacy_achievements', 'no' );
+				break;
+			case 'certificate':
+				$certificate = llms_get_certificate( null, true );
+				if ( $certificate && 1 === $certificate->get_template_version() ) {
+					$use_legacy = 'yes' === get_option( 'lifterlms_has_legacy_certificates', 'no' );
+				}
+				break;
+		}
 
 		/**
 		 * Filter whether or not the legacy default images should be used for achievement and certificates.
@@ -48,7 +66,7 @@ trait LLMS_Trait_Award_Default_Images {
 		 * @param boolean $use_legacy If `true`, the legacy image will be used.
 		 * @param string  $award_type The type of award, either "achievement" or "certificate".
 		 */
-		if ( apply_filters( 'llms_use_legacy_award_images', false, $this->award_type ) ) {
+		if ( apply_filters( 'llms_use_legacy_award_images', $use_legacy, $this->award_type ) ) {
 			$img = "optional_{$this->award_type}.png";
 		}
 

--- a/includes/traits/llms-trait-award-default-images.php
+++ b/includes/traits/llms-trait-award-default-images.php
@@ -46,7 +46,7 @@ trait LLMS_Trait_Award_Default_Images {
 
 		switch ( $this->award_type ) {
 			case 'achievement':
-				$use_legacy = 'yes' === get_option( 'lifterlms_has_legacy_achievements', 'no' );
+				$use_legacy = llms_parse_bool( get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
 				break;
 			case 'certificate':
 				$certificate = llms_get_certificate( null, true );

--- a/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
+++ b/tests/phpunit/unit-tests/admin/settings/class-llms-test-settings-engagements.php
@@ -114,7 +114,7 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 	 */
 	public function test_get_settings_with_legacy() {
 
-		update_option( 'lifterlms_has_legacy_certificates', 'yes' );
+		update_option( 'llms_has_certificates_with_legacy_default_image', 'yes' );
 		$this->expect_legacy_opts = true;
 		parent::test_get_settings();
 		$this->expect_legacy_opts = false;
@@ -183,7 +183,7 @@ class LLMS_Test_Settings_Engagements extends LLMS_Settings_Page_Test_Case {
 	 */
 	public function test_save_with_legacy_opts() {
 
-		update_option( 'lifterlms_has_legacy_certificates', 'yes' );
+		update_option( 'llms_has_certificates_with_legacy_default_image', 'yes' );
 		$this->expect_legacy_opts = true;
 		parent::test_save();
 		$this->expect_legacy_opts = false;

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
@@ -37,8 +37,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		parent::set_up();
 		add_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
-		delete_option( 'lifterlms_has_legacy_achievements' );
-		delete_option( 'lifterlms_has_legacy_certificates' );
+		delete_option( 'llms_has_achievements_with_legacy_default_image' );
+		delete_option( 'llms_has_certificates_with_legacy_default_image' );
 
 	}
 
@@ -53,8 +53,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		parent::tear_down();
 		remove_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
-		delete_option( 'lifterlms_has_legacy_achievements' );
-		delete_option( 'lifterlms_has_legacy_certificates' );
+		delete_option( 'llms_has_achievements_with_legacy_default_image' );
+		delete_option( 'llms_has_certificates_with_legacy_default_image' );
 
 	}
 
@@ -236,8 +236,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 			list( $type, $use_default_image ) = $test;
 
-			delete_option( 'lifterlms_has_legacy_achievements' );
-			delete_option( 'lifterlms_has_legacy_certificates' );
+			delete_option( 'llms_has_achievements_with_legacy_default_image' );
+			delete_option( 'llms_has_certificates_with_legacy_default_image' );
 
 			$awards = $this->create_legacy_awards( 12, $type, $use_default_image );
 
@@ -274,12 +274,12 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 			// Test both legacy options because sometimes paranoia helps sanity.
 			$this->assertEquals(
 				'achievement' === $type && $use_default_image ? 'yes' : 'no',
-				get_option( "lifterlms_has_legacy_achievements", 'no' ),
+				get_option( "llms_has_achievements_with_legacy_default_image", 'no' ),
 				"\$type = $type, \$use_default_image = " . ( $use_default_image ? 'true' : 'false' )
 			);
 			$this->assertEquals(
 				'certificate' === $type && $use_default_image ? 'yes' : 'no',
-				get_option( 'lifterlms_has_legacy_certificates', 'no' ),
+				get_option( 'llms_has_certificates_with_legacy_default_image', 'no' ),
 				"\$type = $type, \$use_default_image = " . ( $use_default_image ? 'true' : 'false' )
 			);
 
@@ -306,8 +306,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 		foreach ( $tests as $type ) {
 
 			$this->assertFalse( $this->call_ns_func( "migrate_{$type}s", array( $type ) ) );
-			$this->assertEquals( 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
-			$this->assertEquals( 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+			$this->assertEquals( 'no', get_option( 'llms_has_achievements_with_legacy_default_image', 'no' ) );
+			$this->assertEquals( 'no', get_option( 'llms_has_certificates_with_legacy_default_image', 'no' ) );
 
 		}
 
@@ -324,8 +324,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		foreach ( array( false, true ) as $use_default_image ) {
 
-			delete_option( 'lifterlms_has_legacy_achievements' );
-			delete_option( 'lifterlms_has_legacy_certificates' );
+			delete_option( 'llms_has_achievements_with_legacy_default_image' );
+			delete_option( 'llms_has_certificates_with_legacy_default_image' );
 
 			$templates = $this->create_legacy_templates( 20, $use_default_image );
 
@@ -349,8 +349,14 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 				}
 			}
 
-			$this->assertEquals( $use_default_image ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
-			$this->assertEquals( $use_default_image ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+			$this->assertEquals(
+				$use_default_image ? 'yes' : 'no',
+				get_option( 'llms_has_achievements_with_legacy_default_image', 'no' )
+			);
+			$this->assertEquals(
+				$use_default_image ? 'yes' : 'no',
+				get_option( 'llms_has_certificates_with_legacy_default_image', 'no' )
+			);
 		}
 
 	}

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
@@ -37,6 +37,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		parent::set_up();
 		add_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
+		delete_option( 'lifterlms_has_legacy_achievements' );
 		delete_option( 'lifterlms_has_legacy_certificates' );
 
 	}
@@ -52,6 +53,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		parent::tear_down();
 		remove_filter( 'llms_update_items_per_page', array( $this, 'per_page' ) );
+		delete_option( 'lifterlms_has_legacy_achievements' );
 		delete_option( 'lifterlms_has_legacy_certificates' );
 
 	}
@@ -228,6 +230,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		foreach ( $tests as $type ) {
 
+			delete_option( 'lifterlms_has_legacy_achievements' );
 			delete_option( 'lifterlms_has_legacy_certificates' );
 
 			$awards = $this->create_legacy_awards( 12, $type );
@@ -262,6 +265,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 			}
 
+			$this->assertEquals( 'achievement' === $type ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
 			$this->assertEquals( 'certificate' === $type ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 
 		}
@@ -287,6 +291,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 		foreach ( $tests as $type ) {
 
 			$this->assertFalse( $this->call_ns_func( "migrate_{$type}s", array( $type ) ) );
+			$this->assertEquals( 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
 			$this->assertEquals( 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 
 		}
@@ -325,6 +330,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 		}
 
+		$this->assertEquals( 'yes', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
 		$this->assertEquals( 'yes', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
 
 	}

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-600.php
@@ -87,8 +87,9 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 *
 	 * @since [version]
 	 *
-	 * @param int    $count Number of award posts to create.
-	 * @param string $type  Type of award, either "achievement" or "certificate".
+	 * @param int    $count             Number of award posts to create.
+	 * @param string $type              Type of award, either "achievement" or "certificate".
+	 * @param bool   $use_default_image If `true`, then the award will not use a custom image.
 	 * @return array[] {
 	 *     Array of data arrays describing the generated award.
 	 *
@@ -99,7 +100,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 *     @type string $title       Title of the award.
 	 * }
 	 */
-	private function create_legacy_awards( $count, $type ) {
+	private function create_legacy_awards( $count, $type, $use_default_image ) {
 
 		remove_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
 		remove_action( "save_post_llms_my_{$type}", array( 'LLMS_Controller_Awards', 'on_save' ), 20 );
@@ -108,7 +109,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 		$i = 0;
 		while ( $i < $count ) {
 			$post_type   = "llms_my_{$type}";
-			$image_id    = $attachment_id = $this->create_attachment( 'christian-fregnan-unsplash.jpg' );
+			$image_id    = $use_default_image ? 0 : $this->create_attachment( 'christian-fregnan-unsplash.jpg' );
 			$template_id = $this->factory->post->create( array( 'post_type' => "llms_{$type}" ) );
 			$user_id     = $this->factory->user->create();
 			$title       = sprintf( '%1$s Title %2$s', ucwords( $type ), wp_generate_password( 4, false ) );
@@ -149,7 +150,8 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 *
 	 * @since [version]
 	 *
-	 * @param int    $count Number of award posts to create.
+	 * @param int  $count             Number of award posts to create.
+	 * @param bool $use_default_image If `true`, then the award will not use a custom image.
 	 * @return array[] {
 	 *     Array of data arrays describing the generated template.
 	 *
@@ -157,7 +159,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 *     @type int    $post_id     WP_Post id of the award post.
 	 * }
 	 */
-	private function create_legacy_templates( $count ) {
+	private function create_legacy_templates( $count, $use_default_image ) {
 
 		$res = array();
 		$i = 0;
@@ -166,7 +168,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 			shuffle( $post_type );
 			$post_type   = $post_type[0];
 			$type        = str_replace( 'llms_', '', $post_type );
-			$image_id    = $attachment_id = $this->create_attachment( 'christian-fregnan-unsplash.jpg' );
+			$image_id    = $use_default_image ? 0 : $this->create_attachment( 'christian-fregnan-unsplash.jpg' );
 			$meta_input  = array(
 				"_llms_{$type}_image"    => $image_id,
 			);
@@ -224,16 +226,20 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 		add_filter( 'llms_update_items_per_page', $per_page );
 
 		$tests = array(
-			'achievement',
-			'certificate',
+			array( 'achievement', false ),
+			array( 'achievement', true ),
+			array( 'certificate', false ),
+			array( 'certificate', true ),
 		);
 
-		foreach ( $tests as $type ) {
+		foreach ( $tests as $test ) {
+
+			list( $type, $use_default_image ) = $test;
 
 			delete_option( 'lifterlms_has_legacy_achievements' );
 			delete_option( 'lifterlms_has_legacy_certificates' );
 
-			$awards = $this->create_legacy_awards( 12, $type );
+			$awards = $this->create_legacy_awards( 12, $type, $use_default_image );
 
 			// Should run 3 times, the 3rd has fewer than max results so we're complete.
 			$i = 1;
@@ -265,8 +271,17 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 
 			}
 
-			$this->assertEquals( 'achievement' === $type ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
-			$this->assertEquals( 'certificate' === $type ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+			// Test both legacy options because sometimes paranoia helps sanity.
+			$this->assertEquals(
+				'achievement' === $type && $use_default_image ? 'yes' : 'no',
+				get_option( "lifterlms_has_legacy_achievements", 'no' ),
+				"\$type = $type, \$use_default_image = " . ( $use_default_image ? 'true' : 'false' )
+			);
+			$this->assertEquals(
+				'certificate' === $type && $use_default_image ? 'yes' : 'no',
+				get_option( 'lifterlms_has_legacy_certificates', 'no' ),
+				"\$type = $type, \$use_default_image = " . ( $use_default_image ? 'true' : 'false' )
+			);
 
 		}
 
@@ -299,7 +314,7 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test migate_award_templates()
+	 * Test migrate_award_templates().
 	 *
 	 * @since [version]
 	 *
@@ -307,31 +322,36 @@ class LLMS_Test_Functions_Updates_600 extends LLMS_UnitTestCase {
 	 */
 	public function test_migrate_award_templates() {
 
-		$templates = $this->create_legacy_templates( 20 );
+		foreach ( array( false, true ) as $use_default_image ) {
 
-		// Should run 5 times, the 5th has no results and the migration is complete.
-		$i = 1;
-		while ( $i <= 5 ) {
-			$this->assertEquals( $i !== 5, $this->call_ns_func( 'migrate_award_templates' ) );
-			$i++;
-		}
+			delete_option( 'lifterlms_has_legacy_achievements' );
+			delete_option( 'lifterlms_has_legacy_certificates' );
 
-		foreach ( $templates as $template ) {
-			$this->assertEquals( $template['image_id'], get_post_thumbnail_id( $template['post_id'] ) );
-			$this->assertFalse( metadata_exists( 'post', $template['post_id'], "_llms_{$template['type']}_image" ) );
+			$templates = $this->create_legacy_templates( 20, $use_default_image );
 
-			if ( 'achievement' === $template['type'] ) {
-				$post = get_post( $template['post_id'] );
-				$this->assertEquals( 'Some content.', $post->post_content );
-				remove_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
-				$this->assertFalse( metadata_exists( 'post', $template['post_id'], '_llms_achievement_content' ) );
-				add_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
+			// Should run 5 times, the 5th has no results and the migration is complete.
+			$i = 1;
+			while ( $i <= 5 ) {
+				$this->assertEquals( $i !== 5, $this->call_ns_func( 'migrate_award_templates' ) );
+				$i++;
 			}
 
-		}
+			foreach ( $templates as $template ) {
+				$this->assertEquals( $template['image_id'], get_post_thumbnail_id( $template['post_id'] ) );
+				$this->assertFalse( metadata_exists( 'post', $template['post_id'], "_llms_{$template['type']}_image" ) );
 
-		$this->assertEquals( 'yes', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
-		$this->assertEquals( 'yes', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+				if ( 'achievement' === $template['type'] ) {
+					$post = get_post( $template['post_id'] );
+					$this->assertEquals( 'Some content.', $post->post_content );
+					remove_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
+					$this->assertFalse( metadata_exists( 'post', $template['post_id'], '_llms_achievement_content' ) );
+					add_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 20, 3 );
+				}
+			}
+
+			$this->assertEquals( $use_default_image ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_achievements', 'no' ) );
+			$this->assertEquals( $use_default_image ? 'yes' : 'no', get_option( 'lifterlms_has_legacy_certificates', 'no' ) );
+		}
 
 	}
 

--- a/tests/phpunit/unit-tests/traits/llms-test-trait-award-default-images.php
+++ b/tests/phpunit/unit-tests/traits/llms-test-trait-award-default-images.php
@@ -36,6 +36,15 @@ class LLMS_Test_Trait_Award_Default_Images extends LLMS_UnitTestCase {
 	 */
 	public function test_get_default_default_image_src() {
 
+		$certificate_version_1_id = $this->factory->post->create( array(
+			'post_type'    => 'llms_certificate',
+			'post_content' => 'Version 1 Certificate.',
+		) );
+		$certificate_version_2_id = $this->factory->post->create( array(
+			'post_type'    => 'llms_certificate',
+			'post_content' => '<!-- wp:llms/certificate-title {"placeholder":"Version 2 Certificate"} -->',
+		) );
+
 		foreach ( $this->instances as $id => $instance ) {
 
 			$this->assertStringContainsString(
@@ -50,6 +59,33 @@ class LLMS_Test_Trait_Award_Default_Images extends LLMS_UnitTestCase {
 			);
 			remove_filter( 'llms_use_legacy_award_images', '__return_true' );
 
+			update_option( "lifterlms_has_legacy_{$id}s", 'yes', 'no' );
+			switch ( $id ) {
+				case 'achievement':
+					$this->assertStringContainsString(
+						"optional_{$id}.png",
+						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
+					);
+					break;
+				case 'certificate':
+					$previous_post = $GLOBALS['post'] ?? null;
+
+					$GLOBALS['post'] = $certificate_version_1_id;
+					$this->assertStringContainsString(
+						"optional_{$id}.png",
+						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
+					);
+
+					$GLOBALS['post'] = $certificate_version_2_id;
+					$this->assertStringContainsString(
+						"default-{$id}.png",
+						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
+					);
+
+					$GLOBALS['post'] = $previous_post;
+					break;
+			}
+			delete_option( "lifterlms_has_legacy_{$id}s" );
 		}
 
 	}

--- a/tests/phpunit/unit-tests/traits/llms-test-trait-award-default-images.php
+++ b/tests/phpunit/unit-tests/traits/llms-test-trait-award-default-images.php
@@ -45,25 +45,25 @@ class LLMS_Test_Trait_Award_Default_Images extends LLMS_UnitTestCase {
 			'post_content' => '<!-- wp:llms/certificate-title {"placeholder":"Version 2 Certificate"} -->',
 		) );
 
-		foreach ( $this->instances as $id => $instance ) {
+		foreach ( $this->instances as $type => $instance ) {
 
 			$this->assertStringContainsString(
-				"default-{$id}.png",
+				"default-{$type}.png",
 				LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
 			);
 
 			add_filter( 'llms_use_legacy_award_images', '__return_true' );
 			$this->assertStringContainsString(
-				"optional_{$id}.png",
+				"optional_{$type}.png",
 				LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
 			);
 			remove_filter( 'llms_use_legacy_award_images', '__return_true' );
 
-			update_option( "lifterlms_has_legacy_{$id}s", 'yes', 'no' );
-			switch ( $id ) {
+			update_option( "llms_has_{$type}s_with_legacy_default_image", 'yes', 'no' );
+			switch ( $type ) {
 				case 'achievement':
 					$this->assertStringContainsString(
-						"optional_{$id}.png",
+						"optional_{$type}.png",
 						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
 					);
 					break;
@@ -72,20 +72,20 @@ class LLMS_Test_Trait_Award_Default_Images extends LLMS_UnitTestCase {
 
 					$GLOBALS['post'] = $certificate_version_1_id;
 					$this->assertStringContainsString(
-						"optional_{$id}.png",
+						"optional_{$type}.png",
 						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
 					);
 
 					$GLOBALS['post'] = $certificate_version_2_id;
 					$this->assertStringContainsString(
-						"default-{$id}.png",
+						"default-{$type}.png",
 						LLMS_Unit_Test_Util::call_method( $instance, 'get_default_default_image_src' )
 					);
 
 					$GLOBALS['post'] = $previous_post;
 					break;
 			}
-			delete_option( "lifterlms_has_legacy_{$id}s" );
+			delete_option( "llms_has_{$type}s_with_legacy_default_image" );
 		}
 
 	}


### PR DESCRIPTION
## Description

1. Added setting the `lifterlms_has_legacy_achievements` option to 'yes' during an update to LifterLMS 6.0.0 if there are any achievement templates or awarded achievements that use the default background image.
2. Changed `LLMS_Test_Trait_Award_Default_Images::test_get_default_default_image_src()`.
    1. All achievements use the old default image if the `lifterlms_has_legacy_achievements` option is 'yes', else the new default image is used.
    2. Version 1 certificates use the old default image if the `lifterlms_has_legacy_certificates` option is 'yes', else the new default image is used.
    3. Version 2 certificates always use the new default image.


Fixes #2030.

## How has this been tested?
Manually and with unit  tests.
1. Install LifterLMS 5.
2. Create achievement and certificate templates that use the default background.
3. Create achievement and certificate templates that use a custom background.
4. Award an achievement and a certificate.
5. Upgrade to LifterLMS 6.
6. View legacy templates and awards.
7. Create a new certificate template.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

