### PR TITLE
Fixed a fatal error on PHP 8+ when restoring a post type from revision

### DIFF
--- a/.changelogs/issue_2164.yml
+++ b/.changelogs/issue_2164.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2164"
+entry: Fixed a fatal error on PHP 8+ when restoring a post type from revision.

--- a/includes/admin/class.llms.admin.post-types.php
+++ b/includes/admin/class.llms.admin.post-types.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since Unknown
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -92,6 +92,7 @@ class LLMS_Admin_Post_Types {
 	 * @since 3.35.0 Fix l10n calls.
 	 * @since 4.7.0 Added `publicly_queryable` check for permalink and preview.
 	 * @since 6.0.0 Handle `llms_my_certificate` and `llms_my_achievement` post types.
+	 * @since [version] Fixed too few arguments passed to sprintf, when building restore from revision message.
 	 *
 	 * @return array $messages Post updated messages.
 	 */
@@ -141,7 +142,14 @@ class LLMS_Admin_Post_Types {
 				2  => __( 'Custom field updated.', 'lifterlms' ),
 				3  => __( 'Custom field deleted.', 'lifterlms' ),
 				4  => sprintf( __( '%s updated.', 'lifterlms' ), $name ),
-				5  => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.', 'lifterlms' ), wp_post_revision_title( llms_filter_input( INPUT_GET, 'revision', FILTER_SANITIZE_NUMBER_INT ), false ) ) : false,
+				5  => isset( $_GET['revision'] ) ? // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No need to verify the nonce here.
+					sprintf(
+						__( '%1$s restored to revision from %2$s.', 'lifterlms' ),
+						$name,
+						wp_post_revision_title( llms_filter_input( INPUT_GET, 'revision', FILTER_SANITIZE_NUMBER_INT ), false )
+					)
+					:
+					false,
 				6  => sprintf( __( '%s published.', 'lifterlms' ), $name ) . $permalink_html,
 				7  => sprintf( __( '%s saved.', 'lifterlms' ), $name ),
 				8  => sprintf( __( '%s submitted.', 'lifterlms' ), $name ) . $preview_link_html,


### PR DESCRIPTION
## Description

Fixes #2164 

## How has this been tested?
manually


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

