### PR TITLE
Fixed regression introduced in version 6.3.0 which prevented the Courses nav item from being customized in the BuddyPress profile nav menu 

### DIFF
--- a/.changelogs/issue_2142.yml
+++ b/.changelogs/issue_2142.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2142"
+entry: Fixed regression introduced in version 6.3.0 which prevented the Courses
+  nav item from being customized in the BuddyPress profile nav menu.

--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -70,14 +70,16 @@ class LLMS_PlayNice {
 	 *
 	 * @return void
 	 */
-	public function buddyboss_compatibilty() {
+	public function buddyboss_compatibility() {
 
 		if ( ! function_exists( 'is_plugin_active' ) || ! function_exists( 'bp_is_my_profile' ) || bp_is_my_profile() ) {
 			return;
 		}
 
-		if ( is_plugin_active( 'buddyboss-platform/bp-loader.php' ) ||
-				( is_multisite() && is_plugin_active_for_network( 'buddyboss-platform/bp-loader.php' ) ) ) {
+		if (
+			is_plugin_active( 'buddyboss-platform/bp-loader.php' ) ||
+			( is_multisite() && is_plugin_active_for_network( 'buddyboss-platform/bp-loader.php' ) )
+		) {
 			$plugin_data    = get_plugin_data( trailingslashit( WP_PLUGIN_DIR ) . 'buddyboss-platform/bp-loader.php' );
 			$plugin_version = ! empty( $plugin_data['Version'] ) ? $plugin_data['Version'] : 0;
 			if ( $plugin_version && version_compare( $plugin_version, '2.0.3', '>=' ) ) {

--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -54,7 +54,7 @@ class LLMS_PlayNice {
 		add_filter( 'wpe_heartbeat_allowed_pages', array( $this, 'wpe_heartbeat_allowed_pages' ) );
 
 		// BuddyBoss profile nav compatibility issue fix (the nav is set up at priority 6).
-		add_action( 'bp_init', array( $this, 'buddyboss_compatibilty' ), 5 );
+		add_action( 'bp_init', array( $this, 'buddyboss_compatibility' ), 5 );
 
 		// Load other playnice things based on the presence of other plugins.
 		add_action( 'init', array( $this, 'plugins_loaded' ), 11 );

--- a/includes/class.llms.playnice.php
+++ b/includes/class.llms.playnice.php
@@ -88,7 +88,7 @@ class LLMS_PlayNice {
 			}
 		}
 
-		// Do not add our profile nav items when not in front-end (and not in "my profile"), to avoid.
+		// Do not add our profile nav items when not in front-end (and not in "my profile"), to avoid a fatal error.
 		$bp_integration = llms()->integrations()->get_integration( 'buddypress' );
 		remove_action( 'bp_setup_nav', array( $bp_integration, 'add_profile_nav_items' ) );
 

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -119,19 +119,11 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	 * @since 6.3.0 Display all registered dashboard tabs (enabled in the settings) automatically.
 	 *              Use `bp_loggedin_user_domain()` to determine the current user domain
 	 *              to be used in the profile nav item's links, in favor of relying on the global `$bp`.
+	 * @since [version] Revert adding nav items only on bp my profile. @link https://github.com/gocodebox/lifterlms/issues/2142.
+	 *
 	 * @return void
 	 */
 	public function add_profile_nav_items() {
-
-		/**
-		 * Determine user domain to use.
-		 *
-		 * Note: we only display our tabs on the current user profile,
-		 * this implies we don't display our tabs to visitors.
-		 */
-		if ( ! bp_is_my_profile() ) {
-			return;
-		}
 
 		$profile_endpoints = $this->get_profile_endpoints();
 
@@ -139,8 +131,9 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 			return;
 		}
 
-		$user_domain    = bp_loggedin_user_domain();
-		$first_endpoint = reset( $profile_endpoints );
+		$bp_is_my_profile = bp_is_my_profile();
+		$user_domain      = bp_loggedin_user_domain();
+		$first_endpoint   = reset( $profile_endpoints );
 		/**
 		 * Filters the LifterLMS main nav item slug in the BuddyPress  profile menu.
 		 *
@@ -161,8 +154,8 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 				 *
 				 * @param string $label The LifterLMS main nav item label in the BuddyPress profile menu.
 				 */
-				'name'                => apply_filters( 'llms_buddypress_main_nav_item_label', _x( 'Courses', 'BuddyPress profile main nav item label', 'lifterlms' ) ),
-				'slug'                => $main_nav_slug,
+				'name'                    => apply_filters( 'llms_buddypress_main_nav_item_label', _x( 'Courses', 'BuddyPress profile main nav item label', 'lifterlms' ) ),
+				'slug'                    => $main_nav_slug,
 				/**
 				 * Filters the LifterLMS main nav item position in the BuddyPress profile menu.
 				 *
@@ -170,8 +163,9 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 				 *
 				 * @param string $position The LifterLMS main nav item position in the BuddyPress profile menu.
 				 */
-				'position'            => apply_filters( 'llms_buddypress_main_nav_item_position', 20 ),
-				'default_subnav_slug' => $first_endpoint['endpoint'],
+				'position'                => apply_filters( 'llms_buddypress_main_nav_item_position', 20 ),
+				'default_subnav_slug'     => $first_endpoint['endpoint'],
+				'show_for_displayed_user' => false,
 			)
 		);
 
@@ -186,6 +180,7 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 					'screen_function' => function() use ( $ep_key, $profile_endpoint ) {
 						$this->endpoint_content( $ep_key, $profile_endpoint['content'] );
 					},
+					'user_has_access' => $bp_is_my_profile,
 				)
 			);
 		}

--- a/includes/integrations/class.llms.integration.buddypress.php
+++ b/includes/integrations/class.llms.integration.buddypress.php
@@ -613,13 +613,14 @@ class LLMS_Integration_Buddypress extends LLMS_Abstract_Integration {
 	 * Get a list of custom endpoints to add to BuddyPress profile page.
 	 *
 	 * @since 6.3.0
+	 * @since [version] Remove redundant check on `is_null()`: `isset()` already implies it.
 	 *
 	 * @param bool $active_only If true, returns only active endpoints.
 	 * @return array
 	 */
 	public function get_profile_endpoints( $active_only = true ) {
 
-		if ( ! isset( $this->endpoints ) || is_null( $this->endpoints ) ) {
+		if ( ! isset( $this->endpoints ) ) {
 			$this->populate_profile_endpoints();
 		}
 


### PR DESCRIPTION
## Description
Fixes #2142 
This regression fix doesn't apply for BuddyBoss < 2.3.0, because of a bug on their side (fixed in 2.3.0) which could produce a fatal both in Appearance -> Menu and in the customizer.

## How has this been tested?
manually and (modified) unit tests.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

