### PR TITLE
Admin settings improvements

### DIFF
--- a/.changelogs/dashicon-helper.yml
+++ b/.changelogs/dashicon-helper.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+entry: Added admin settings helper function, `llms_get_dashicon_link()`,
+  intended to enable the addition of external resource helper links to settings
+  field descriptions.

--- a/.changelogs/issue_2132-1.yml
+++ b/.changelogs/issue_2132-1.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+comment: Added block display and margin settings to quiz label and 2022 theme.
+links:
+  - "#2132"
+entry: Fixes Hello Theme's word-break and spacing for quiz answer options and
+  fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/.changelogs/issue_2132-1.yml
+++ b/.changelogs/issue_2132-1.yml
@@ -1,7 +1,0 @@
-significance: patch
-type: fixed
-comment: Added block display and margin settings to quiz label and 2022 theme.
-links:
-  - "#2132"
-entry: Fixes Hello Theme's word-break and spacing for quiz answer options and
-  fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/.changelogs/issue_2132.yml
+++ b/.changelogs/issue_2132.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: fixed
+comment: Fixes Hello Theme's word-break and spacing for quiz answer options.
+  Also fixes text/label alignment in Twenty-Twenty-Two Theme.
+links:
+  - "#2132"
+entry: Added block display and margin setting to quiz label and
+  twenty-twenty-two compatibility.

--- a/.changelogs/issue_2132.yml
+++ b/.changelogs/issue_2132.yml
@@ -1,8 +1,8 @@
 significance: patch
 type: fixed
-comment: Fixes Hello Theme's word-break and spacing for quiz answer options.
-  Also fixes text/label alignment in Twenty-Twenty-Two Theme.
+comment: Added block display and margin setting to quiz label and
+  twenty-twenty-two compatibility.
 links:
   - "#2132"
-entry: Added block display and margin setting to quiz label and
-  twenty-twenty-two compatibility.
+entry: Fixes Hello Theme's word-break and spacing for quiz answer options.
+  Also fixes text/label alignment in Twenty-Twenty-Two Theme.

--- a/.changelogs/settings-after-html.yml
+++ b/.changelogs/settings-after-html.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: dev
+entry: Admin settings fields now display `after_html` for additional field types
+  which support `desc`.

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -165,6 +165,9 @@
 			margin: 0;
 			padding: 0;
 			position: relative;
