### PR TITLE
Payment plan ended

### DIFF
--- a/.changelogs/dev.yml
+++ b/.changelogs/dev.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2067"
+entry: Fixes an issue encountered when editing an order with a completed payment plan.

--- a/.changelogs/dev.yml
+++ b/.changelogs/dev.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#2067"
-entry: Fixes an issue encountered when editing an order with a completed payment plan.
+entry: Fixed an issue encountered when editing an order with a completed payment plan.

--- a/includes/admin/views/metaboxes/view-order-details.php
+++ b/includes/admin/views/metaboxes/view-order-details.php
@@ -6,6 +6,8 @@
  *
  * @since 5.3.0
  * @since 5.4.0 Inform about deleted products.
+ * @since [version] Add validation to the remaining payments input.
+ *              Allow the number of remaining payments to be `0` for already-completed payment plans.
  * @version 5.4.0
  *
  * @property LLMS_Order           $order                     Order object.
@@ -165,7 +167,8 @@ defined( 'ABSPATH' ) || exit;
 
 		<?php
 		if ( $order->has_plan_expiration() ) :
-			$remaining = $order->get_remaining_payments();
+			$remaining               = $order->get_remaining_payments();
+			$remaining_input_min_val = 0 === $remaining ? 0 : 1;
 			?>
 			<div class="llms-metabox-field">
 				<label><?php _e( 'Remaining Payments:', 'lifterlms' ); ?></label>
@@ -178,7 +181,7 @@ defined( 'ABSPATH' ) || exit;
 
 						<label>
 							<span><?php _e( 'Remaining payments', 'lifterlms' ); ?></span>
-							<input type="number" id="llms-num-remaining-payments" value="<?php echo $remaining; ?>" min="1" step="1">
+							<input type="number" id="llms-num-remaining-payments" value="<?php echo $remaining; ?>" min="<?php echo $remaining_input_min_val; ?>" step="1">
 						</label>
 
 						<label>
@@ -187,14 +190,26 @@ defined( 'ABSPATH' ) || exit;
 							<em><?php _e( 'For internal use only, not visible to the customer.', 'lifterlms' ); ?></em>
 						</label>
 
-						<button id="llms-save-remaining-payments" class="button button-primary button-large"><?php _e( 'Save', 'lifterlms' ); ?></button>
+						<button id="llms-save-remaining-payments" name="fake" class="button button-primary button-large"><?php _e( 'Save', 'lifterlms' ); ?></button>
 
 						<script>
 							(function(){
 								document.getElementById( 'llms-save-remaining-payments' ).addEventListener( 'click', function() {
+									var remainingEl = document.getElementById( 'llms-num-remaining-payments' ),
+										errEl       = document.getElementById( 'llms-remaining-payments-err' ),
+										remaining   = remainingEl.value,
+										note        = document.getElementById( 'llms-remaining-payments-note' ).value;
+
+									if ( errEl ) {
+										errEl.remove();
+									}
+
+									if ( ! remainingEl.checkValidity() ) {
+										remainingEl.insertAdjacentHTML( 'afterend', '<em id="llms-remaining-payments-err" class="llms-error">' + remainingEl.validationMessage + '</em>' );
+										return;
+									}
+
 									tb_remove();
-									var remaining = document.getElementById( 'llms-num-remaining-payments' ).value,
-										note      = document.getElementById( 'llms-remaining-payments-note' ).value;
 
 									document.querySelector( 'input[name="_llms_remaining_payments"]' ).value = remaining;
 									document.querySelector( 'input[name="_llms_remaining_note"]' ).value = note;

--- a/includes/admin/views/metaboxes/view-order-details.php
+++ b/includes/admin/views/metaboxes/view-order-details.php
@@ -190,7 +190,7 @@ defined( 'ABSPATH' ) || exit;
 							<em><?php _e( 'For internal use only, not visible to the customer.', 'lifterlms' ); ?></em>
 						</label>
 
-						<button id="llms-save-remaining-payments" name="fake" class="button button-primary button-large"><?php _e( 'Save', 'lifterlms' ); ?></button>
+						<button id="llms-save-remaining-payments" class="button button-primary button-large"><?php _e( 'Save', 'lifterlms' ); ?></button>
 
 						<script>
 							(function(){


### PR DESCRIPTION
## Description

Fixes #2067

## How has this been tested?

+ Manually

## Screenshots <!-- if applicable -->

https://user-images.githubusercontent.com/1290739/159368536-c1cf3dab-b427-47d3-a8af-c0e111bf16b2.mp4


Note that the jump from 0 to 7 when editing the plan forced to 0 remaining payments happened because the data was forced so the value in the database was actually 4 (instead of the 0 seen on screen) so the jump from 0 -> 7 is expected given the way I was testing this.

The math actually works right it just looks wrong in this particular video that I recorded to quickly demonstrate how it's working with this change introduced.


## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

