### PR TITLE
Display instructions in extended manual payment gateway classes

### DIFF
--- a/.changelogs/extended-manual-payment-gateway-instructions.yml
+++ b/.changelogs/extended-manual-payment-gateway-instructions.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Allowed classes extended from the manual payment gateway class to display payment instructions.

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.0.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -54,11 +54,12 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 	}
 
 	/**
-	 * Output payment instructions if the order is pending
+	 * Output payment instructions if the order is pending.
 	 *
-	 * @return   void
-	 * @since    3.0.0
-	 * @version  3.10.0
+	 * @since 3.0.0
+	 * @since [version] Allowed classes extended from this manual payment gateway class to display payment instructions.
+	 *
+	 * @return void
 	 */
 	public function before_view_order_table() {
 
@@ -68,10 +69,11 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 
 			$order = new LLMS_Order( intval( $wp->query_vars['orders'] ) );
 
-			if ( 'manual' === $order->get( 'payment_gateway' ) && in_array( $order->get( 'status' ), array( 'llms-pending', 'llms-on-hold' ) ) ) {
-
+			if (
+				$order->get( 'payment_gateway' ) === $this->id &&
+				in_array( $order->get( 'status' ), array( 'llms-pending', 'llms-on-hold' ) )
+			) {
 				echo $this->get_payment_instructions();
-
 			}
 		}
 

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -71,7 +71,7 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 
 			if (
 				$order->get( 'payment_gateway' ) === $this->id &&
-				in_array( $order->get( 'status' ), array( 'llms-pending', 'llms-on-hold' ) )
+				in_array( $order->get( 'status' ), array( 'llms-pending', 'llms-on-hold', true ) )
 			) {
 				echo $this->get_payment_instructions();
 			}


### PR DESCRIPTION
## Description
Fixed an issue where classes extended from the manual payment gateway class would not display the payment instructions.

Fixes an issue raised in a [Slack chat](https://lifterlms.slack.com/archives/CCESQHE82/p1649355547483109?thread_ts=1648744033.805029&cid=CCESQHE82).

## How has this been tested?
Manually.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

