### PR TITLE
fixed required fields duplication when the form is a child of a `.wp-block-column` element.

### DIFF
--- a/.changelogs/issue_2134.yml
+++ b/.changelogs/issue_2134.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2134"
+entry: Fixed required fields duplication when the form is a child of a
+  `.wp-block-column` element.

--- a/assets/js/app/llms-forms.js
+++ b/assets/js/app/llms-forms.js
@@ -4,7 +4,7 @@
  * @package LifterLMS/Scripts
  *
  * @since 5.0.0
- * @version 5.3.3
+ * @version [version]
  */
 
 LLMS.Forms = {
@@ -197,20 +197,14 @@ LLMS.Forms = {
 	 * Retrieve the parent element for a given field.
 	 *
 	 * The parent element is hidden when the field isn't required.
-	 * Looks for a WP column wrapper and falls back to the field's
-	 * wrapper div.
 	 *
 	 * @since 5.0.0
+	 * @since [version] Do not look for a WP column wrapper anymore, always return the field's wrapper div.
 	 *
 	 * @param {Object} $field jQuery dom object.
 	 * @return {Object}
 	 */
 	get_field_parent: function( $field ) {
-
-		var $block = $field.closest( '.wp-block-column' );
-		if ( $block.length ) {
-			return $block;
-		}
 
 		return $field.closest( '.llms-form-field' );
 


### PR DESCRIPTION
## Description

Fixes #2134 
As said in https://github.com/gocodebox/lifterlms/issues/2134#issuecomment-1109621295 the "offending" code was, in my opinion, an outdated code that made sense when we used block-editor's columns to render our fields.
I did various tests and cannot find a reason to keep that code.

## How has this been tested?
manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

