### PR TITLE
Make sure the current user can edit the lesson, when changing its com…

### DIFF
--- a/.changelogs/check-can-mark-complete.yml
+++ b/.changelogs/check-can-mark-complete.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Make sure the current user can edit the lesson, when changing its
+  completion status from the admin reporting.

--- a/includes/controllers/class.llms.controller.lesson.progression.php
+++ b/includes/controllers/class.llms.controller.lesson.progression.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Controllers/Classes
  *
  * @since 3.17.1
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -80,6 +80,7 @@ class LLMS_Controller_Lesson_Progression {
 	 *
 	 * @since 3.29.0
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 * @since [version] Check the current user can edit the lesson they're going to mark complete/incomplete.
 	 *
 	 * @return void
 	 */
@@ -94,7 +95,7 @@ class LLMS_Controller_Lesson_Progression {
 		$student_id = absint( llms_filter_input( INPUT_POST, 'student_id' ) );
 
 		// Missing required data.
-		if ( empty( $action ) || empty( $lesson_id ) || empty( $student_id ) ) {
+		if ( empty( $action ) || empty( $lesson_id ) || empty( $student_id ) || ! current_user_can( 'edit_post', $lesson_id ) ) {
 			return;
 		}
 

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-lesson-progression.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-lesson-progression.php
@@ -26,6 +26,7 @@ class LLMS_Test_Controller_Lesson_Progression extends LLMS_UnitTestCase {
 	 * Test the handle_admin_managment_forms() method.
 	 *
 	 * @since 3.29.0
+	 * @since [version] Added tests on user caps.
 	 *
 	 * @return void
 	 */
@@ -62,21 +63,42 @@ class LLMS_Test_Controller_Lesson_Progression extends LLMS_UnitTestCase {
 		$this->assertEquals( 0, did_action( 'llms_mark_incomplete' ) );
 		$this->assertEquals( 0, did_action( 'llms_mark_complete' ) );
 
-		// All data but invalid action..
+		// All data but invalid action...
 		$data['llms-lesson-action'] = 'fake';
 		$this->mockPostRequest( $data );
 		$class->handle_admin_managment_forms();
 		$this->assertEquals( 0, did_action( 'llms_mark_incomplete' ) );
 		$this->assertEquals( 0, did_action( 'llms_mark_complete' ) );
 
-		// Mark the lesson complete..
+		// Mark lessons complete/incomplete as users with no adequate caps, or no user.
+		wp_set_current_user( 0 );
+
+		// Mark the lesson complete...
+		$data['llms-lesson-action'] = 'complete';
+		$this->mockPostRequest( $data );
+		$class->handle_admin_managment_forms();
+		$this->assertEquals( 0, did_action( 'llms_mark_incomplete' ) );
+		$this->assertEquals( 0, did_action( 'llms_mark_complete' ) );
+
+		// Mark it incomplete...
+		$data['llms-lesson-action'] = 'incomplete';
+		$this->mockPostRequest( $data );
+		$class->handle_admin_managment_forms();
+		$this->assertEquals( 0, did_action( 'llms_mark_incomplete' ) );
+		$this->assertEquals( 0, did_action( 'llms_mark_complete' ) );
+
+		// Mark lessons complete/incomplete as users with adequate caps.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'lms_manager' ) ) );
+		$data['llms-admin-progression-nonce'] = wp_create_nonce( 'llms-admin-lesson-progression' );
+
+		// Mark the lesson complete...
 		$data['llms-lesson-action'] = 'complete';
 		$this->mockPostRequest( $data );
 		$class->handle_admin_managment_forms();
 		$this->assertEquals( 0, did_action( 'llms_mark_incomplete' ) );
 		$this->assertEquals( 1, did_action( 'llms_mark_complete' ) );
 
-		// Mark it incomplete..
+		// Mark it incomplete...
 		$data['llms-lesson-action'] = 'incomplete';
 		$this->mockPostRequest( $data );
 		$class->handle_admin_managment_forms();


### PR DESCRIPTION
…pletion status from the admin reporting


## Description
see https://github.com/gocodebox/lifterlms-advanced-videos/pull/92#discussion_r945893851

## How has this been tested?
new unit tests

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

