### PR TITLE
Bypass drip content restriction on already completed lessons

### DIFF
--- a/.changelogs/issue_1835-1.yml
+++ b/.changelogs/issue_1835-1.yml
@@ -2,5 +2,5 @@ significance: minor
 type: dev
 links:
   - "#1835"
-entry: Added a new filter `llms_lesson_drip_bypass_if_completed` to control
-  whether or not drip content restrictions on already completed lessons should be bypassed.
+entry: Added a new filter, `llms_lesson_drip_bypass_if_completed`, which controls
+  the automatic bypass of drip restrictions for completed lessons.

--- a/.changelogs/issue_1835-1.yml
+++ b/.changelogs/issue_1835-1.yml
@@ -2,6 +2,5 @@ significance: minor
 type: dev
 links:
   - "#1835"
-entry: Added new filter `llms_lesson_drip_bypass_if_completed` to control
-  whether or not bypassing drip content restrictions on already completed
-  lessons.
+entry: Added a new filter `llms_lesson_drip_bypass_if_completed` to control
+  whether or not drip content restrictions on already completed lessons should be bypassed.

--- a/.changelogs/issue_1835-1.yml
+++ b/.changelogs/issue_1835-1.yml
@@ -1,0 +1,7 @@
+significance: minor
+type: dev
+links:
+  - "#1835"
+entry: Added new filter `llms_lesson_drip_bypass_if_completed` to control
+  whether or not bypassing drip content restrictions on already completed
+  lessons.

--- a/.changelogs/issue_1835.yml
+++ b/.changelogs/issue_1835.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#1835"
-entry: Fixed already completed lesson's content locked by drip content restrictions.
+entry: Students who have already completed a lesson will now automatically bypass the lesson's drip restrictions.

--- a/.changelogs/issue_1835.yml
+++ b/.changelogs/issue_1835.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#1835"
+entry: Fixed already completed lesson's content locked by drip content restrictions.

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -336,27 +336,24 @@ function llms_is_post_restricted_by_drip_settings( $post_id, $user_id = null ) {
 				return false;
 			}
 			break;
-		default: // Don't pass other post types than lesson or quiz.
+		default: // Don't pass other post types.
 			return false;
 	}
 
 	$lesson  = new LLMS_Lesson( $lesson_id );
 	$user_id = $user_id ?? get_current_user_id();
 	/**
-	 * Filters whether or not bypass drip restrictions on completed lessons.
+	 * Filters whether or not to bypass drip restrictions on completed lessons.
 	 *
 	 * @since [version]
 	 *
-	 * @param boolean $drip_bypass Whether or not bypass drip restrictions on completed lessons.
+	 * @param boolean $drip_bypass Whether or not to bypass drip restrictions on completed lessons.
 	 * @param int     $post_id     WP Post ID of a lesson or quiz potentially restricted by drip settings.
 	 * @param int     $user_id     WP User ID.
 	 */
 	$is_available = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id ) &&
-		llms_is_complete( $user_id, $lesson_id, 'lesson' )
-		?
-		true
-		:
-		$lesson->is_available();
+	                llms_is_complete( $user_id, $lesson_id, 'lesson' ) ||
+	                $lesson->is_available();
 
 	return $is_available ? false : $lesson_id;
 
@@ -394,7 +391,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 				return false;
 			}
 			break;
-		default: // Don't pass other post types than lesson or quiz.
+		default: // Don't pass other post types.
 			return false;
 	}
 
