### PR TITLE
Add WP Engine cache exclusions.

### DIFF
--- a/.changelogs/issue_1717-wpengine-cache.yml
+++ b/.changelogs/issue_1717-wpengine-cache.yml
@@ -2,5 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#1717"
-entry: Added automatic exclusion of dashboard and checkout pages, including
-  dashboard endpoints like 'lost-pasword', from the WP Engine server-side cache.
+entry: Added automatic exclusion of "no cache" pages from the WP Engine server-side cache.

--- a/.changelogs/issue_1717-wpengine-cache.yml
+++ b/.changelogs/issue_1717-wpengine-cache.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#1717"
+entry: Added automatic exclusion of dashboard and checkout pages, including
+  dashboard endpoints like 'lost-pasword', from the WP Engine server-side cache.

--- a/.changelogs/issue_1717-wpengine-cache.yml
+++ b/.changelogs/issue_1717-wpengine-cache.yml
@@ -3,3 +3,5 @@ type: fixed
 links:
   - "#1717"
 entry: Added automatic exclusion of "no cache" pages from the WP Engine server-side cache.
+  Note":" Caching is allowed if "Settings -> Permalinks" is "Plain", which prevent users
+  from being able to successfully use the "Lost your password?" feature.

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -34,9 +34,6 @@ class LLMS_Cache_Helper {
 	/**
 	 * Sets a browser cookie that tells WP Engine to exclude a page from server caching.
 	 *
-	 * If "Settings -> Permalinks" is "Plain", i.e. the `permalink_structure` option is '',
-	 * then the entire site will be excluded from server caching.
-	 *
 	 * @see https://wpengine.com/support/cache/#Default_Cache_Exclusions
 	 * @see https://wpengine.com/support/determining-wp-engine-environment/
 	 *
@@ -49,6 +46,14 @@ class LLMS_Cache_Helper {
 	private function exclude_page_from_wpe_server_cache( $post = null ) {
 
 		if ( function_exists( 'is_wpe' ) && is_wpe() ) {
+
+			/* If "Settings -> Permalinks" is "Plain", i.e. the `permalink_structure` option is '',
+			 * allow the entire site to be cached by WP Engine.
+			 * Note: This will prevent users from being able to successfully use the "Lost your password?" feature.
+			 */
+			if ( isset( $GLOBALS['wp_rewrite'] ) && '' === $GLOBALS['wp_rewrite']->permalink_structure ) {
+				return;
+			}
 
 			$path = wp_parse_url( get_permalink( $post ), PHP_URL_PATH );
 			llms_setcookie( 'wordpress_wpe_no_cache', '1', 0, $path, COOKIE_DOMAIN, is_ssl(), true );

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.15.0
- * @version 6.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,6 +29,30 @@ class LLMS_Cache_Helper {
 
 		add_action( 'wp', array( $this, 'maybe_no_cache' ) );
 
+	}
+
+	/**
+	 * Sets a browser cookie that tells WP Engine to exclude a page from server caching.
+	 *
+	 * If "Settings -> Permalinks" is "Plain", i.e. the `permalink_structure` option is '',
+	 * then the entire site will be excluded from server caching.
+	 *
+	 * @see https://wpengine.com/support/cache/#Default_Cache_Exclusions
+	 * @see https://wpengine.com/support/determining-wp-engine-environment/
+	 *
+	 * @since [version]
+	 *
+	 * @param int|WP_Post $post Optional. Post ID or post object. Default is the global `$post`.
+	 *
+	 * @return void
+	 */
+	private function exclude_page_from_wpe_server_cache( $post = null ) {
+
+		if ( function_exists( 'is_wpe' ) && is_wpe() ) {
+
+			$path = wp_parse_url( get_permalink( $post ), PHP_URL_PATH );
+			llms_setcookie( 'wordpress_wpe_no_cache', '1', 0, $path, COOKIE_DOMAIN, is_ssl(), true );
+		}
 	}
 
 	/**
@@ -83,7 +107,8 @@ class LLMS_Cache_Helper {
 	 *
 	 * @since 3.15.0
 	 * @since 6.4.0 Force no caching on quiz pages.
-	 *               Added 'no-store' to the default WordPress nocache headers.
+	 *              Added 'no-store' to the default WordPress nocache headers.
+	 * @since [version] Added WP Engine server-side cache exclusions.
 	 *
 	 * @return void
 	 */
@@ -125,6 +150,7 @@ class LLMS_Cache_Helper {
 			llms_maybe_define_constant( 'DONOTCACHEOBJECT', true );
 			llms_maybe_define_constant( 'DONOTCACHEDB', true );
 			nocache_headers();
+			$this->exclude_page_from_wpe_server_cache();
 
 			remove_filter( 'nocache_headers', array( __CLASS__, 'additional_nocache_headers' ), 99 );
 

--- a/includes/forms/controllers/class.llms.controller.account.php
+++ b/includes/forms/controllers/class.llms.controller.account.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Forms/Controllers/Classes
  *
  * @since 3.7.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -381,6 +381,7 @@ class LLMS_Controller_Account {
 	 *
 	 * @since 5.0.0
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 * @since [version] Prevented client and server caching of the password reset form page.
 	 *
 	 * @return void
 	 */

--- a/includes/forms/controllers/class.llms.controller.account.php
+++ b/includes/forms/controllers/class.llms.controller.account.php
@@ -392,6 +392,7 @@ class LLMS_Controller_Account {
 			$uid  = $user ? $user->ID : 0;
 			$val  = sprintf( '%1$d:%2$s', $uid, wp_unslash( llms_filter_input_sanitize_string( INPUT_GET, 'key' ) ) );
 
+			( new LLMS_Cache_Helper() )->maybe_no_cache();
 			llms_set_password_reset_cookie( $val );
 			llms_redirect_and_exit( add_query_arg( 'reset-pass', 1, llms_lostpassword_url() ) );
 		}

--- a/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
+++ b/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
@@ -29,8 +29,7 @@ class LLMS_Test_Cache_Helper extends LLMS_Unit_Test_Case {
 			return;
 		}
 
-		function is_wpe()
-		{
+		function is_wpe() {
 			return getenv('IS_WPE');
 		}
 	}

--- a/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
+++ b/tests/phpunit/unit-tests/class-llms-test-cache-helper.php
@@ -8,9 +8,97 @@
  * @group cache_helper
  *
  * @since 4.0.0
- * @version 6.4.0
  */
 class LLMS_Test_Cache_Helper extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Sets the WP Engine "live" status and defines the is_wpe() function, if not already defined.
+	 *
+	 * @see https://wpengine.com/support/determining-wp-engine-environment/
+	 *
+	 * @since [version]
+	 *
+	 * @param bool $is_live "Live" means a production, development or staging environment, but not a legacy staging site.
+	 * @return void
+	 */
+	private function set_wpe_status( bool $is_live ) {
+
+		putenv( 'IS_WPE=' . (int) $is_live );
+
+		if ( function_exists( 'is_wpe' ) ) {
+			return;
+		}
+
+		function is_wpe()
+		{
+			return getenv('IS_WPE');
+		}
+	}
+
+	/**
+	 * Tests the exclude_page_from_wpe_server_cache() method.
+	 *
+	 * @see LLMS_Cache_Helper::exclude_page_from_wpe_server_cache()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_exclude_page_from_wpe_server_cache() {
+
+		// Setup.
+		$helper  = new LLMS_Cache_Helper();
+		$cookies = LLMS_Tests_Cookies::instance();
+		$cookies->unset( 'wordpress_wpe_no_cache' );
+		LLMS_Install::create_pages();
+		$this->set_permalink_structure( '/%postname%/' );
+		$dashboard_id    = llms_get_page_id( 'myaccount' );
+		$dashboard_path  = parse_url( get_permalink( $dashboard_id ), PHP_URL_PATH );
+		$expected_cookie = array(
+			'value'    => '1',
+			'expires'  => 0,
+			'path'     => '',
+			'domain'   => COOKIE_DOMAIN,
+			'secure'   => is_ssl(),
+			'httponly' => true,
+		);
+
+		// is_wpe() function is not defined.
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertNull( $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// is_wpe() returns 0.
+		$this->set_wpe_status( false );
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertNull( $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// is_wpe() returns 1, $post not given and global $post is not set.
+		$this->set_wpe_status( true );
+		unset( $GLOBALS['post'] );
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertEquals( $expected_cookie, $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// is_wpe() returns 1, $post parameter is not given, global $post is for a LifterLMS dashboard page.
+		$GLOBALS['post']         = get_post( $dashboard_id );
+		$expected_cookie['path'] = $dashboard_path;
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertEquals( $expected_cookie, $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// is_wpe() returns 1, $post parameter is for a LifterLMS dashboard page.
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache', array( $dashboard_id ) );
+		$this->assertEquals( $expected_cookie, $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// URI contains a LifterLMS dashboard endpoint.
+		$_SERVER['REQUEST_URI'] = '/dashboard/my-courses/';
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertEquals( $expected_cookie, $cookies->get( 'wordpress_wpe_no_cache' ) );
+
+		// Set permalink structure to plain.
+		$this->set_permalink_structure( '' );
+		$expected_cookie['path'] = '/';
+		LLMS_Unit_Test_Util::call_method( $helper, 'exclude_page_from_wpe_server_cache' );
+		$this->assertEquals( $expected_cookie, $cookies->get( 'wordpress_wpe_no_cache' ) );
+	}
 
 	/**
 	 * Test get_prefix() method.


### PR DESCRIPTION
## Description
1. Added the `LLMS_Cache_Helper::exclude_page_from_wpe_server_cache()` method that if we're on a live WP Engine site, excludes the page from the WP Engine server-side cache.
2. Updated `LLMS_Cache_Helper::maybe_no_cache()` to call `LLMS_Cache_Helper::exclude_page_from_wpe_server_cache()`.

See https://wpengine.com/support/cache/#Default_Cache_Exclusions.
See https://wpengine.com/support/determining-wp-engine-environment/

Fixes #1717.

## How has this been tested?
Manually locally, manually on WP Engine site, and with a new unit test.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

