### PR TITLE
Prevent unwanted course enrollment changes

### DIFF
--- a/.changelogs/membership-auto-unenroll.yml
+++ b/.changelogs/membership-auto-unenroll.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: fixed
+links:
+  - "#1861"
+entry: Prevent course enrollment changes while removing a user's membership level
+  if the user was auto-enrolled in the course by a different membership.
+
+


### PR DESCRIPTION
## Description
Prevent course enrollment changes while removing a user's membership level if the user was auto-enrolled in the course by a different membership.

Fixes #1861

## How has this been tested?
Manually and with a new unit test.

1. Enroll user in membership 'm1' that auto-enrolls user in course 'c1'.
2. Enroll user in membership 'm2' that auto-enrolls user in courses 'c1' and 'c2'.
3. Expire the user's enrollment in membership 'm1'. The user's enrollment status in both courses is still 'enrolled'.
4. Delete the user's enrollment in membership 'm1'.
5. Expire the user's enrollment in membership 'm2'. The user's enrollment status in both courses is 'expired'.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

