### PR TITLE
llms_is_user_enrolled always return false for non existing or unlogged users

### DIFF
--- a/.changelogs/check_user_existence_on_checking_enrollment.yml
+++ b/.changelogs/check_user_existence_on_checking_enrollment.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+entry: The function `llms_is_user_enrolled()` will always return `false` for non
+  existing users. While, before, it could return `true` if a now removed user
+  was enrolled into a the given course or membership.

--- a/.changelogs/enrollment-no-user.yml
+++ b/.changelogs/enrollment-no-user.yml
@@ -1,0 +1,5 @@
+significance: major
+type: performance
+entry: Immediately return false when running `llms_is_user_enrolled()` on logged
+  out or no longer existing users, avoiding running additional DB queries e.g.
+  when displaying course or membership catalogs for visitors.

--- a/.changelogs/enrollment-no-user.yml
+++ b/.changelogs/enrollment-no-user.yml
@@ -1,4 +1,4 @@
-significance: major
+significance: patch
 type: performance
 entry: Immediately return false when running `llms_is_user_enrolled()` on logged
   out or no longer existing users, avoiding running additional DB queries e.g.

--- a/includes/functions/llms.functions.person.php
+++ b/includes/functions/llms.functions.person.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 7.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -292,10 +292,12 @@ function llms_is_complete( $user_id, $object_id, $object_type = 'course' ) {
 }
 
 /**
- * Checks if user is currently enrolled in course
+ * Checks if user is currently enrolled courses, sections, lessons, or memberships.
  *
  * @since Unknown
  * @since 3.25.0 Unknown.
+ * @since [version] From now on this function will always return false for non existing users,
+ *               e.g. deleted users.
  *
  * @see LLMS_Student->is_enrolled()
  *
@@ -309,7 +311,9 @@ function llms_is_complete( $user_id, $object_id, $object_type = 'course' ) {
  */
 function llms_is_user_enrolled( $user_id, $product_id, $relation = 'all', $use_cache = true ) {
 	$student = new LLMS_Student( $user_id );
-	return $student->is_enrolled( $product_id, $relation, $use_cache );
+	return $student->exists() ?
+		$student->is_enrolled( $product_id, $relation, $use_cache ) :
+		false;
 }
 
 /**

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions/Templates
  *
  * @since 1.0.0
- * @version 5.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -665,15 +665,18 @@ function llms_get_progress_bar_html( $percentage ) {
 
 
 /**
- * Output a course continue button linking to the incomplete lesson for a given student
- * If the course is complete "Course Complete" is displayed
+ * Output a course continue button linking to the incomplete lesson for a given student.
  *
- * @param    int        $post_id   WP Post ID for a course, lesson, or quiz
- * @param    obj        $student   instance of an LLMS_Student, defaults to current student
- * @param    integer    $progress  current progress of the student through the course
- * @return   void
- * @since    3.11.1
- * @version  3.15.0
+ * If the course is complete "Course Complete" is displayed.
+ *
+ * @since 3.11.1
+ * @since 3.15.0 Unknown.
+ * @since [version] Remove check on student existence, now included in the enrollment check.
+ *
+ * @param int          $post_id  WP Post ID for a course, lesson, or quiz.
+ * @param LLMS_Student $student  Instance of an LLMS_Student, defaults to current student.
+ * @param int          $progress Current progress of the student through the course.
+ * @return void
  */
 if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 
@@ -700,7 +703,7 @@ if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 		if ( ! $student ) {
 			$student = llms_get_student();
 		}
-		if ( ! $student || ! $student->exists() || ! llms_is_user_enrolled( $student->get_id(), $course->get( 'id' ) ) ) {
+		if ( ! $student || ! llms_is_user_enrolled( $student->get_id(), $course->get( 'id' ) ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
## Description
While looking at https://github.com/gocodebox/private-issues/issues/63
I realized that we "try" to query the DB looking for enrollments even for not logged in users, and generally for non existing users (e.g. deleted users). In this PR I just return immediately false when checking for enrollments of non existing users when using `llms_is_user_enrolled()`. 
This is technically a breaking change (so will ideally push the next LifterLMS version to 8.0), as we're changing the default behavior of a public function although we internally always used that assuming that the user was existing: with that function you could theoretically query the enrollment status of a student in a course even if the student was deleted.
Also consider that in the future we  want to delete the enrollment related data of a user upon its removal (see https://github.com/gocodebox/lifterlms/issues/940 bullet  _Delete data from lifterlms_user_postmeta table_). Maybe we want take the occasion and implement a fix for #940 so to release a new major version including this PR?

This PR will also basically fix https://github.com/gocodebox/private-issues/issues/63

Also this PR has some perfomance impact (improvements) on not logged in users visiting e.g. courses or membership catalogs: for each course/membership in the current catalog page we check whether or not the current user (user with ID 0 for non logged in users) is enrolled in the course/membership performing a custom and not simple DB query (although on an index of the table).

## How has this been tested?
manually and existing unit tests


## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

