### PR TITLE
Add llms_is_option_secure().

### DIFF
--- a/includes/functions/llms-functions-options.php
+++ b/includes/functions/llms-functions-options.php
@@ -56,7 +56,7 @@ function llms_get_secure_option( $secure_name, $default = false, $db_name = '' )
 function llms_is_option_secure( $option_name ) {
 
 	// Sanity check for empty strings to prevent `getenv()` from returning ALL variables.
-	if ( empty( $option_name ) ) {
+	if ( '' === $option_name ) {
 		return false;
 	}
 

--- a/includes/functions/llms-functions-options.php
+++ b/includes/functions/llms-functions-options.php
@@ -40,7 +40,31 @@ function llms_get_secure_option( $secure_name, $default = false, $db_name = '' )
 		return get_option( $db_name, $default );
 	}
 
-	// Return default.
+	// Return the default value.
 	return $default;
 
+}
+
+/**
+ * Determines if the given option name is stored in a "secure" manner, i.e. an environment variable or a constant.
+ *
+ * @since [version]
+ *
+ * @param string $option_name The name of the possibly secure option.
+ * @return bool Returns `true` if the option is defined in an environment variable or a constant, else `false`.
+ */
+function llms_is_option_secure( $option_name ) {
+
+	// Sanity check for empty strings to prevent `getenv()` from returning ALL variables.
+	if ( empty( $option_name ) ) {
+		return false;
+	}
+
+	// Note: Do not store `false` values in an environment variable
+	// because `getenv()` returns `false` if the variable is not set.
+	if ( false !== getenv( $option_name ) ) {
+		return true;
+	}
+
+	return defined( $option_name );
 }

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-options.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-options.php
@@ -44,4 +44,31 @@ class LLMS_Test_Functions_Options extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Tests the llms_is_option_secure() function.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_is_option_secure() {
+
+		// Empty name.
+		$this->assertFalse( llms_is_option_secure( '' ) );
+
+		// Environment variable.
+		putenv( 'FOO=BAR' );
+		$this->assertTrue( llms_is_option_secure( 'FOO' ) );
+
+		// Unset environment variable.
+		putenv( 'FOO' );
+		$this->assertFalse( llms_is_option_secure( 'FOO' ) );
+
+		// Undefined constant.
+		$this->assertFalse( llms_is_option_secure( 'F00D' ) );
+
+		// Defined constant.
+		define( 'F00D', 'BAD' );
+		$this->assertTrue( llms_is_option_secure( 'F00D' ) );
+	}
 }


### PR DESCRIPTION
## Description
Adds a `llms_is_option_secure()` function that tests if the given option is defined in an environment variable of a constant.

Fixes part of gocodebox/lifterlms-gateway-paypal#73.

## How has this been tested?
New unit test.


## Types of changes
New development feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

