### PR TITLE
Add additional prefixes to llms_strip_prefixes()

### DIFF
--- a/includes/forms/controllers/class.llms.controller.account.php
+++ b/includes/forms/controllers/class.llms.controller.account.php
@@ -79,6 +79,14 @@ class LLMS_Controller_Account {
 		$order->set_status( $new_status );
 		$order->add_note( $note );
 
+		/**
+		 * Action triggered after a recurring subscription is cancelled from the student dashboard by the student.
+		 * 
+		 * @since 3.17.8
+		 *
+		 * @param LLMS_Order $order The order object.
+		 * @param integer    $uid   The WP_User ID the student who cancelled the subscription.
+		 */
 		do_action( 'llms_subscription_cancelled_by_student', $order, $uid );
 
 	}

--- a/includes/functions/llms-functions-options.php
+++ b/includes/functions/llms-functions-options.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.29.0
- * @version 3.29.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -60,8 +60,10 @@ function llms_is_option_secure( $option_name ) {
 		return false;
 	}
 
-	// Note: Do not store `false` values in an environment variable
-	// because `getenv()` returns `false` if the variable is not set.
+	/*
+	 * Note: Do not store `false` values in an environment variable
+	 * because `getenv()` returns `false` if the variable is not set.
+	 */
 	if ( false !== getenv( $option_name ) ) {
 		return true;
 	}

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -1201,11 +1201,12 @@ function llms_set_time_limit( $limit = 0 ) {
 /**
  * Strips a list of prefixes from the start of a string.
  *
- * By default, strips `llms_` or `lifterlms_`. Other prefixes may be provided.
+ * By default, strips `llms_`, `lifterlms_`, 'llms-', or 'lifterlms-'. Other prefixes may be provided.
  *
  * Will strip only the first prefix found from the list of supplied prefixes.
  *
  * @since 6.0.0
+ * @since [version] Added `llms-` and `lifterlms-` as additional default prefixes to strip.
  *
  * @param string   $string   String to modify.
  * @param string[] $prefixes List of prefixs.
@@ -1213,7 +1214,7 @@ function llms_set_time_limit( $limit = 0 ) {
  */
 function llms_strip_prefixes( $string, $prefixes = array() ) {
 
-	$prefixes = empty( $prefixes ) ? array( 'llms_', 'lifterlms_' ) : $prefixes;
+	$prefixes = empty( $prefixes ) ? array( 'llms_', 'lifterlms_', 'llms-', 'lifterlms-' ) : $prefixes;
 
 	foreach ( $prefixes as $prefix ) {
 		if ( 0 === strpos( $string, $prefix ) ) {

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-core.php
@@ -1024,16 +1024,25 @@ class LLMS_Test_Functions_Core extends LLMS_UnitTestCase {
 			array( 'llms_test', array(), 'test' ),
 			array( 'lifterlms_test', null, 'test' ),
 			array( 'lifterlms_test', array(), 'test' ),
+			array( 'llms-test', null, 'test' ),
+			array( 'llms-test', array(), 'test' ),
+			array( 'lifterlms-test', null, 'test' ),
+			array( 'lifterlms-test', array(), 'test' ),
+
 
 			// Only strip from the start of the string.
 			array( 'test_llms_test', null, 'test_llms_test' ),
 			array( 'test_lifterlms_test', null, 'test_lifterlms_test' ),
 			array( 'test_llms_', null, 'test_llms_' ),
 			array( 'test_lifterlms_', null, 'test_lifterlms_' ),
+			array( 'test_llms-', null, 'test_llms-' ),
+			array( 'test_lifterlms-', null, 'test_lifterlms-' ),
 
 			// Don't strip multiple prefixes.
 			array( 'llms_lifterlms_test', null, 'lifterlms_test' ),
 			array( 'lifterlms_llms_test', null, 'llms_test' ),
+			array( 'llms-lifterlms-test', null, 'lifterlms-test' ),
+			array( 'lifterlms-llms-test', null, 'llms-test' ),
 
 			// Custom prefix.
 			array( 'test_llms_test', array( 'test_' ), 'llms_test' ),


### PR DESCRIPTION
## Description
Add lifterlms- and llms- to default stripped prefixes

## How has this been tested?
New & existing unit tests

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

