### PR TITLE
gateway temp ids

### DIFF
--- a/includes/controllers/class-llms-controller-checkout.php
+++ b/includes/controllers/class-llms-controller-checkout.php
@@ -538,8 +538,8 @@ class LLMS_Controller_Checkout {
 			return new WP_Error( 'switch-source-action-invalid', __( 'Invalid action.', 'lifterlms' ), 'error' );
 		}
 
-		// Temporarily store the gateway IDs so the previous values are accessible to the old gateway after the source switch. 
-		$order->set( 
+		// Temporarily store the gateway IDs so the previous values are accessible to the old gateway after the source switch.
+		$order->set(
 			'temp_gateway_ids',
 			array(
 				'customer'     => $order->get( 'gateway_customer_id' ),

--- a/includes/controllers/class-llms-controller-checkout.php
+++ b/includes/controllers/class-llms-controller-checkout.php
@@ -541,10 +541,28 @@ class LLMS_Controller_Checkout {
 		// Temporarily store the gateway IDs so the previous values are accessible to the old gateway after the source switch.
 		$order->set(
 			'temp_gateway_ids',
-			array(
-				'customer'     => $order->get( 'gateway_customer_id' ),
-				'source'       => $order->get( 'gateway_source_id' ),
-				'subscription' => $order->get( 'gateway_subscription_id' ),
+			/**
+			 * Filters the gateway IDs that are temporarily stored during a payment source switch.
+			 *
+			 * @since [version]
+			 *
+			 * @param array      $temp_ids {
+			 *     An array of gateway-related IDs to be temporarily cached.
+			 *
+			 *     @type string customer     The value of the `gateway_customer_id` property.
+			 *     @type string source       The value of the `gateway_source_id` property.
+			 *     @type string subscription The value of the `gateway_subscription_id` property.
+			 * }
+			 * @param LLMS_Order $order     The order object.
+			 */
+			apply_filters(
+				'llms_order_set_temp_gateway_ids',
+				array(
+					'customer'     => $order->get( 'gateway_customer_id' ),
+					'source'       => $order->get( 'gateway_source_id' ),
+					'subscription' => $order->get( 'gateway_subscription_id' ),
+				),
+				$order
 			)
 		);
 

--- a/includes/controllers/class-llms-controller-checkout.php
+++ b/includes/controllers/class-llms-controller-checkout.php
@@ -538,6 +538,16 @@ class LLMS_Controller_Checkout {
 			return new WP_Error( 'switch-source-action-invalid', __( 'Invalid action.', 'lifterlms' ), 'error' );
 		}
 
+		// Temporarily store the gateway IDs so the previous values are accessible to the old gateway after the source switch. 
+		$order->set( 
+			'temp_gateway_ids',
+			array(
+				'customer'     => $order->get( 'gateway_customer_id' ),
+				'source'       => $order->get( 'gateway_source_id' ),
+				'subscription' => $order->get( 'gateway_subscription_id' ),
+			)
+		);
+
 		return compact( 'old_gateway', 'new_gateway', 'order' );
 
 	}
@@ -585,6 +595,9 @@ class LLMS_Controller_Checkout {
 		 * @param string     $old_gateway The payment gateway ID of the previous gateway.
 		 */
 		do_action( 'llms_order_payment_source_switched', $order, $new_gateway, $old_gateway );
+
+		// Cleanup temp data.
+		delete_post_meta( $order->get( 'id' ), '_llms_temp_gateway_ids' );
 
 	}
 

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -67,6 +67,15 @@ defined( 'ABSPATH' ) || exit;
  * @property float  $sale_price              Sale price before coupon adjustments.
  * @property float  $sale_value              The value of the sale, `$original_total` - `$sale_price`.
  * @property string $start_date              Date when access was initially granted; this is used to determine when access expires.
+ * @property array  $temp_gateway_ids        {
+ *     An associative array containing gateway ids. The gateway IDs are cached in this meta property while the source is being
+ *     switched. Any gateway running actions when a source is switched may need to know the previous source IDs which might be
+ *     cleared or overwritten by other gateways during the switch.
+ *
+ *     @type string customer     The value of the `gateway_customer_id` property when the source switch starts.
+ *     @type string source       The value of the `gateway_source_id` property when the source switch starts.
+ *     @type string subscription The value of the `gateway_subscription_id` property when the source switch starts.
+ * }
  * @property float  $total                   Actual price of the order, after applicable sale & coupon adjustments.
  * @property int    $trial_length            Length of the trial. Combined with $trial_period to determine the actual length of the trial.
  * @property string $trial_offer             Whether or not there was a trial offer applied to the order, either yes or no.

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -163,6 +163,8 @@ class LLMS_Order extends LLMS_Post_Model {
 		'date_next_payment'    => 'text',
 		'date_trial_end'       => 'text',
 
+		'temp_gateway_ids'     => 'array',
+
 	);
 
 	/**


### PR DESCRIPTION
## Description

Adds a transient order property to be used by gateways during recurring order payment source switching actions.

A gateway (such as PayPal CP) may need to perform clean-up actions following a successful source switch. For example, if switching from a PayPal CP subscription to Stripe, the `gateway_subscription_id` *prior* to the switch is a PayPal subscription ID that the PayPal gateway requires in order to cancel the PayPal subscription.

This PR "caches" the order's gateway ID properties so that gateways have access to original IDs before the switch. The IDs are available for the new `llms_order_payment_source_switched` (triggered during the same request) and are deleted immediately after.

## How has this been tested?

+ Manually
+ New unit tests 

## Screenshots <!-- if applicable -->

## Types of changes
+ New "feature"

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

