### PR TITLE
Retrieve the redirection URL directly from the access plan on purchas…

### DIFF
--- a/.changelogs/issue_2229-1.yml
+++ b/.changelogs/issue_2229-1.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: dev
+entry: Added new parameter to LLMS_Access_Plan::get_redirection_url() to
+  optionally get a raw (not encoded) URL.

--- a/.changelogs/issue_2229-1.yml
+++ b/.changelogs/issue_2229-1.yml
@@ -1,4 +1,6 @@
 significance: minor
 type: dev
-entry: Added new parameter to LLMS_Access_Plan::get_redirection_url() to
-  optionally get a raw (not encoded) URL.
+entry: Added two new parameters to LLMS_Access_Plan::get_redirection_url()
+  - `$encode` to optionally get a raw (not encoded) URL.
+  - `$querystring_only` to optionally get only the redirect URL
+  if set via NPUT_GET variable.

--- a/.changelogs/issue_2229-2.yml
+++ b/.changelogs/issue_2229-2.yml
@@ -1,3 +1,3 @@
 significance: minor
 type: dev
-entry: Added new parameter `$querystring_only` the filter hook `llms_plan_get_checkout_redirection`.
+entry: Added new parameter `$querystring_only` to the filter hook `llms_plan_get_checkout_redirection`.

--- a/.changelogs/issue_2229-2.yml
+++ b/.changelogs/issue_2229-2.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: dev
+entry: Added new parameter `$querystring_only` the filter hook `llms_plan_get_checkout_redirection`.

--- a/.changelogs/issue_2229-3.yml
+++ b/.changelogs/issue_2229-3.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2234"
+entry: Fixed an issue that prevented disabling the access plan’s option,
+  Override Membership Redirects, once enabled.

--- a/.changelogs/issue_2229.yml
+++ b/.changelogs/issue_2229.yml
@@ -2,5 +2,8 @@ significance: major
 type: added
 links:
   - "#2229"
-entry: On purchase completed retrieve the redirection URL from the purchased
-  access plan settings if no 'redirect' GET variable is passed.
+entry: On purchase completed retrieve the redirection URL from the
+  INPUT_POST 'redirect' variable, if no 'redirect' variable is passed
+  via INPUT_GET.
+  The INPUT_POST 'redirect' variable comes from the new checkout form's
+  hidden field 'redirect' populated with LLMS_Access_Plan::get_redirection_url().

--- a/.changelogs/issue_2229.yml
+++ b/.changelogs/issue_2229.yml
@@ -1,0 +1,6 @@
+significance: major
+type: added
+links:
+  - "#2229"
+entry: On purchase completed retrieve the redirection URL from the purchased
+  access plan settings if no 'redirect' GET variable is passed.

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -442,7 +442,7 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		$redirect = urldecode( llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) );
 
 		// Get the redirect parameter from INPUT_POST if not INPUT_GET redirect pased.
-		$redirect = $redirect ? $redirect : urldecode( llms_filter_input( INPUT_POST, 'redirect' ) );
+		$redirect = $redirect ? $redirect : llms_filter_input( INPUT_POST, 'redirect', FILTER_VALIDATE_URL );
 
 		// Redirect to the product's permalink, if no redirect found yet.
 		$redirect = $redirect ? $redirect : get_permalink( $order->get( 'product_id' ) );
@@ -460,10 +460,10 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 
 		// Redirection url on free checkout form.
 		$quick_enroll_form      = llms_filter_input( INPUT_POST, 'form' );
