### PR TITLE
The coupon code in the student's order details table is now wrapped in a `code` instead of a `a` tag.

### DIFF
--- a/.changelogs/dashboard-pagination.yml
+++ b/.changelogs/dashboard-pagination.yml
@@ -2,4 +2,4 @@ significance: minor
 type: changed
 links:
   - "#669"
-entry: The achivements and certificates dashboard endpoints are now paginated.
+entry: The achievements and certificates dashboard endpoints are now paginated.

--- a/.changelogs/order-information.yml
+++ b/.changelogs/order-information.yml
@@ -2,4 +2,4 @@ significance: minor
 type: changed
 links:
   - "#2033"
-entry: The coupon code in the student's order details table is now wrapped in a `code` instead of a `a` tag.
+entry: The coupon code in the student's order details table is now wrapped in a `<code>` tag instead of an `<a>` tag.

--- a/.changelogs/order-information.yml
+++ b/.changelogs/order-information.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: changed
+links:
+  - "#2033"
+entry: The coupon code in the student's order details table is now wrapped in a `code` instead of a `a` tag.

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -51,7 +51,7 @@ defined( 'ABSPATH' ) || exit;
 						<td>
 							<?php echo $order->get_coupon_amount( 'trial' ); ?>
 							(<?php echo llms_price( $order->get_price( 'coupon_value_trial', array(), 'float' ) * - 1 ); ?>)
-							[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
+							[<code><?php echo $order->get( 'coupon_code' ); ?></code>]
 						</td>
 					</tr>
 				<?php endif; ?>
@@ -87,7 +87,7 @@ defined( 'ABSPATH' ) || exit;
 						<td>
 							<?php echo $order->get_coupon_amount( 'regular' ); ?>
 							(<?php echo llms_price( $order->get_price( 'coupon_value', array(), 'float' ) * - 1 ); ?>)
-							[<a href="<?php echo get_edit_post_link( $order->get( 'coupon_id' ) ); ?>"><?php echo $order->get( 'coupon_code' ); ?></a>]
+							[<code><?php echo $order->get( 'coupon_code' ); ?></code>]
 						</td>
 					</tr>
 				<?php endif; ?>


### PR DESCRIPTION
## Description
Fixes #2033 

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

