### PR TITLE
Fix documented parameter/element name in record_refund().

### DIFF
--- a/includes/models/model.llms.transaction.php
+++ b/includes/models/model.llms.transaction.php
@@ -449,10 +449,10 @@ class LLMS_Transaction extends LLMS_Post_Model {
 	 * @param array  $refund {
 	 *      Refund arguments.
 	 *
-	 *     @type float  $amount    The refund amount.
-	 *     @type string $refund_id The generated refund ID.
-	 *     @type string $method    The refund processing method ID.
-	 *     @type string $date      The refund date in MySQL date format. If not supplied, the current time is used.
+	 *     @type float  $amount The refund amount.
+	 *     @type string $id     The generated refund ID.
+	 *     @type string $method The refund processing method ID.
+	 *     @type string $date   The refund date in MySQL date format. If not supplied, the current time is used.
 	 * }
 	 * @param string $note User-submitted refund note to add to the order alongside the refund.
 	 * @return void


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
`$refund['id']` was documented as `$refund['refund_id']`.


## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots <!-- if applicable -->

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