-		$free_checkout_redirect = llms_filter_input( INPUT_POST, 'free_checkout_redirect' );
+		$free_checkout_redirect = llms_filter_input( INPUT_POST, 'free_checkout_redirect', FILTER_VALIDATE_URL );
 
 		if ( get_current_user_id() && ( 'free_enroll' === $quick_enroll_form ) && $free_checkout_redirect ) {
-			$redirect = urldecode( $free_checkout_redirect );
+			$redirect = $free_checkout_redirect;
 		}
 
 		/**

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -441,7 +441,7 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		// Get the redirection URL.
 		$plan_id  = $order->get( 'plan_id' );
 		$plan     = llms_get_post( $plan_id );
-		$redirect = is_a( $plan, 'LLMS_Access_Plan' ) ? urldecode( $plan->get_redirection_url() ) : '';
+		$redirect = is_a( $plan, 'LLMS_Access_Plan' ) ? $plan->get_redirection_url( false ) : '';
 
 		// Redirect to the product's permalink, if no parameter was set.
 		$redirect = ! empty( $redirect ) ? $redirect : get_permalink( $order->get( 'product_id' ) );

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -440,8 +440,8 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 
 		// Get the redirection URL.
 		$plan_id  = $order->get( 'plan_id' );
-		$plan     = new LLMS_Access_Plan( $plan_id );
-		$redirect = urldecode( $plan->get_redirection_url( true ) );
+		$plan     = llms_get_post( $plan_id );
+		$redirect = is_a( $plan, 'LLMS_Access_Plan' ) ? urldecode( $plan->get_redirection_url() ) : '';
 
 		// Redirect to the product's permalink, if no parameter was set.
 		$redirect = ! empty( $redirect ) ? $redirect : get_permalink( $order->get( 'product_id' ) );

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -428,17 +428,20 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 	}
 
 	/**
-	 * Calculates the url to redirect to on transaction completion
+	 * Calculates the url to redirect to on transaction completion.
 	 *
 	 * @since 3.30.0
+	 * @since [version] Retrieve the redirection URL directly from the access plan.
 	 *
 	 * @param LLMS_Order $order The order object.
 	 * @return string
 	 */
 	protected function get_complete_transaction_redirect_url( $order ) {
 
-		// Get the redirect parameter.
-		$redirect = urldecode( llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) );
+		// Get the redirection URL.
+		$plan_id  = $order->get( 'plan_id' );
+		$plan     = new LLMS_Access_Plan( $plan_id );
+		$redirect = urldecode( $plan->get_redirection_url( true ) );
 
 		// Redirect to the product's permalink, if no parameter was set.
 		$redirect = ! empty( $redirect ) ? $redirect : get_permalink( $order->get( 'product_id' ) );

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.0.0
- * @version 6.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -781,6 +781,7 @@ GROUP BY locations.meta_value";
 	 * @since 5.0.0
 	 * @since 5.1.0 Specifiy to pass the new 3rd param to the `llms_forms_block_to_field_settings` filter callback.
 	 * @since 5.9.0 Fix php 8.1 deprecation warnings when `get_form_fields()` returns `false`.
+	 * @since [version] Retrieve and use the free checkout redirect URL as not encoded.
 	 *
 	 * @param LLMS_Access_Plan $plan Access plan being used for enrollment.
 	 * @return array[] List of LLMS_Form_Field settings arrays.
@@ -799,7 +800,7 @@ GROUP BY locations.meta_value";
 		$fields[] = array(
 			'name'           => 'free_checkout_redirect',
 			'type'           => 'hidden',
-			'value'          => $plan->get_redirection_url(),
+			'value'          => $plan->get_redirection_url( false ),
 			'data_store_key' => false,
 		);
 

--- a/includes/functions/llms-functions-access-plans.php
+++ b/includes/functions/llms-functions-access-plans.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.29.0
- * @version 3.30.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,6 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * @since 3.29.0
  * @since 3.30.0 Added checkout redirect options.
  * @since 3.30.3 Fixed spelling errors.
