### PR TITLE
Change llmsStudentsSelect2() to use the LifterLMS REST API

### DIFF
--- a/.changelogs/ajax-students-select.yml
+++ b/.changelogs/ajax-students-select.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Changed the `llmsStudentsSelect2()` JavaScript function to use the LifterLMS REST API
+  "list students" endpoint instead of the `LLMS_AJAX_Handler::query_students()` PHP function.

--- a/.changelogs/deprecate-ajax-query-students.yml
+++ b/.changelogs/deprecate-ajax-query-students.yml
@@ -1,3 +1,3 @@
 significance: minor
 type: deprecated
-entry: Deprecated `LLMS_AJAX_Handler::query_students()`. Use LifterLMS REST API 'GET https://example.tld/wp-json/llms/v1/students' instead.
+entry: Deprecated `LLMS_AJAX_Handler::query_students()`. Use the [REST API list students](https://developer.lifterlms.com/rest-api/#tag/Students/paths/~1students/get) endpoint instead.

--- a/.changelogs/deprecate-ajax-query-students.yml
+++ b/.changelogs/deprecate-ajax-query-students.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: deprecated
+entry: Deprecated `LLMS_AJAX_Handler::query_students()`. Use LifterLMS REST API 'GET https://example.tld/wp-json/llms/v1/students' instead.

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -2,7 +2,7 @@
  * LifterLMS Admin Panel Javascript
  *
  * @since Unknown
- * @version 4.5.1
+ * @version [version]
  *
  * @param obj $ Traditional jQuery reference.
  * @return void
@@ -152,9 +152,11 @@
 	 * @since Unknown
 	 * @since 3.17.5 Unknown.
 	 * @since 4.4.0 Update ajax nonce source.
+	 * @since [version] Use the LifterLMS REST API "list students" endpoint
+	 *              instead of the `LLMS_AJAX_Handler::query_students()` PHP function.
 	 *
-	 * @param obj options Options passed to Select2. Each default option will be pulled from the elements data-attributes.
-	 * @return void
+	 * @param {Object} options Options passed to Select2. Each default option will be pulled from the elements data-attributes.
+	 * @return {jQuery}
 	 */
 	$.fn.llmsStudentsSelect2 = function( options ) {
 
@@ -183,34 +185,37 @@
 			ajax: {
 				dataType: 'JSON',
 				delay: 250,
-				method: 'POST',
-				url: window.ajaxurl,
+				method: 'GET',
+				url: '/wp-json/llms/v1/students',
 				data: function( params ) {
 					return {
-						_ajax_nonce: window.llms.ajax_nonce,
-						action: 'query_students',
-						page: params.page,
+						_wpnonce: window.wpApiSettings.nonce,
+						context: 'edit',
+						page: params.page || 1,
+						per_page: 10,
 						not_enrolled_in: params.not_enrolled_in || options.not_enrolled_in,
 						enrolled_in: params.enrolled_in || options.enrolled_in,
 						roles: params.roles || options.roles,
-						term: params.term,
+						search: params.term,
+						search_columns: 'email,name,username',
 					};
 				},
 				processResults: function( data, params ) {
+					var page       = params.page || 1;
+					var totalPages = this._request.getResponseHeader( 'X-WP-TotalPages' );
 					return {
-						results: $.map( data.items, function( item ) {
+						results: $.map( data, function( item ) {
 
 							return {
-								text: item.name + ' <' + item.email +'>',
+								text: item.name + ' <' + item.email + '>',
 								id: item.id,
 							};
 
 						} ),
 						pagination: {
-							more: data.more
+							more: page < totalPages
 						}
 					};
-
 				},
 			},
 			cache: true,

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -183,34 +183,37 @@
 			ajax: {
 				dataType: 'JSON',
 				delay: 250,
-				method: 'POST',
-				url: window.ajaxurl,
+				method: 'GET',
+				url: '/wp-json/llms/v1/students',
 				data: function( params ) {
 					return {
-						_ajax_nonce: window.llms.ajax_nonce,
-						action: 'query_students',
-						page: params.page,
+						_wpnonce: window.wpApiSettings.nonce,
+						context: 'edit',
+						page: params.page || 1,
+						per_page: 10,
 						not_enrolled_in: params.not_enrolled_in || options.not_enrolled_in,
 						enrolled_in: params.enrolled_in || options.enrolled_in,
 						roles: params.roles || options.roles,
-						term: params.term,
+						search: params.term,
+						search_columns: 'email,name,username',
 					};
 				},
 				processResults: function( data, params ) {
+					var page       = params.page || 1;
+					var totalPages = this._request.getResponseHeader( 'X-WP-TotalPages' );
 					return {
-						results: $.map( data.items, function( item ) {
+						results: $.map( data, function( item ) {
 
 							return {
-								text: item.name + ' <' + item.email +'>',
+								text: item.name + ' <' + item.email + '>',
 								id: item.id,
 							};
 
 						} ),
 						pagination: {
-							more: data.more
+							more: page < totalPages
 						}
 					};
-
 				},
 			},
 			cache: true,

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -392,10 +392,14 @@ class LLMS_AJAX_Handler {
 	 * @since 3.14.2 Unknown.
 	 * @since 5.5.0 Do not encode quotes when sanitizing search term.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 * @deprecated [version] `LLMS_AJAX_Handler::query_students()` is deprecated. Use LifterLMS REST API
+	 *                   'GET https://example.tld/wp-json/llms/v1/students' instead.
 	 *
 	 * @return void
 	 */
 	public static function query_students() {
+
+		_deprecated_function( __METHOD__, '[version]', 'GET https://example.tld/wp-json/llms/v1/students' );
 
 		// Grab the search term if it exists.
 		$term = array_key_exists( 'term', $_REQUEST ) ? llms_filter_input_sanitize_string( INPUT_POST, 'term', array( FILTER_FLAG_NO_ENCODE_QUOTES ) ) : '';

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -392,14 +392,14 @@ class LLMS_AJAX_Handler {
 	 * @since 3.14.2 Unknown.
 	 * @since 5.5.0 Do not encode quotes when sanitizing search term.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
-	 * @deprecated [version] `LLMS_AJAX_Handler::query_students()` is deprecated. Use LifterLMS REST API
+	 * @deprecated [version] `LLMS_AJAX_Handler::query_students()` is deprecated in favor of the REST API list students endpoint.
 	 *                   'GET https://example.tld/wp-json/llms/v1/students' instead.
 	 *
 	 * @return void
 	 */
 	public static function query_students() {
 
-		_deprecated_function( __METHOD__, '[version]', 'GET https://example.tld/wp-json/llms/v1/students' );
+		_deprecated_function( __METHOD__, '[version]', 'the REST API list students endpoint' );
 
 		// Grab the search term if it exists.
 		$term = array_key_exists( 'term', $_REQUEST ) ? llms_filter_input_sanitize_string( INPUT_POST, 'term', array( FILTER_FLAG_NO_ENCODE_QUOTES ) ) : '';


### PR DESCRIPTION
## Description
Changed the `llmsStudentsSelect2()` JavaScript function to use the [LifterLMS REST API "list students" endpoint](https://developer.lifterlms.com/rest-api/#tag/Students/paths/~1students/get) instead of the [`LLMS_AJAX_Handler::query_students()`](https://github.com/gocodebox/lifterlms/blob/6.1.0/includes/class.llms.ajax.handler.php#L398) PHP function.

Fixes LifterLMS Private Areas [60](https://github.com/gocodebox/lifterlms-private-areas/issues/60).

## How has this been tested?
Manually:
1. Add new private post. Select a student. Optionally select a course.
2. LifterLMS -> Reporting -> Sales -> Toggle Filters. Select students.

Checked JavaScript console and PHP error log.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

