### PR TITLE
Sequential id quick fix

### DIFF
--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -229,11 +229,11 @@ function llms_get_certificate_orientations() {
 }
 
 /**
- * Retrieve the current or next sequential ID for a given certificate template.
+ * Retrieve the next sequential ID for a given certificate template and optionally increment it.
  *
- * If there's no existing ID, the ID starts at 1 and will *not* be incremented.
+ * If there's no existing ID.
  *
- * When the ID is incremented the new value is automatically persisted to the database.
+ * When an increment is requested, the new incremented ID will be automatically persisted to the database.
  *
  * @since 6.0.0
  *
@@ -264,20 +264,20 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		$starting_id = apply_filters( 'llms_certificate_sequential_id_starting_number', 1, $template_id );
 		$id          = absint( $starting_id );
 
-		// Don't increment the starting ID!
+		// If there's no stored ID we don't want to increment it because it'll default to 1 next time anyway.
 		$increment = false;
 		$update    = true;
 
 	}
 
-	if ( $increment ) {
-		++$id;
+	if ( $update ) {
+		update_post_meta( $template_id, $key, $increment ? $id + 1 : $id );
 	}
 
 	/**
 	 * Filters the sequential ID number for a given certificate template.
 	 *
-	 * The returned number *must* be an absolute integer (zero included). The returned value will be
+	 * The returned number *must* be an absolute integer. The returned value will be
 	 * passed through `absint()` to sanitize the filtered value.
 	 *
 	 * @since 6.0.0
@@ -285,13 +285,7 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 	 * @param int $id          The sequential ID.
 	 * @param int $template_id WP_Post ID of the certificate template.
 	 */
