### PR TITLE
Instructor menu hack

### DIFF
--- a/.changelogs/instructor-menu-hack.yml
+++ b/.changelogs/instructor-menu-hack.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: dev
+entry: Added new filter to allow customizing which user roles are affected by
+  the `LLMS_Admin_Menus::instructor_menu_hack` function.

--- a/includes/admin/class.llms.admin.menus.php
+++ b/includes/admin/class.llms.admin.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -127,7 +127,6 @@ class LLMS_Admin_Menus {
 		return $flag;
 
 	}
-
 
 	/**
 	 * Handle init actions on the course builder page
@@ -287,6 +286,8 @@ class LLMS_Admin_Menus {
 	 * but this hack will allow instructors to publish new lessons, quizzes, & questions.
 	 *
 	 * @since 3.13.0
+	 * @since [version] Added filterable early return allowing 3rd parties to modify
+	 *               the user roles affected by this hack.
 	 *
 	 * @link https://core.trac.wordpress.org/ticket/22895
 	 * @link https://core.trac.wordpress.org/ticket/16808
@@ -294,8 +295,25 @@ class LLMS_Admin_Menus {
 	 * @return void
 	 */
 	public function instructor_menu_hack() {
+
+		/**
+		 * Filters the WP_User roles should receive the instructor admin menu hack.
+		 *
+		 * If you wish to provide explicit access to the `post` post type, to the
+		 * instrutor or instructor's assistant role, the role will need to be
+		 * removed from this array so they can access to the post type edit.php
+		 * screen.
+		 *
+		 * @see LLMS_Admin_Menus::instructor_menu_hack
+		 *
+		 * @since [version]
+		 *
+		 * @param string[] $roles The list of WP_User roles which need the hack.
+		 */
+		$roles = apply_filters( 'llms_instructor_menu_hack_roles', array( 'instructor', 'instructors_assistant' ) );
+
 		$user = wp_get_current_user();
-		if ( array_intersect( array( 'instructor', 'instructors_assistant' ), $user->roles ) ) {
+		if ( array_intersect( $roles, $user->roles ) ) {
 			remove_menu_page( 'edit.php' );
 		}
 	}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-menus.php
@@ -46,6 +46,78 @@ class LLMS_Test_Admin_Menus extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Retrieves a mock admin menu array.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	private function get_mock_admin_menu() {
+
+		$menu = array();
+		$menu[2]  = array( __( 'Dashboard' ), 'read', 'index.php', '', 'menu-top menu-top-first menu-icon-dashboard', 'menu-dashboard', 'dashicons-dashboard' );
+		$menu[4]  = array( '', 'read', 'separator1', '', 'wp-menu-separator' );
+		$menu[5] = array( 'Posts', 'edit_posts', 'edit.php', '', 'menu-top menu-icon-post open-if-no-js', 'menu-posts', 'dashicons-admin-post' );
+		$menu[7] = array( '', 'read', 'separator2', '', 'wp-menu-separator' );
+
+		return $menu;
+
+	}
+
+	/**
+	 * Tests {@see LLMS_Admin_Menus::instructor:menu_hack}.
+	 *
+	 * @since [version]
+	 */
+	public function test_instructor_menu_hack() {
+
+		global $menu;
+
+		$tests = array(
+			'administrator'         => array( 2, 4, 5, 7 ),
+			'lms_manager'           => array( 2, 4, 5, 7 ),
+			'author'                => array( 2, 4, 5, 7 ),
+			'instructor'            => array( 2, 4, 7 ),
+			'instructors_assistant' => array( 2, 4, 7 ),
+		);
+
+		foreach ( $tests as $role => $expected ) {
+			$menu = $this->get_mock_admin_menu();
+			wp_set_current_user( $this->factory->user->create( compact( 'role' ) ) );
+			$this->main->instructor_menu_hack();
+			$this->assertEquals( $expected, array_keys( $menu ), $role );
+		}
+
+	}
+
+	/**
+	 * Tests {@see LLMS_Admin_Menus::instructor:menu_hack} when an instructor is
+	 * explicitly allowed to edit posts.
+	 *
+	 * @since [version]
+	 */
+	public function test_instructor_menu_hack_removed() {
+
+		global $menu;
+		$menu = $this->get_mock_admin_menu();
+
+		// Allow instructor to edit.
+		$handler = function( $roles ) {
+			return array( 'instructors_assistant' );
+		};
+		add_filter( 'llms_instructor_menu_hack_roles', $handler );
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'instructor' ) ) );
+
+		$this->main->instructor_menu_hack();
+		$this->assertEquals( array( 2, 4, 5, 7 ), array_keys( $menu ) );
+
+		remove_filter( 'llms_instructor_menu_hack_roles', $handler );
+		unset( $menu );
+
+	}
+
+	/**
 	 * Test reporting_page_init() when there's permission issues.
 	 *
 	 * @since 4.7.0


### PR DESCRIPTION
A dev asked about the instructor admin menu hack -- still an open trac bug: https://core.trac.wordpress.org/ticket/16808

This dev is adding the ability for an instructor to edit posts, our "hack" doesn't differentiate between explicitly granting the edit_posts capability, and having the capability for the purposes of this hack.

I looked into removing it or implementing a different solution. And found adding a filter probably the simplest way to achieve the dev's needs. The instructor role can be removed via filter and then the hack won't affect them anymore and they'll be able to edit posts due to being granted the additional permissions explicitly.

## How has this been tested?

+ New unit tests
+ Manually


## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