+ * @since [version] Correctly handle `$checkout_redirect_forced` property when updating.
  *
  * @param array $props {
  *     An array of of properties that make up the plan to create or update.
@@ -32,6 +33,7 @@ defined( 'ABSPATH' ) || exit;
  *     @type string $access_period Time period of access from time of purchase, combine with $access_length. Only applicable when $access_expiration is "limited-period" [year|month|week|day].
  *     @type string $availability Determine if this access plan is available to anyone or to members only. Use with $availability_restrictions to determine if the member can use the access plan. [open|members].
  *     @type array $availability_restrictions Indexed array of LifterLMS Membership IDs a user must belong to to use the access plan. Only applicable if $availability is "members".
+ *     @type string $checkout_redirect_forced On a members' only access plan, whether to force redirect users back to the redirect settings specified in this access plan.
  *     @type string $checkout_redirect_type Type of checkout redirection [self|page|url].
  *     @type string $content Plan description (post_content).
  *     @type string $enroll_text Text to display on buy buttons.
@@ -67,7 +69,17 @@ function llms_insert_access_plan( $props = array() ) {
 			return new WP_Error( 'invalid-plan', sprintf( __( 'Access Plan ID "%s" is not valid.', 'lifterlms' ), $props['id'] ) );
 		}
 		unset( $props['id'] );
-		$props = wp_parse_args( $props, $plan->toArray() );
+		$plan_array = $plan->toArray();
+		/**
+		 * The property 'checkout_redirect_forced' is not sent when the related checkbox is unchecked,
+		 * so we have to avoid to override it with the saved value.
+		 *
+		 * {@see https://github.com/gocodebox/lifterlms/issues/2234}
+		 */
+		if ( ! isset( $props['checkout_redirect_forced'] ) ) {
+			unset( $plan_array['checkout_redirect_forced'] );
+		}
+		$props = wp_parse_args( $props, $plan );
 
 	}
 
@@ -77,24 +89,25 @@ function llms_insert_access_plan( $props = array() ) {
 		apply_filters(
 			'llms_access_plan_default_properties',
 			array(
-				'access_expiration'      => 'lifetime',
-				'access_length'          => 1,
-				'access_period'          => 'year',
-				'availability'           => 'open',
-				'checkout_redirect_type' => 'self',
-				'frequency'              => 0,
-				'is_free'                => 'yes',
-				'length'                 => 0,
-				'on_sale'                => 'no',
-				'period'                 => 'year',
-				'price'                  => 0,
-				'sale_price'             => 0,
-				'title'                  => __( 'Access Plan', 'lifterlms' ),
-				'trial_length'           => 1,
-				'trial_offer'            => 'no',
-				'trial_period'           => 'year',
-				'trial_price'            => 0,
-				'visibility'             => 'visible',
+				'access_expiration'        => 'lifetime',
+				'access_length'            => 1,
+				'access_period'            => 'year',
+				'availability'             => 'open',
+				'checkout_redirect_forced' => 'no',
+				'checkout_redirect_type'   => 'self',
+				'frequency'                => 0,
+				'is_free'                  => 'yes',
+				'length'                   => 0,
+				'on_sale'                  => 'no',
+				'period'                   => 'year',
+				'price'                    => 0,
+				'sale_price'               => 0,
+				'title'                    => __( 'Access Plan', 'lifterlms' ),
+				'trial_length'             => 1,
+				'trial_offer'              => 'no',
+				'trial_period'             => 'year',
+				'trial_price'              => 0,
+				'visibility'               => 'visible',
 			)
 		)
 	);

--- a/includes/models/model.llms.access.plan.php
+++ b/includes/models/model.llms.access.plan.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.0.0
- * @version 5.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -215,34 +215,36 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 	}
 
 	/**
-	 * Retrieve the full URL to redirect to after successful checkout
+	 * Retrieve the full URL to redirect to after successful checkout.
 	 *
-	 * @since    3.30.0
-	 * @version  3.30.0
+	 * @since 3.30.0
+	 * @since [version] Addeded `$encode` parameter.
 	 *
-	 * @return   string
+	 * @param bool $encode Whether or not encoding the URL.
+	 * @return string
 	 */
