### PR TITLE
Fix comments are not enabled by default when creating a lesson with the Course builder

### DIFF
--- a/.changelogs/issue_2099.yml
+++ b/.changelogs/issue_2099.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2099"
+entry: Fixed lesson's comments status not reflecting default global setting when
+  created with the course builder.

--- a/includes/models/model.llms.lesson.php
+++ b/includes/models/model.llms.lesson.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 5.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -214,9 +214,10 @@ class LLMS_Lesson extends LLMS_Post_Model {
 	}
 
 	/**
-	 * An array of default arguments to pass to $this->create() when creating a new post
+	 * An array of default arguments to pass to $this->create() when creating a new post.
 	 *
 	 * @since 3.13.0
+	 * @since [version] Retrieve `comment_status` parameter value from the global discussion settings.
 	 *
 	 * @param array $args Optional. Args of data to be passed to `wp_insert_post()`. Default `null`.
 	 * @return array
@@ -235,17 +236,18 @@ class LLMS_Lesson extends LLMS_Post_Model {
 			);
 		}
 
-		$args = wp_parse_args(
+		$post_type = $this->get( 'db_post_type' );
+		$args      = wp_parse_args(
 			$args,
 			array(
-				'comment_status' => 'closed',
+				'comment_status' => get_default_comment_status( $post_type ),
 				'ping_status'    => 'closed',
 				'post_author'    => get_current_user_id(),
 				'post_content'   => '',
 				'post_excerpt'   => '',
 				'post_status'    => 'publish',
 				'post_title'     => '',
-				'post_type'      => $this->get( 'db_post_type' ),
+				'post_type'      => $post_type,
 			)
 		);
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-lesson.php
@@ -13,6 +13,7 @@
  * @since 4.4.0 Added tests on next/previous lessons retrieval.
  * @since 4.4.2 Added additional navigation testing scenarios.
  * @since 4.11.0 Addeed additional tests when retrieving next/prev lesson with empty sibling sections.
+ * @since [version] Added tests on comment_status reflecting default settings on lesson creation.
  */
 class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 
@@ -607,6 +608,32 @@ class LLMS_Test_LLMS_Lesson extends LLMS_PostModelUnitTestCase {
 			++$i;
 
 		}
+
+	}
+
+	/**
+	 * Test comment status on creation.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_comment_status_on_creation() {
+
+		$original_comments_status = get_default_comment_status( $this->post_type );
+		update_option( 'default_comment_status', 'open' );
+		$lesson = new LLMS_Lesson( 'new', 'Lesson with open comments' );
+		$this->assertEquals(
+			'open',
+			$lesson->get( 'comment_status' )
+		);
+		update_option( 'default_comment_status', 'closed' );
+		$lesson = new LLMS_Lesson( 'new', 'Lesson with closed comments' );
+		$this->assertEquals(
+			'closed',
+			$lesson->get( 'comment_status' )
+		);
+		update_option( 'default_comment_status', $original_comments_status );
 
 	}
 


### PR DESCRIPTION
## Description
Fixes #2099

I just implemented what @pondermatic suggested, so credits to him.

## How has this been tested?
manually and with new unit test

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

