### PR TITLE
Force no cache on quiz pages

### DIFF
--- a/.changelogs/issue_2092-1.yml
+++ b/.changelogs/issue_2092-1.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: changed
-entry: Reinforce taking quiz prevention when attempts limit reached.
+entry: Improved checks related to the number of quiz attempts allowed for each student.

--- a/.changelogs/issue_2092-1.yml
+++ b/.changelogs/issue_2092-1.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Reinforce taking quiz prevention when attempts limit reached.

--- a/.changelogs/issue_2092-2.yml
+++ b/.changelogs/issue_2092-2.yml
@@ -1,0 +1,6 @@
+significance: minor
+type: dev
+links:
+  - "#2092"
+entry: Added new filter 'llms_no_cache' to control whether or not LifterLMS will
+  send nocache headers.

--- a/.changelogs/issue_2092.yml
+++ b/.changelogs/issue_2092.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: changed
+links:
+  - "#2092"
+entry: Prevent browser page caching on quizzes.

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -676,10 +676,11 @@ class LLMS_AJAX_Handler {
 	}
 
 	/**
-	 * AJAX Quiz answer question
+	 * AJAX Quiz answer question.
 	 *
 	 * @since 3.9.0
 	 * @since 3.27.0 Unknown.
+	 * @since [version] Make sure attempts limit was not reached.
 	 *
 	 * @param array $request $_POST data.
 	 * @return WP_Error|string
@@ -706,9 +707,26 @@ class LLMS_AJAX_Handler {
 		$question_id = absint( $request['question_id'] );
 		$answer      = array_map( 'stripslashes_deep', isset( $request['answer'] ) ? $request['answer'] : array() );
 
-		$attempt = $student->quizzes()->get_attempt_by_key( $attempt_key );
+		$student_quizzes = $student->quizzes();
+		$attempt         = $student_quizzes->get_attempt_by_key( $attempt_key );
 		if ( ! $attempt ) {
 			$err->add( 500, __( 'There was an error recording your answer the quiz. Please return to the lesson and begin again.', 'lifterlms' ) );
+			return $err;
+		}
+
+		/**
+		 * Check limit not reached.
+		 *
+		 * First check whether the quiz is open (so to leverage the `llms_quiz_is_open` filter ),
+		 * if not, check also for remaining attempts.
+		 *
+		 * At this point the current attempt has already been counted (maybe the last allowed),
+		 * so we check that the remaining attempt is just greater than -1.
+		 */
+		$quiz_id = $attempt->get( 'quiz_id' );
+		if ( ! ( new LLMS_Quiz( $quiz_id ) )->is_open() &&
+				$student_quizzes->get_attempts_remaining_for_quiz( $quiz_id, true ) < 0 ) {
+			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz", 'lifterlms' ) );
 			return $err;
 		}
 

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -600,10 +600,11 @@ class LLMS_AJAX_Handler {
 	}
 
 	/**
-	 * Start a Quiz Attempt
+	 * Start a Quiz Attempt.
 	 *
 	 * @since 3.9.0
 	 * @since 3.16.4 Unknown.
+	 * @since [version] Make sure attempts limit was not reached.
 	 *
 	 * @param array $request $_POST data.
 	 *                       required:
@@ -624,8 +625,14 @@ class LLMS_AJAX_Handler {
 			return $err;
 		}
 
+		// Limit reached?
+		if ( isset( $request['quiz_id'] ) && ! ( new LLMS_Quiz( $request['quiz_id'] ) )->is_open() ) {
+			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz", 'lifterlms' ) );
+			return $err;
+		}
+
 		$attempt = false;
-		if ( isset( $request['attempt_key'] ) && $request['attempt_key'] ) {
+		if ( ! empty( $request['attempt_key'] ) ) {
 			$attempt = $student->quizzes()->get_attempt_by_key( $request['attempt_key'] );
 		}
 

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -710,7 +710,7 @@ class LLMS_AJAX_Handler {
 		$student_quizzes = $student->quizzes();
 		$attempt         = $student_quizzes->get_attempt_by_key( $attempt_key );
 		if ( ! $attempt ) {
-			$err->add( 500, __( 'There was an error recording your answer the quiz. Please return to the lesson and begin again.', 'lifterlms' ) );
+			$err->add( 500, __( 'There was an error recording your answer. Please return to the lesson and begin again.', 'lifterlms' ) );
 			return $err;
 		}
 

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -627,7 +627,7 @@ class LLMS_AJAX_Handler {
 
 		// Limit reached?
 		if ( isset( $request['quiz_id'] ) && ! ( new LLMS_Quiz( $request['quiz_id'] ) )->is_open() ) {
-			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz", 'lifterlms' ) );
+			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz.", 'lifterlms' ) );
 			return $err;
 		}
 
@@ -726,7 +726,7 @@ class LLMS_AJAX_Handler {
 		$quiz_id = $attempt->get( 'quiz_id' );
 		if ( ! ( new LLMS_Quiz( $quiz_id ) )->is_open() &&
 				$student_quizzes->get_attempts_remaining_for_quiz( $quiz_id, true ) < 0 ) {
-			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz", 'lifterlms' ) );
+			$err->add( 400, __( "You've reached the maximum number of attempts for this quiz.", 'lifterlms' ) );
 			return $err;
 		}
 

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -150,28 +150,22 @@ class LLMS_Cache_Helper {
 	public static function additional_nocache_headers( $headers ) {
 
 		// First tree are the default ones.
-		$nocache_headers = array(
+		$nocache_headers_cache_control = array(
 			'no-cache',
 			'must-revalidate',
 			'max-age=0',
 			'no-store',
 		);
 
-		$headers['Cache-Control'] = implode(
-			', ',
-			empty( $headers['Cache-Control'] ) ?
-				$nocache_headers
-				:
-				array_unique(
-					array_merge(
-						$nocache_headers,
-						array_map(
-							'trim',
-							explode( ',', $headers['Cache-Control'] )
-						)
-					)
-				)
-		);
+		if ( ! empty( $headers['Cache-Control'] ) ) {
+			$original_headers_cache_control = array_map( 'trim', explode( ',', $headers['Cache-Control'] ) );
+			// Merge original headers with our nocache headers.
+			$nocache_headers_cache_control = array_merge( $nocache_headers_cache_control, $original_headers_cache_control );
+			// Avoid duplicates.
+			$nocache_headers_cache_control = array_unique( $nocache_headers_cache_control );
+		}
+
+		$headers['Cache-Control'] = implode( ', ', $nocache_headers_cache_control );
 
 		return $headers;
 

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -149,11 +149,12 @@ class LLMS_Cache_Helper {
 	 */
 	public static function additional_nocache_headers( $headers ) {
 
-		$headers['Cache-Control'] = isset( $headers['Cache-Control'] )
-			?
-			$headers['Cache-Control'] . ', no-store'
-			:
-			'no-cache, no-store, must-revalidate';
+		if ( ! isset( $headers['Cache-Control'] ) ) {
+			$headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
+		} elseif ( false === strpos( $headers['Cache-Control'], 'no-store' ) ) {
+			$headers['Cache-Control'] .= ', no-store';
+		}
+
 		return $headers;
 
 	}

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -149,11 +149,29 @@ class LLMS_Cache_Helper {
 	 */
 	public static function additional_nocache_headers( $headers ) {
 
-		if ( ! isset( $headers['Cache-Control'] ) ) {
-			$headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
-		} elseif ( false === strpos( $headers['Cache-Control'], 'no-store' ) ) {
-			$headers['Cache-Control'] .= ', no-store';
-		}
+		// First tree are the default ones.
+		$nocache_headers = array(
+			'no-cache',
+			'must-revalidate',
+			'max-age=0',
+			'no-store',
+		);
+
+		$headers['Cache-Control'] = implode(
+			', ',
+			empty( $headers['Cache-Control'] ) ?
+				$nocache_headers
+				:
+				array_unique(
+					array_merge(
+						$nocache_headers,
+						array_map(
+							'trim',
+							explode( ',', $headers['Cache-Control'] )
+						)
+					)
+				)
+		);
 
 		return $headers;
 

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -83,7 +83,6 @@ class LLMS_Cache_Helper {
 	 *
 	 * @since 3.15.0
 	 * @since [version] Force no caching on quiz pages.
-	 *               Added `llms_no_cache` filter hook.
 	 *               Added 'no-store' to the default WordPress nocache headers.
 	 *
 	 * @return void

--- a/includes/models/model.llms.student.quizzes.php
+++ b/includes/models/model.llms.student.quizzes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.9.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -161,7 +161,7 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Get the # of attempts remaining by a student for a given quiz.
+	 * Get the number of attempts remaining by a student for a given quiz.
 	 *
 	 * @since 3.16.0
 	 * @since [version] Added parameter `$allow_negative` to allow remaining negative remaining attempts.
@@ -195,6 +195,16 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 
 		}
 
+		/**
+		 * Filters the number of attempts remaining by a student for a given quiz.
+		 *
+		 * @since 3.16.0
+		 *
+		 * @param mixed                $ret             The number of attempts remaining by a student for a given quiz,
+		 *                                              or 'Unlimited' for quizzes with no attempts limit.
+		 * @param LLMS_Quiz            $quiz            Quiz object.
+		 * @param LLMS_Student_Quizzes $student_quizzes Student quizzes object.
+		 */
 		return apply_filters( 'llms_student_quiz_attempts_remaining_for_quiz', $ret, $quiz, $this );
 
 	}

--- a/includes/models/model.llms.student.quizzes.php
+++ b/includes/models/model.llms.student.quizzes.php
@@ -161,14 +161,18 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 	}
 
 	/**
-	 * Get the # of attempts remaining by a student for a given quiz
+	 * Get the # of attempts remaining by a student for a given quiz.
 	 *
 	 * @since 3.16.0
+	 * @since [version] Added parameter `$allow_negative` to allow remaining negative remaining attempts.
+	 *               It can happen when the allowed attempts number is decreased to a number lower than
+	 *               the number of the attempts already made by a given student.
 	 *
-	 * @param int $quiz_id WP Post ID of the Quiz.
+	 * @param int  $quiz_id        WP Post ID of the Quiz.
+	 * @param bool $allow_negative Allow returning negative remaining attempts.
 	 * @return mixed
 	 */
