### PR TITLE
Do template loading at template_include with priority 100 instead of 10

### DIFF
--- a/.changelogs/issue_2063-1.yml
+++ b/.changelogs/issue_2063-1.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: dev
+entry: Added new filter `llms_template_loader_priority` to control the priority
+  of the `template_include` hook callback used to load restricted content
+  templates.

--- a/.changelogs/issue_2063.yml
+++ b/.changelogs/issue_2063.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2063"
+entry: Fixed a compatiblity issue with the Divi Theme Builder ignoring access
+  restrictions when using template with custom body.

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -29,26 +29,26 @@ class LLMS_Template_Loader {
 	 * @since 3.20.0 Unknown.
 	 * @since 3.41.1 Predispose posts content restriction in REST requests.
 	 * @since 5.8.0 Handle block templates loading.
-	 * @since [versin] Added 'llms_template_loader_priority' filter.
+	 * @since [version] Added 'llms_template_loader_priority' filter.
 	 */
 	public function __construct() {
 
 		// Template loading for FSE themes.
 		add_action( 'template_redirect', array( $this, 'hook_block_template_loader' ) );
 
+		/**
+		* Filters the template loading priority.
+		*
+		* Callback for the WP core filter `template_include`.
+		*
+		* @since [version]
+		*
+		* @param $priority The filter callback priority.
+		*/
+		$template_loader_cb_priority = apply_filters( 'llms_template_loader_priority', 100 );
+
 		// Do template loading.
-		add_filter(
-			'template_include',
-			array( $this, 'template_loader' ),
-			/**
-			 * Filter the template loader filter callback priority.
-			 *
-			 * @since [version]
-			 *
-			 * @param $priority The filter callback priority.
-			 */
-			apply_filters( 'llms_template_loader_priority', 100 )
-		);
+		add_filter( 'template_include', array( $this, 'template_loader' ), $template_loader_cb_priority );
 
 		add_action( 'rest_api_init', array( $this, 'maybe_prepare_post_content_restriction' ) );
 

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 1.0.0
- * @version 5.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,6 +29,7 @@ class LLMS_Template_Loader {
 	 * @since 3.20.0 Unknown.
 	 * @since 3.41.1 Predispose posts content restriction in REST requests.
 	 * @since 5.8.0 Handle block templates loading.
+	 * @since [versin] Added 'llms_template_loader_priority' filter.
 	 */
 	public function __construct() {
 
@@ -36,7 +37,18 @@ class LLMS_Template_Loader {
 		add_action( 'template_redirect', array( $this, 'hook_block_template_loader' ) );
 
 		// Do template loading.
-		add_filter( 'template_include', array( $this, 'template_loader' ) );
+		add_filter(
+			'template_include',
+			array( $this, 'template_loader' ),
+			/**
+			 * Filter the template loader filter callback priority.
+			 *
+			 * @since [version]
+			 *
+			 * @param $priority The filter callback priority.
+			 */
+			apply_filters( 'llms_template_loader_priority', 100 )
+		);
 
 		add_action( 'rest_api_init', array( $this, 'maybe_prepare_post_content_restriction' ) );
 


### PR DESCRIPTION
## Description
Fixes #2063

## How has this been tested?
Tested with Divi  using reproduction steps in #2063 
I also tested the following themes ensuring no regression was introduced.

- [x] 2020
- [x] 2021
- [x] 2022
- [x] Astra
- [x] BuddyBoss
- [x] OceanWP
- [x] Kadence
- [x] GeneratePress

Any other theme I need to test?

## Types of changes
Compatibility fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

