### PR TITLE
Array settings fields

### DIFF
--- a/.changelogs/array-settings-fields-1.yml
+++ b/.changelogs/array-settings-fields-1.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: deprecated
+entry: Deprecated the `lifterlms_update_option_{$type}` action in favor of the
+  `llms_update_option_{$type}` filter.

--- a/.changelogs/array-settings-fields.yml
+++ b/.changelogs/array-settings-fields.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: Added handling for admin settings options that store their option values
+  in a nested array.

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -999,10 +999,9 @@ class LLMS_Admin_Settings {
 					break;
 
 				default:
-
 					/**
 					 * Action run for external field types.
-					 * 
+					 *
 					 * @since Unknown
 					 * @deprecated [version] Use `llms_update_option_{$type}` filter hook instead.
 					 *
@@ -1011,14 +1010,14 @@ class LLMS_Admin_Settings {
 					do_action_deprecated( "lifterlms_update_option_{$type}", array( $field ), '[version]' );
 
 			}
-			
+
 			/**
 			 * Filters the value of a settings field after it has been parsed and sanitized
 			 * and before it is saved to the database.
 			 *
 			 * The dynamic portion of this hook, `{$type}` refers to the setting field type:
 			 * email, text, checkbox, etc...
-			 * 
+			 *
 			 * @since [version]
 			 *
 			 * @param string|null $option_value The sanitized option value or `null`.
@@ -1059,7 +1058,7 @@ class LLMS_Admin_Settings {
 			 *
 			 * An update isn't guaranteed after this action if the method's logic can't
 			 * find a valid posted valued to persist to the database.
-			 * 
+			 *
 			 * @since Unknown
 			 *
 			 * @param array $field The admin setting field array to be updated.
@@ -1080,7 +1079,7 @@ class LLMS_Admin_Settings {
 	}
 
 	/**
-	 * Retrieves the posted value for an array type setting field. 
+	 * Retrieves the posted value for an array type setting field.
 	 *
 	 * @since [version]
 	 *

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -902,13 +902,14 @@ class LLMS_Admin_Settings {
 	/**
 	 * Save admin fields.
 	 *
-	 * Loops though the lifterlms options array and outputs each field.
+	 * Loops though a LifterLMS settings field options array and saves the values via `update_option()`.
 	 *
 	 * @since 1.0.0
 	 * @since 3.29.0 Unknown.
 	 * @since 3.35.0 Sanitize `$_POST` data.
 	 * @since 3.35.2 Don't strip tags on editor and textarea fields that allow HTML.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 * @since [version] Add handling for array fields for standard input types.
 	 *
 	 * @param array $settings Opens array to output
 	 * @return boolean
@@ -924,52 +925,45 @@ class LLMS_Admin_Settings {
 		$update_options = array();
 
 		// Loop options and get values to save.
-		foreach ( $settings as $value ) {
+		foreach ( $settings as $field ) {
 
-			if ( ! isset( $value['id'] ) ) {
-				continue; }
+			if ( ! isset( $field['id'] ) ) {
+				continue;
+			}
 
-			$type = isset( $value['type'] ) ? sanitize_title( $value['type'] ) : '';
+			$type = isset( $field['type'] ) ? sanitize_title( $field['type'] ) : '';
 
 			// Remove secure options from the database.
-			if ( isset( $value['secure_option'] ) && llms_get_secure_option( $value['secure_option'] ) ) {
-				delete_option( $value['id'] );
+			if ( isset( $field['secure_option'] ) && llms_get_secure_option( $field['secure_option'] ) ) {
+				delete_option( $field['id'] );
 				continue;
 			}
 
 			// Get the option name.
 			$option_value = null;
 
+			// Determines if the option value is an array.
+			$is_array_option = false !== strpos( $field['id'], '[' );
+
 			switch ( $type ) {
 
-				// Standard types.
 				case 'checkbox':
-					// Ooboi this is gross.
-					if ( strstr( $value['id'], '[' ) ) {
-						parse_str( $value['id'], $option_data );
-						$main_option_names = array_keys( $option_data );
-						$main_option_vals  = array_keys( $option_data[ $main_option_names[0] ] );
-						if ( isset( $_POST[ $main_option_names[0] ] ) && in_array( $main_option_vals[0], array_keys( $_POST[ $main_option_names[0] ] ) ) ) {
-							$option_value = 'yes';
-						} else {
-							$option_value = 'no';
-						}
-					} elseif ( isset( $_POST[ $value['id'] ] ) ) {
+					if ( $is_array_option ) {
+						$option_value = self::get_array_field_posted_value( $field['id'] ) ? 'yes' : 'no';
+					} elseif ( isset( $_POST[ $field['id'] ] ) ) {
 						$option_value = 'yes';
 					} else {
 						$option_value = 'no';
 					}
-
 					break;
 
 				case 'textarea':
 				case 'wpeditor':
-					if ( isset( $_POST[ $value['id'] ] ) ) {
-						$option_value = wp_kses_post( trim( llms_filter_input( INPUT_POST, $value['id'], FILTER_DEFAULT ) ) );
+					if ( isset( $_POST[ $field['id'] ] ) ) {
+						$option_value = wp_kses_post( trim( llms_filter_input( INPUT_POST, $field['id'], FILTER_DEFAULT ) ) );
 					} else {
 						$option_value = '';
 					}
-
 					break;
 
 				case 'password':
@@ -982,74 +976,126 @@ class LLMS_Admin_Settings {
 				case 'radio':
 				case 'hidden':
 				case 'image':
-					if ( isset( $_POST[ $value['id'] ] ) ) {
-						$option_value = llms_filter_input_sanitize_string( INPUT_POST, $value['id'] );
+					if ( $is_array_option ) {
+						$option_value = self::get_array_field_posted_value( $field['id'] );
+					} elseif ( isset( $_POST[ $field['id'] ] ) ) {
+						$option_value = llms_filter_input_sanitize_string( INPUT_POST, $field['id'] );
 					} else {
 						$option_value = '';
 					}
 
-					if ( isset( $value['sanitize'] ) && 'slug' === $value['sanitize'] ) {
+					if ( isset( $field['sanitize'] ) && 'slug' === $field['sanitize'] ) {
 						$option_value = sanitize_title( $option_value );
 					}
 
 					break;
 
 				case 'multiselect':
-					if ( isset( $_POST[ $value['id'] ] ) ) {
-						$option_value = llms_filter_input_sanitize_string( INPUT_POST, $value['id'], array( FILTER_REQUIRE_ARRAY ) );
+					if ( isset( $_POST[ $field['id'] ] ) ) {
+						$option_value = llms_filter_input_sanitize_string( INPUT_POST, $field['id'], array( FILTER_REQUIRE_ARRAY ) );
 					} else {
 						$option_value = '';
 					}
 					break;
 
-				// Custom handling.
 				default:
-					do_action( 'lifterlms_update_option_' . $type, $value );
 
-					break;
+					/**
+					 * Action run for external field types.
+					 * 
+					 * @since Unknown
+					 * @deprecated [version] Use `llms_update_option_{$type}` filter hook instead.
+					 *
+					 * @param type $arg Description.
+					 */
+					do_action_deprecated( "lifterlms_update_option_{$type}", array( $field ), '[version]' );
 
 			}
