### PR TITLE
Fix firing of the external engagement filters

### DIFF
--- a/.changelogs/filter_parsed_engagements.yml
+++ b/.changelogs/filter_parsed_engagements.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+links:
+  - "https://github.com/gocodebox/lifterlms-integration-twilio/issues/32"
+entry: Fixed the ability for 3rd party plugins to use the
+  `lifterlms_external_engagement_handler_arguments` and
+  `lifterlms_external_engagement_query_arguments`.

--- a/.changelogs/filter_parsed_engagements.yml
+++ b/.changelogs/filter_parsed_engagements.yml
@@ -1,7 +1,7 @@
 significance: patch
 type: fixed
 links:
-  - "https://github.com/gocodebox/lifterlms-integration-twilio/issues/32"
+  - "gocodebox/lifterlms-integration-twilio#32"
 entry: Fixed the ability for 3rd party plugins to use the
   `lifterlms_external_engagement_handler_arguments` and
-  `lifterlms_external_engagement_query_arguments`.
+  `lifterlms_external_engagement_query_arguments` filters.

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 2.3.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -342,9 +342,11 @@ class LLMS_Engagements {
 	}
 
 	/**
-	 * Parse incoming hook / callback data to determine if an engagement should be triggered from a given hook
+	 * Parse incoming hook / callback data to determine if an engagement should be triggered from a given hook.
 	 *
 	 * @since 6.0.0
+	 * @since [version] Fixed an issue where the `lifterlms_external_engagement_query_arguments` filter
+	 *              would not trigger if a 3rd party registered a trigger hook.
 	 *
 	 * @param string $action Action hook name.
 	 * @param array  $args   Array of arguments passed to the callback function.
@@ -364,29 +366,35 @@ class LLMS_Engagements {
 			'related_post_id' => null,
 		);
 
-		// Verify that it's a supported hook.
+		/**
+		 * Allows 3rd parties to hook into the core engagement system by parsing data passed to the hook.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param array $parsed {
+		 *     An associative array of parsed data used to trigger the engagement.
+		 *
+		 *     @type string $trigger_type    (Required) The name of the engagement trigger. See `llms_get_engagement_triggers()` for a list of valid triggers.
+		 *     @type int    $user_id         (Required) The WP_User ID of the user who the engagement is being awarded or sent to.
+		 *     @type int    $related_post_id (Optional) The WP_Post ID of a related post.
+		 *  }
+		 *  @param string $action The name of the hook which triggered the engagement.
+		 *  @param array  $args   The original arguments provided by the triggering hook.
+		 */
+		$filtered_parsed = apply_filters(
+			'lifterlms_external_engagement_query_arguments',
+			$parsed,
+			$action,
+			$args
+		);
+		// If valid, return the filtered parsed data.
+		if ( isset( $filtered_parsed['trigger_type'] ) && isset( $filtered_parsed['user_id'] ) ) {
+			return $filtered_parsed;
+		}
+
+		// Verify that the action is a supported hook.
 		if ( ! in_array( $action, $this->get_trigger_hooks(), true ) ) {
-			/**
-			 * Allows 3rd parties to hook into the core engagement system by parsing data passed to the hook.
-			 *
-			 * @since Unknown
-			 *
-			 * @param array $parsed {
-			 *     An associative array of parsed data used to trigger the engagement.
-			 *
-			 *     @type string $trigger_type    (Required) The name of the engagement trigger. See `llms_get_engagement_triggers()` for a list of valid triggers.
-			 *     @type int    $user_id         (Required) The WP_User ID of the user who the engagement is being awarded or sent to.
-			 *     @type int    $related_post_id (Optional) The WP_Post ID of a related post.
-			 *  }
-			 *  @param string $action The name of the hook which triggered the engagement.
-			 *  @param array  $args   The original arguments provided by the triggering hook.
-			 */
-			return apply_filters(
-				'lifterlms_external_engagement_query_arguments',
-				$parsed,
-				$action,
-				$args
-			);
+			return $parsed;
 		}
 
 		// The user registration action doesn't have a related post id.
