### PR TITLE
When saving an admin setting (text/textarea) which has a maxlength of N chars, trim it to that length

### DIFF
--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -935,6 +935,7 @@ class LLMS_Admin_Settings {
 	 * @since 3.35.2 Don't strip tags on editor and textarea fields that allow HTML.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
 	 * @since [version] Add handling for array fields for standard input types.
+	 *               Account for the `maxlength` input text and textarea attribute.
 	 *
 	 * @param array $settings Opens array to output
 	 * @return boolean
@@ -1034,6 +1035,11 @@ class LLMS_Admin_Settings {
 					 */
 					do_action_deprecated( "lifterlms_update_option_{$type}", array( $field ), '[version]' );
 
+			}
+
+			// Special treatment for the 'maxlength' attribute.
+			if ( in_array( $type, array( 'text', 'textarea', true ) ) && isset( $field['custom_attributes']['maxlength'] ) ) {
+				$option_value = llms_trim_string( $option_value, (int) $field['custom_attributes']['maxlength'], '' );
 			}
 
 			/**

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -935,7 +935,7 @@ class LLMS_Admin_Settings {
 	 * @since 3.35.2 Don't strip tags on editor and textarea fields that allow HTML.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
 	 * @since [version] Add handling for array fields for standard input types.
-	 *               Account for the `maxlength` input text and textarea attribute.
+	 *              Account for the `maxlength` input text and textarea attribute.
 	 *
 	 * @param array $settings Opens array to output
 	 * @return boolean
@@ -1038,7 +1038,7 @@ class LLMS_Admin_Settings {
 			}
 
 			// Special treatment for the 'maxlength' attribute.
-			if ( in_array( $type, array( 'text', 'textarea', true ) ) && isset( $field['custom_attributes']['maxlength'] ) ) {
+			if ( in_array( $type, array( 'text', 'textarea' ), true ) && isset( $field['custom_attributes']['maxlength'] ) ) {
 				$option_value = llms_trim_string( $option_value, (int) $field['custom_attributes']['maxlength'], '' );
 			}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-settings.php
@@ -63,7 +63,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 				'id'   => $id,
 			)
 		);
-		
+
 		// Previous value should be overwritten.
 		update_option( $id, 'previous val' );
 
@@ -103,7 +103,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 				'id'   => $id . '[two]',
 			)
 		);
-		
+
 		// Previous value should be overwritten.
 		update_option( $id, 'previous val' );
 
@@ -148,7 +148,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 		);
 
 		foreach ( $types as $type ) {
-	
+
 			$id     = "mock_{$type}_field";
 			$val    = (string) time();
 			$fields = array(
@@ -157,7 +157,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 					'id'   => $id,
 				)
 			);
-			
+
 			// Previous value should be overwritten.
 			update_option( $id, 'previous val' );
 
@@ -208,13 +208,13 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 			),
 		) );
 		$res = LLMS_Admin_Settings::save_fields( $fields );
-		$this->assertEquals( 
+		$this->assertEquals(
 			array(
 				'one' => $val,
 				'two' => '',
 			),
 			get_option( $id )
-		);	
+		);
 
 		// Post only one value.
 		$this->mockPostRequest( array(
@@ -223,13 +223,13 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 			),
 		) );
 		$res = LLMS_Admin_Settings::save_fields( $fields );
-		$this->assertEquals( 
+		$this->assertEquals(
 			array(
 				'one' => '',
 				'two' => $val,
 			),
 			get_option( $id )
-		);	
+		);
 
 		// Post both values.
 		$this->mockPostRequest( array(
@@ -239,13 +239,13 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 			),
 		) );
 		$res = LLMS_Admin_Settings::save_fields( $fields );
-		$this->assertEquals( 
+		$this->assertEquals(
 			array(
 				'one' => "{$val}_1",
 				'two' => "{$val}_2",
 			),
 			get_option( $id )
-		);	
+		);
 
 	}
 
@@ -276,7 +276,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 			$id => $val,
 		) );
 		$res = LLMS_Admin_Settings::save_fields( $fields );
-		$this->assertEquals( $val, get_option( $id ) );	
+		$this->assertEquals( $val, get_option( $id ) );
 
 		// The secure value is defined so the DB value will be deleted.
 		putenv( "{$secure_id}=SECURE-VAL" );
@@ -284,7 +284,7 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 			$id => $val,
 		) );
 		$res = LLMS_Admin_Settings::save_fields( $fields );
-		$this->assertEquals( 'NOT-FOUND', get_option( $id, 'NOT-FOUND' ) );	
+		$this->assertEquals( 'NOT-FOUND', get_option( $id, 'NOT-FOUND' ) );
 
 	}
 
@@ -311,6 +311,81 @@ class LLMS_Test_Admin_Settings extends LLMS_UnitTestCase {
 		$res = LLMS_Admin_Settings::save_fields( $fields );
 		$this->assertSame( $actions, did_action( 'lifterlms_update_option' ) );
 
+	}
+
+
+	/**
+	 * Test save_fields() on fields with maxlength attribute.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_save_field_with_maxlength() {
+
+		// Checking on an array of fields.
+		$id     = 'mock_text_arr_field';
+		$val    = '123456789101112';
+		$fields = array(
+			array(
+				'type' => 'text',
+				'id'   => $id . '[one]',
+				'custom_attributes' => array(
+					'maxlength' => 9,
+				)
+			),
+			array(
+				'type' => 'text',
+				'id'   => $id . '[two]',
+			)
+		);
+
+		// Post only one value.
+		$this->mockPostRequest( array(
+			$id => array(
+				'one' => $val
+			),
+		) );
+
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals(
+			array(
+				'one' => '123456789',
+				'two' => '',
+			),
+			get_option( $id )
+		);
+
+		// Post only one value.
+		$this->mockPostRequest( array(
+			$id => array(
+				'two' => $val
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals(
+			array(
+				'one' => '',
+				'two' => $val,
+			),
+			get_option( $id )
+		);
+
+		// Post both values.
+		$this->mockPostRequest( array(
+			$id => array(
+				'one' => $val,
+				'two' => $val,
+			),
+		) );
+		$res = LLMS_Admin_Settings::save_fields( $fields );
+		$this->assertEquals(
+			array(
+				'one' => '123456789',
+				'two' => $val,
+			),
+			get_option( $id )
+		);
 	}
 
 }


### PR DESCRIPTION
## Description
We use the maxlength attribute here:
https://github.com/gocodebox/lifterlms-gateway-paypal/pull/80/files#diff-74f1922674dab64b0f53fc22d5cba5911a855f02d9b31d552920cc9d15884e9fR96

## How has this been tested?
manually and new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

