### PR TITLE
Updated terms and conditions block to hold inline-block setting to fi…

### DIFF
--- a/.changelogs/termsandconditions.yml
+++ b/.changelogs/termsandconditions.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#1938"
+entry: Fixed an issue with OceanWP and Twenty Twenty, where the terms and conditions checkbox displayed incorrectly.

--- a/assets/scss/_includes/_llms-form-field.scss
+++ b/assets/scss/_includes/_llms-form-field.scss
@@ -70,7 +70,7 @@
 		&.type-checkbox {
 			input,
 			label {
-				display: inline;
+				display: inline-block;
 				width: auto;
 			}
 			input {


### PR DESCRIPTION
## Description
Updated terms and conditions block to hold inline-block setting to fix OceanWP issue


Fixes #1938 

## How has this been tested?
I tested it manually (after running npm run build:styles)
Tested against default twenty-nineteen, twenty-twenty, twenty twenty-one, and twenty twenty-two. 
Tested also with Divi, Astra, Kadence, Elementor's Hello Theme, LaunchPad, BuddyBoss, and Page Builder Framework


## Types of changes
added display: inline-block to &.type-radio, &.type-checkbox

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