@@ -481,9 +489,11 @@ class LLMS_Engagements {
 	}
 
 	/**
-	 * Parse engagement objects from the DB and return data needed to trigger the engagements
+	 * Parse engagement objects from the DB and return data needed to trigger the engagements.
 	 *
 	 * @since 6.0.0
+	 * @since [version] Fixed an issue where the `lifterlms_external_engagement_handler_arguments` filter
+	 *              would not trigger if a 3rd party registered an engagement type.
 	 *
 	 * @param object $engagement   The engagement object from the `get_engagements()` query.
 	 * @param array  $trigger_data Parsed hook data from `parse_hook()`.
@@ -501,31 +511,38 @@ class LLMS_Engagements {
 			'handler_args'   => null,
 		);
 
+		/**
+		 * Enable 3rd parties to parse custom engagement types.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param array $parsed {
+		 *     An associative array of parsed data used to trigger the engagement.
+		 *
+		 *     @type string $handler_action (Required) Hook name of the action that will handle awarding the sending the engagement.
+		 *     @type array  $handler_args   (Required) Arguments passed to the `$handler_action` callback.
+		 * }
+		 * @param object $engagement      The engagement object from the `get_engagements()` query.
+		 * @param int    $user_id         WP_User ID who will be awarded the engagement.
+		 * @param int    $related_post_id WP_Post ID of the related post.
+		 * @param string $event_type      The type of engagement event.
+		 */
+		$filtered_parsed = apply_filters(
+			'lifterlms_external_engagement_handler_arguments',
+			$parsed,
+			$engagement,
+			$trigger_data['user_id'],
+			$trigger_data['related_post_id'],
+			$engagement->event_type
+		);
+		// If valid, return the filtered parsed data.
+		if ( isset( $filtered_parsed['handler_action'] ) && isset( $filtered_parsed['handler_args'] ) ) {
+			return $filtered_parsed;
+		}
+
+		// Verify that the engagement event type is supported.
 		if ( ! array_key_exists( $engagement->event_type, llms_get_engagement_types() ) ) {
-			/**
-			 * Enable 3rd parties to parse custom engagement types
-			 *
-			 * @since Unknown
-			 *
-			 * @param array $parsed {
-			 *     An associative array of parsed data used to trigger the engagement.
-			 *
-			 *     @type string $handler_action (Required) Hook name of the action that will handle awarding the sending the engagement.
-			 *     @type array  $handler_args   (Required) Arguments passed to the `$handler_action` callback.
-			 * }
-			 * @param object $engagement      The engagement object from the `get_engagements()` query.
-			 * @param int    $user_id         WP_User ID who will be awarded the engagement.
-			 * @param int    $related_post_id WP_Post ID of the related post.
-			 * @param string $event_type      The type of engagement event.
-			 */
-			return apply_filters(
-				'lifterlms_external_engagement_handler_arguments',
-				$parsed,
-				$engagement,
-				$trigger_data['user_id'],
-				$trigger_data['related_post_id'],
-				$engagement->event_type
-			);
+			return $parsed;
 		}
 
 		$parsed['handler_args'] = array(

--- a/tests/phpunit/unit-tests/class-llms-test-engagements.php
+++ b/tests/phpunit/unit-tests/class-llms-test-engagements.php
@@ -32,6 +32,7 @@ class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 			public $post_type = 'llms_mock_diploma';
 
 			public function __construct() {
+				register_post_type( 'llms_mock_diploma' );
 				add_filter( 'lifterlms_engagement_types', array( $this, 'register_engagement_types' ), 10, 1 );
 				add_filter( 'lifterlms_engagement_actions', array( $this, 'register_engagement_actions' ), 10, 1 );
 
@@ -48,6 +49,10 @@ class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 					10,
 					3
 				);
+			}
+
+			public function __destruct() {
+				unregister_post_type( 'llms_mock_diploma' );
 			}
 
 			public function filter_engagement_handler_arguments( $parsed, $engagement, $user_id, $related_post_id, $event_type ) {

--- a/tests/phpunit/unit-tests/class-llms-test-engagements.php
+++ b/tests/phpunit/unit-tests/class-llms-test-engagements.php
@@ -13,6 +13,81 @@
 class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 
 	/**
+	 * Returns a mock 3rd party engagements class.
+	 *
+	 * @since [version]
+	 *
+	 * @return object
+	 */
+	private function instantiate_mock_engagements() {
+
+		$mock_engagements = new class {
+
+			public $engagement_action = 'llms_mock_curriculum_completed';
+
+			public $event_type = 'diploma';
+
+			public $handler_action = 'lifterlms_engagement_ship_diploma';
+
+			public $post_type = 'llms_mock_diploma';
+
+			public function __construct() {
+				add_filter( 'lifterlms_engagement_types', array( $this, 'register_engagement_types' ), 10, 1 );
+				add_filter( 'lifterlms_engagement_actions', array( $this, 'register_engagement_actions' ), 10, 1 );
+
+				add_filter(
+					'lifterlms_external_engagement_handler_arguments',
+					array( $this, 'filter_engagement_handler_arguments' ),
+					10,
+					5
+				);
+
+				add_filter(
+					'lifterlms_external_engagement_query_arguments',
+					array( $this, 'filter_engagement_query_arguments' ),
+					10,
+					3
+				);
+			}
+
+			public function filter_engagement_handler_arguments( $parsed, $engagement, $user_id, $related_post_id, $event_type ) {
+				if ( $this->event_type !== $event_type ) {
+					return $parsed;
+				}
+				$parsed['handler_action'] = $this->handler_action;
+				$parsed['handler_args']   = array( $user_id, $engagement->engagement_id, $related_post_id, $engagement->trigger_id );
+
+				return $parsed;
+			}
+
+			public function filter_engagement_query_arguments( $parsed, $action, $args ) {
+				if ( $this->engagement_action !== $action ) {
+					return $parsed;
+				}
+				$parsed['trigger_type']    = $action;
+				$parsed['user_id']         = $args[0];
+				$parsed['related_post_id'] = $args[1];
+
+				return $parsed;
+			}
+
+			public function register_engagement_types( $engagement_types ) {
+				$engagement_types[ $this->event_type ] = __( 'Print and mail a diploma', 'lifterlms' );
+
+				return $engagement_types;
+			}
+
+			public function register_engagement_actions( $engagement_actions ) {
+				$engagement_actions[] = $this->engagement_action;
+
+				return $engagement_actions;
+			}
+		};
+
+		return new $mock_engagements;
+	}
+
+	/**
 	 * Set up before class.
 	 *
 	 * @since 6.0.0
@@ -418,6 +493,137 @@ class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 
 		}
 
+	}
+
+	/**
+	 * Test parse_engagement().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 * @throws ReflectionException
+	 */
+	public function test_parse_engagement() {
+
+		$mock_engagements = $this->instantiate_mock_engagements();
+		$engagements      = llms()->engagements();
+
+		// Set up course, engagement to be triggered, trigger settings, and student.
+		$course_id       = $this->factory->course->create();
+		$engagement_id   = $this->factory->post->create( array( 'post_type' => $mock_engagements->post_type ) );
+		$mock_engagement = $this->create_mock_engagement(
+			'course_track_completed',
+			'certificate',
+			0,
+			$course_id,
+			$engagement_id
+		);
+		$trigger_id      = $mock_engagement->ID;
+		$student_id      = $this->factory->student->create();
+
+		// Set up parse_engagement() arguments.
+		$engagement                = new stdClass();
+		$engagement->engagement_id = $engagement_id;
+		$engagement->trigger_id    = $trigger_id;
+		$engagement->trigger_event = 'course_completed';
+		$engagement->event_type    = 'email';
+		$engagement->delay         = 0;
+
+		$parse_args = array(
+			$engagement,
+			array(
+				'trigger_type'    => 'course_enrollment',
+				'user_id'         => $student_id,
+				'related_post_id' => $course_id,
+			)
+		);
+
+		$expected_handler_args = array(
+			$student_id,
+			$engagement_id,
+			$course_id, // Related Post ID.
+			$trigger_id,
+		);
+
+		// Test a core email engagement event type.
+		$expected_handler_action = 'lifterlms_engagement_send_email';
+		$handler                 = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_engagement', $parse_args );
+		$this->assertEquals( $expected_handler_action, $handler['handler_action'] );
+		$this->assertEquals( $expected_handler_args, $handler['handler_args'] );
+
+		// Test a core certificate engagement event type.
+		$engagement->event_type  = 'certificate';
+		$expected_handler_action = 'lifterlms_engagement_award_certificate';
+		$handler                 = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_engagement', $parse_args );
+		$this->assertEquals( $expected_handler_action, $handler['handler_action'] );
+		$this->assertEquals( $expected_handler_args, $handler['handler_args'] );
+
+		// Test an unknown engagement event type.
+		$engagement->event_type = 'unknown_action';
+		$handler                = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_engagement', $parse_args );
+		$this->assertNull( $handler['handler_action'] );
+		$this->assertNull( $handler['handler_args'] );
+
+		// Test a non-core engagement event type.
+		$engagement->event_type  = $mock_engagements->event_type;
+		$expected_handler_action = $mock_engagements->handler_action;
+		$handler                 = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_engagement', $parse_args );
+		$this->assertEquals( $expected_handler_action, $handler['handler_action'] );
+		$this->assertEquals( $expected_handler_args, $handler['handler_args'] );
+	}
+
+	/**
+	 * Test parse_hook().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 * @throws ReflectionException
+	 */
+	public function test_parse_hook() {
+
+		$mock_engagements = $this->instantiate_mock_engagements();
+		$engagements      = llms()->engagements();
+
+		// Set up course and student.
+		$related_post_id = $this->factory->course->create();
+		$user_id         = $this->factory->student->create();
+
+		// Set up parse_hook() arguments.
+		$parse_args    = array(
+			&$action,
+			array(
+				$user_id,
+				$related_post_id,
+			),
+		);
+		$expected_hook = array(
+			'user_id'         => $user_id,
+			'trigger_type'    => &$trigger_type,
+			'related_post_id' => $related_post_id
+		);
+
+		// Test a core hook.
+		$action       = 'llms_user_enrolled_in_course';
+		$trigger_type = 'course_enrollment';
+		$actual_hook  = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_hook', $parse_args );
+		$this->assertEqualSetsWithIndex( $expected_hook, $actual_hook );
+
+		// Test an unknown action.
+		$action                = 'unknown';
+		$expected_unknown_hook = array(
+			'user_id'         => null,
+			'trigger_type'    => null,
+			'related_post_id' => null
+		);
+		$actual_hook           = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_hook', $parse_args );
+		$this->assertEqualSetsWithIndex( $expected_unknown_hook, $actual_hook );
+
+		// Test a non-core hook.
+		$action       = $mock_engagements->engagement_action; // Input to parse_hook().
+		$trigger_type = $mock_engagements->engagement_action; // Output from parse_hook().
+		$actual_hook  = LLMS_Unit_Test_Util::call_method( $engagements, 'parse_hook', $parse_args );
+		$this->assertEqualSetsWithIndex( $expected_hook, $actual_hook );
 	}
 
 	/**


### PR DESCRIPTION
## Description

In LifterLMS 6.0.0, it is possible for the `lifterlms_external_engagement_handler_arguments` and `lifterlms_external_engagement_query_arguments` filters to not be fired.

### [LifterLMS before 6.0.0](https://github.com/gocodebox/lifterlms/blob/5.10.0/includes/class.llms.engagements.php) Logic
1. If the hook action or the engagement event type is not in a hardcoded switch statement, apply the filters, which may result in a parsed array with null values if the filter has no callables.

### [LifterLMS 6.0.0](https://github.com/gocodebox/lifterlms/blob/6.0.0/includes/class.llms.engagements.php#L522) Logic
1. If the hook action or the engagement event type are not registered, apply the filters and return the result, which may be a parsed array with null values if the filter has no callables.
3. Else, parse and return.

### This PR Logic
1. Always apply the filters and return the result if the parsed data is valid.
4. Else, if the hook action or the engagement event type are not registered, return a parsed array with null values.
5. Else parsing continues as it did before.

Fixes [gocodebox/lifterlms-integration-twilio#32](https://github.com/gocodebox/lifterlms-integration-twilio/issues/32).

## How has this been tested?
* Manually with the Twilio add-on.
* New LifterLMS core unit tests.
* Existing LifterLMS core unit tests.

## Types of changes
Bugfix.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

