### PR TITLE
Allow avoiding error returning when updating an llms post meta with the same value as stored in the db

### DIFF
--- a/.changelogs/issue_909.yml
+++ b/.changelogs/issue_909.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: dev
+links:
+  - "#909"
+entry: Allow avoiding error returning when updating an LLMS_Post_Model post meta
+  with the same value as the one stored in the db.

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -1532,7 +1532,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 			'html',
 			'float',
 		);
-		if ( in_array( $this->get_property_type( $key ), $string_types, true ) ) {
+		if ( in_array( $this->get_property_type( $key ), $scalar_types, true ) ) {
 			$sanitized = (string) $sanitized;
 		}
 

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -1281,7 +1281,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 			);
 		}
 
-		return $this->set_bulk( $model_array, $allow_same_meta_value );
+		return $this->set_bulk( $model_array, false, $allow_same_meta_value );
 
 	}
 

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -1531,6 +1531,9 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 			'yesno',
 			'html',
 			'float',
+			'int',
+			'bool',
+			'boolean',
 		);
 
 		if ( in_array( $this->get_property_type( $key ), $scalar_types, true ) ) {

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -1161,7 +1161,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 */
 	protected function scrub( $key, $val ) {
 		/**
-		 * Filters the property type being scrubbed
+		 * Filters the property type being scrubbed.
 		 *
 		 * The dynamic portion of this hook, `$this->model_post_type`, refers to the model's post type. For example "course",
 		 * "lesson", "membership", etc...
@@ -1174,7 +1174,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 		$type = apply_filters( "llms_get_{$this->model_post_type}_property_type", $this->get_property_type( $key ), $this );
 
 		/**
-		 * Filters the scrubbed property
+		 * Filters the scrubbed property.
 		 *
 		 * The first dynamic portion of this hook, `$this->model_post_type`, refers to the model's post type. For example "course",
 		 * "lesson", "membership", etc...
@@ -1532,6 +1532,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 			'html',
 			'float',
 		);
+
 		if ( in_array( $this->get_property_type( $key ), $scalar_types, true ) ) {
 			$sanitized = (string) $sanitized;
 		}

--- a/includes/abstracts/abstract.llms.post.model.php
+++ b/includes/abstracts/abstract.llms.post.model.php
@@ -1339,7 +1339,7 @@ abstract class LLMS_Post_Model implements JsonSerializable {
 	 * @since [version]
 	 *
 	 * @param array $model_array Associative array of key/val pairs.
-	 * @return array|false False if nothing to set. An array that contains all the post properties and all the metas to set, otherwise.
+	 * @return array|bool Returns `false` if nothing to set or an array that contains all the post properties and all the metas to set.
 	 */
 	private function parse_properties_to_set( $model_array ) {
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
@@ -9,7 +9,7 @@
  * @group post_models
  *
  * @since 4.10.0
- * @since [version] Added tests on updating meta with the same value as the ones stored in the db.
+ * @since [version] Added various tests on set_bulk() method.
  */
 class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 
@@ -336,6 +336,107 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 		}
 
 		$this->_unstage_meta_test();
+
+	}
+
+	/**
+	 * Test set_bulk() method passing empty data array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_bulk_empty_data() {
+
+		// Return WP_Error, don't allow same meta value.
+		$result = $this->stub->set_bulk(
+			array(),
+			true,
+			false
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'empty_data', $result );
+
+		// Return WP_Error, allow same meta value.
+		$result = $this->stub->set_bulk(
+			array(),
+			true,
+			true
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'empty_data', $result );
+
+		// Don't return WP_Error, don't allow same meta value.
+		$this->assertFalse(
+			$this->stub->set_bulk(
+				array(),
+				false,
+				true
+			)
+		);
+
+		// Don't return WP_Error, allow same meta value.
+		$this->assertFalse(
+			$this->stub->set_bulk(
+				array(),
+				false,
+				false
+			)
+		);
+
+	}
+
+	/**
+	 * Test set_bulk() method passing invalid data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_bulk_invalid_data() {
+
+		// Setting only unsettable properties produces invalid data error.
+		$unsettable_properties = LLMS_Unit_Test_Util::call_method( $this->stub, 'get_unsettable_properties' );
+
+		// Return WP_Error, don't allow same meta value.
+		$result = $this->stub->set_bulk(
+			array_flip( $unsettable_properties ),
+			true,
+			false
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'invalid_data', $result );
+
+		// Return WP_Error, allow same meta value.
+		$result = $this->stub->set_bulk(
+			array_flip( $unsettable_properties ),
+			true,
+			false
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'invalid_data', $result );
+
+		// Don't return WP_Error, don't allow same meta value.
+		$this->assertFalse(
+			$this->stub->set_bulk(
+				array_flip( $unsettable_properties ),
+				false,
+				false
+			)
+		);
+
+		// Don't return WP_Error, allow same meta value.
+		$this->assertFalse(
+			$this->stub->set_bulk(
+				array_flip( $unsettable_properties ),
+				false,
+				true
+			)
+		);
 
 	}
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
@@ -9,7 +9,7 @@
  * @group post_models
  *
  * @since 4.10.0
- * @since [version] Added various tests on set_bulk() method.
+ * @since [version] Added various tests on set()/set_bulk() methods.
  */
 class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 
@@ -437,6 +437,110 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 				true
 			)
 		);
