### PR TITLE
Replace use of deprecated functions.

### DIFF
--- a/includes/class.llms.post-types.php
+++ b/includes/class.llms.post-types.php
@@ -441,6 +441,7 @@ class LLMS_Post_Types {
 	 *             Add thumbnail support for achievement and certificates (earned and template)
 	 *             Renames `llms_certificate` slug from `certificate` to `certificate-template`.
 	 *             Rename `llms_my_certificate` slug from `my_certificate` to `certificate`.
+	 *             Replaced the use of the deprecated `get_page() function with `get_post()`.
 	 *
 	 * @return void
 	 */
@@ -482,7 +483,7 @@ class LLMS_Post_Types {
 				),
 				'query_var'           => true,
 				'supports'            => array( 'title', 'author', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-clone-post', 'llms-export-post', 'llms-sales-page' ),
-				'has_archive'         => ( $catalog_id && get_page( $catalog_id ) ) ? get_page_uri( $catalog_id ) : _x( 'courses', 'course archive url slug', 'lifterlms' ),
+				'has_archive'         => ( $catalog_id && get_post( $catalog_id ) ) ? get_page_uri( $catalog_id ) : _x( 'courses', 'course archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,
 			)
@@ -672,7 +673,7 @@ class LLMS_Post_Types {
 				),
 				'query_var'           => true,
 				'supports'            => array( 'title', 'editor', 'thumbnail', 'comments', 'custom-fields', 'page-attributes', 'revisions', 'llms-sales-page' ),
-				'has_archive'         => ( $membership_page_id && get_page( $membership_page_id ) ) ? get_page_uri( $membership_page_id ) : _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
+				'has_archive'         => ( $membership_page_id && get_post( $membership_page_id ) ) ? get_page_uri( $membership_page_id ) : _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
 				'show_in_nav_menus'   => true,
 				'menu_position'       => 52,
 			)

--- a/includes/privacy/class-llms-privacy-exporters.php
+++ b/includes/privacy/class-llms-privacy-exporters.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Privacy/Classes
  *
  * @since 3.18.0
- * @version 3.37.9
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -140,18 +140,19 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 
 
 	/**
-	 * Get data for a certificate
+	 * Get data for a certificate.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Replaced the use of the deprecated `certificate_title` meta key with the post's title property.
 	 *
-	 * @param  LLMS_User_Certificate $cert Certificate object.
+	 * @param LLMS_User_Certificate $cert Certificate object.
 	 * @return array
 	 */
 	private static function get_certificate_data( $cert ) {
 
 		$data = array();
 
-		$title = $cert->get( 'certificate_title' );
+		$title = $cert->get( 'title' );
 
 		$filename = llms()->certificates()->get_export( $cert->get( 'id' ), true );
 		if ( ! is_wp_error( $filename ) ) {
@@ -426,16 +427,18 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 	}
 
 	/**
-	 * Add files to the zip file for a data export request
-	 * Adds certificate files into the /certificates/ directory within the archive
+	 * Add files to the zip file for a data export request.
 	 *
-	 * @since    3.18.0
+	 * Adds certificate files into the `/certificates/` directory within the archive.
 	 *
-	 * @param    string $archive_pathname      full path to the zip archive
-	 * @param    string $archive_url           full uri to the zip archive
-	 * @param    string $html_report_pathname  full path to the .html file within the archive
-	 * @param    int    $request_id            WP Post ID of the export request
-	 * @return   void
+	 * @since 3.18.0
+	 * @since [version] Replaced the use of the deprecated `wp_get_user_request_data()` function with `wp_get_user_request()`.
+	 *
+	 * @param string $archive_pathname     Full path to the zip archive.
+	 * @param string $archive_url          Full URI to the zip archive.
+	 * @param string $html_report_pathname Full path to the .html file within the archive.
+	 * @param int    $request_id           WP Post ID of the export request.
+	 * @return void
 	 */
 	public static function maybe_add_export_files( $archive_pathname, $archive_url, $html_report_pathname, $request_id ) {
 
@@ -443,7 +446,7 @@ class LLMS_Privacy_Exporters extends LLMS_Privacy {
 			return;
 		}
 
-		$request = wp_get_user_request_data( $request_id );
+		$request = wp_get_user_request( $request_id );
 		$student = self::get_student_by_email( $request->email );
 
 		if ( ! $student ) {

--- a/includes/privacy/class-llms-privacy.php
+++ b/includes/privacy/class-llms-privacy.php
@@ -189,27 +189,35 @@ class LLMS_Privacy extends LLMS_Abstract_Privacy {
 	}
 
 	/**
-	 * Retrieve student certificates
+	 * Retrieve student achievements.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Updated the use of `LLMS_Student::get_achievements()` with its new behavior.
 	 *
 	 * @param LLMS_Student $student Student object.
-	 * @return array
+	 * @return LLMS_User_Achievement[]
 	 */
 	protected static function get_student_achievements( $student ) {
-		return $student->get_achievements( 'updated_date', 'DESC', 'achievements' );
+
+		$query = $student->get_achievements( array( 'sort' => array( 'date' => 'DESC' ) ) );
+
+		return $query->get_awards();
 	}
 
 	/**
-	 * Retrieve student certificates
+	 * Retrieve student certificates.
 	 *
 	 * @since 3.18.0
+	 * @since [version] Updated the use of `LLMS_Student::get_certificates()` with its new behavior.
 	 *
 	 * @param LLMS_Student $student Student object.
-	 * @return array
+	 * @return LLMS_User_Certificate[]
 	 */
 	protected static function get_student_certificates( $student ) {
-		return $student->get_certificates( 'updated_date', 'DESC', 'certificates' );
+
+		$query = $student->get_certificates( array( 'sort' => array( 'date' => 'DESC' ) ) );
+
+		return $query->get_awards();
 	}
 
 	/**


### PR DESCRIPTION
## Description
Replace use of deprecated functions and updated how `LLMS_Trait_Student_Awards::get_achievements()` and `LLMS_Trait_Student_Awards::get_student_certificates()` is used for their new behavior.

Fixes #2045

## How has this been tested?
Manually by comparing exports of before and after these changes, plus checking the PHP error log.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

