### PR TITLE
Remove superfluous acheivement modal opener

### DIFF
--- a/.changelogs/achievements-hash-validation-1.yml
+++ b/.changelogs/achievements-hash-validation-1.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed a jQuery error encountered on various pages when an invalid
+  achievement ID is passed in the web address hash.

--- a/.changelogs/achievements-hash-validation.yml
+++ b/.changelogs/achievements-hash-validation.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: deprecated
+links:
+  - gocodebox/private-issues#61
+entry: Deprecated JS method `LLMS.Achievements.maybe_open()` with no replacement.

--- a/assets/js/app/llms-achievements.js
+++ b/assets/js/app/llms-achievements.js
@@ -4,7 +4,7 @@
  * @package LifterLMS/Scripts
  *
  * @since 3.14.0
- * @version 4.5.1
+ * @version [version]
  */
 
 LLMS.Achievements = {
@@ -14,18 +14,17 @@ LLMS.Achievements = {
 	 *
 	 * @since 3.14.0
 	 * @since 4.5.1 Fix conditional loading check.
+	 * @since [version] Don't run deprecated method `maybe_open()`.
+	 *               Removed reliance on jQuery.
 	 *
 	 * @return void
 	 */
 	init: function() {
 
-		if ( $( '.llms-achievement' ).length ) {
-
+		if ( document.querySelector( '.llms-achievement' ) ) {
 			var self = this;
-
-			$( function() {
+			setTimeout( () => {
 				self.bind();
-				self.maybe_open();
 			} );
 		}
 
@@ -111,16 +110,12 @@ LLMS.Achievements = {
 	 * On page load, opens a modal if the URL contains an achievement in the location hash
 	 *
 	 * @since 3.14.0
+	 * @deprecated [version] LLMS.Achievements.maybe_open() is deprecated with no replacement.
 	 *
 	 * @return void
 	 */
 	maybe_open: function() {
-
-		var hash = window.location.hash;
-		if ( hash && -1 !== hash.indexOf( 'achievement-' ) ) {
-			$( 'a[href="' + hash + '"]' ).first().trigger( 'click' );
-		}
-
+		console.warn( 'LLMS.Achievements.maybe_open() is deprecated with no replacement.' );
 	}
 
 };


### PR DESCRIPTION
Fixes https://github.com/gocodebox/private-issues/issues/61 

This PR removes the buggy method as noted in the above issue. It's a superfluous method as the iziModal library automatically opens the modals when history is enabled. By removing it we also automatically fix the reported bug

## How has this been tested?

+ Manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