+			label {
+				display: block;
+			}
 
 			&:last-child {
 				border-bottom: none;

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -165,9 +165,6 @@
 			margin: 0;
 			padding: 0;
 			position: relative;
-			label {
-				display: block;
-			}
 
 			&:last-child {
 				border-bottom: none;
@@ -209,6 +206,7 @@
 			}
 
 			label {
+				display: block;
 				margin: 0;
 				padding: 10px 20px;
 				position: relative;

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -628,7 +628,7 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * Enables forcing the logging status for the gateway on or off.
 		 *
 		 * The dynamic portion of this hook, `{$this->id}`, refers to the gateway's ID.
-		 * 
+		 *
 		 * @since [version]
 		 *
 		 * @param null|bool $forced The forced status. If `null`, the default status derived from the gateway options will be used.

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -237,13 +237,13 @@ class LLMS_Admin_Settings {
 	 *     @type string $css               An inline CSS style string.
 	 *     @type string $default           The default value of the setting.
 	 *     @type string $desc              The setting's description.
-	 *     @type boo    $desc_tooltip      If `true`, displays `$desc` in a hoverable tooltip.
+	 *     @type bool   $desc_tooltip      If `true`, displays `$desc` in a hoverable tooltip.
 	 *     @type string $value             The value of the setting. If supplied this will override the automatic setting retrieval
 	 *                                     using `get_option( $id, $default )`.
 	 *     @type array  $custom_attributes An associative array of custom HTML attributes to be added to the form element (the
 	 *                                     `<input>`, `<select>` etc...).
 	 *     @type bool   $disabled          If `true` adds the `llms-disabled-field` class to the settings field wrapper.
-	 *     @type bool   $required
+	 *     @type bool   $required          If `true`, text, email, number, and password fields will require user input.
 	 *     @type string $secure_option     The name of settings secure option equivalent. If specified, the fields value will be
 	 *                                     automatically removed from the database and the value will be masked when displayed on
 	 *                                     on screen. See {@see llms_get_secure_option()} for more information.

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -223,38 +223,38 @@ class LLMS_Admin_Settings {
 	 *     Array of field settings.
 	 *
 	 *     @type string $id                The setting ID. Used as the from element's `name` and `id` attributes and
-	 *           						   automatically correspond to an option key using the WP options API.
+	 *                                     automatically correspond to an option key using the WP options API.
 	 *     @type string $type              The field type. Accepts: 'title', 'table', 'subtitle', 'desc', 'custom-html',
-	 *           						   'custom-html-no-wrap', 'sectionstart', 'sectionend', 'button', 'hidden', 'keyval',
-	 *           						   'text', 'email', 'number', 'password', 'textarea', 'wpeditor', 'select', 'multiselect',
-	 *           						   'radio', 'checkbox', 'image', 'single_select_page', 'single_select_membership'.
+	 *                                     'custom-html-no-wrap', 'sectionstart', 'sectionend', 'button', 'hidden', 'keyval',
+	 *                                     'text', 'email', 'number', 'password', 'textarea', 'wpeditor', 'select', 'multiselect',
+	 *                                     'radio', 'checkbox', 'image', 'single_select_page', 'single_select_membership'.
 	 *     @type string $title             The title / name of the option as displayed to the user.
 	 *     @type string $name              For "button" fields only: used as HTML `name` attribute. If not supplied the default
-	 *           						   value "save" will be used. For other field types used as a fallback for `$title` if
-	 *           						   no value is supplied.
+	 *                                     value "save" will be used. For other field types used as a fallback for `$title` if
+	 *                                     no value is supplied.
 	 *     @type string $class             A space-separated list of CSS class names to apply the setting form element (the
 	 *                                     `<input>`, `<select>` etc...).
 	 *     @type string $css               An inline CSS style string.
 	 *     @type string $default           The default value of the setting.
-	 *     @type string $desc              The setting's description.              
+	 *     @type string $desc              The setting's description.
 	 *     @type boo    $desc_tooltip      If `true`, displays `$desc` in a hoverable tooltip.
 	 *     @type string $value             The value of the setting. If supplied this will override the automatic setting retrieval
-	 *           					       using `get_option( $id, $default )`.
+	 *                                     using `get_option( $id, $default )`.
 	 *     @type array  $custom_attributes An associative array of custom HTML attributes to be added to the form element (the
 	 *                                     `<input>`, `<select>` etc...).
 	 *     @type bool   $disabled          If `true` adds the `llms-disabled-field` class to the settings field wrapper.
-	 *     @type bool   $required          
+	 *     @type bool   $required
 	 *     @type string $secure_option     The name of settings secure option equivalent. If specified, the fields value will be
 	 *                                     automatically removed from the database and the value will be masked when displayed on
 	 *                                     on screen. See {@see llms_get_secure_option()} for more information.
 	 *     @type string $sanitize          Automatically apply the specified sanitization to the value before storing and outputting
-	 *           						   the stored value. Supported filters:
-	 *           						     + "slug": Uses `sanitize_title()` on the value when storing and `urldecode()` when displaying.
+	 *                                     the stored value. Supported filters:
+	 *                                       + "slug": Uses `sanitize_title()` on the value when storing and `urldecode()` when displaying.
 	 *     @type string $after_html        Additional HTML to add after the field's form element.
 	 *     @type array  $editor_settings   Used with "wpeditor" field type only. An array of options to pass to `wp_editor()` as the `$settings` argument.
 	 *     @type array  $options           For "select", "multiselect", and "radio" fields, an array of key/value pairs where the
-	 *           						   key is the setting value stored in database and the value is the setting label displayed
-	 *           						   on screen.
+	 *                                     key is the setting value stored in database and the value is the setting label displayed
+	 *                                     on screen.
 	 * }
 	 * @return void
 	 */
@@ -769,22 +769,25 @@ class LLMS_Admin_Settings {
 	 *
 	 * @since 1.4.5
 	 * @since [version] Use `wp_parse_args()` to simplify method logic & add `after_html` default.
-	 * 
+	 *
 	 * @param array $field Associative array of field data, {@see LLMS_Admin_Settings::output_field()} for a full description.
 	 * @return array
 	 */
 	public static function set_field_defaults( $field = array() ) {
 
-		$field = wp_parse_args( $field, array(
-			'id'           => '',
-			'title'        => $field['name'] ?? '',
-			'class'        => '',
-			'css'          => '',
-			'default'      => '',
-			'desc'         => '',
-			'desc_tooltip' => '',
-			'after_html'   => '',
-		) );
+		$field = wp_parse_args(
+			$field,
+			array(
+				'id'           => '',
+				'title'        => $field['name'] ?? '',
+				'class'        => '',
+				'css'          => '',
+				'default'      => '',
+				'desc'         => '',
+				'desc_tooltip' => '',
+				'after_html'   => '',
+			)
+		);
 
 		return $field;
 

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -135,6 +135,49 @@ function llms_get_add_on( $addon = array(), $lookup_key = 'id' ) {
 }
 
 /**
+ * Retrieves HTML for a Dashicon wrapped in an anchor.
+ *
+ * A utility for adding links to external documentation.
+ *
+ * @since [version]
+ *
+ * @param string $url The URL of the anchor tag.
+ * @param array  $args {
+ *     An array of optional configuration options.
+ *
+ *     @type integer $size  The size of the icon. Default 18.
+ *     @type string  $title The title attribute of the anchor tag. Default: "More information".
+ *     @type string  $icon  The Dashicon icon to use, {@see @link https://developer.wordpress.org/resource/dashicons/}. Default: "external".
+ * }
+ * @return string 
+ */
+function llms_get_dashicon_link( $url, $args = array() ) {
+
+	$args = wp_parse_args( 
+		$args,
+		array(
+			'size'   => 18,
+			'title'  => esc_attr__( 'More information', 'lifterlms' ),
+			'icon'   => 'external',
+		)
+	);
+
+	$dashicon = sprintf(
+		'<span class="dashicons dashicons-%1$s" style="font-size:%2$dpx;width:%2$dpx;height:%2$dpx"></span>',
+		esc_attr( $args['icon'] ),
+		$args['size']
+	);
+
+	return sprintf(
+		'<a href="%1$s" style="text-decoration:none;" target="_blank" rel="noreferrer" title="%2$s">%3$s</a>',
+		esc_url( $url ),
+		esc_attr( $args['title'] ),
+		$dashicon
+	);
+
+}
+
+/**
  * Get an array of available course/membership sales page options
  *
  * @return   array

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -149,16 +149,16 @@ function llms_get_add_on( $addon = array(), $lookup_key = 'id' ) {
  *     @type string  $title The title attribute of the anchor tag. Default: "More information".
  *     @type string  $icon  The Dashicon icon to use, {@see @link https://developer.wordpress.org/resource/dashicons/}. Default: "external".
  * }
- * @return string 
+ * @return string
  */
 function llms_get_dashicon_link( $url, $args = array() ) {
 
-	$args = wp_parse_args( 
+	$args = wp_parse_args(
 		$args,
 		array(
-			'size'   => 18,
-			'title'  => esc_attr__( 'More information', 'lifterlms' ),
-			'icon'   => 'external',
+			'size'  => 18,
+			'title' => esc_attr__( 'More information', 'lifterlms' ),
+			'icon'  => 'external',
 		)
 	);
 

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -92,7 +92,7 @@ class LLMS_Twenty_Twenty_Two {
 			$styles[] = '.llms-form-field input, .llms-form-field textarea, .llms-form-field select { padding: 6px 10px }';
 
 			// Question layout.
-			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); margin-top: 0; }';
+			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { margin-top: 0; }';
 
 			// Payment gateway stylized radio buttons.
 			$styles[] = LLMS_Theme_Support::get_css(

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -92,7 +92,7 @@ class LLMS_Twenty_Twenty_Two {
 			$styles[] = '.llms-form-field input, .llms-form-field textarea, .llms-form-field select { padding: 6px 10px }';
 
 			// Question layout.
-			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); }';
+			$styles[] = '.llms-question-wrapper ol.llms-question-choices li.llms-choice .llms-choice-text { width: calc( 100% - 110px); margin-top: 0; }';
 
 			// Payment gateway stylized radio buttons.
 			$styles[] = LLMS_Theme_Support::get_css(

--- a/includes/theme-support/class-llms-twenty-twenty-two.php
+++ b/includes/theme-support/class-llms-twenty-twenty-two.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/ThemeSupport/Classes
  *
  * @since 5.8.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -72,6 +72,7 @@ class LLMS_Twenty_Twenty_Two {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Fixed stretched images in questions with pictures, and images in quiz/questions description.
+	 * @since [version] Fixed label/text alignment by removing text’s margin top. Also, removed now outdated width rule.
 	 *
 	 * @param string|null $context Inline CSS context. Accepts "editor" to define styles loaded within the block editor or `null` for frontend styles.
 	 * @return string

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
@@ -11,6 +11,35 @@
  */
 class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 
+	public function test_set_field_defaults() {
+
+		$expected = array(
+			'id'           => '',
+			'title'        => '',
+			'class'        => '',
+			'css'          => '',
+			'default'      => '',
+			'desc'         => '',
+			'desc_tooltip' => '',
+			'after_html'   => '',
+		);
+
+		$this->assertEquals( $expected, LLMS_Admin_Settings::set_field_defaults( array() ) );
+
+		// Test all default values will be set.
+		foreach ( array_keys( $expected ) as $key ) {
+			$expected[ $key ] = 'abc';
+			$this->assertEquals( $expected, LLMS_Admin_Settings::set_field_defaults( array( $key => 'abc' ) ) );
+			$expected[ $key ] = '';
+		}
+
+		// Title fallback to name.
+		$expected['name']  = 'abc';
+		$expected['title'] = 'abc';
+		$this->assertEquals( $expected, LLMS_Admin_Settings::set_field_defaults( array( 'name' => 'abc' ) ) );
+
+	}
+
 	/**
 	 * Test save_fields() with a single checkbox type field.
 	 *

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
@@ -11,6 +11,13 @@
  */
 class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 
+	/**
+	 * Tests set_field_defaults().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	public function test_set_field_defaults() {
 
 		$expected = array(

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-admin.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-admin.php
@@ -101,6 +101,38 @@ class LLMS_Test_Functions_Admin extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test llms_get_dashicon_link().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_get_dashicon_link() {
+
+		$url = 'https://mock.tld/fake';
+
+		// Defaults.
+		$this->assertEquals(
+			'<a href="https://mock.tld/fake" style="text-decoration:none;" target="_blank" rel="noreferrer" title="More information"><span class="dashicons dashicons-external" style="font-size:18px;width:18px;height:18px"></span></a>',
+			llms_get_dashicon_link( $url )
+		);
+
+		// Custom args.
+		$this->assertEquals(
+			'<a href="https://mock.tld/fake" style="text-decoration:none;" target="_blank" rel="noreferrer" title="Something..."><span class="dashicons dashicons-fake" style="font-size:22px;width:22px;height:22px"></span></a>',
+			llms_get_dashicon_link( 
+				$url,
+				array(
+					'size'   => 22,
+					'title'  => 'Something...',
+					'icon'   => 'fake',
+				)
+			)
+		);
+
+	}
+
+	/**
 	 * test the llms_get_sales_page_types() function
 	 *
 	 * @since 3.23.0


### PR DESCRIPTION
## Description

+ Always show the `after_html` for settings fields that support descriptions
+ Adds a utility method to standardize external resource links in settings descriptions

## How has this been tested?

+ Manually
+ new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
New dev-related functions

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

