### PR TITLE
Fixed an issue the prevented the students searching in some admin areas when WordPress was installed in a subdirectory

### DIFF
--- a/.changelogs/dev.yml
+++ b/.changelogs/dev.yml
@@ -2,5 +2,5 @@ significance: patch
 type: fixed
 links:
   - "#2096"
-entry: Fixed an issue the prevented the students searching in some admin areas
+entry: Fixed an issue that prevented searching students in some admin areas
   when WordPress was installed in a subdirectory.

--- a/.changelogs/dev.yml
+++ b/.changelogs/dev.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2096"
+entry: Fixed an issue the prevented the students searching in some admin areas
+  when WordPress was installed in a subdirectory.

--- a/assets/js/llms-admin.js
+++ b/assets/js/llms-admin.js
@@ -2,7 +2,7 @@
  * LifterLMS Admin Panel Javascript
  *
  * @since Unknown
- * @version 6.2.0
+ * @version [version]
  *
  * @param obj $ Traditional jQuery reference.
  * @return void
@@ -154,6 +154,7 @@
 	 * @since 4.4.0 Update ajax nonce source.
 	 * @since 6.2.0 Use the LifterLMS REST API "list students" endpoint
 	 *              instead of the `LLMS_AJAX_Handler::query_students()` PHP function.
+	 * @since [version] Fixed student's REST API URL.
 	 *
 	 * @param {Object} options Options passed to Select2. Each default option will be pulled from the elements data-attributes.
 	 * @return {jQuery}
@@ -186,7 +187,7 @@
 				dataType: 'JSON',
 				delay: 250,
 				method: 'GET',
-				url: '/wp-json/llms/v1/students',
+				url: window.wpApiSettings.root + 'llms/v1/students',
 				data: function( params ) {
 					return {
 						_wpnonce: window.wpApiSettings.nonce,


### PR DESCRIPTION
## Description

Fixes #2096 

## How has this been tested?
manually (and on the user's staging website, after manually altering the js file).

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

