### PR TITLE
Use of deprecated LLMS_Abstract_Query items

### DIFF
--- a/.changelogs/query-properties.yml
+++ b/.changelogs/query-properties.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed access of protected LLMS_Abstract_Query properties.

--- a/includes/admin/settings/class.llms.settings.notifications.php
+++ b/includes/admin/settings/class.llms.settings.notifications.php
@@ -75,7 +75,7 @@ class LLMS_Settings_Notifications extends LLMS_Settings_Page {
 	 * @since 5.2.0 Merge controller additional options.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
 	 *
-	 * @param LLMS_Notification_Controller $controller Instance of an LLMS_Notification_Controller extending class.
+	 * @param LLMS_Abstract_Notification_Controller $controller Instance of an LLMS_Abstract_Notification_Controller extending class.
 	 * @return array
 	 */
 	private function get_notification_settings( $controller ) {

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Notifications/Controllers/Classes
  *
  * @since 3.8.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -80,12 +80,13 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	}
 
 	/**
-	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 * Get an array of LifterLMS Admin Page settings to send test notifications.
 	 *
-	 * @param    string $type  notification type [basic|email]
-	 * @return   array
-	 * @since    3.24.0
-	 * @version  3.24.0
+	 * @since 3.24.0
+	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @return array
 	 */
 	public function get_test_settings( $type ) {
 
@@ -103,7 +104,7 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 			'' => '',
 		);
 		$attempts = array();
-		$results  = $query->results;
+		$results  = $query->get_results();
 		if ( $query->has_results() ) {
 			foreach ( $query->get_attempts() as $attempt ) {
 				$quiz    = llms_get_post( $attempt->get( 'quiz_id' ) );

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -84,6 +84,7 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	 *
 	 * @since 3.24.0
 	 * @since [version] Fixed access of protected LLMS_Abstract_Query properties.
+	 *              Fixed issue where void was returned instead of an empty array if the type was 'email'.
 	 *
 	 * @param string $type Notification type [basic|email].
 	 * @return array
@@ -91,7 +92,7 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 	public function get_test_settings( $type ) {
 
 		if ( 'email' !== $type ) {
-			return;
+			return array();
 		}
 
 		$query    = new LLMS_Query_Quiz_Attempt(


### PR DESCRIPTION
## Description
+ Updated the use of LLMS_Abstract_Query protected properties.
+ Fixed issue where void was returned instead of an empty array if the type was 'email' in `LLMS_Notification_Controller_Quiz_Failed::get_test_settings()`.

## How has this been tested?
Only unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

