### PR TITLE
Make  elements in quiz attempt results scrollable

### DIFF
--- a/.changelogs/attempts-pre.yml
+++ b/.changelogs/attempts-pre.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Make `<pre>` elements in quiz attempt results scrollable.

--- a/assets/scss/_includes/_quiz-result-question-list.scss
+++ b/assets/scss/_includes/_quiz-result-question-list.scss
@@ -36,7 +36,9 @@
 				background-color: $color-red;
 			}
 		}
-
+		pre {
+			overflow: auto;
+		}
 		.llms-question-title {
 			float: left;
 			margin: 0;

--- a/assets/scss/admin/_reporting.scss
+++ b/assets/scss/admin/_reporting.scss
@@ -215,6 +215,7 @@
 
 	.llms-reporting-tab-main {
 		flex: 3;
+		max-width: 75%;
 	}
 	.llms-reporting-tab-side {
 		flex: 1;


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Related to: https://github.com/gocodebox/lifterlms-advanced-quizzes/pull/40

Also made sure that, in reporting, the `.llms-reporting-tab-main` element never grows more than its allowed space (`flex-grow:3` => `max-width: 75%;`)

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)/Enhancement

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

