### PR TITLE
phpcs exclude src

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,7 +24,7 @@
     <exclude-pattern>*.asset.php</exclude-pattern>
 
     <!-- Let ESLint handle ESNext JS -->
-    <exclude-pattern>src/**/*</exclude-pattern>
+    <exclude-pattern type="relative">src/**/*</exclude-pattern>
     <exclude-pattern>webpack.config.js</exclude-pattern>
 
     <!-- Exclude node packages -->


### PR DESCRIPTION
## Description
Fixed the `src` exclusion pattern to work when using a checkout of [WordPress/wordpress-develop](https://github.com/WordPress/wordpress-develop).

## How has this been tested?
Ensured that the number of files sniffed was the same between:
1. the unmodified config file with the `src` directory moved elsewhere
2. the modified config file with the `src` directory in its normal location

The number of files sniffed on my system is 780, which matches the number sniffed by the GitHub action.

Made sure that files can still be given on the command line, e.g. `composer check-cs includes/class-llms-events.php`.

## Types of changes
 Bugfix for developers.

## Checklist:
- [ ] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

