### PR TITLE
Introduce "enum-link" pattern and allow customization of the instructor admin menu hack

### DIFF
--- a/.changelogs/dev-1.yml
+++ b/.changelogs/dev-1.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: deprecated
+entry: Deprecated public constant `LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP` in
+  favor of `LLMS_Capabilities::MANAGE_EARNED_ENGAGEMENT`.

--- a/.changelogs/dev.yml
+++ b/.changelogs/dev.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: dev
+entry: Added `LLMS_Abstract_Enum` which defines a pattern for creating enum-like
+  objects based on public class constants.

--- a/includes/abstracts/llms-abstract-enum.php
+++ b/includes/abstracts/llms-abstract-enum.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * LLMS_Abstract_Enum abstract class file
+ *
+ * @package LifterLMS/Abstracts/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base class for creating enum-like objects.
+ *
+ * @since [version]
+ */
+abstract class LLMS_Abstract_Enum {
+
+	/**
+	 * Retrieves all cases defined in the enum.
+	 *
+	 * @since [version]
+	 *
+	 * @return LLMS_Enum_Case[] An array of enum case objects.
+	 */
+	public static function cases() {
+
+		$ref = new ReflectionClass( static::class );
+		return $ref->getConstants( ReflectionClassConstant::IS_PUBLIC );
+
+	}
+
+}

--- a/includes/admin/class.llms.admin.menus.php
+++ b/includes/admin/class.llms.admin.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -127,7 +127,6 @@ class LLMS_Admin_Menus {
 		return $flag;
 
 	}
