### PR TITLE
WP 6.0 test compat: remove block layout support during reusable block testing

### DIFF
--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-certificates.php
@@ -88,10 +88,21 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 	 * Test llms_get_certificate_content() with reusable blocks and merge codes.
 	 *
 	 * @since 6.4.0
+	 * @since [version] Remove layout filters for easier snapshots across WP versions.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_certificate_content_reusable_blocks() {
+
+		/**
+		 * Remove layout support for the purposes of this test.
+		 *
+		 * It's complicated to conditionally match the classes added to column wrappers (added via this filter)
+		 * so we'll just disable them.
+		 *
+		 * @todo When the minimum supported WP version is 6.0 we can remove this an update the snapshots.
+		 */
+		remove_filter( 'render_block', 'wp_render_layout_support_flag', 10 );
 
 		// Define reusable blocks.
 		$reusable_blocks = array(
@@ -192,6 +203,10 @@ class LLMS_Test_Functions_Certificates extends LLMS_UnitTestCase {
 				"template #$key, reusable block #$reusable_key"
 			);
 		}
+		
+		// Restore filter.
+		add_filter( 'render_block', 'wp_render_layout_support_flag', 10, 2 );
+
 	}
 
 	/**


### PR DESCRIPTION
## Description

Fixes test failing against WP 6.0-RC3 related to block markup.

The test themselves are still valid but since the block markup changes in 6.0 (related to columns) the tests are failing. This PR just removes the filter callback that adds the layout classes. We can update the snapshots once 6.0 is the min supported WP core version.

## How has this been tested?

+ Tests 

## Screenshots <!-- if applicable -->

## Types of changes

WP 6.0 test compat

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

