### PR TITLE
WP 6.0 Compatibility: comment counting

### DIFF
--- a/.changelogs/wp-6.0-comments-count.yml
+++ b/.changelogs/wp-6.0-comments-count.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+entry: Stop subtracting LifterLMS order note comments from global comment counts
+  via the `wp_count_comments` filter on WordPress 6.0 and later. See related
+  WordPress Trac ticket [19901](https://core.trac.wordpress.org/ticket/19901).

--- a/tests/phpunit/unit-tests/class-llms-test-comments.php
+++ b/tests/phpunit/unit-tests/class-llms-test-comments.php
@@ -11,15 +11,54 @@
 class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
 
 	/**
+	 * Conditionally skips a test related to the `wp_count_comments()` method.
+	 *
+	 * @since [version]
+	 *
+	 * @param boolean $should_count Whether the current version of WP should count comments.
+	 * @return void
+	 */
+	public function maybe_skip_count_test( $should_count = false ) {
+
+		if ( $should_count === LLMS_Unit_Test_Util::call_method( 'LLMS_Comments', 'should_modify_comment_counts' ) ) {
+			global $wp_version;
+			$this->markTestSkipped( "Test skipped on WP Version: {$wp_version}." );
+		}
+
+	}
+
+	/**
+	 * Test wp_count_comments() throws `_doing_it_wrong()` and returns early when called on WP 6.0 or later.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_wp_count_comments_wp_6_dot_0_or_later() {
+
+		$this->maybe_skip_count_test( true );
+
+		$this->setExpectedIncorrectUsage( 'LLMS_Comments::wp_count_comments' );
+
+		$expect = array( 123 );
+		$this->assertEquals( $expect, LLMS_Comments::wp_count_comments( $expect, 123 ) );
+
+	}
+
+	/**
 	 * Test wp_count_comments() when passing in a specific post id.
 	 *
 	 * @since 3.37.12
+	 * @since [version] Added mock input data to guard against false-positives.
+	 *               Skip test on WP 6.0 or later.
 	 *
 	 * @return void
 	 */
 	public function test_wp_count_comments_specific_post() {
 
-		$expect = array();
+		$this->maybe_skip_count_test();
+
+		$expect = array( 123 );
 		$this->assertEquals( $expect, LLMS_Comments::wp_count_comments( $expect, 123 ) );
 
 	}
@@ -28,10 +67,13 @@ class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
 	 * Test wp_count_comments() when the transient already exists.
 	 *
 	 * @since 3.37.12
+	 * @since [version] Skip test on WP 6.0 or later.
 	 *
 	 * @return void
 	 */
 	public function test_wp_count_comments_transient_exists() {
+
+		$this->maybe_skip_count_test();
 
 		$expect = array( 1 );
 		set_transient( 'llms_count_comments', $expect, 10 );
@@ -44,10 +86,13 @@ class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
 	 * Test wp_count_comments() when a new stats object should be generated
 	 *
 	 * @since 3.37.12
+	 * @since [version] Skip test on WP 6.0 or later.
 	 *
 	 * @return void
 	 */
 	public function test_wp_count_comments_new() {
+
+		$this->maybe_skip_count_test();
 
 		// Insert 5 regular comments.
 		$this->factory->comment->create_many( 5 );
@@ -81,10 +126,13 @@ class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
 	 * Test wp_count_comments() when another plugin has already created a stats object we want to modify
 	 *
 	 * @since 3.37.12
+	 * @since [version] Skip test on WP 6.0 or later.
 	 *
 	 * @return void
 	 */
 	public function test_wp_count_comments_modify_existing() {
+
+		$this->maybe_skip_count_test();
 
 		// Insert 5 regular comments.
 		$this->factory->comment->create_many( 5 );
@@ -116,6 +164,39 @@ class LLMS_Test_Comments extends LLMS_Unit_Test_Case {
 		$this->assertEquals( 0, $res->trash );
 		$this->assertEquals( 0, $res->{'post-trashed'} );
 
+	}
+
+	/**
+	 * Test should_modify_comment_counts().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_should_modify_comment_counts() {
+
+		global $wp_version;
+
+		$orig_version = $wp_version;
+
+		$tests = array(
+			'6.0'     => false,
+			'6.0-RC3' => false,
+			'6.0-src' => false,
+			'6.0.1'   => false,
+			'5.9.3'   => true,
+			'5.9.1'   => true,
+			'5.9'     => true,
+			'5.8.1'   => true,
+			'5.8'     => true,
+			'5.7'     => true,
+		);
+
+		foreach ( $tests as $wp_version => $expected ) {
+			$this->assertEquals( $expected, LLMS_Unit_Test_Util::call_method( 'LLMS_Comments', 'should_modify_comment_counts' ) );
+		}
+
+		$wp_version = $orig_version;
 	}
 
 }


### PR DESCRIPTION
## Description

Fixes failing unit tests on WP 6.0-RC3

## How has this been tested?

+ New & existing tests

## Screenshots <!-- if applicable -->

## Types of changes

WP 6.0 compat, maintains backwards compat with 5.9 & earlier.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

