### PR TITLE
Manual gateway: Use `llms_redirect_and_exit()` and add tests

### DIFF
--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.0.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -150,21 +150,21 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 	}
 
 	/**
-	 * Handle a Pending Order
-	 * Called by LLMS_Controller_Orders->create_pending_order() on checkout form submission
-	 * All data will be validated before it's passed to this function
+	 * Handle a Pending Order.
 	 *
-	 * @param   obj       $order   Instance LLMS_Order for the order being processed
-	 * @param   obj       $plan    Instance LLMS_Access_Plan for the order being processed
-	 * @param   obj       $person  Instance of LLMS_Student for the purchasing customer
-	 * @param   obj|false $coupon  Instance of LLMS_Coupon applied to the order being processed, or false when none is being used
-	 * @return  void
-	 * @since   3.0.0
-	 * @version 3.10.0
+	 * @since 3.0.0
+	 * @since 3.10.0 Unknown.
+	 * @since [version] Use `llms_redirect_and_exit()` in favor of `wp_redirect()` and `exit()`.
+	 *
+	 * @param LLMS_Order          $order   Order object.
+	 * @param LLMS_Access_Plan    $plan    Access plan object.
+	 * @param LLMS_Student        $student Student object.
+	 * @param LLMS_Coupon|boolean $coupon  Coupon object or `false` when no coupon is being used for the order.
+	 * @return void
 	 */
-	public function handle_pending_order( $order, $plan, $person, $coupon = false ) {
+	public function handle_pending_order( $order, $plan, $student, $coupon = false ) {
 
-		// No payment (free orders).
+		// Free orders (no payment is due).
 		if ( floatval( 0 ) === $order->get_initial_price( array(), 'float' ) ) {
 
 			// Free access plans do not generate receipts.
@@ -190,22 +190,32 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 
 			}
 
-			$this->complete_transaction( $order );
-
-			// Payment due.
-		} else {
-
-			/**
-			 * @hooked LLMS_Notification: manual_payment_due - 10
-			 */
-			do_action( 'llms_manual_payment_due', $order, $this );
-
-			// Show the user payment instructions for the order.
-			do_action( 'lifterlms_handle_pending_order_complete', $order );
-			wp_redirect( $order->get_view_link() );
-			exit;
+			return $this->complete_transaction( $order );
 
 		}
+
+		/**
+		 * Action triggered when a manual payment is due.
+		 *
+		 * @hooked LLMS_Notification: manual_payment_due - 10
+		 *
+		 * @since Unknown.
+		 *
+		 * @param LLMS_Order                  $order   The order object.
+		 * @param LLMS_Payment_Gateway_Manual $gateway Manual gateway instance.
+		 */
+		do_action( 'llms_manual_payment_due', $order, $this );
+
+		/**
+		 * Action triggered when the pending order processing has been completed.
+		 *
+		 * @since Unknown.
+		 *
+		 * @param LLMS_Order $order The order object.
+		 */
+		do_action( 'lifterlms_handle_pending_order_complete', $order );
+
+		llms_redirect_and_exit( $order->get_view_link() );
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-gateway-manual.php
+++ b/tests/phpunit/unit-tests/class-llms-test-gateway-manual.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Test LLMS_Payment_Gateway_Manual class.
+ *
+ * @group checkout
+ * @group gateways
+ * @group gateway_manual
+ *
+ * @since [version]
+ */
+class LLMS_Test_Gateway_Manual extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+		$this->main = llms()->payment_gateways()->get_gateway_by_id( 'manual' );
+
+	}
+
+	/**
+	 * Test handle_pending_order() for a paid order.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_pending_order() {
+
+		$actions = array(
+			did_action( 'llms_manual_payment_due' ),
+			did_action( 'lifterlms_handle_pending_order_complete' ),
+		);
+
+		$plan  = $this->get_mock_plan();
+		$order = $this->get_mock_order( $plan );
+
+		$view_link = $order->get_view_link();
+
+		try {
+
+			$this->main->handle_pending_order( $order, $plan, null );
+
+		} catch( LLMS_Unit_Test_Exception_Redirect $exception ) {
+
+			$this->assertEquals( "{$view_link} [302] YES", $exception->getMessage() );
+
+			$this->assertEquals( ++$actions[0], did_action( 'llms_manual_payment_due' ) );
+			$this->assertEquals( ++$actions[1], did_action( 'lifterlms_handle_pending_order_complete' ) );
+
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Description

Did a minor refactor on `LLMS_Payment_Gateway_Manual::handle_pending_order()`, primarily using `llms_redirect_and_exit()` in favor of `wp_redirect()` and `exit()`.

At this moment I don't recall why I did this. I think I wanted to be able to test something better using the manual gateway as a stub in the unit test and this made it easier to do so. I don't recall.

Split this into a separate PR because my local is a disaster right now and I need to clean up the various branching changes to make code review in the future easier.

## How has this been tested?

Manually & New unit tests

## Screenshots <!-- if applicable -->

## Types of changes

Minor refactor for easier unit tests

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