@@ -488,7 +485,7 @@ function llms_is_post_restricted_by_time_period( $post_id, $user_id = null ) {
 		case 'course':
 			$course_id = $post_id;
 			break;
-		default: // Don't pass other post types than lesson or quiz.
+		default: // Don't pass other post types.
 			return false;
 	}
 

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -351,9 +351,8 @@ function llms_is_post_restricted_by_drip_settings( $post_id, $user_id = null ) {
 	 * @param int     $post_id     WP Post ID of a lesson or quiz potentially restricted by drip settings.
 	 * @param int     $user_id     WP User ID.
 	 */
-	$is_available = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id );
-	
-	$is_available = ( $user_id && llms_is_complete( $user_id, $lesson_id, 'lesson' ) ) || $lesson->is_available();
+	$drip_bypass  = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id );
+	$is_available = ( $drip_bypass && $user_id && llms_is_complete( $user_id, $lesson_id, 'lesson' ) ) || $lesson->is_available();
 
 	return $is_available ? false : $lesson_id;
 

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -5,13 +5,14 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 5.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Determine if content should be restricted.
+ *
  * Called during "template_include" to determine if redirects
  * or template overrides are in order.
  *
@@ -311,6 +312,8 @@ function llms_is_page_restricted( $post_id, $user_id = null ) {
  * @since 3.0.0
  * @since 3.16.11 Unknown.
  * @since 3.37.10 Use strict comparison '===' in place of '=='.
+ * @since [version] Improve code readability turning if-elseif into a switch-case.
+ *                Bypass drip content restriction on already completed lessons.
  *
  * @param int      $post_id WP Post ID of a lesson or quiz.
  * @param int|null $user_id Optional. WP User ID (will use get_current_user_id() if none supplied). Default `null`.
@@ -321,27 +324,41 @@ function llms_is_post_restricted_by_drip_settings( $post_id, $user_id = null ) {
 
 	$post_type = get_post_type( $post_id );
 
-	// if we're on a lesson, lesson id is the post id.
-	if ( 'lesson' === $post_type ) {
-		$lesson_id = $post_id;
-	} elseif ( 'llms_quiz' === $post_type ) {
-		$quiz      = llms_get_post( $post_id );
-		$lesson_id = $quiz->get( 'lesson_id' );
-		if ( ! $lesson_id ) {
+	switch ( $post_type ) {
+		// If we're on a lesson, lesson id is the post id.
+		case 'lesson':
+			$lesson_id = $post_id;
+			break;
+		case 'llms_quiz':
+			$quiz      = llms_get_post( $post_id );
+			$lesson_id = $quiz->get( 'lesson_id' );
+			if ( ! $lesson_id ) {
+				return false;
+			}
+			break;
+		default: // Don't pass other post types than lesson or quiz.
 			return false;
-		}
-	} else {
-		// dont pass other post types in here dumb dumb.
-		return false;
 	}
 
-	$lesson = new LLMS_Lesson( $lesson_id );
+	$lesson  = new LLMS_Lesson( $lesson_id );
+	$user_id = $user_id ?? get_current_user_id();
+	/**
+	 * Filters whether or not bypass drip restrictions on completed lessons.
+	 *
+	 * @since [version]
+	 *
+	 * @param boolean $drip_bypass Whether or not bypass drip restrictions on completed lessons.
+	 * @param int     $post_id     WP Post ID of a lesson or quiz potentially restricted by drip settings.
+	 * @param int     $user_id     WP User ID.
+	 */
+	$is_available = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id ) &&
+		llms_is_complete( $user_id, $lesson_id, 'lesson' )
+		?
+		true
+		:
+		$lesson->is_available();
 
-	if ( $lesson->is_available() ) {
-		return false;
-	} else {
-		return $lesson_id;
-	}
+	return $is_available ? false : $lesson_id;
 
 }
 
@@ -350,6 +367,7 @@ function llms_is_post_restricted_by_drip_settings( $post_id, $user_id = null ) {
  *
  * @since 3.0.0
  * @since 3.16.11 Unknown.
+ * @since [version] Improve code readability turning if-elseif into a switch-case.
  *
  * @param int      $post_id WP Post ID of a lesson or quiz.
  * @param int|null $user_id Optional. WP User ID (will use get_current_user_id() if none supplied). Default `null`.
@@ -364,16 +382,20 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 
 	$post_type = get_post_type( $post_id );
 
-	if ( 'lesson' === $post_type ) {
-		$lesson_id = $post_id;
-	} elseif ( 'llms_quiz' === $post_type ) {
-		$quiz      = llms_get_post( $post_id );
-		$lesson_id = $quiz->get( 'lesson_id' );
-		if ( ! $lesson_id ) {
+	switch ( $post_type ) {
+		// If we're on a lesson, lesson id is the post id.
+		case 'lesson':
+			$lesson_id = $post_id;
+			break;
+		case 'llms_quiz':
+			$quiz      = llms_get_post( $post_id );
+			$lesson_id = $quiz->get( 'lesson_id' );
+			if ( ! $lesson_id ) {
+				return false;
+			}
+			break;
+		default: // Don't pass other post types than lesson or quiz.
 			return false;
-		}
-	} else {
-		return false;
 	}
 
 	$lesson = llms_get_post( $lesson_id );
@@ -383,7 +405,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 		return false;
 	}
 
-	// get an array of all possible prereqs.
+	// Get an array of all possible prerequisites.
 	$prerequisites = array();
 
 	if ( $course->has_prerequisite( 'course' ) ) {
@@ -407,12 +429,12 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 		);
 	}
 
-	// prereqs exist and user is not logged in, return the first prereq id.
+	// Prerequisites exist and user is not logged in, return the first prereq id.
 	if ( $prerequisites && ! $user_id ) {
 
 		return array_shift( $prerequisites );
 
-		// if incomplete, send the prereq id.
+		// If incomplete, send the prereq id.
 	} else {
 
 		$student = new LLMS_Student( $user_id );
@@ -423,8 +445,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
 		}
 	}
 
