### PR TITLE
Added CSS to fix quiz label alignment, and margin correction for Twen…

### DIFF
--- a/.changelogs/issue_2132-1.yml
+++ b/.changelogs/issue_2132-1.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+comment: Added block display and margin settings to quiz label and 2022 theme.
+links:
+  - "#2132"
+entry: Fixes Hello Theme's word-break and spacing for quiz answer options and
+  fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/.changelogs/issue_2132-1.yml
+++ b/.changelogs/issue_2132-1.yml
@@ -1,7 +1,0 @@
-significance: patch
-type: fixed
-comment: Added block display and margin settings to quiz label and 2022 theme.
-links:
-  - "#2132"
-entry: Fixes Hello Theme's word-break and spacing for quiz answer options and
-  fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/.changelogs/issue_2132.yml
+++ b/.changelogs/issue_2132.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: fixed
+comment: Fixes Hello Theme's word-break and spacing for quiz answer options.
+  Also fixes text/label alignment in Twenty-Twenty-Two Theme.
+links:
+  - "#2132"
+entry: Added block display and margin setting to quiz label and
+  twenty-twenty-two compatibility.

--- a/.changelogs/issue_2132.yml
+++ b/.changelogs/issue_2132.yml
@@ -1,8 +1,8 @@
 significance: patch
 type: fixed
-comment: Fixes Hello Theme's word-break and spacing for quiz answer options.
-  Also fixes text/label alignment in Twenty-Twenty-Two Theme.
+comment: Added block display and margin setting to quiz label and
+  twenty-twenty-two compatibility.
 links:
   - "#2132"
-entry: Added block display and margin setting to quiz label and
-  twenty-twenty-two compatibility.
+entry: Fixes Hello Theme's word-break and spacing for quiz answer options.
+  Also fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -165,6 +165,9 @@
 			margin: 0;
 			padding: 0;
 			position: relative;
+			label {
+				display: block;
+			}
 
 			&:last-child {
 				border-bottom: none;

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -165,9 +165,6 @@
 			margin: 0;
 			padding: 0;
 			position: relative;
-			label {
-				display: block;
-			}
 
 			&:last-child {
 				border-bottom: none;
@@ -209,6 +206,7 @@
 			}
 
 			label {
+				display: block;
 				margin: 0;
 				padding: 10px 20px;
 				position: relative;

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -92,7 +92,7 @@ class LLMS_Twenty_Twenty_Two {
 			$styles[] = '.llms-form-field input, .llms-form-field textarea, .llms-form-field select { padding: 6px 10px }';
 
 			// Question layout.
-			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); margin-top: 0; }';
+			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { margin-top: 0; }';
 
 			// Payment gateway stylized radio buttons.
 			$styles[] = LLMS_Theme_Support::get_css(

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -92,7 +92,7 @@ class LLMS_Twenty_Twenty_Two {
 			$styles[] = '.llms-form-field input, .llms-form-field textarea, .llms-form-field select { padding: 6px 10px }';
 
 			// Question layout.
-			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); }';
+			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); margin-top: 0; }';
 
 			// Payment gateway stylized radio buttons.
 			$styles[] = LLMS_Theme_Support::get_css(

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/ThemeSupport/Classes
  *
  * @since 5.8.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -72,6 +72,7 @@ class LLMS_Twenty_Twenty_Two {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Fixed stretched images in questions with pictures, and images in quiz/questions description.
+	 * @since [version] Fixed label/text alignment by removing text’s margin top. Also, removed now outdated width rule.
 	 *
 	 * @param string|null $context Inline CSS context. Accepts "editor" to define styles loaded within the block editor or `null` for frontend styles.
 	 * @return string


### PR DESCRIPTION
Added CSS to fix quiz label alignment, and margin correction for Twenty Twenty-Two theme, though the line may no longer be needed.

## Description
Fixes Hello Theme's word-break and spacing for quiz answer options. Also fixes text/label alignment in Twenty-Twenty-Two Theme

Fixes #2132 

## How has this been tested?
I tested it manually (after running npm run build:styles)
Tested against default twenty-nineteen, twenty-twenty, twenty twenty-one, and twenty twenty-two.
Tested also with Divi, Astra, Kadence, Elementor's Hello Theme, LaunchPad, BuddyBoss, and Page Builder Framework

## Types of changes
added: Display: block
added: margin: 0 to Twenty-Twent-Two Theme compatibility

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

