### PR TITLE
Fix compatibility with the Elementor Pro theme builder on courses/archives catalogs

### DIFF
--- a/.changelogs/issue_2111-1.yml
+++ b/.changelogs/issue_2111-1.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+entry: Added new filter `llms_template_loader_restricted_priority` to control
+  the priority of the `template_include` hook callback used to load restricted
+  content single templates.

--- a/.changelogs/issue_2111.yml
+++ b/.changelogs/issue_2111.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2111"
+entry: "Fixed a compatibility with the Elementor Pro: course/membership catalogs
+  built with its Theme Builder were overridden by our default templates."

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -30,6 +30,8 @@ class LLMS_Template_Loader {
 	 * @since 3.41.1 Predispose posts content restriction in REST requests.
 	 * @since 5.8.0 Handle block templates loading.
 	 * @since 6.2.0 Added 'llms_template_loader_priority' filter.
+	 * @since [version] Reverted back the priority of the `$this->template_loader()` callback
+	 *              (`template_include` hook's callback) from 100 to 10.
 	 */
 	public function __construct() {
 
@@ -45,9 +47,14 @@ class LLMS_Template_Loader {
 		*
 		* @param int $priority The filter callback priority.
 		*/
-		$template_loader_cb_priority = apply_filters( 'llms_template_loader_priority', 100 );
-
-		// Do template loading.
+		$template_loader_cb_priority = apply_filters( 'llms_template_loader_priority', 10 );
+		/**
+		 * Do template loading.
+		 *
+		 * The default priority is 10, so to allow theme builders, like Divi and Elementor (Pro),
+		 * to override our templates (except single content restricted).
+		 * see https://github.com/gocodebox/lifterlms/issues/2111
+		 */
 		add_filter( 'template_include', array( $this, 'template_loader' ), $template_loader_cb_priority );
 
 		add_action( 'rest_api_init', array( $this, 'maybe_prepare_post_content_restriction' ) );
@@ -449,7 +456,7 @@ class LLMS_Template_Loader {
 	 *
 	 * @since 5.8.0
 	 * @since 6.0.0 Remove LifterLMS 6.0 version check about the certificate template.
-	 *               Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
+	 *              Use `llms_is_block_theme()` in favor of `wp_is_block_theme()`.
 	 *
 	 * @param WP_Block_Template[] $result        Array of found block templates.
 	 * @param array               $query {
@@ -510,6 +517,7 @@ class LLMS_Template_Loader {
 	 * @since 3.37.2 Make sure to print notices on sales page redirect.
 	 * @since 4.10.1 Refactor to reduce code duplication and replace usage of `llms_shop` with `courses` for catalog check.
 	 * @since 5.8.0 Refactor: moved the template guessing in a specific method.
+	 * @since [version] Defer single content restricted template loading.
 	 *
 	 * @param string $template The template to load.
 	 * @return string
@@ -552,12 +560,49 @@ class LLMS_Template_Loader {
 			}
 		}
 
+		$forced_template = $this->maybe_force_php_template( $template );
+
+		/**
+		 * When restricting single content use a lower priority so to always override
+		 * theme builders like Divi and Elementor (Pro).
+		 * see https://github.com/gocodebox/lifterlms/issues/2063.
+		 */
+		if ( llms_template_file_path( 'single-no-access.php' ) === $forced_template ) {
+
+			/**
+			 * Filters the template loading priority for single restricted content.
+			 *
+			 * @since [version]
+			 *
+			 * @param int $priority The filter callback priority.
+			 */
+			$template_loader_restricted_cb_priority = apply_filters( 'llms_template_loader_restricted_priority', 100 );
+			add_filter( 'template_include', array( $this, 'maybe_force_php_template' ), $template_loader_restricted_cb_priority );
+
+		} else {
+			$template = $forced_template;
+		}
+
+		return $template;
+
+	}
+
+	/**
+	 * Force the PHP template to be loaded.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $template The original template to load.
+	 * @return string
+	 */
+	public function maybe_force_php_template( $template ) {
+
 		/**
 		 * Filters whether or not forcing a LifterLMS php template to be loaded.
 		 *
 		 * @since 5.8.0
 		 *
-		 * @param bool $force Whether or not forcing a LifterLMS php template to be loaded.
+		 * @param bool $force Whether or not forcing a LifterLMS PHP template to be loaded.
 		 */
 		$forced_template = apply_filters( 'llms_force_php_template_loading', true ) ? $this->get_maybe_forced_template() : false;
 		return $forced_template ? llms_template_file_path( "{$forced_template}.php" ) : $template;

--- a/tests/phpunit/unit-tests/class-llms-test-template-loader.php
+++ b/tests/phpunit/unit-tests/class-llms-test-template-loader.php
@@ -8,6 +8,7 @@
  *
  * @since 3.41.1
  * @since 6.0.0 Added tests for the block loader.
+ * @since [version] Updated tests on single restricted content template loading.
  */
 class LLMS_Test_Template_Loader extends LLMS_UnitTestCase {
 
@@ -266,6 +267,7 @@ class LLMS_Test_Template_Loader extends LLMS_UnitTestCase {
 	 * Test template_loader() for restricted pages.
 	 *
 	 * @since 4.10.1
+	 * @since [version] Updated to reflect changes in the `template_loader()` method for single restricted content template.
 	 *
 	 * @return void
 	 */
@@ -274,7 +276,12 @@ class LLMS_Test_Template_Loader extends LLMS_UnitTestCase {
 		add_filter( 'llms_page_restricted', array( $this, 'mock_page_restricted' ), 10, 2 );
 
 		// Modify the template & fire actions.
-		$this->assertEquals( 'single-no-access.php', basename( $this->main->template_loader( '/html/wp-content/theme/atheme/mock.php' ) ) );
+		// `template_loader()` returns the original template for single restricted content.
+		$this->assertEquals( 'mock.php', basename( $this->main->template_loader( '/html/wp-content/theme/atheme/mock.php' ) ) );
+		// And defers the single restricted content template redirect at `template_include|100`.
+		$this->assertSame( 100, has_filter( 'template_include', array( $this->main, 'maybe_force_php_template' ) ) );
+		// `maybe_force_php_template()` returns the single restricted content template.
+		$this->assertEquals( 'single-no-access.php', basename( $this->main->maybe_force_php_template( '/html/wp-content/theme/atheme/mock.php' ) ) );
 		$this->assertSame( 1, did_action( 'lifterlms_content_restricted' ) );
 		$this->assertSame( 1, did_action( 'llms_content_restricted_by_mock' ) );
 
@@ -297,8 +304,6 @@ class LLMS_Test_Template_Loader extends LLMS_UnitTestCase {
 
 	/**
 	 * Test block_template_loader() for restricted pages.
-	 *
-	 * @group aaa
 	 *
 	 * @since 6.0.0
 	 *


### PR DESCRIPTION
## Description
Load LifterLMS PHP templates at `template_include|10` except the single
restricted content which is loaded at `template_include|100` for compatibility
with theme builders such as Divi and Elementor Pro ones.

Fixes #2111 

## How has this been tested?
Tested it manually both with Elementor Pro (on catalogs built with its theme builder) and Divi (see #2063) ensuring no regression was introduced.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