-	// otherwise return false.
-	// no prereq.
+	// Otherwise return false: no prerequisite.
 	return false;
 
 }
@@ -435,6 +456,7 @@ function llms_is_post_restricted_by_prerequisite( $post_id, $user_id = null ) {
  * @since 3.0.0
  * @since 3.16.11 Unknown.
  * @since 5.7.0 Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
+ * @since [version] Improve code readability turning if-elseif into a switch-case.
  *
  * @param int      $post_id WP Post ID of a course, lesson, or quiz.
  * @param int|null $user_id Optional. WP User ID (will use get_current_user_id() if none supplied). Default `null`.
@@ -445,40 +467,34 @@ function llms_is_post_restricted_by_time_period( $post_id, $user_id = null ) {
 
 	$post_type = get_post_type( $post_id );
 
-	// if we're on a lesson, get course information.
-	if ( 'lesson' === $post_type ) {
-
-		$lesson    = new LLMS_Lesson( $post_id );
-		$course_id = $lesson->get( 'parent_course' );
-
-	} elseif ( 'llms_quiz' === $post_type ) {
-		$quiz      = llms_get_post( $post_id );
-		$lesson_id = $quiz->get( 'lesson_id' );
-		if ( ! $lesson_id ) {
+	switch ( $post_type ) {
+		// If we're on a lesson, get course information.
+		case 'lesson':
+			$lesson    = new LLMS_Lesson( $post_id );
+			$course_id = $lesson->get( 'parent_course' );
+			break;
+		case 'llms_quiz':
+			$quiz      = llms_get_post( $post_id );
+			$lesson_id = $quiz->get( 'lesson_id' );
+			if ( ! $lesson_id ) {
+				return false;
+			}
+			$lesson = llms_get_post( $lesson_id );
+			if ( ! $lesson_id ) {
+				return false;
+			}
+			$course_id = $lesson->get( 'parent_course' );
+			break;
+		case 'course':
+			$course_id = $post_id;
+			break;
+		default: // Don't pass other post types than lesson or quiz.
 			return false;
-		}
-		$lesson = llms_get_post( $lesson_id );
-		if ( ! $lesson_id ) {
-			return false;
-		}
-		$course_id = $lesson->get( 'parent_course' );
-
-	} elseif ( 'course' === $post_type ) {
-
-		$course_id = $post_id;
-
-	} else {
-
-		return false;
-
 	}
 
 	$course = new LLMS_Course( $course_id );
-	if ( $course->is_open() ) {
-		return false;
-	} else {
-		return $course_id;
-	}
+
+	return $course->is_open() ? false : $course_id;
 
 }
 
@@ -642,7 +658,7 @@ function llms_is_quiz_accessible( $post_id, $user_id = null ) {
 	$quiz      = llms_get_post( $post_id );
 	$lesson_id = $quiz->get( 'lesson_id' );
 
-	// no lesson or the user is not enrolled.
+	// No lesson or the user is not enrolled.
 	if ( ! $lesson_id || ! llms_is_user_enrolled( $user_id, $lesson_id ) ) {
 		return $post_id;
 	}

--- a/includes/functions/llms.functions.access.php
+++ b/includes/functions/llms.functions.access.php
@@ -351,9 +351,9 @@ function llms_is_post_restricted_by_drip_settings( $post_id, $user_id = null ) {
 	 * @param int     $post_id     WP Post ID of a lesson or quiz potentially restricted by drip settings.
 	 * @param int     $user_id     WP User ID.
 	 */
-	$is_available = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id ) &&
-	                llms_is_complete( $user_id, $lesson_id, 'lesson' ) ||
-	                $lesson->is_available();
+	$is_available = apply_filters( 'llms_lesson_drip_bypass_if_completed', true, $post_id, $user_id );
+	
+	$is_available = ( $user_id && llms_is_complete( $user_id, $lesson_id, 'lesson' ) ) || $lesson->is_available();
 
 	return $is_available ? false : $lesson_id;
 

--- a/tests/phpunit/unit-tests/class-llms-test-functions-access.php
+++ b/tests/phpunit/unit-tests/class-llms-test-functions-access.php
@@ -7,6 +7,7 @@
  * @since 3.7.3
  * @since 3.16.0 Unknown.
  * @since 3.37.10 Added tests on sitewide membership restriction.
+ * @since [version] Added tests for drip restrictions on completed lessons.
  */
 class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
@@ -76,6 +77,42 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 		// now available.
 		llms_tests_mock_current_time( '+4 days' );
 		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
+
+	}
+
+	/**
+	 * Test drip restriction for already completed lesson.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_is_post_restricted_by_drip_settings_completed_lesson() {
+
+		$course    = $this->factory->course->create_and_get();
+		$lesson    = $course->get_lessons()[0];
+		$lesson_id = $lesson->get( 'id' );
+		$student   = $this->get_mock_student();
+		wp_set_current_user( $student->get( 'id' ) );
+		$student->enroll( $course );
+
+		// No drip settings, lesson is currently available.
+		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
+
+		// Add any drip settings, lesson available in the future.
+		$lesson->set( 'drip_method', 'date' );
+		$lesson->set( 'date_available', date( 'm/d/Y', current_time( 'timestamp' ) + DAY_IN_SECONDS ) );
+		$this->assertEquals( $lesson_id, llms_is_post_restricted_by_drip_settings( $lesson_id ) );
+
+		// Mark the lesson complete.
+		$student->mark_complete( $lesson_id, 'lesson' );
+		// We expect the lesson to be not restricted by drip settings anymore.
+		$this->assertFalse( llms_is_post_restricted_by_drip_settings( $lesson_id ) );
+
+		// Turn off the drip bypass filter: lesson drip.
+		add_filter( 'llms_lesson_drip_bypass_if_completed', '__return_false', 10 );
+		$this->assertEquals( $lesson_id, llms_is_post_restricted_by_drip_settings( $lesson_id ) );
+		remove_filter( 'llms_lesson_drip_bypass_if_completed', '__return_false', 10 );
 
 	}
 


### PR DESCRIPTION
## Description
Fixes #1835 

## How has this been tested?
new unit tests, written and run before writing the fix.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