-
 
 	/**
 	 * Handle init actions on the course builder page
@@ -287,6 +286,8 @@ class LLMS_Admin_Menus {
 	 * but this hack will allow instructors to publish new lessons, quizzes, & questions.
 	 *
 	 * @since 3.13.0
+	 * @since [version] Added filterable early return allowing 3rd parties to modify
+	 *               the user roles affected by this hack.
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/22895
 	 * @link https://core.trac.wordpress.org/ticket/16808
@@ -294,8 +295,25 @@ class LLMS_Admin_Menus {
 	 * @return void
 	 */
 	public function instructor_menu_hack() {
+
+		/**
+		 * Filters the WP_User roles should receive the instructor admin menu hack.
+		 *
+		 * If you wish to provide explicit access to the `post` post type, to the
+		 * instrutor or instructor's assistant role, the role will need to be
+		 * removed from this array so they can access to the post type edit.php
+		 * screen.
+		 *
+		 * @see LLMS_Admin_Menus::instructor_menu_hack
+		 *
+		 * @since [version]
+		 *
+		 * @param string[] $roles The list of WP_User roles which need the hack.
+		 */
+		$roles = apply_filters( 'llms_instructor_menu_hack_roles', array( 'instructor', 'instructors_assistant' ) );
+
 		$user = wp_get_current_user();
-		if ( array_intersect( array( 'instructor', 'instructors_assistant' ), $user->roles ) ) {
+		if ( array_intersect( $roles, $user->roles ) ) {
 			remove_menu_page( 'edit.php' );
 		}
 	}

--- a/includes/class-llms-capabilities.php
+++ b/includes/class-llms-capabilities.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * LLMS_Capabilities class file
+ *
+ * @package LifterLMS/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LifterLMS user capabilities enum.
+ *
+ * @since [version]
+ */
+class LLMS_Capabilities extends LLMS_Abstract_Enum {
+
+	/**
+	 * Create, read, update, delete, and award earned engagements.
+	 */
+	public const MANAGE_EARNED_ENGAGEMENT = 'manage_earned_engagement';
+
+	/**
+	 * Read and write access to all LifterLMS settings.
+	 */
+	public const MANAGE_LIFTERLMS = 'manage_lifterlms';
+
+	/**
+	 * Utility capability which denotes the user is an instructor.
+	 */
+	public const INSTRUCTOR = 'lifterlms_instructor';
+
+	/**
+	 * View reporting for student accounts which have an instructor relationship
+	 * with the user.
+	 */
+	public const VIEW_REPORTS = 'view_lifterlms_reports';
+
+	/**
+	 * View reporting for student accounts which do not have an instructor
+	 * relationship with the user.
+	 */
+	public const VIEW_OTHERS_REPORTS = 'view_others_lifterlms_reports';
+
+	/**
+	 * Enroll user accounts.
+	 */
+	public const ENROLL = 'enroll';
+
+	/**
+	 * Unenroll user accounts.
+	 */
+	public const UNENROLL = 'unenroll';
+
+	/**
+	 * Create new student accounts.
+	 */
+	public const CREATE_STUDENTS = 'create_students';
+
+	/**
+	 * View grades for student accounts which have an instructor relationship
+	 * with the user.
+	 */
+	public const VIEW_GRADES = 'view_grades';
+
+	/**
+	 * View the account information of student accounts which have an instructor
+	 * relationship with the user.
+	 */
+	public const VIEW_STUDENTS = 'view_students';
+
+	/**
+	 * View the account information of student accounts which do not have an
+	 * instructor relationship with the user.
+	 */
+	public const VIEW_OTHERS_STUDENTS = 'view_others_students';
+
+	/**
+	 * Edit the account information of student accounts which have an instructor
+	 * relationship with the user.
+	 */
+	public const EDIT_STUDENTS = 'edit_students';
+
+	/**
+	 * Edit the account information of student accounts which do not have an
+	 * instructor relationship with the user.
+	 */
+	public const EDIT_OTHERS_STUDENTS = 'edit_others_students';
+
+	/**
+	 * Delete student accounts which have an instructor relationship with the
+	 * user.
+	 */
+	public const DELETE_STUDENTS = 'delete_students';
+
+	/**
+	 * Delete student accounts which do not have an instructor relationship with
+	 * the user.
+	 */
+	public const DELETE_OTHERS_STUDENTS = 'delete_others_students';
+
+}

--- a/includes/class.llms.roles.php
+++ b/includes/class.llms.roles.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.13.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -21,8 +21,8 @@ class LLMS_Roles {
 	 * The capability name to manage earned engagament.
 	 *
 	 * @since 6.0.0
-	 *
-	 * @var string
+	 * @deprecated [version] Constant {@see LLMS_Roles::MANAGE_EARNED_ENGAGEMENT_CAP}
+	 *                       is deprecated in favor of {@see LLMS_Capabilities::MANAGE_EARNED_ENGAGEMENT}.
 	 */
 	const MANAGE_EARNED_ENGAGEMENT_CAP = 'manage_earned_engagement';
 
@@ -53,8 +53,10 @@ class LLMS_Roles {
 	 * @since 3.34.0 Added capabilities for student management.
 	 * @since 4.21.2 Added the `view_grades` capability.
 	 * @since 6.0.0 Added `manage_earned_engagement` capability.
+	 * @since [version] Use {@see LLMS_Capabilities} in favor of a hard-coded list.
 	 *
 	 * @link https://lifterlms.com/docs/roles-and-capabilities/
+	 * @see LLMS_Capabilities
 	 *
 	 * @return string[]
 	 */
@@ -69,70 +71,54 @@ class LLMS_Roles {
 		 */
 		return apply_filters(
 			'llms_get_all_core_caps',
-			array(
-				'lifterlms_instructor',
-				'manage_lifterlms',
-				self::MANAGE_EARNED_ENGAGEMENT_CAP,
-				'view_lifterlms_reports',
-				'view_others_lifterlms_reports',
-				'enroll',
-				'unenroll',
-				'create_students',
-				'view_grades',
-				'view_students',
-				'view_others_students',
-				'edit_students',
-				'edit_others_students',
-				'delete_students',
-				'delete_others_students',
-			)
+			array_values( LLMS_Capabilities::cases() )
 		);
 	}
 
 	/**
-	 * Retrieve the LifterLMS core capabilities for a give role
+	 * Retrieves all the LifterLMS core capabilities for a give role.
 	 *
 	 * @since 3.13.0
 	 * @since 3.34.0 Added student management capabilities.
 	 * @since 4.21.2 Added 'view_grades' to the list of instructor/assistant caps which are not automatically available.
 	 * @since 6.0.0 Added `manage_earned_engagement` to the list of instructor/assistant caps which are not automatically available.
+	 * @since [version] Refactored for reduced cognitive complexity.
+	 *               Reference capabilities from {@see LLMS_Capabilities} constants in favor of using strings.
 	 *
 	 * @param string $role Name of the role.
-	 * @return string[]
+	 * @return bool[] An associative array where the array key is the capability name and the array value is `true`.
 	 */
 	private static function get_core_caps( $role ) {
 
-		$all_caps = array_fill_keys( array_values( self::get_all_core_caps() ), true );
+		$all_caps = array_fill_keys(
+			array_values( self::get_all_core_caps() ),
+			true
+		);
 
-		switch ( $role ) {
-
-			case 'instructor':
-			case 'instructors_assistant':
-				$caps = $all_caps;
-				unset(
-					$caps['enroll'],
-					$caps['unenroll'],
-					$caps['manage_lifterlms'],
-					$caps[ self::MANAGE_EARNED_ENGAGEMENT_CAP ],
-					$caps['view_others_lifterlms_reports'],
-					$caps['create_students'],
-					$caps['view_others_students'],
-					$caps['edit_students'],
-					$caps['edit_others_students'],
-					$caps['delete_students'],
-					$caps['delete_others_students'],
-					$caps['view_grades']
-				);
-				break;
-
-			case 'administrator':
-			case 'lms_manager':
-				$caps = $all_caps;
-				break;
-
-			default:
-				$caps = array();
-
+		$caps = array();
+		if ( in_array( $role, array( 'administrator', 'lms_manager' ), true ) ) {
+			$caps = $all_caps;
+		} elseif ( in_array( $role, array( 'instructor', 'instructors_assistant' ), true ) ) {
+			$caps = array_diff_key(
+				$all_caps,
+				array_fill_keys(
+					array(
+						LLMS_Capabilities::ENROLL,
+						LLMS_Capabilities::UNENROLL,
+						LLMS_Capabilities::MANAGE_LIFTERLMS,
+						LLMS_Capabilities::MANAGE_EARNED_ENGAGEMENT,
+						LLMS_Capabilities::VIEW_OTHERS_REPORTS,
+						LLMS_Capabilities::CREATE_STUDENTS,
+						LLMS_Capabilities::VIEW_OTHERS_STUDENTS,
+						LLMS_Capabilities::EDIT_STUDENTS,
+						LLMS_Capabilities::EDIT_OTHERS_STUDENTS,
+						LLMS_Capabilities::DELETE_STUDENTS,
+						LLMS_Capabilities::DELETE_OTHERS_STUDENTS,
+						LLMS_Capabilities::VIEW_GRADES,
+					),
+					true
+				)
+			);
 		}
 
 		/**

--- a/tests/phpunit/framework/class-llms-enum-mock.php
+++ b/tests/phpunit/framework/class-llms-enum-mock.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Mock enum testing.
+ *
+ * @since [version]
+ */
+class LLMS_Enum_Mock extends LLMS_Abstract_Enum {
+
+	public const MOCK_CASE_A = 'mock_case_a';
+	public const MOCK_CASE_B = 'mock_case_b';
+	public const MOCK_CASE_C = 'mock_case_c';
+
+	public const MOCK_CASE_INT = 1;
+
+	public const MOCK_CASE_BOOL = true;
+
+};

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-enum.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-enum.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tests for the LLMS_Abstract_Enum class
+ *
+ * @package LifterLMS/Tests/Abstracts
+ *
+ * @group abstracts
+ * @group enum
+ *
+ * @since [version]
+ */
+class LLMS_Test_Abstract_Enum extends LLMS_UnitTestCase {
+
+	/**
+	 * Tests {@see LLMS_Test_Abstract_Enum::cases}.
+	 *
+	 * @since [version]
+	 */
+	public function test_cases() {
+
+		$cases = LLMS_Enum_Mock::cases();
+
+		$this->assertTrue( is_array( $cases ) );
+
+		$this->assertSame( LLMS_Enum_Mock::MOCK_CASE_A, $cases['MOCK_CASE_A'] );
+		$this->assertSame( LLMS_Enum_Mock::MOCK_CASE_B, $cases['MOCK_CASE_B'] );
+		$this->assertSame( LLMS_Enum_Mock::MOCK_CASE_C, $cases['MOCK_CASE_C'] );
+		$this->assertSame( LLMS_Enum_Mock::MOCK_CASE_INT, $cases['MOCK_CASE_INT'] );
+		$this->assertSame( LLMS_Enum_Mock::MOCK_CASE_BOOL, $cases['MOCK_CASE_BOOL'] );
+
+
+
+	}
+
+}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
@@ -46,6 +46,78 @@ class LLMS_Test_Admin_Menus extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Retrieves a mock admin menu array.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	private function get_mock_admin_menu() {
+
+		$menu = array();
+		$menu[2]  = array( __( 'Dashboard' ), 'read', 'index.php', '', 'menu-top menu-top-first menu-icon-dashboard', 'menu-dashboard', 'dashicons-dashboard' );
+		$menu[4]  = array( '', 'read', 'separator1', '', 'wp-menu-separator' );
+		$menu[5] = array( 'Posts', 'edit_posts', 'edit.php', '', 'menu-top menu-icon-post open-if-no-js', 'menu-posts', 'dashicons-admin-post' );
+		$menu[7] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
+
+		return $menu;
+
+	}
+
+	/**
+	 * Tests {@see LLMS_Admin_Menus::instructor:menu_hack}.
+	 *
+	 * @since [version]
+	 */
+	public function test_instructor_menu_hack() {
+
+		global $menu;
+
+		$tests = array(
+			'administrator'         => array( 2, 4, 5, 7 ),
+			'lms_manager'           => array( 2, 4, 5, 7 ),
+			'author'                => array( 2, 4, 5, 7 ),
+			'instructor'            => array( 2, 4, 7 ),
+			'instructors_assistant' => array( 2, 4, 7 ),
+		);
+
+		foreach ( $tests as $role => $expected ) {
+			$menu = $this->get_mock_admin_menu();
+			wp_set_current_user( $this->factory->user->create( compact( 'role' ) ) );
+			$this->main->instructor_menu_hack();
+			$this->assertEquals( $expected, array_keys( $menu ), $role );
+		}
+
+	}
+
+	/**
+	 * Tests {@see LLMS_Admin_Menus::instructor:menu_hack} when an instructor is
+	 * explicitly allowed to edit posts.
+	 *
+	 * @since [version]
+	 */
+	public function test_instructor_menu_hack_removed() {
+
+		global $menu;
+		$menu = $this->get_mock_admin_menu();
+
+		// Allow instructor to edit.
+		$handler = function( $roles ) {
+			return array( 'instructors_assistant' );
+		};
+		add_filter( 'llms_instructor_menu_hack_roles', $handler );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'instructor' ) ) );
+
+		$this->main->instructor_menu_hack();
+		$this->assertEquals( array( 2, 4, 5, 7 ), array_keys( $menu ) );
+
+		remove_filter( 'llms_instructor_menu_hack_roles', $handler );
+		unset( $menu );
+
+	}
+
+	/**
 	 * Test reporting_page_init() when there's permission issues.
 	 *
 	 * @since 4.7.0


### PR DESCRIPTION
## Description

A dev asked about the instructor admin menu hack -- still an open trac bug: https://core.trac.wordpress.org/ticket/16808

This dev is adding the ability for an instructor to edit posts, our "hack" doesn't differentiate between explicitly granting the `edit_posts` capability, and having the capability for the purposes of this hack.

I looked into removing it or implementing a different solution. And found adding a filter probably the simplest way to achieve the dev's needs. The `instructor` role can be removed via filter and then the hack won't affect them anymore and they'll be able to edit posts due to being granted the additional permissions explicitly.

Additionally, I've been working on this enum concept for a bit and felt this was a simple place to introduce it for review and inclusion.

Neither of these are high priority and I'm open to feedback on a better implementation.

I included the capabilities "enum" because I initially planned to add a new capability that would be used in favor of `edit_posts`. If they had this cap, we'd "pseudo add" `edit_posts` conditionally via the `user_has_cap` filter... But this got complicated quick and I started to question the removal of the `edit_posts` cap. It would require a database migration and possibly could break existing customizations. But I'd already written the code so I included it.

## How has this been tested?

+ Manually
+ New & existing unit tests

## Screenshots <!-- if applicable -->

## Types of changes
New feature (non-breaking change which adds functionality

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-runx, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