-	public function get_attempts_remaining_for_quiz( $quiz_id ) {
+	public function get_attempts_remaining_for_quiz( $quiz_id, $allow_negative = false ) {
 
 		$quiz = llms_get_post( $quiz_id );
 
@@ -187,7 +191,7 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 			$remaining = ( $allowed - $used );
 
 			// Don't show negative attempts.
-			$ret = max( 0, $remaining );
+			$ret = $allow_negative ? $remaining : max( 0, $remaining );
 
 		}
 

--- a/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
+++ b/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
@@ -53,7 +53,150 @@ class LLMS_Test_AJAX_Handler_Quizzes extends LLMS_UnitTestCase {
 
 	}
 
-	public test_quiz_start() {
+	/**
+	 * Test quiz_start() when no student logged in.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_quiz_start_no_student() {
+
+		wp_set_current_user( 0 );
+
+		$res = LLMS_AJAX_Handler::quiz_start(
+			array()
+		);
+
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 400, $res );
+		$this->assertWPErrorMessageEquals( 'You must be logged in to take quizzes.', $res );
+
+	}
+
+	/**
+	 * Test attempts limit check in quiz_start().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_quiz_start_test_attempts_limit() {
+
+		wp_set_current_user( $this->student->get( 'id' ) );
+
+		// Limit quiz's attempts.
+		$this->quiz->set( 'limit_attempts', 'yes' );
+		$this->quiz->set( 'allowed_attempts', 1 );
+
+		// Record an attempt so to reach the limit.
+		$attempt = LLMS_Quiz_Attempt::init(
+			$this->quiz->get( 'id' ),
+			$this->lesson->get( 'id' ),
+			$this->student->get( 'id' )
+		);
+		$attempt->save();
+
+		$res = LLMS_AJAX_Handler::quiz_start(
+			array(
+				'quiz_id' => $this->quiz->get( 'id' ),
+			)
+		);
+
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 400, $res );
+		$this->assertWPErrorMessageEquals( "You've reached the maximum number of attempts for this quiz.", $res );
+
+		// Increase the limit.
+		$this->quiz->set( 'allowed_attempts', 2 );
+		$res = LLMS_AJAX_Handler::quiz_start(
+			array(
+				'quiz_id'   => $this->quiz->get( 'id' ),
+				'lesson_id' => $this->lesson->get( 'id' ),
+			)
+		);
+		// Attempt recorded.
+		$this->assertArrayHasKey(
+			'attempt_key',
+			$res
+		);
+
+		// Reset.
+		$this->quiz->set( 'limit_attempts', 'no' );
+		wp_set_current_user( 0 );
+
+	}
+
+	/**
+	 * Test attempts limit check in quiz_answer_question().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_quiz_answer_question_test_attempts_limit() {
+
+		wp_set_current_user( $this->student->get( 'id' ) );
+
+		// Start a quiz first.
+		$res = LLMS_AJAX_Handler::quiz_start(
+			array(
+				'quiz_id'   => $this->quiz->get( 'id' ),
+				'lesson_id' => $this->lesson->get( 'id' ),
+			)
+		);
+
+		$attempt_key = $res['attempt_key'];
+		$student_quizzes = $this->student->quizzes();
+
+		// Limit quiz's attempts so that this attempt is the last possible.
+		$this->quiz->set( 'limit_attempts', 'yes' );
+		$this->quiz->set( 'allowed_attempts', $student_quizzes->count_attempts_by_quiz( $this->quiz->get( 'id' ) ) );
+
+		$question = $this->quiz->get_questions()[0];
+
+		$res = LLMS_AJAX_Handler::quiz_answer_question(
+			array(
+				'question_id'   => $this->quiz->get( 'id' ),
+				'attempt_key'   => $attempt_key,
+				'question_id'   => $question->get( 'id' ),
+				'question_type' => $question->get( 'type' ),
+			)
+		);
+		// Quiz completed, expect an array with 'redirect' key.
+		$this->assertArrayHasKey(
+			'redirect',
+			$res
+		);
+
+		// Now increase the limit.
+		$this->quiz->set( 'allowed_attempts', $this->quiz->get( 'allowed_attempts' ) + 1 );
+		// Start the quiz again.
+		$res = LLMS_AJAX_Handler::quiz_start(
+			array(
+				'quiz_id'   => $this->quiz->get( 'id' ),
+				'lesson_id' => $this->lesson->get( 'id' ),
+			)
+		);
+		// Decrease the limit.
+		$this->quiz->set( 'allowed_attempts', $this->quiz->get( 'allowed_attempts' ) - 1 );
+
+		$res = LLMS_AJAX_Handler::quiz_answer_question(
+			array(
+				'question_id'   => $this->quiz->get( 'id' ),
+				'attempt_key'   => $attempt_key,
+				'question_id'   => $question->get( 'id' ),
+				'question_type' => $question->get( 'type' ),
+			)
+		);
+
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 400, $res );
+		$this->assertWPErrorMessageEquals( "You've reached the maximum number of attempts for this quiz.", $res );
+
+		// Reset.
+		$this->quiz->set( 'limit_attempts', 'no' );
+		wp_set_current_user( 0 );
 
 	}
 

--- a/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
+++ b/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Test Quizzes-related methods in the LLMS_AJAX_Handler class.
+ *
+ * @package LifterLMS/Tests/AJAX
+ *
+ * @group ajax_quizzes
+ * @group ajax
+ * @group quizzes
+ *
+ * @since [version]
+ */
+class LLMS_Test_AJAX_Handler_Quizzes extends LLMS_UnitTestCase {
+
+	/**
+	 * Student instance.
+	 *
+	 * @var LLMS_Student
+	 */
+	protected $student;
+
+	/**
+	 * Quiz's lesson instance.
+	 *
+	 * @var LLMS_Lesson
+	 */
+	protected $lesson;
+
+	/**
+	 * Quiz instance.
+	 *
+	 * @var LLMS_Quiz
+	 */
+	protected $quiz;
+
+	/**
+	 * Setup test.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+
+		$this->student = $this->get_mock_student();
+		// Create new course with quiz.
+		$courses      = $this->generate_mock_courses( 1, 1, 1, 1, 1 );
+		$course       = llms_get_post( $courses[0] );
+		$this->lesson = $course->get_lessons()[0];
+		$this->quiz   = $this->lesson->get_quiz();
+
+	}
+
+	public test_quiz_start() {
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
+++ b/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
@@ -8,7 +8,7 @@
  * @group cache_helper
  *
  * @since 4.0.0
- * @version 4.0.0
+ * @version [version]
  */
 class LLMS_Test_Cache_Helper extends LLMS_Unit_Test_Case {
 
@@ -59,6 +59,48 @@ class LLMS_Test_Cache_Helper extends LLMS_Unit_Test_Case {
 
 		// Cached item is gone.
 		$this->assertFalse( wp_cache_get( sprintf( 'fake_%s', $prefix ), $group ) );
+
+	}
+
+	/**
+	 * Test additional_nocache_headers() method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_additional_nocache_headers() {
+
+		$headers = array();
+
+		$this->assertEquals(
+			array(
+				'Cache-Control' => 'no-cache, must-revalidate, max-age=0, no-store',
+			),
+			LLMS_Cache_Helper::additional_nocache_headers( $headers )
+		);
+
+		$headers = array(
+			'Cache-Control' => '',
+		);
+
+		$this->assertEquals(
+			array(
+				'Cache-Control' => 'no-cache, must-revalidate, max-age=0, no-store',
+			),
+			LLMS_Cache_Helper::additional_nocache_headers( $headers )
+		);
+
+		$headers = array(
+			'Cache-Control' => 'no-cache, something, no-store, something-else',
+		);
+
+		$this->assertEquals(
+			array(
+				'Cache-Control' => 'no-cache, must-revalidate, max-age=0, no-store, something, something-else',
+			),
+			LLMS_Cache_Helper::additional_nocache_headers( $headers )
+		);
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for LifterLMS Student Quizzes Model
+ *
+ * @group LLMS_Student_Quizzes
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_LLMS_Student_Quizzes extends LLMS_UnitTestCase {
+
+	/**
+	 * Student instance.
+	 *
+	 * @var LLMS_Student
+	 */
+	protected $student;
+
+	/**
+	 * Quiz's lesson instance.
+	 *
+	 * @var LLMS_Lesson
+	 */
+	protected $lesson;
+
+	/**
+	 * Quiz instance.
+	 *
+	 * @var LLMS_Quiz
+	 */
+	protected $quiz_id;
+
+	/**
+	 * Setup test
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+
+		$this->student = $this->get_mock_student();
+		// Create new course with quiz.
+		$courses      = $this->generate_mock_courses( 1, 1, 1, 1, 1 );
+		$course       = llms_get_post( $courses[0] );
+		$this->lesson = $course->get_lessons()[0];
+		$this->quiz   = $this->lesson->get_quiz();
+
+	}
+
+	/**
+	 * Test get_attempts_remaining_for_quiz().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_attempts_remaining_for_quiz() {
+
+		$this->assertEquals(
+			'Unlimited',
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ) )
+		);
+
+		$attempt = LLMS_Quiz_Attempt::init(
+			$this->quiz->get( 'id' ),
+			$this->lesson->get( 'id' ),
+			$this->student->get( 'id' )
+		);
+		$attempt->save();
+
+		$this->assertEquals(
+			'Unlimited',
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ) )
+		);
+
+		// Limit quiz's attempts.
+		$this->quiz->set( 'limit_attempts', 'yes' );
+		$this->quiz->set( 'allowed_attempts', 2 );
+
+		$this->assertEquals(
+			1,
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ) )
+		);
+
+		$attempt = LLMS_Quiz_Attempt::init(
+			$this->quiz->get( 'id' ),
+			$this->lesson->get( 'id' ),
+			$this->student->get( 'id' )
+		);
+		$attempt->save();
+
+		$this->assertEquals(
+			0,
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ) )
+		);
+
+		// Decrease attempts limit.
+		$this->quiz->set( 'allowed_attempts', 1 );
+		$this->assertEquals(
+			0,
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ) )
+		);
+		$this->assertEquals( // Allow for negative values.
+			-1,
+			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ), true )
+		);
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
@@ -28,7 +28,7 @@ class LLMS_Test_LLMS_Student_Quizzes extends LLMS_UnitTestCase {
 	 *
 	 * @var LLMS_Quiz
 	 */
-	protected $quiz_id;
+	protected $quiz;
 
 	/**
 	 * Setup test.
@@ -107,6 +107,9 @@ class LLMS_Test_LLMS_Student_Quizzes extends LLMS_UnitTestCase {
 			-1,
 			$this->student->quizzes()->get_attempts_remaining_for_quiz( $this->quiz->get( 'id' ), true )
 		);
+
+		// Reset attempts limit.
+		$this->quiz->set( 'limit_attempts', 'no' );
 
 	}
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student-quizzes.php
@@ -31,7 +31,7 @@ class LLMS_Test_LLMS_Student_Quizzes extends LLMS_UnitTestCase {
 	protected $quiz_id;
 
 	/**
-	 * Setup test
+	 * Setup test.
 	 *
 	 * @since [version]
 	 *

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
@@ -6,8 +6,7 @@
  *
  * @since 3.33.0
  * @since 3.36.2 Added tests on membership enrollment with related courses enrollments deletion.
- *
- * @version [vrsion]
+ * @version 3.36.2
  */
 class LLMS_Test_LLMS_Student extends LLMS_UnitTestCase {
 


### PR DESCRIPTION
## Description
Fixes #2092 
It also reinforces the taking quiz prevention when attempts limit reached.

## How has this been tested?
manually (working on automatic tests)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