-	$id = absint( apply_filters( 'llms_certificate_sequential_id', $id, $template_id ) );
-
-	if ( $update ) {
-		update_post_meta( $template_id, $key, $id );
-	}
-
-	return $id;
+	return absint( apply_filters( 'llms_certificate_sequential_id', $id, $template_id ) );
 
 }
 

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -244,6 +244,7 @@ function llms_get_certificate_orientations() {
 function llms_get_certificate_sequential_id( $template_id, $increment = false ) {
 
 	$key    = '_llms_sequential_id';
+	$update = $increment;
 	$id     = absint( get_post_meta( $template_id, $key, true ) );
 
 	// No id, get the initial ID.
@@ -252,7 +253,7 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		/**
 		 * Determines the default starting number for the a certificate's sequential ID.
 		 *
-		 * The returned number *must* be an absolute integer. The returned value will be
+		 * The returned number *must* be an absolute integer (zero included). The returned value will be
 		 * passed through `absint()` to sanitize the filtered value.
 		 *
 		 * @since 6.0.0
@@ -262,12 +263,12 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		 */
 		$starting_id = apply_filters( 'llms_certificate_sequential_id_starting_number', 1, $template_id );
 		$id          = absint( $starting_id );
-		$increment   = true;
+		$update      = true;
 
 	}
 
-	if ( $increment ) {
-		update_post_meta( $template_id, $key, $id + 1 );
+	if ( $update ) {
+		update_post_meta( $template_id, $key, $increment ? $id + 1 : $id );
 	}
 
 	/**

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -244,7 +244,6 @@ function llms_get_certificate_orientations() {
 function llms_get_certificate_sequential_id( $template_id, $increment = false ) {
 
 	$key    = '_llms_sequential_id';
-	$update = $increment;
 	$id     = absint( get_post_meta( $template_id, $key, true ) );
 
 	// No id, get the initial ID.
@@ -263,15 +262,12 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		 */
 		$starting_id = apply_filters( 'llms_certificate_sequential_id_starting_number', 1, $template_id );
 		$id          = absint( $starting_id );
-
-		// If there's no stored ID don't increment again or we'll end up getting 2 instead of 1 for the first id.
-		$increment = false;
-		$update    = true;
+		$increment   = true;
 
 	}
 
-	if ( $update ) {
-		update_post_meta( $template_id, $key, $increment ? $id + 1 : $id );
+	if ( $increment ) {
+		update_post_meta( $template_id, $key, $id + 1 );
 	}
 
 	/**

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -231,7 +231,7 @@ function llms_get_certificate_orientations() {
 /**
  * Retrieve the next sequential ID for a given certificate template and optionally increment it.
  *
- * If there's no existing ID.
+ * If there's no existing ID, a default ID of 1 will be used. This can be customized using the filter `llms_certificate_sequential_id_starting_number`.
  *
  * When an increment is requested, the new incremented ID will be automatically persisted to the database.
  *

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -253,7 +253,7 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		/**
 		 * Determines the default starting number for the a certificate's sequential ID.
 		 *
-		 * The returned number *must* be an absolute integer (zero included). The returned value will be
+		 * The returned number *must* be an absolute integer. The returned value will be
 		 * passed through `absint()` to sanitize the filtered value.
 		 *
 		 * @since 6.0.0
@@ -264,7 +264,7 @@ function llms_get_certificate_sequential_id( $template_id, $increment = false ) 
 		$starting_id = apply_filters( 'llms_certificate_sequential_id_starting_number', 1, $template_id );
 		$id          = absint( $starting_id );
 
-		// If there's no stored ID we don't want to increment it because it'll default to 1 next time anyway.
+		// If there's no stored ID don't increment again or we'll end up getting 2 instead of 1 for the first id.
 		$increment = false;
 		$update    = true;
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
@@ -131,22 +131,37 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 
 		$template_id = $this->factory->post->create( array( 'post_type' => 'llms_certificate' ) );
 
-		// Default ID (skips incrementing).
-		$this->assertEquals( 1, llms_get_certificate_sequential_id( $template_id, true ) );
+		$id = 1;
+		while ( $id <= 100 ) {
 
-		// Increment the ID.
-		$this->assertEquals( 2, llms_get_certificate_sequential_id( $template_id, true ) );
+			// Just get the next ID, don't increment.
+			$this->assertEquals( $id, llms_get_certificate_sequential_id( $template_id, false ) );
+			$this->assertEquals( $id, absint( get_post_meta( $template_id, '_llms_sequential_id', true ) ) );
 
-		// Retrieve the stored ID.
-		$this->assertEquals( 2, llms_get_certificate_sequential_id( $template_id, false ) );
+			// Increment the ID.
+			$this->assertEquals( $id, llms_get_certificate_sequential_id( $template_id, true ) );
+			$this->assertEquals( $id + 1, absint( get_post_meta( $template_id, '_llms_sequential_id', true ) ) );
 
-		// Set it to a new value & retrieve it.
-		update_post_meta( $template_id, '_llms_sequential_id', 923409 );
-		$this->assertEquals( 923409, llms_get_certificate_sequential_id( $template_id, false ) );
+			$id++;
 
-		// Increment it and retrieve it.
-		$this->assertEquals( 923410, llms_get_certificate_sequential_id( $template_id, true ) );
-		$this->assertEquals( 923410, llms_get_certificate_sequential_id( $template_id, false ) );
+		}
+
+		// Big numbers.
+		$id = 923409;
+		update_post_meta( $template_id, '_llms_sequential_id', $id );
+		while ( $id <= 923512 ) {
+
+			// Just get the next ID, don't increment.
+			$this->assertEquals( $id, llms_get_certificate_sequential_id( $template_id, false ) );
+			$this->assertEquals( $id, absint( get_post_meta( $template_id, '_llms_sequential_id', true ) ) );
+
+			// Increment the ID.
+			$this->assertEquals( $id, llms_get_certificate_sequential_id( $template_id, true ) );
+			$this->assertEquals( $id + 1, absint( get_post_meta( $template_id, '_llms_sequential_id', true ) ) );
+
+			$id++;
+
+		}
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
@@ -103,8 +103,8 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 				'post_status' => 'publish',
 			)
 		);
-		$this->assertEquals( 26, $cert->get( 'sequential_id' ) );
-		$this->assertEquals( 26, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
+		$this->assertEquals( 25, $cert->get( 'sequential_id' ) );
+		$this->assertEquals( 25, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
 
 		// Save the awarded certificate again, make sure the seq id is not incremented.
 		wp_update_post(
@@ -113,16 +113,16 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 				'post_title' => 'Title changes',
 			)
 		);
-		$this->assertEquals( 26, $cert->get( 'sequential_id' ) );
-		$this->assertEquals( 26, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
+		$this->assertEquals( 25, $cert->get( 'sequential_id' ) );
+		$this->assertEquals( 25, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
 
 		// Test seq id incremented on creation if post status is publish.
 		$template_id = $this->create_certificate_template();
 		update_post_meta( $template_id, '_llms_sequential_id', 25 );
 
 		$cert = new $this->class_name( 'new', array( 'post_parent' => $template_id, 'post_status' => 'publish' ) );
-		$this->assertEquals( 26, $cert->get( 'sequential_id' ) );
-		$this->assertEquals( 26, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
+		$this->assertEquals( 25, $cert->get( 'sequential_id' ) );
+		$this->assertEquals( 25, get_post_meta( $cert->get('id'), '_llms_sequential_id', true ) );
 
 		// No parent id, nothing to increment.
 		$cert = new $this->class_name( 'new', array(  'post_status' => 'publish' ) );
@@ -146,10 +146,12 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 
 		// Set a parent.
 		$template_id = $this->create_certificate_template();
-		update_post_meta( $template_id, '_llms_sequential_id', 25 );
+		update_post_meta( $template_id, '_llms_sequential_id', 15 );
 
 		$this->obj->set( 'parent', $template_id );
-		$this->assertEquals( 26, $this->obj->update_sequential_id() );
+		$this->assertEquals( 15, $this->obj->update_sequential_id() );
+
+		$this->assertEquals( 16, llms_get_certificate_sequential_id( $template_id, false ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
@@ -151,7 +151,31 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 		$this->obj->set( 'parent', $template_id );
 		$this->assertEquals( 15, $this->obj->update_sequential_id() );
 
+		// Incremented the templates's ID.
 		$this->assertEquals( 16, llms_get_certificate_sequential_id( $template_id, false ) );
+
+	}
+
+	/**
+	 * Test update_sequential_id() when creating several awards from a single template.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_sequential_id_multi() {
+
+		$template_id = $this->create_certificate_template();
+
+		$id = 1;
+		while ( $id <= 5 ) {
+
+			$this->create();
+			$this->obj->set( 'parent', $template_id );
+			$this->assertEquals( $id, $this->obj->update_sequential_id(), $id );
+
+			$id++;
+		}
 
 	}
 


### PR DESCRIPTION
## Description

During prerelease Q&A / testing I noticed that a certificate using the `{sequential_id}` merge code resulted in `000002` being generated for the first certificate awarded via an engagement. This addresses that issue.

Additionally prevents the sequential id from being merged when manually awarding a certificate via the admin UI

## How has this been tested?

+ Updated unit tests


## Screenshots <!-- if applicable -->

## Types of changes
+ Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

