### PR TITLE
Fixed PHP warning raised when logging errors during the notification emails dispatching

### DIFF
--- a/.changelogs/issue_2250.yml
+++ b/.changelogs/issue_2250.yml
@@ -2,5 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#2250"
-entry: Fixed PHP warning raised when logging errors during the notification
-  emails dispatching.
+entry: Fixed a PHP warning raised when logging errors during email notification dispatch.

--- a/.changelogs/issue_2250.yml
+++ b/.changelogs/issue_2250.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2250"
+entry: Fixed PHP warning raised when logging errors during the notification
+  emails dispatching.

--- a/includes/abstracts/llms.abstract.notification.processor.php
+++ b/includes/abstracts/llms.abstract.notification.processor.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.8.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -58,21 +58,33 @@ abstract class LLMS_Abstract_Notification_Processor extends WP_Background_Proces
 	}
 
 	/**
-	 * Starts the queue
+	 * Starts the queue.
 	 *
 	 * @since 3.8.0
 	 * @since 3.38.0 Added return from parent method.
+	 * @since [version] Fixed malformed sprintf when logging dispatch errors.
 	 *
 	 * @return array|WP_Error Response from `wp_remote_post()`.
 	 */
 	public function dispatch() {
 
-		$this->log( sprintf( 'Dispatching %s', $this->action ) );
+		$this->log(
+			sprintf(
+				'Dispatching %s',
+				$this->action
+			)
+		);
 
 		$dispatched = parent::dispatch();
 
 		if ( is_wp_error( $dispatched ) ) {
-			$this->log( sprintf( 'Unable to dispatch %1$s: %2$s' ), $this->action, $dispatched->get_error_message() );
+			$this->log(
+				sprintf(
+					'Unable to dispatch %1$s: %2$s',
+					$this->action,
+					$dispatched->get_error_message()
+				)
+			);
 		}
 
 		return $dispatched;


### PR DESCRIPTION
## Description

Fixes #2250 

## How has this been tested?
manually


## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

