### PR TITLE
Update webpack.config.js

### DIFF
--- a/.changelogs/eri-trabiccolo-patch-1.yml
+++ b/.changelogs/eri-trabiccolo-patch-1.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: dev
+entry: Updated webpack.config so to allow the deletion of files inside the
+  protected directories (assets/{js|css}).

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -4,7 +4,7 @@
  * @package LifterLMS_Groups/Scripts/Dev
  *
  * @since Unknown
- * @version 3.0.0
+ * @version [version]
  */
 
 // Deps.
@@ -84,6 +84,7 @@ function setupEntry( js, srcPath ) {
  * @since 1.2.1
  * @since 2.0.0 Remove default DependencyExtractionWebpackPlugin in favor of our custom loader.
  * @since 2.1.0 Added `cleanAfterEveryBuildPatterns` parameter.
+ * @since [version] Add `protectWebpackAssets = false` to the `CleanWebpackPlugin` config. 
  *
  * @param {Object[]} plugins                      Array of plugin objects or classes.
  * @param {String[]} css                          Array of CSS file slugs.

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -104,7 +104,8 @@ function setupPlugins( plugins, css, prefix, cleanAfterEveryBuildPatterns ) {
 					...plugin.cleanAfterEveryBuildPatterns,
 					...cleanAfterEveryBuildPatterns,
 				];
-
+				// Allow removal of current webpack assets.
+				plugin.protectWebpackAssets = false;
 			}
 
 			return plugin;


### PR DESCRIPTION

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
This patch would allow us to delete files inside the "protected" directories, e.g. in
https://github.com/gocodebox/lifterlms-groups/tree/trunk/assets/js
would allow us to delete `js/*.asset.php`
https://github.com/johnagan/clean-webpack-plugin/issues/121#issuecomment-479826571


## How has this been tested?
I'm testing it while working on the theme, so I guess it should be better tested throughout the projects using this config.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

