### PR TITLE
Fix issue with hidden checkboxes on LifterLMS forms.

### DIFF
--- a/.changelogs/hidden-checkboxes.yml
+++ b/.changelogs/hidden-checkboxes.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed issue with hidden checkboxes on LifterLMS forms.

--- a/includes/forms/class-llms-form-field.php
+++ b/includes/forms/class-llms-form-field.php
@@ -175,11 +175,11 @@ class LLMS_Form_Field {
 				$checked = in_array( $key, $value, true );
 			}
 
-			if ( $is_hidden && false === $checked ) {
+			if ( $is_hidden && ! $checked ) {
 				continue;
 			}
 
-			$fields[] = new LLMS_Form_Field(
+			$fields[] = new self(
 				array(
 					'data_store' => false,
 					'id'         => sprintf( '%1$s--%2$s', $this->settings['id'], $key ),

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -476,8 +476,8 @@ class LLMS_Forms {
 
 			if ( empty( $settings ) ) {
 				continue;
-
-			} elseif (
+			}
+			if (
 				'hidden' === ( $settings['type'] ?? null ) &&
 				in_array( $block['attrs']['field'] ?? null, array( 'checkbox', 'radio' ) )
 			) {

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -456,14 +456,15 @@ class LLMS_Forms {
 	}
 
 	/**
-	 * Retrieve an array of LLMS_Form_Fields settings arrays from an array of blocks
+	 * Retrieve an array of LLMS_Form_Field settings from an array of blocks.
 	 *
 	 * @since 5.0.0
 	 * @since 5.1.0 Pass the whole list of blocks to the `$this->block_to_field_settings()` method
-	 *              To better check whether a block is visible.
+	 *              to better check whether a block is visible.
+	 * @since [version] Exploded hidden checkbox and radio fields.
 	 *
 	 * @param  array $blocks Array of WP Block arrays from `parse_blocks()`.
-	 * @return false|array
+	 * @return array
 	 */
 	public function get_fields_settings_from_blocks( $blocks ) {
 
@@ -472,7 +473,22 @@ class LLMS_Forms {
 
 		foreach ( $blocks as $block ) {
 			$settings = $this->block_to_field_settings( $block, $blocks );
-			if ( $settings ) {
+
+			if ( empty( $settings ) ) {
+				continue;
+
+			} elseif (
+				'hidden' === ( $settings['type'] ?? null ) &&
+				in_array( $block['attrs']['field'] ?? null, array( 'checkbox', 'radio' ) )
+			) {
+				// Convert hidden checkbox or radio settings into multiple "checked" hidden fields.
+				$settings['type'] = $block['attrs']['field'];
+				$field            = new LLMS_Form_Field( $settings );
+				$form_fields      = $field->explode_options_to_fields( true );
+				foreach ( $form_fields as $form_field ) {
+					$fields[] = $form_field->get_settings();
+				}
+			} else {
 				$field    = new LLMS_Form_Field( $settings );
 				$fields[] = $field->get_settings();
 			}
@@ -1115,7 +1131,7 @@ class LLMS_Forms {
 	 * Backwards incompatible changes and/or method removal may occur without notice.
 	 *
 	 * @since 5.0.0
-	 * @since [versino] Added `$block_list` param.
+	 * @since 5.1.0 Added `$block_list` param.
 	 * @access private
 	 *
 	 * @param array   $attrs      LLMS_Form_Field settings array for the field.

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -461,7 +461,7 @@ class LLMS_Forms {
 	 * @since 5.0.0
 	 * @since 5.1.0 Pass the whole list of blocks to the `$this->block_to_field_settings()` method
 	 *              to better check whether a block is visible.
-	 * @since [version] Exploded hidden checkbox and radio fields.
+	 * @since [version] Exploded hidden checkbox fields.
 	 *
 	 * @param  array $blocks Array of WP Block arrays from `parse_blocks()`.
 	 * @return array
@@ -479,9 +479,9 @@ class LLMS_Forms {
 			}
 			if (
 				'hidden' === ( $settings['type'] ?? null ) &&
-				in_array( $block['attrs']['field'] ?? null, array( 'checkbox', 'radio' ) )
+				isset( $block['attrs']['field'] ) && 'checkbox' === $block['attrs']['field']
 			) {
-				// Convert hidden checkbox or radio settings into multiple "checked" hidden fields.
+				// Convert hidden checkbox settings into multiple "checked" hidden fields.
 				$settings['type'] = $block['attrs']['field'];
 				$field            = new LLMS_Form_Field( $settings );
 				$form_fields      = $field->explode_options_to_fields( true );

--- a/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-forms.php
@@ -7,9 +7,30 @@
  * @group forms
  *
  * @since 5.0.0
- * @version 5.1.1
+ * @version [version]
  */
 class LLMS_Test_Forms extends LLMS_UnitTestCase {
+
+	/**
+	 * @var LLMS_Forms
+	 */
+	private LLMS_Forms $forms;
+
+	/**
+	 * Serializes checkboxes attributes and appends a 'llms/form-field-checkboxes' block markup to the form.
+	 *
+	 * @since [version]
+	 *
+	 * @param int   $form_id    WP post ID of the form to append to.
+	 * @param array $checkboxes Attributes, {@see LLMS_Test_Forms::get_checkboxes_attributes()}.
+	 * @return void
+	 */
+	private function append_checkboxes_to_form( $form_id, $checkboxes ) {
+
+		$form_post               = get_post( $form_id );
+		$form_post->post_content .= '<!-- wp:llms/form-field-checkboxes ' . wp_json_encode( $checkboxes ) . ' /-->';
+		wp_update_post( $form_post );
+	}
 
 	/**
 	 * Setup the test
@@ -41,6 +62,40 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 		global $wpdb;
 		$wpdb->delete( $wpdb->posts, array( 'post_type' => 'llms_form' ) );
 
+	}
+
+	/**
+	 * Returns an array of attributes for a 'llms/form-field-checkboxes' block to be serialized into
+	 * a form's `post_content`.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $form_id WP post ID of the form.
+	 * @return array
+	 */
+	private function get_checkboxes_attributes( $form_id ) {
+
+		$checkboxes = array(
+			'field' => 'checkbox',
+			'id'    => "checkbox-{$form_id}-1",
+			'label' => 'Do you like coffee?',
+			'options' => array(
+				array(
+					'text'    => 'Yes',
+					'key'     => 'like_coffee_yes',
+				),
+				array(
+					'text'    => 'No',
+					'key'     => 'like_coffee_no',
+				),
+				array(
+					'text'    => 'No, but I like the smell of it.',
+					'key'     => 'like_coffee_smell',
+				),
+			),
+		);
+
+		return $checkboxes;
 	}
 
 	/**
@@ -569,15 +624,18 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 
 
 	/**
-	 * Test the get_fields_settings_from_blocks() method
+	 * Test the get_fields_settings_from_blocks() method.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Added checkboxes.
 	 *
 	 * @return void
 	 */
 	public function test_get_fields_settings_from_blocks() {
 
-		$this->forms->create( 'checkout', true );
+		$form_id    = $this->forms->create( 'checkout', true );
+		$checkboxes = $this->get_checkboxes_attributes( $form_id );
+		$this->append_checkboxes_to_form( $form_id, $checkboxes );
 
 		$blocks = $this->forms->get_form_blocks( 'checkout' );
 
@@ -603,42 +661,60 @@ class LLMS_Test_Forms extends LLMS_UnitTestCase {
 			'llms_billing_state',
 			'llms_billing_zip',
 			'llms_phone',
+			$checkboxes['id'],
 		);
 		$this->assertEquals( $expect, wp_list_pluck( $fields, 'name' ) );
 
 	}
 
 	/**
-	 * Test get_free_enroll_form_fields()
+	 * Test get_free_enroll_form_fields().
 	 *
 	 * @since 5.0.0
+	 * @since [version] Added checkboxes.
 	 *
 	 * @return void
 	 */
 	public function test_get_free_enroll_form_fields() {
 
 		$plan = $this->get_mock_plan();
-		wp_set_current_user( $this->factory->user->create() );
 
-		$this->forms->create( 'checkout', true );
+		$form_id = $this->forms->create( 'checkout', true );
+
+		// Add a checkboxes block to the form.
+		$checkboxes = $this->get_checkboxes_attributes( $form_id );
+		$this->append_checkboxes_to_form( $form_id, $checkboxes );
+		$checkboxes_id    = $checkboxes['id'];
+		$checkboxes_key_2 = $checkboxes['options'][2]['key'];
+
+		// The user has checked the 2nd checkbox.
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+		add_user_meta( $user_id, $checkboxes_id, array( $checkboxes_key_2 ) );
+
+		// Expected field IDs and names.
+		$expected_fields = array(
+			array( 'id' => 'first_name', 'name' => 'first_name' ),
+			array( 'id' => 'last_name', 'name' => 'last_name' ),
+			array( 'id' => 'llms_billing_address_1', 'name' => 'llms_billing_address_1' ),
+			array( 'id' => 'llms_billing_address_2', 'name' => 'llms_billing_address_2' ),
+			array( 'id' => 'llms_billing_city', 'name' => 'llms_billing_city' ),
+			array( 'id' => 'llms_billing_country', 'name' => 'llms_billing_country' ),
+			array( 'id' => 'llms_billing_state', 'name' => 'llms_billing_state' ),
+			array( 'id' => 'llms_billing_zip', 'name' => 'llms_billing_zip' ),
+			array( 'id' => 'llms_phone', 'name' => 'llms_phone' ),
+			array( 'id' => "{$checkboxes_id}--{$checkboxes_key_2}", 'name' => "{$checkboxes_id}[]" ),
+			array( 'id' => null, 'name' => 'free_checkout_redirect' ),
+			array( 'id' => 'llms-plan-id', 'name' => 'llms_plan_id' ),
+		);
 
 		$fields = $this->forms->get_free_enroll_form_fields( $plan );
+		$this->assertCount( count( $expected_fields ), $fields );
 
-		// Expected field list by name.
-		$expect = array(
-			'first_name',
-			'last_name',
-			'llms_billing_address_1',
-			'llms_billing_address_2',
-			'llms_billing_city',
-			'llms_billing_country',
-			'llms_billing_state',
-			'llms_billing_zip',
-			'llms_phone',
-			'free_checkout_redirect',
-			'llms_plan_id',
-		);
-		$this->assertEquals( $expect, wp_list_pluck( $fields, 'name' ) );
+		foreach ( $fields as $index => $field ) {
+			$actual = array( 'id' => $field['id'] ?? null, 'name' => $field['name'] );
+			$this->assertEquals( $expected_fields[ $index ], $actual );
+		}
 
 		// Only hidden fields.
 		$this->assertEquals( array( 'hidden' ), array_unique( wp_list_pluck( $fields, 'type' ) ) );


### PR DESCRIPTION
## Description
When a block of checkboxes or radio buttons are displayed as hidden inputs, for example on the "free enrollment" form, the user's selected options are converted to hidden inputs instead of a single hidden input for the block.

Fixes #2066.

## How has this been tested?
Manually and with new unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

