### PR TITLE
Add certificate {earned_date} merge code.

### DIFF
--- a/.changelogs/certificate-current-date.yml
+++ b/.changelogs/certificate-current-date.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Changed the label for the `{current_date}` certificate merge code from 'Earned Date' to 'Current Date'.

--- a/.changelogs/certificate-earned-date.yml
+++ b/.changelogs/certificate-earned-date.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added the `{earned_date}` certificate merge code.

--- a/includes/functions/llms.functions.certificate.php
+++ b/includes/functions/llms.functions.certificate.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 2.2.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -182,15 +182,17 @@ function llms_get_certificate_image( $id = 0 ) {
  * Retrieve a list of merge codes that can be used in certificate templates.
  *
  * @since 6.0.0
+ * @since [version] Changed `{current_date}` label from 'Earned Date' to 'Current Date' and added `{earned_date}` merge code.
  *
- * @return array[] Associative array of merge codes where the array key is the merge code and the array value is a name / description of the merge code.
+ * @return string[] Associative array of merge codes where the array key is the merge code and the array value is a name / description of the merge code.
  */
 function llms_get_certificate_merge_codes() {
 
 	return array(
 		'{site_title}'     => __( 'Site Title', 'lifterlms' ),
 		'{site_url}'       => __( 'Site URL', 'lifterlms' ),
-		'{current_date}'   => __( 'Earned Date', 'lifterlms' ),
+		'{current_date}'   => __( 'Current Date', 'lifterlms' ),
+		'{earned_date}'    => __( 'Earned Date', 'lifterlms' ),
 		'{first_name}'     => __( 'Student First Name', 'lifterlms' ),
 		'{last_name}'      => __( 'Student Last Name', 'lifterlms' ),
 		'{email_address}'  => __( 'Student Email', 'lifterlms' ),

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -451,8 +451,10 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 	 * Retrieve merge codes and data.
 	 *
 	 * @since 6.0.0
+	 * @since [version] Added `{earned_date}` merge code.
+	 *               Allowed `{current_date}` to be mocked.
 	 *
-	 * @return array Array mapping merge codes to the merge data.
+	 * @return string[] Array mapping merge codes to the merge data.
 	 */
 	protected function get_merge_data() {
 
@@ -460,6 +462,7 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 		$user_id       = $this->get_user_id();
 		$related_id    = $this->get( 'related' );
 		$engagement_id = $this->get( 'engagement' );
+		$date_format   = get_option( 'date_format' );
 
 		$user = get_userdata( $user_id );
 
@@ -474,7 +477,8 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 			'{email_address}'  => $user ? $user->user_email : '',
 			'{student_id}'     => $user ? $user_id : '',
 			// Certificate.
-			'{current_date}'   => wp_date( get_option( 'date_format' ) ),
+			'{current_date}'   => wp_date( $date_format, llms_current_time( 'timestamp' ) ),
+			'{earned_date}'    => $this->get_date( 'date', $date_format ),
 			'{certificate_id}' => $this->get( 'id' ),
 			'{sequential_id}'  => $this->get_sequential_id(),
 		);

--- a/includes/schemas/llms-block-templates.php
+++ b/includes/schemas/llms-block-templates.php
@@ -87,6 +87,7 @@ $blocks_styles = apply_filters( 'llms_block_templates_styling', $blocks_styles )
  * Shared block template for the `llms_certificate` and `llms_my_certificate` post types.
  *
  * @since 6.0.0
+ * @since [version] Changed the certificate template's use of the `{current_date}` merge code to `{earned_date}`.
  */
 $certificates = array(
 	array(
@@ -148,7 +149,7 @@ $certificates = array(
 						'core/paragraph',
 						array(
 							'align'   => 'center',
-							'content' => '{current_date}',
+							'content' => '{earned_date}',
 							'style'   => $blocks_styles['certificate']['p']['style'],
 						),
 					),

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-user-certificate.php
@@ -696,6 +696,7 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 	 * Test merge_content()
 	 *
 	 * @since 6.0.0
+	 * @since [version] Added testing of the `{earned_date}` merge code.
 	 *
 	 * @return void
 	 */
@@ -715,6 +716,8 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 
 		$content          = '';
 		$expected_content = '';
+		$date_format      = get_option( 'date_format' );
+		$earned_date      = null;
 
 		$merge_codes = llms_get_certificate_merge_codes();
 		// Add user info shortcodes.
@@ -736,7 +739,9 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 					$expected = get_permalink( llms_get_page_id( 'myaccount' ) );
 					break;
 				case '{current_date}':
-					$expected = date_i18n( get_option( 'date_format' ), current_time( 'timestamp' ) );
+				case '{earned_date}':
+					$expected = wp_date( $date_format, llms_current_time( 'timestamp' ) );
+					$earned_date = $expected;
 					break;
 				case '{email_address}':
 					$expected = $user_info['user_email'];
@@ -770,19 +775,30 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 
 		}
 
+		// Create a certificate template and award it to the student.
+		llms_tests_mock_current_time( 'now' );
 		$template = $this->create_certificate_template( 'Title', $content, 456 );
-		$cert     = LLMS_Unit_Test_Util::call_method( 'LLMS_Engagement_Handler', 'create', array( 'certificate', $user->get( 'id' ), $template, $related ) );
+		/** @var LLMS_User_Certificate $cert */
+		$cert = LLMS_Unit_Test_Util::call_method(
+			'LLMS_Engagement_Handler',
+			'create',
+			array( 'certificate', $user->get( 'id' ), $template, $related )
+		);
 
 		// Add the cert id (not available until the earned post exists).
 		$expected_content = str_replace( '[[CERTID]]', $cert->get( 'id' ), $expected_content );
 
 		$this->assertEquals( $expected_content, $cert->get( 'content', true ) );
 
+		// Time travel to the future.
+		llms_tests_mock_current_time( 'now +1 day' );
+		$updated_date = wp_date( $date_format, llms_current_time( 'timestamp' ) );
+
 		// Update the template and sync.
 		$thumbnail_id = $this->create_attachment( 'christian-fregnan-unsplash.jpg' );
 		wp_update_post( array(
 			'ID'           => $template,
-			'post_content' => 'Updated and {user_login}',
+			'post_content' => 'Updated on {current_date}. Earned on {earned_date}. Login = {user_login}.',
 			'post_title'   => 'Template Title',
 			'meta_input'   => array(
 				'_thumbnail_id' => $thumbnail_id,
@@ -790,7 +806,8 @@ class LLMS_Test_LLMS_User_Certificate extends LLMS_PostModelUnitTestCase {
 		) );
 
 		$this->assertTrue( $cert->sync() );
-		$this->assertEquals( "Updated and {$user_info['user_login']}", $cert->get( 'content', true ) );
+		$expected = "Updated on {$updated_date}. Earned on {$earned_date}. Login = {$user_info['user_login']}.";
+		$this->assertEquals( $expected, $cert->get( 'content', true ) );
 		$this->assertEquals( 'Title', $cert->get( 'title', true ) );
 		$this->assertEquals( $thumbnail_id, get_post_thumbnail_id( $cert->get( 'id' ) ) );
 	}


### PR DESCRIPTION
## Description
* Added an `{earned_date}` certificate merge code.
* Relabeled the `{current_date}` certificate merge code from "Earned Date" to "Current Date".
* Updated the default certificate template to use `{earned_date}` instead of `{current_date}`.

Fixes #2069.

## How has this been tested?
Manually and with unit tests.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

