### PR TITLE
[dev cli] Account for spaces in the file paths

### DIFF
--- a/packages/dev/src/cmds/release/archive.js
+++ b/packages/dev/src/cmds/release/archive.js
@@ -19,7 +19,7 @@ module.exports = {
 			);
 		// Unzip the archive for inspection.
 		if ( inspect ) {
-			execSync( `unzip ${ fileName }`, ! verbose, { cwd: distDir } );
+			execSync( `unzip "${ fileName }"`, ! verbose, { cwd: distDir } );
 		}
 
 		logResult( `Distribution file ${ chalk.bold( fileName ) } created successfully.`, 'success' );

--- a/packages/dev/src/cmds/release/create.js
+++ b/packages/dev/src/cmds/release/create.js
@@ -144,7 +144,7 @@ module.exports = {
 
 		createArgs.push( `--title "Version ${ version }"` );
 		createArgs.push( `--target ${ branch }` );
-		createArgs.push( `--notes-file ${ notesFile }` );
+		createArgs.push( `--notes-file "${ notesFile }"` );
 
 		if ( draft ) {
 			createArgs.push( '--draft' );
@@ -159,6 +159,6 @@ module.exports = {
 		logResult( `Release v${ chalk.bold( version ) } published. Permalink: ${ chalk.underline( res ) }.` );
 
 		// Cleanup the tmp notesfile.
-		execSync( `rm ${ notesFile }` );
+		execSync( `rm "${ notesFile }"` );
 	},
 };

--- a/packages/dev/src/cmds/release/prepare.js
+++ b/packages/dev/src/cmds/release/prepare.js
@@ -8,6 +8,7 @@ const
  * Call the cli from within the cli.
  *
  * @since 0.0.1
+ * @since [version] Account for spaces in the file paths.
  *
  * @param {string}  cmd    CLI command and options.
  * @param {boolean} silent If `true`, silence STDOUT.
@@ -17,7 +18,7 @@ function callSelf( cmd, silent = true ) {
 	const [ node, cli ] = process.argv;
 	let ret = null;
 	try {
-		ret = execSync( `${ node } ${ cli } ${ cmd }`, silent );
+		ret = execSync( `"${ node }" "${ cli }" ${ cmd }`, silent );
 	} catch ( e ) {
 		logResult( `${ e.type }: ${ e.message }.`, 'error' );
 		console.error( e );

--- a/packages/dev/src/utils/create-dist-file.js
+++ b/packages/dev/src/utils/create-dist-file.js
@@ -55,7 +55,7 @@ module.exports = ( distDir, silent, log = () => {} ) => {
 	}
 
 	// Create the initial archive using composer.
-	execSync( `composer archive --format=zip --dir=${ distDir } --file=${ name.replace( '.zip', '' ) }`, true );
+	execSync( `composer archive --format=zip --dir="${ distDir }" --file=${ name.replace( '.zip', '' ) }`, true );
 
 	// Unzip the initial archive into a subdirectory matching the project's slug.
 	execSync( `unzip ${ name } -d ${ slug }`, silent, { cwd } );

--- a/packages/dev/src/utils/push-dist-file.js
+++ b/packages/dev/src/utils/push-dist-file.js
@@ -28,7 +28,7 @@ module.exports = ( distFile, branch, message, silent = true ) => {
 		url = execSync( 'git config --get remote.origin.url', true );
 
 	// Clone the repo into a temp directory.
-	execSync( `git clone ${ url } ${ cwd }`, silent );
+	execSync( `git clone ${ url } "${ cwd }"`, silent );
 
 	// Checkout to the publication branch.
 	execSync( `git checkout -b ${ branch }`, silent, { cwd } );
@@ -37,7 +37,7 @@ module.exports = ( distFile, branch, message, silent = true ) => {
 	execSync( `mv .git ../ && cd ../ && rm -rf ./git && mkdir git && mv .git ./git && cd git`, silent, { cwd } );
 
 	// Extract the distribution file.
-	execSync( `unzip ${ distFile } -d ./tmp/git/`, silent );
+	execSync( `unzip "${ distFile }" -d ./tmp/git/`, silent );
 
 	// Move all the contents into the publication branch.
 	execSync( `mv ./${ slug }/* ./ && rm -rf ${ slug }/`, silent, { cwd } );


### PR DESCRIPTION
Should fix the issue with the spaces in file paths occurring e.g. on Windows.

I tested it trying to reproduce the same "environment": both `npm` executable and the project directory inside directories with a spaces in their name.

Seems to work fine with my tests,
I tested the following `release` commands:
- `prepare` (the one that failed)
- `archive`

I didn't thoroughly tested the `create` command to avoid inadvertently pushing on the repo, but it should work fine.