### PR TITLE
Initialize shortcodes early

### DIFF
--- a/.changelogs/init-shortcodes-early.yml
+++ b/.changelogs/init-shortcodes-early.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2070"
+entry: Fixed an issue that caused shortcodes to not be replaced in some engagement emails.

--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 6.1.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -67,6 +67,7 @@ final class LifterLMS {
 	 * @since 4.13.0 Check site duplicate status on `admin_init`.
 	 * @since 5.3.0 Move the loading of the LifterLMS autoloader to the main `lifterlms.php` file.
 	 * @since 6.1.0 Automatically load payment gateways.
+	 * @since [version] Moved registration of `LLMS_Shortcodes::init()` with the 'init' hook to `LLMS_Shortcodes::__construct()`.
 	 *
 	 * @return void
 	 */
@@ -98,7 +99,6 @@ final class LifterLMS {
 		add_action( 'init', array( $this, 'init_session' ), 6 ); // After table installation which happens at init 5.
 		add_action( 'init', array( $this, 'payment_gateways' ) );
 		add_action( 'init', array( $this, 'include_template_functions' ) );
-		add_action( 'init', array( 'LLMS_Shortcodes', 'init' ) );
 
 		add_action( 'admin_init', array( 'LLMS_Site', 'check_status' ) );
 

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -230,10 +230,14 @@ class LLMS_Loader {
 	 * @since 5.6.0 Include `LLMS_Prevent_Concurrent_Logins`.
 	 * @since 6.0.0 Included `LLMS_Block_Library`, `LLMS_Controller_Awards`, and `LLMS_Engagement_Handler`.
 	 *              Removed loading of class files that don't instantiate their class in favor of autoloading.
+	 * @since [version] Instantiated `LLMS_Shortcodes` before `LLMS_Controller_Orders`.
 	 *
 	 * @return void
 	 */
 	public function includes() {
+
+		// Instantiate LLMS_Shortcodes before LLMS_Controller_Orders.
+		new LLMS_Shortcodes();
 
 		// Functions.
 		require_once LLMS_PLUGIN_DIR . 'includes/llms.functions.core.php';

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -230,14 +230,14 @@ class LLMS_Loader {
 	 * @since 5.6.0 Include `LLMS_Prevent_Concurrent_Logins`.
 	 * @since 6.0.0 Included `LLMS_Block_Library`, `LLMS_Controller_Awards`, and `LLMS_Engagement_Handler`.
 	 *              Removed loading of class files that don't instantiate their class in favor of autoloading.
-	 * @since [version] Instantiated `LLMS_Shortcodes` before `LLMS_Controller_Orders`.
+	 * @since [version] Included `LLMS_Shortcodes` before `LLMS_Controller_Orders`.
 	 *
 	 * @return void
 	 */
 	public function includes() {
 
 		// Instantiate LLMS_Shortcodes before LLMS_Controller_Orders.
-		new LLMS_Shortcodes();
+		require_once LLMS_PLUGIN_DIR . 'includes/shortcodes/class.llms.shortcodes.php';
 
 		// Functions.
 		require_once LLMS_PLUGIN_DIR . 'includes/llms.functions.core.php';

--- a/includes/models/model.llms.user.certificate.php
+++ b/includes/models/model.llms.user.certificate.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.8.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -703,6 +703,7 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 	 * Merges the post content based on content from the template.
 	 *
 	 * @since 6.0.0
+	 * @since [version] Removed initialization of shortcodes now that they are registered earlier.
 	 *
 	 * @return string
 	 */
@@ -713,7 +714,6 @@ class LLMS_User_Certificate extends LLMS_Abstract_User_Engagement {
 		$content = str_replace( array_keys( $merge ), array_values( $merge ), $this->get( 'content', true ) );
 
 		// Do shortcodes.
-		LLMS_Shortcodes::init(); // In certain circumstances shortcodes won't be registered yet.
 		add_filter( 'llms_user_info_shortcode_user_id', array( $this, 'get_user_id' ) );
 		$content = do_shortcode( $content );
 		remove_filter( 'llms_user_info_shortcode_user_id', array( $this, 'get_user_id' ) );

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -619,4 +619,4 @@ class LLMS_Shortcodes {
 
 }
 
-new LLMS_Shortcodes();
+return new LLMS_Shortcodes();

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -5,7 +5,6 @@
  * @package LifterLMS/Classes/Shortcodes
  *
  * @since 1.0.0
- * @since [version] Added self instantiation.
  * @version [version]
  */
 

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes/Shortcodes
  *
  * @since 1.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -17,6 +17,17 @@ defined( 'ABSPATH' ) || exit;
  * @since 4.0.0 Remove reliance on deprecated class `LLMS_Quiz_Legacy` & stop registering deprecated shortcode `[courses]` and `[lifterlms_user_statistics]`.
  */
 class LLMS_Shortcodes {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since [version]
+	 * @return void
+	 */
+	public function __construct() {
+
+		add_action( 'init', array( 'LLMS_Shortcodes', 'init' ) );
+	}
 
 	/**
 	 * Initialize shortcodes array.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -5,6 +5,7 @@
  * @package LifterLMS/Classes/Shortcodes
  *
  * @since 1.0.0
+ * @since [version] Added self instantiation.
  * @version [version]
  */
 
@@ -617,3 +618,5 @@ class LLMS_Shortcodes {
 	}
 
 }
+
+new LLMS_Shortcodes();

--- a/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
+++ b/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
@@ -137,4 +137,40 @@ class LLMS_Test_Shortcodes extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Tests that the shortcodes are initialized before the WordPress 'init' action hook calls any other LifterLMS callbacks.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_shortcodes_initialized_early() {
+
+		global $wp_filter;
+
+		$shortcodes_init_is_found = false;
+		foreach ( $wp_filter['init'][10] as $idx => $callback ) {
+
+			// $idx is a unique ID that for static methods will be class_name . '::' . method_name.
+			if ( 'LLMS_Shortcodes::init' === $idx ) {
+				$shortcodes_init_is_found = true;
+				continue;
+			}
+
+			if ( is_array( $callback['function'] ) ) {
+				$class = is_object( $callback['function'][0] ) ? get_class( $callback['function'][0] ) : $callback['function'][0];
+				$function = "{$class}::{$callback['function'][1]}";
+			} else {
+				$function = $callback['function'];
+			}
+
+			if ( 0 === strpos( $function, 'LLMS_' ) ) {
+				$this->assertTrue(
+					$shortcodes_init_is_found,
+					"Should find LLMS_Shortcodes::init callback before $function."
+				);
+			}
+		}
+	}
+
 }


### PR DESCRIPTION
## Description
Initialized shortcodes before the WP 'init' hook calls any other LifterLMS methods/functions.

Fixes #2070.
The `LLMS_Controller_Order` 'init' actions were being called before `LLMS_Shortcodes::init()` was called, which prevented shortcodes from being replaced in engagement emails.

Flow:
1. `lifterlms.php:49`
2. `LLMS_Loader::__construct():130`
3. `LLMS_Loader::includes():283`
4. `LLMS_Controller_Orders::__construct():41-43`
5. register order actions on 'init' hook priority 10
6. `llms(), lifterlms.php:65`
8. `LifterLMS::__construct():101`
9. register `LLMS_Shortcodes::init()` on 'init' hook priority 10

Options:
1. Register `LLMS_Controller_Orders` form processing actions with a priority higher than 10.
2. Register `LLMS_Shortcodes::init()` with a priority lower than 10.
3. Load `LLMS_Shortcodes` in `LLMS_Loader::includes()`, before loading `LLMS_Controller_Orders` AND add a constructor to `LLMS_Shortcodes` that registers `init()` with the 'init' hook priority 10

I was concerned that options 1 and 2 might cause a conflict with 3rd parties, so I implemented option 3.


## How has this been tested?
Manually and with a new unit test.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

