### PR TITLE
Make the LifterLMS menu meta box initially available on Appearance -> Menus

### DIFF
--- a/.changelogs/lifterlms-menu-metabox.yml
+++ b/.changelogs/lifterlms-menu-metabox.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Make the LifterLMS menu meta box initially available on Appearance -> Menus.

--- a/includes/class.llms.nav.menus.php
+++ b/includes/class.llms.nav.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 3.14.7
- * @version 4.12.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,6 +26,8 @@ class LLMS_Nav_Menus {
 	 *
 	 * @since 3.14.7
 	 * @since 3.22.0 Unknown.
+	 * @since [version] Postpone the LifterLMS menu meta box addition to `admin_head-nav-menus.php`
+	 *               rather than `load-nav-menus.php` it's not initially hidden (for new users).
 	 *
 	 * @return void
 	 */
@@ -35,7 +37,7 @@ class LLMS_Nav_Menus {
 		add_filter( 'wp_nav_menu_objects', array( $this, 'filter_nav_items' ) );
 
 		// Add meta box to the Appearance -> Menus screen on admin panel.
-		add_action( 'load-nav-menus.php', array( $this, 'add_metabox' ) );
+		add_action( 'admin_head-nav-menus.php', array( $this, 'add_metabox' ) );
 
 		// Add LifterLMS menu item type section to customizer.
 		add_filter( 'customize_nav_menu_available_item_types', array( $this, 'customize_add_type' ) );


### PR DESCRIPTION
## Description
@chrisbadgett asked me to look into how to make the LifterLMS meta box available/visible by default under Appearance -> Menus, without the need of enabling it via Screen Options.
This PR allows that. Of course it will only apply to new users from now on, as for older users who already opened that page WordPress already saved the hiding of that item as user "preference".

More in depth description:
- [as soon as you go](https://github.com/WordPress/WordPress/blob/599201eca70e810931efab24a21ec87e45921594/wp-admin/nav-menus.php#L611) in Appearance -> Menu, WordPress runs this:
https://developer.wordpress.org/reference/functions/wp_initial_nav_menu_meta_boxes/
- so the first time you go there the option `metaboxhidden_nav-menus` is not set, so only the defined _initial meta boxes_ are displayed: 	`$initial_meta_boxes = array( 'add-post-type-page', 'add-post-type-post', 'add-custom-links', 'add-category' );`
- All the others (see `global $wp_meta_boxes` ) that have been added until that point are marked as _hidden_, and the list of the hidden meta boxes is saved into the option `metaboxhidden_nav-menus`., so next time they won't be shown. This option can be altered then via the Screen Options on that Appearance -> Menus page.
- In this PR we add the [meta box after](https://github.com/WordPress/WordPress/blob/599201eca70e810931efab24a21ec87e45921594/wp-admin/nav-menus.php#L691) the `wp_initial_nav_menu_meta_boxes()` has run, so our meta box won't be part of the `global $wp_meta_boxes` seen by that function, so it won't be automatically marked as hidden, while prior to this PR the meta box addition would run before `wp_initial_nav_menu_meta_boxes()`, so the added meta box would be marked as hidden and saved as such.
- This means that an admin user headed to that menus page prior to this PR would have the LifterLMS meta box automatically saved as hidden, hence this PR won't affect them.

(the new hook is the same hook used by WooCommerce for the same purpose)

## How has this been tested?
manually, creating a new (administrator) user and switching to it.

## Screenshots <!-- if applicable -->
![screenshotW-20230125_130512_381105809](https://user-images.githubusercontent.com/7689242/214560603-129307b7-8b4c-4ed8-a5ad-548df22a6eb8.png)

## Types of changes
UX improvement?

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

