### PR TITLE
Allow filtering of the `LLMS_Shortcode_User_Info` class

### DIFF
--- a/.changelogs/filter-LLMS_Shortcode_User_Info.yml
+++ b/.changelogs/filter-LLMS_Shortcode_User_Info.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Allowed the `LLMS_Shortcode_User_Info` class to be filtered by the `llms_load_shortcodes` and `llms_load_shortcode_path` hooks.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes/Shortcodes
  *
  * @since 1.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,6 +25,7 @@ class LLMS_Shortcodes {
 	 * @since 3.11.1 Unknown.
 	 * @since 4.0.0 Stop registering previously deprecated shortcode `[courses]` and `[lifterlms_user_statistics]`.
 	 * @since 6.0.0 Removed loading of class files that don't instantiate their class in favor of autoloading.
+	 * @since [version] Allowed `LLMS_Shortcode_User_Info` class to be filtered.
 	 *
 	 * @return void
 	 */
@@ -33,7 +34,7 @@ class LLMS_Shortcodes {
 		// New method.
 		$scs = apply_filters(
 			/**
-			 * Filters the shortcodes to initialize
+			 * Filters the shortcodes to initialize.
 			 *
 			 * @since Unknown
 			 *
@@ -55,24 +56,28 @@ class LLMS_Shortcodes {
 				'LLMS_Shortcode_Membership_Link',
 				'LLMS_Shortcode_My_Achievements',
 				'LLMS_Shortcode_Registration',
+				'LLMS_Shortcode_User_Info',
 			)
 		);
 
-		// Include abstracts.
-		require_once LLMS_PLUGIN_DIR . 'includes/shortcodes/class-llms-shortcode-user-info.php';
+		$hyphenated_file_classes = array(
+			'LLMS_Shortcode_User_Info',
+		);
 
 		foreach ( $scs as $class ) {
 
-			$filename = strtolower( str_replace( '_', '.', $class ) );
+			$separator = in_array( $class, $hyphenated_file_classes, true ) ? '-' : '.';
+			$filename  = "class{$separator}" . strtolower( str_replace( '_', $separator, $class ) );
+
 			/**
-			 * Filters the path of the shortcode class file
+			 * Filters the path of the shortcode class file.
 			 *
 			 * @since Unknown
 			 *
 			 * @param string $file  The shortcode class file name.
 			 * @param string $class The shortcode class name.
 			 */
-			$path = apply_filters( 'llms_load_shortcode_path', LLMS_PLUGIN_DIR . 'includes/shortcodes/class.' . $filename . '.php', $class );
+			$path = apply_filters( 'llms_load_shortcode_path', LLMS_PLUGIN_DIR . "includes/shortcodes/{$filename}.php", $class );
 
 			if ( file_exists( $path ) ) {
 				require_once $path;


### PR DESCRIPTION
## Description
Added the ability to filter the `LLMS_Shortcode_User_Info` class by the `llms_load_shortcodes` and `llms_load_shortcode_path` hooks.

## How has this been tested?
Manually and with unit tests.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