+			
+			/**
+			 * Filters the value of a settings field after it has been parsed and sanitized
+			 * and before it is saved to the database.
+			 *
+			 * The dynamic portion of this hook, `{$type}` refers to the setting field type:
+			 * email, text, checkbox, etc...
+			 * 
+			 * @since [version]
+			 *
+			 * @param string|null $option_value The sanitized option value or `null`.
+			 * @param array       $field        The settings field array.
+			 */
+			$option_value = apply_filters( "llms_update_option_{$type}", $option_value, $field );
 
 			if ( ! is_null( $option_value ) ) {
-				// Check if option is an array.
-				if ( strstr( $value['id'], '[' ) ) {
 
-					parse_str( $value['id'], $option_array );
+				if ( $is_array_option ) {
+
+					parse_str( $field['id'], $option_array );
 
 					// Option name is first key.
 					$option_name = current( array_keys( $option_array ) );
 
 					// Get old option value.
 					if ( ! isset( $update_options[ $option_name ] ) ) {
-						 $update_options[ $option_name ] = get_option( $option_name, array() ); }
+						$update_options[ $option_name ] = get_option( $option_name, array() );
+					}
 
 					if ( ! is_array( $update_options[ $option_name ] ) ) {
-						$update_options[ $option_name ] = array(); }
+						$update_options[ $option_name ] = array();
+					}
 
 					// Set keys and value.
 					$key = key( $option_array[ $option_name ] );
 
 					$update_options[ $option_name ][ $key ] = $option_value;
 
-					// Single value.
 				} else {
-					$update_options[ $value['id'] ] = $option_value;
+					$update_options[ $field['id'] ] = $option_value;
 				}
 			}
 