-	public function get_redirection_url() {
+	public function get_redirection_url( $encode = true ) {
 
-		// what type of redirection is set up by user?
+		// What type of redirection is set up by user?
 		$redirect_type = $this->get( 'checkout_redirect_type' );
 
 		$query_redirection = llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL );
 
-		// force redirect querystring parameter over all else.
+		// Force redirect querystring parameter over all else.
 		$redirection = ! empty( $query_redirection ) ? $query_redirection : $this->calculate_redirection_url( $redirect_type );
 
 		/**
-		 * Filter the checkout redirection parameter
+		 * Filter the checkout redirection parameter.
 		 *
-		 * @since    3.30.0
-		 * @version  3.30.0
+		 * @since 3.30.0
 		 *
-		 * @param    string               $redirection The calculated url to redirect to.
-		 * @param    string               $redirection_type Available redirection types 'self', 'membership', 'page', 'url' or a custom type.
-		 * @param    LLMS_Acccess_Plan    $this Current Access Plan object.
+		 * @param string            $redirection      The calculated url to redirect to.
+		 * @param string            $redirection_type Available redirection types 'self', 'membership', 'page', 'url' or a custom type.
+		 * @param LLMS_Acccess_Plan $access_plan      Current Access Plan object.
 		 */
-		return urlencode( apply_filters( 'llms_plan_get_checkout_redirection', $redirection, $redirect_type, $this ) );
+		$redirection = apply_filters( 'llms_plan_get_checkout_redirection', $redirection, $redirect_type, $this );
+
+		return $encode ? urlencode( $redirection ) : $redirection;
 
 	}
 

--- a/includes/models/model.llms.access.plan.php
+++ b/includes/models/model.llms.access.plan.php
@@ -218,12 +218,13 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 	 * Retrieve the full URL to redirect to after successful checkout.
 	 *
 	 * @since 3.30.0
-	 * @since [version] Addeded `$encode` parameter.
+	 * @since [version] Addeded `$encode` and `$querystring_only` parameters.
 	 *
-	 * @param bool $encode Whether or not encoding the URL.
+	 * @param bool $encode           Whether or not encoding the URL.
+	 * @param bool $querystring_only Only return the redirect URL bassed by the querystring.
 	 * @return string
 	 */
