### PR TITLE
Automatically initialize payment gateways

### DIFF
--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 5.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -66,6 +66,7 @@ final class LifterLMS {
 	 *               Remove deprecated `__autoload()` & initialize new file loader class.
 	 * @since 4.13.0 Check site duplicate status on `admin_init`.
 	 * @since 5.3.0 Move the loading of the LifterLMS autoloader to the main `lifterlms.php` file.
+	 * @since [version] Automatically load payment gateways.
 	 *
 	 * @return void
 	 */
@@ -95,6 +96,7 @@ final class LifterLMS {
 		add_action( 'init', array( $this, 'processors' ), 5 );
 		add_action( 'init', array( $this, 'events' ), 5 );
 		add_action( 'init', array( $this, 'init_session' ), 6 ); // After table installation which happens at init 5.
+		add_action( 'init', array( $this, 'payment_gateways' ) );
 		add_action( 'init', array( $this, 'include_template_functions' ) );
 		add_action( 'init', array( 'LLMS_Shortcodes', 'init' ) );
 


### PR DESCRIPTION
## Description

Fixes #2074

The issue is occurring because the `LLMS_Payment_Gateways` singleton isn't initialized until code accesses the `llms()->payment_gateways()` method. In the core plugin, when viewing an order, this doesn't happen until this hook:

https://github.com/gocodebox/lifterlms/blob/0a5e0a2c7cd522074f1988dd0979e3aa6289a0c3/templates/myaccount/view-order.php#L58

That means that the previous hook isn't accessible to payment gateway classes: https://github.com/gocodebox/lifterlms/blob/0a5e0a2c7cd522074f1988dd0979e3aa6289a0c3/templates/myaccount/view-order.php#L47

(Unless the core implements logic to load gateways before that hook)

This PR automatically loads all payment gateways at `init`, priority 10. This means that payment gateways that expect to be able to utilize this (or other) hooks, can do so.

The primary issue is here: https://github.com/gocodebox/lifterlms/blob/0a5e0a2c7cd522074f1988dd0979e3aa6289a0c3/includes/class.llms.gateway.manual.php#L52

## How has this been tested?

+ Manually


## Screenshots <!-- if applicable -->

## Types of changes
+ Bugfix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