+
+	}
+
+	/**
+	 * Test setting (bulk) post property that would generate an error.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_bulk_post_properties_with_error() {
+
+		// Simulate empty content error.
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$properties = array(
+			'content' => '',
+			'title'   => ''
+		);
+
+		// Returning WP_Error, don't allow same meta.
+		$result = $this->stub->set_bulk(
+			$properties,
+			true,
+			false
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'empty_content', $result );
+
+		// Returning WP_Error, allow same meta.
+		$result = $this->stub->set_bulk(
+			$properties,
+			true,
+			true
+		);
+
+		$this->assertWPError( $result );
+		$this->assertWPErrorCodeEquals( 'empty_content', $result );
+
+		// Not returning WP_Error, do not allow same meta.
+		$this->assertFalse(
+			$result = $this->stub->set_bulk(
+				$properties,
+				false,
+				false
+			)
+		);
+
+		// Not returning WP_Error, allow same meta.
+		$this->assertFalse(
+			$result = $this->stub->set_bulk(
+				$properties,
+				false,
+				true
+			)
+		);
+
+		// Simulate empty content error.
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+	}
+
+
+	/**
+	 * Test setting post property that would generate an error.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_post_properties_with_error() {
+
+		// Simulate empty content error.
+		add_filter( 'wp_insert_post_empty_content', '__return_true' );
+
+		$properties = array(
+			'content' => '',
+			'title'   => '',
+		);
+
+		foreach ( $properties as $key => $val ) {
+
+			$this->assertFalse(
+				// Allow same meta.
+				$this->stub->set(
+					$key,
+					$val,
+					true,
+				)
+			);
+
+			$this->assertFalse(
+				// Don't allow same meta.
+				$this->stub->set(
+					$key,
+					$val,
+					false,
+				)
+			);
+		}
+
+		// Simulate empty content error.
+		remove_filter( 'wp_insert_post_empty_content', '__return_true' );
 
 	}
 

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-post-model.php
@@ -223,7 +223,25 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 		$values = array(
 			'meta_1' => 'val_1',
 			'meta_2' => 'val_2',
+			'meta_3' => array( // Non scalar value.
+				'val_3',
+			),
 		);
+
+		$declare_property_types = function( $props ) {
+			return array_merge(
+				$props,
+				array(
+					'meta_1' => 'text',
+					'meta_2' => 'text',
+					'meta_3' => 'array',
+					'meta_4' => 'absint',
+				)
+			);
+		};
+
+		$model_post_type = LLMS_Unit_Test_Util::get_private_property_value( $this->stub, 'model_post_type' );
+		add_filter( "llms_get_{$model_post_type}_properties", $declare_property_types );
 
 		$result = $this->stub->set_bulk(
 			$values,
@@ -236,7 +254,7 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 		$new_values = array_merge(
 			$values,
 			array(
-				'meta_3' => 'val_3',
+				'meta_4' => 4,
 			)
 		);
 
@@ -256,11 +274,11 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 			);
 		}
 
-		// Meta 3 updated.
-		$this->assertEquals( 'val_3', $this->stub->get( 'meta_3' ) );
+		// Meta 4 updated.
+		$this->assertEquals( 4, $this->stub->get( 'meta_4' ) );
 
+		remove_filter( "llms_get_{$model_post_type}_properties", $declare_property_types );
 	}
-
 
 	/**
 	 * Test setting meta with the same values as the stored ones, allowed.
@@ -274,7 +292,25 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 		$values = array(
 			'meta_1' => 'val_1',
 			'meta_2' => 'val_2',
+			'meta_3' => array( // Non scalar value.
+				'val_3',
+			),
 		);
+
+		$declare_property_types = function( $props ) {
+			return array_merge(
+				$props,
+				array(
+					'meta_1' => 'text',
+					'meta_2' => 'text',
+					'meta_3' => 'array',
+					'meta_4' => 'absint',
+				)
+			);
+		};
+
+		$model_post_type = LLMS_Unit_Test_Util::get_private_property_value( $this->stub, 'model_post_type' );
+		add_filter( "llms_get_{$model_post_type}_properties", $declare_property_types );
 
 		$result = $this->stub->set_bulk(
 			$values,
@@ -287,7 +323,7 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 		$new_values = array_merge(
 			$values,
 			array(
-				'meta_3' => 'val_3',
+				'meta_4' => 4,
 			)
 		);
 
@@ -307,6 +343,35 @@ class LLMS_Test_Abstract_Post_Model extends LLMS_UnitTestCase {
 				$key
 			);
 		}
+
+		// Update meta 3 with a different array.
+		$new_values = array_merge(
+			$values,
+			array(
+				'meta_3' => array(
+					'value_3_changed',
+				),
+			)
+		);
+
+		$result = $this->stub->set_bulk(
+			$new_values,
+			true,
+			true
+		);
+
+		$this->assertTrue( $result );
+
+		// Meta updated.
+		foreach ( $new_values as $key => $value ) {
+			$this->assertEquals(
+				$this->stub->get( $key ),
+				$value,
+				$key
+			);
+		}
+
+		remove_filter( "llms_get_{$model_post_type}_properties", $declare_property_types );
 
 	}
 


### PR DESCRIPTION
## Description

Fixes #909 and needed to fix https://github.com/gocodebox/lifterlms-rest/issues/222
This PR, aside from some code reorganization, just adds this piece of code:
https://github.com/gocodebox/lifterlms/pull/2129/files#diff-3f0337a1db5180a72d1b5434e90b08b7b0f4b7ee5997ac4dd50efa7b6d3c21a8R1482-R1497

## How has this been tested?
existing unit tests (doesn't introduce any drawback since the old behavior is the default one).
working on new unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