-	public function get_redirection_url( $encode = true ) {
+	public function get_redirection_url( $encode = true, $querystring_only = false ) {
 
 		// What type of redirection is set up by user?
 		$redirect_type = $this->get( 'checkout_redirect_type' );
@@ -231,48 +232,52 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 		$query_redirection = llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL );
 
 		// Force redirect querystring parameter over all else.
-		$redirection = ! empty( $query_redirection ) ? $query_redirection : $this->calculate_redirection_url( $redirect_type );
+		$redirection = $query_redirection;
+		if ( ! $querystring_only ) {
+			$redirection = $query_redirection ? $query_redirection : $this->calculate_redirection_url( $redirect_type );
+		}
 
 		/**
 		 * Filter the checkout redirection parameter.
 		 *
 		 * @since 3.30.0
+		 * @since [version] Added `$querystring_only` parameter.
 		 *
 		 * @param string            $redirection      The calculated url to redirect to.
 		 * @param string            $redirection_type Available redirection types 'self', 'membership', 'page', 'url' or a custom type.
 		 * @param LLMS_Acccess_Plan $access_plan      Current Access Plan object.
+		 * @param bool              $querystring_only Whether or not it was requested to only return the redirect URL passed by querystring.
 		 */
-		$redirection = apply_filters( 'llms_plan_get_checkout_redirection', $redirection, $redirect_type, $this );
+		$redirection = apply_filters( 'llms_plan_get_checkout_redirection', $redirection, $redirect_type, $this, $querystring_only );
 
 		return $encode ? urlencode( $redirection ) : $redirection;
 
 	}
 
 	/**
-	 * Retrieve the full URL to the checkout screen for the plan
+	 * Retrieve the full URL to the checkout screen for the plan.
 	 *
 	 * @since 3.0.0
 	 * @since 3.30.0 Added access plan redirection settings.
 	 * @since 3.31.0 The `$check_availability` parameter was added to the filter `llms_plan_get_checkout_url`
+	 * @since [version] No need to add the redirect querystring parameter if not already set, except for unavailable members only plans.
 	 *
-	 * @param    bool $check_availability  determine if availability checks should be made (allows retrieving plans on admin panel).
-	 * @return   string
+	 * @param bool $check_availability Determine if availability checks should be made (allows retrieving plans on admin panel).
+	 * @return string
 	 */
 	public function get_checkout_url( $check_availability = true ) {
 
 		$ret       = '#llms-plan-locked';
 		$available = $this->is_available_to_user( get_current_user_id() );
 
-		$redirection = $this->get_redirection_url();
-
 		// if bypassing availability checks OR plan is available to user.
 		if ( ! $check_availability || $available ) {
 
-			$ret_params = array(
+			$ret_params  = array(
 				'plan' => $this->get( 'id' ),
 			);
-
-			if ( ! empty( $redirection ) ) {
+			$redirection = $this->get_redirection_url( true, true );
+			if ( $redirection ) {
 				$ret_params['redirect'] = $redirection;
 			}
 
@@ -285,8 +290,10 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 
 			// if there's only 1 plan associated with the membership return that url.
 			if ( 1 === count( $memberships ) ) {
-				$ret = get_permalink( $memberships[0] );
-				if ( ! empty( $redirection ) ) {
+				$ret         = get_permalink( $memberships[0] );
+				$redirection = $this->get_redirection_url();
+
+				if ( $redirection ) {
 					$ret = add_query_arg(
 						array(
 							'redirect' => $redirection,

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -297,10 +297,11 @@ class LLMS_Shortcode_Checkout {
 		$atts['form_fields']   = self::clean_form_fields( llms_get_form_html( $atts['form_location'], array( 'plan' => $plan ) ) );
 
 		// Add 'redirect' URL hidden field to be used on purchase completion.
-		$plan_redirection_url  = $plan->get_redirection_url();
+		$plan_redirection_url = $plan->get_redirection_url( false );
 		if ( $plan_redirection_url ) {
 			$atts['form_fields'] .= ( new LLMS_Form_Field(
 				array(
+					'id'             => 'llms-redirect',
 					'name'           => 'redirect',
 					'type'           => 'hidden',
 					'value'          => $plan_redirection_url,

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -1,13 +1,13 @@
 <?php
 /**
- * LifterLMS Checkout Page Shortcode.
+ * LifterLMS Checkout Page Shortcode
  *
  * Controls functionality associated with shortcode [llms_checkout].
  *
  * @package LifterLMS/Shortcodes/Classes
  *
  * @since 1.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -274,13 +274,14 @@ class LLMS_Shortcode_Checkout {
 	}
 
 	/**
-	 * Setup attributes for plan and form information
+	 * Setup attributes for plan and form information.
 	 *
 	 * @since 5.0.0
 	 * @since 5.1.0 Properly detect empty form fields when the html is only composed of blanks and empty paragraphs.
+	 * @since [version] Add 'redirect' hidden field to be used on purchase completion.
 	 *
 	 * @param int   $plan_id LLMS_Access_Plan post id.
-	 * @param array $atts Existing attributes.
+	 * @param array $atts    Existing attributes.
 	 * @return array Modified attributes array.
 	 */
 	protected static function setup_plan_and_form_atts( $plan_id, $atts ) {
@@ -294,6 +295,19 @@ class LLMS_Shortcode_Checkout {
 		$atts['form_location'] = 'checkout';
 		$atts['form_title']    = llms_get_form_title( $atts['form_location'], array( 'plan' => $plan ) );
 		$atts['form_fields']   = self::clean_form_fields( llms_get_form_html( $atts['form_location'], array( 'plan' => $plan ) ) );
+
+		// Add 'redirect' URL hidden field to be used on purchase completion.
+		$plan_redirection_url  = $plan->get_redirection_url();
+		if ( $plan_redirection_url ) {
+			$atts['form_fields'] .= ( new LLMS_Form_Field(
+				array(
+					'name'           => 'redirect',
+					'type'           => 'hidden',
+					'value'          => $plan_redirection_url,
+					'data_store_key' => false,
+				)
+			) )->get_html();
+		}
 
 		return $atts;
 	}

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-checkout.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-checkout.php
@@ -46,7 +46,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		foreach ( $actions as $hook => $priority ) {
 			$this->assertEquals( $priority, has_action( 'init', array( $this->main, $hook ) ) );
-		}		
+		}
 
 	}
 
@@ -89,7 +89,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 			'llms_order_key' => 'NOT-A-REAL-ORDER-KEY',
 		) );
 		$this->assertFalse( $this->main->confirm_pending_order() );
-		
+
 	}
 
 	/**
@@ -283,7 +283,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'llms-order-gen-order-not-found', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 	}
@@ -521,7 +521,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'llms-order-gen-plan-required', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 	}
@@ -549,7 +549,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 		};
 		$this->load_payment_gateway( $gateway );
 
-		$this->mockPostRequest( 
+		$this->mockPostRequest(
 			array_merge(
 				$this->get_mock_checkout_data_array(),
 				array(
@@ -567,7 +567,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'gateway-err', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 		$this->unload_payment_gateway( 'fake-create-pending-order-ajax-gateway-err' );
@@ -597,7 +597,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 		};
 		$this->load_payment_gateway( $gateway );
 
-		$this->mockPostRequest( 
+		$this->mockPostRequest(
 			array_merge(
 				$this->get_mock_checkout_data_array(),
 				array(
@@ -615,8 +615,8 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertEquals( 'yes', $res['success'] );
-		$this->assertArrayHasKey( 'order_key', $res ); 
-		
+		$this->assertArrayHasKey( 'order_key', $res );
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 		$this->unload_payment_gateway( 'fake-create-pending-order-ajax-success' );
@@ -707,7 +707,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 			'order_id'             => $this->factory->post->create(),
 		) );
 		$this->assertNull( $this->main->switch_payment_source() );
-		$this->assertHasNotice( 'Invalid order.', 'error' );	
+		$this->assertHasNotice( 'Invalid order.', 'error' );
 
 	}
 
@@ -728,7 +728,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 			'order_id'             => $order->get( 'id' ),
 		) );
 		$this->assertNull( $this->main->switch_payment_source() );
-		$this->assertHasNotice( 'Invalid order.', 'error' );	
+		$this->assertHasNotice( 'Invalid order.', 'error' );
 
 	}
 
@@ -752,7 +752,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 			'order_id'             => $order->get( 'id' ),
 		) );
 		$this->assertNull( $this->main->switch_payment_source() );
-		$this->assertHasNotice( 'Missing gateway information.', 'error' );	
+		$this->assertHasNotice( 'Missing gateway information.', 'error' );
 
 	}
 
@@ -777,7 +777,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 			'llms_payment_gateway' => 'FAKE',
 		) );
 		$this->assertNull( $this->main->switch_payment_source() );
-		$this->assertHasNotice( 'The selected payment gateway is not valid.', 'error' );	
+		$this->assertHasNotice( 'The selected payment gateway is not valid.', 'error' );
 
 	}
 
@@ -1020,7 +1020,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'switch-source-order-missing', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 	}
@@ -1048,7 +1048,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'switch-source-order-invalid', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 	}
@@ -1079,7 +1079,7 @@ class LLMS_Test_Controller_Checkout extends LLMS_UnitTestCase {
 
 		$res = json_decode( ob_get_clean(), true );
 		$this->assertArrayHasKey( 'switch-source-order-invalid', $res['errors'] );
-		
+
 		remove_filter( 'wp_die_ajax_handler', array( $this, 'get_wp_die_handler') );
 
 	}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
@@ -1210,4 +1210,82 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test method `get_redirection_url()` when there's no 'redirect' $_GET variable.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_redirection_url_no_input_get() {
+
+		$this->set_obj_product( 'course' );
+		$this->obj->set( 'checkout_redirect_type', 'url' );
+		$this->obj->set( 'checkout_redirect_url', 'https:://example.com' );
+
+		// Expect the encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( $this->obj->get( 'checkout_redirect_url' ) ) );
+		// Expect the not-encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url( false ), $this->obj->get( 'checkout_redirect_url' ) );
+
+		$this->obj->set( 'checkout_redirect_type', 'self' ); // Default.
+		$this->obj->set( 'checkout_redirect_url', '' );
+
+		// Expect empty string.
+		$this->assertEmpty( $this->obj->get_redirection_url() );
+
+	}
+
+	/**
+	 * Test method `get_redirection_url()` when there's a 'redirect' $_GET variable.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_redirection_url_with_input_get() {
+
+		$this->set_obj_product( 'course' );
+
+		$this->mockGetRequest(
+			array(
+				'redirect' => '',
+			)
+		);
+		// Expect empty string.
+		$this->assertEmpty( $this->obj->get_redirection_url() );
+
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://example-redirect-get.com',
+			)
+		);
+		// Expect the encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
+		// Expect the not-encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
+
+		// Set access plan redirect options, still the $_GET variable will win.
+		$this->obj->set( 'checkout_redirect_type', 'url' );
+		$this->obj->set( 'checkout_redirect_url', 'https:://example.com' );
+
+		// Expect the encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
+		// Expect the not-encoded url.
+		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
+
+		$this->obj->set( 'checkout_redirect_type', 'self' ); // Default.
+		$this->obj->set( 'checkout_redirect_url', '' );
+
+		$this->mockGetRequest(
+			array(
+				'redirect' => '',
+			)
+		);
+
+		// Expect empty string.
+		$this->assertEmpty( $this->obj->get_redirection_url() );
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
@@ -7,8 +7,9 @@
  * @group access_plan
  *
  * @since 3.23.0
- * @since 3.30.1 Add tests for get_initial_price() method.
+ * @since 3.30.1 Add tests for `get_initial_price()` method.
  * @since 3.40.0 Improved tests for the `requires_payment()` method.
+ * @since [version] Added tests for `get_redirection_url()` method.
  */
 class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 
@@ -1223,17 +1224,23 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 		$this->obj->set( 'checkout_redirect_type', 'url' );
 		$this->obj->set( 'checkout_redirect_url', 'https:://example.com' );
 
-		// Expect the encoded url.
+		// Expect the encoded URL.
 		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( $this->obj->get( 'checkout_redirect_url' ) ) );
-		// Expect the not-encoded url.
+		// Require only querystring, expect empty string.
+		$this->assertEmpty( $this->obj->get_redirection_url( true, true ) );
+
+		// Expect the not-encoded URL.
 		$this->assertEquals( $this->obj->get_redirection_url( false ), $this->obj->get( 'checkout_redirect_url' ) );
+		// Require only querystring, expect empty string.
+		$this->assertEmpty( $this->obj->get_redirection_url( false, true ) );
+
 
 		$this->obj->set( 'checkout_redirect_type', 'self' ); // Default.
 		$this->obj->set( 'checkout_redirect_url', '' );
 
 		// Expect empty string.
 		$this->assertEmpty( $this->obj->get_redirection_url() );
-
+		$this->assertEmpty( $this->obj->get_redirection_url( true, false ) );
 	}
 
 	/**
@@ -1260,10 +1267,15 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 				'redirect' => 'https://example-redirect-get.com',
 			)
 		);
-		// Expect the encoded url.
+		// Expect the encoded URL.
 		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
-		// Expect the not-encoded url.
+		// Require only querystring, expect the encoded URL.
+		$this->assertEquals( $this->obj->get_redirection_url( true, true ), urlencode( 'https://example-redirect-get.com' ) );
+
+		// Expect the not-encoded URL.
 		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
+		// Require only querystring, expect the not-encoded URL.
+		$this->assertEquals( $this->obj->get_redirection_url( false, true ), 'https://example-redirect-get.com' );
 
 		// Set access plan redirect options, still the $_GET variable will win.
 		$this->obj->set( 'checkout_redirect_type', 'url' );
@@ -1271,8 +1283,13 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 
 		// Expect the encoded url.
 		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
+		// Require only querystring, expect the encoded URL.
+		$this->assertEquals( $this->obj->get_redirection_url( true, true ), urlencode( 'https://example-redirect-get.com' ) );
+
 		// Expect the not-encoded url.
 		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
+		// Require only querystring, expect the not-encoded URL.
+		$this->assertEquals( $this->obj->get_redirection_url( false, true ), 'https://example-redirect-get.com' );
 
 		$this->obj->set( 'checkout_redirect_type', 'self' ); // Default.
 		$this->obj->set( 'checkout_redirect_url', '' );
@@ -1285,6 +1302,7 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 
 		// Expect empty string.
 		$this->assertEmpty( $this->obj->get_redirection_url() );
+		$this->assertEmpty( $this->obj->get_redirection_url( true, false ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
+++ b/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
@@ -5,12 +5,12 @@
  * @group shortcodes
  *
  * @since 5.1.0
- * @version 5.1.0
+ * @version [version]
  */
 class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 
 	/**
-	 * Test shortcode registration
+	 * Test shortcode registration.
 	 *
 	 * @since 5.1.0
 	 *
@@ -21,7 +21,7 @@ class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 	}
 
 	/**
-	 * Test clean_form_fields
+	 * Test clean_form_fields.
 	 *
 	 * @since 5.1.0
 	 *
@@ -39,8 +39,73 @@ class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 		);
 
 		foreach ( $checks as $check => $expect ) {
-			$this->assertEquals( $expect, LLMS_Unit_Test_Util::call_method( 'LLMS_Shortcode_Checkout', 'clean_form_fields', array( $check ) ), $check );
+			$this->assertEquals(
+				$expect,
+				LLMS_Unit_Test_Util::call_method(
+					'LLMS_Shortcode_Checkout',
+					'clean_form_fields',
+					array( $check )
+				),
+				$check
+			);
 		}
 
 	}
+
+	/**
+	 * Test setup_plan_and_form_atts() method adds redirection hidden field when needed.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_setup_plan_and_form_atts_check_redirection() {
+
+		$plan      = $this->get_mock_plan();
+		$contained = '<input class="llms-field-input" id="llms-redirect"'; // Redirect field.
+
+		$atts = LLMS_Unit_Test_Util::call_method(
+			'LLMS_Shortcode_Checkout',
+			'setup_plan_and_form_atts',
+			array(
+				$plan->get('id'),
+				array(),
+			)
+		);
+
+		$this->assertStringNotContainsString( $contained, $atts['form_fields'] );
+
+		// Setup a redirect URL for the access plan.
+		$plan->set( 'checkout_redirect_type', 'url' );
+		$plan->set( 'checkout_redirect_url', 'https://example.com' );
+		$atts = LLMS_Unit_Test_Util::call_method(
+			'LLMS_Shortcode_Checkout',
+			'setup_plan_and_form_atts',
+			array(
+				$plan->get('id'),
+				array(),
+			)
+		);
+		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="https://example.com" />';
+		$this->assertStringContainsString( $contained, $atts['form_fields'] );
+
+		// INPUT_GET wins over plan's setting.
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://example-redirect-get.com',
+			)
+		);
+		$atts = LLMS_Unit_Test_Util::call_method(
+			'LLMS_Shortcode_Checkout',
+			'setup_plan_and_form_atts',
+			array(
+				$plan->get('id'),
+				array(),
+			)
+		);
+		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="https://example-redirect-get.com" />';
+		$this->assertStringContainsString( $contained, $atts['form_fields'] );
+
+	}
+
 }

--- a/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
+++ b/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
@@ -5,7 +5,6 @@
  * @group shortcodes
  *
  * @since 5.1.0
- * @version [version]
  */
 class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 


### PR DESCRIPTION
…e completed

## Description

Fixes #2229
Fixes #2234 
Fixes https://github.com/gocodebox/lifterlms-gateway-paypal/issues/110

## How has this been tested?
new and old unit tests 

manually with:
- PayPal gateway 3.0-alpha
- Stripe

both with access plans having a redirect URL set, and with access plans without redirect URL set.
Also tested using a plan purchase link of the type `https://example.com/purchase/?plan=72&redirect=https%3A%2F%2Fwww.lifterlms.com` and without the `redirect` GET var. In the first case the GET var wins over the access plan's settings. When passing no `redirect` GET var then the access plan settings will be honored.

I also tested this manually buying memberships coming from a pricing table of a course with an access plan limited to members only, with redirect settings overriding membership's ones.

## Screenshots <!-- if applicable -->
n/a

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is a breaking change because before if you purchased and access plan without specifying a `redirect` GET var in the purchase link you wouldn't be redirected on purchase completed, no matter what the access plan redirections settings were.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