-			// Custom handling.
-			do_action( 'lifterlms_update_option', $value );
+			/**
+			 * Action run prior to the update of a LifterLMS setting field option.
+			 *
+			 * An update isn't guaranteed after this action if the method's logic can't
+			 * find a valid posted valued to persist to the database.
+			 * 
+			 * @since Unknown
+			 *
+			 * @param array $field The admin setting field array to be updated.
+			 */
+			do_action( 'lifterlms_update_option', $field );
+
 		}
+
 		// Now save the options.
 		foreach ( $update_options as $name => $value ) {
-
 			update_option( $name, $value );
-
 		}
 
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		return true;
+
+	}
+
+	/**
+	 * Retrieves the posted value for an array type setting field. 
+	 *
+	 * @since [version]
+	 *
+	 * @param string $id The field ID, eg: "my_setting[field_one]".
+	 * @return string Returns the (sanitized) posted value or an empty string if it wasn't posted.
+	 */
+	private static function get_array_field_posted_value( $id ) {
+
+		parse_str( $id, $parsed_id );
+		$opt_id  = current( array_keys( $parsed_id ) );
+		$opt_key = key( $parsed_id[ $opt_id ] );
+		$posted  = llms_filter_input_sanitize_string( INPUT_POST, $opt_id, array( FILTER_REQUIRE_ARRAY ) );
+
+		return $posted[ $opt_key ] ?? '';
+
 	}
 
 }

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -902,7 +902,7 @@ class LLMS_Admin_Settings {
 	/**
 	 * Save admin fields.
 	 *
-	 * Loops though a LifterLMS settings field options array and saves the values via `update_option()`.
+	 * Loops through a LifterLMS settings field options array and saves the values via `update_option()`.
 	 *
 	 * @since 1.0.0
 	 * @since 3.29.0 Unknown.
@@ -1089,7 +1089,7 @@ class LLMS_Admin_Settings {
 	private static function get_array_field_posted_value( $id ) {
 
 		parse_str( $id, $parsed_id );
-		$opt_id  = current( array_keys( $parsed_id ) );
+		$opt_id  = key( $parsed_id );
 		$opt_key = key( $parsed_id[ $opt_id ] );
 		$posted  = llms_filter_input_sanitize_string( INPUT_POST, $opt_id, array( FILTER_REQUIRE_ARRAY ) );
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Tests for LLMS_Admin_Settings class
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group admin_settings
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
+
+	/**
+	 * Test save_fields() with a single checkbox type field.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_checkbox() {
+
+		$id     = 'mock_checkbox_field';
+		$fields = array(
+			array(
+				'type' => 'checkbox',
+				'id'   => $id,
+			)
+		);
+		
+		// Previous value should be overwritten.
+		update_option( $id, 'previous val' );
+
+		// Post a new value.
+		$this->mockPostRequest( array(
+			$id => 'doensntmatter',
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( 'yes', get_option( $id ) );
+
+		// The element wasn't posted.
+		$this->mockPostRequest( array(
+			'mock' => '1',
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertSame( 'no', get_option( $id ) );
+
+	}
+
+	/**
+	 * Test save_fields() with an checkbox group (array) field.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_checkboxes() {
+
+		$id     = 'mock_checkbox_field';
+		$fields = array(
+			array(
+				'type' => 'checkbox',
+				'id'   => $id . '[one]',
+			),
+			array(
+				'type' => 'checkbox',
+				'id'   => $id . '[two]',
+			)
+		);
+		
+		// Previous value should be overwritten.
+		update_option( $id, 'previous val' );
+
+		// Post a new value.
+		$this->mockPostRequest( array(
+			$id => array(
+				'one' => 'doesntmatter',
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( array( 'one' => 'yes', 'two' => 'no' ), get_option( $id ) );
+
+		// The element wasn't posted.
+		$this->mockPostRequest( array(
+			'mock' => '1',
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertSame( array( 'one' => 'no', 'two' => 'no' ), get_option( $id ) );
+
+	}
+
+	/**
+	 * Tests save_fields() with regular fields.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_basic() {
+
+		$types = array(
+			'password',
+			'text',
+			'email',
+			'number',
+			'select',
+			'single_select_page',
+			'single_select_membership',
+			'radio',
+			'hidden',
+			'image',
+		);
+
+		foreach ( $types as $type ) {
+	
+			$id     = "mock_{$type}_field";
+			$val    = (string) time();
+			$fields = array(
+				array(
+					'type' => 'text',
+					'id'   => $id,
+				)
+			);
+			
+			// Previous value should be overwritten.
+			update_option( $id, 'previous val' );
+
+			// Post a new value.
+			$this->mockPostRequest( array(
+				$id => $val,
+			) );
+			$res = LLMS_Admin_Settings::save_fields( $fields );
+			$this->assertEquals( $val, get_option( $id ) );
+
+			// The element wasn't posted.
+			$this->mockPostRequest( array(
+				'mock' => '1',
+			) );
+			$res = LLMS_Admin_Settings::save_fields( $fields );
+			$this->assertSame( '', get_option( $id ) );
+
+		}
+
+	}
+
+	/**
+	 * Test save_fields() with array type fields.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_array() {
+
+		$id     = 'mock_text_arr_field';
+		$val    = (string) time();
+		$fields = array(
+			array(
+				'type' => 'text',
+				'id'   => $id . '[one]',
+			),
+			array(
+				'type' => 'text',
+				'id'   => $id . '[two]',
+			)
+		);
+
+		// Post only one value.
+		$this->mockPostRequest( array(
+			$id => array(
+				'one' => $val
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( 
+			array(
+				'one' => $val,
+				'two' => '',
+			),
+			get_option( $id )
+		);	
+
+		// Post only one value.
+		$this->mockPostRequest( array(
+			$id => array(
+				'two' => $val
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( 
+			array(
+				'one' => '',
+				'two' => $val,
+			),
+			get_option( $id )
+		);	
+
+		// Post both values.
+		$this->mockPostRequest( array(
+			$id => array(
+				'one' => "{$val}_1",
+				'two' => "{$val}_2",
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( 
+			array(
+				'one' => "{$val}_1",
+				'two' => "{$val}_2",
+			),
+			get_option( $id )
+		);	
+
+	}
+
+	/**
+	 * Test save_fields() with a secure option.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_secure_option() {
+
+		$id        = 'mock_secure_field_' . time();
+		$secure_id = strtoupper( $id );
+		$val       = (string) time();
+		$fields    = array(
+			array(
+				'type'          => 'text',
+				'id'            => $id,
+				'secure_option' => $secure_id,
+			),
+		);
+
+		update_option( $id, 'db-value' );
+
+		// A constant/env var isn't defined so save the value.
+		$this->mockPostRequest( array(
+			$id => $val,
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( $val, get_option( $id ) );	
+
+		// The secure value is defined so the DB value will be deleted.
+		putenv( "{$secure_id}=SECURE-VAL" );
+		$this->mockPostRequest( array(
+			$id => $val,
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals( 'NOT-FOUND', get_option( $id, 'NOT-FOUND' ) );	
+
+	}
+
+	/**
+	 * Test save_fields() for a setting field with no ID.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_fields_no_id() {
+
+		$actions = did_action( 'lifterlms_update_option' );
+
+		$fields = array(
+			array(
+				'type' => 'text',
+			),
+		);
+
+		$this->mockPostRequest( array(
+			'mock' => '1',
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertSame( $actions, did_action( 'lifterlms_update_option' ) );
+
+	}
+
+
+}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
@@ -277,5 +277,4 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 
 	}
 
-
 }


### PR DESCRIPTION
## Description

Adds handling for admin settings fields that nest options into an associative array.

We already have support for checkboxes to do this, this PR introduces the ability to do this with "regular" fields (like email, text, selects, etc...).

This will allow settings field code like this:

```php
$fields = array(
	array(
		'type' => 'text',
		'id'   => 'my_field[one]',
	),
	array(
		'type' => 'text',
		'id'   => 'my_field[two]',
	)
);
```

To save an associative array option:

```php
get_option( 'my_field' ) === array( 'one' => 'val_one', 'two' => 'val_two' )
```

This can be useful when creating options which will generally be used together, they can be retrieved together with a single database request / function call.


I've deprecated a (previously undocumented) action as that action should have likely been initially introduced as a filter since the action itself cannot act on the supplied argument.

## How has this been tested?

+ New unit tests -- I wrote a bunch of tests before modifying the code and then improved the code to ensure tests continue to pass for unaffected options

+ I've tested the checkbox code against the PDF plugin options which utilize the checkbox functionality already

+ I've added new options to the PayPal gateway which utilize the new code for a series of select fields.

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

