### PR TITLE
Fixed possible admin notices duplication when activating/deactivating or installing add-ons from the page Add-ons & more

### DIFF
--- a/.changelogs/issue_23240.yml
+++ b/.changelogs/issue_23240.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2340"
+entry: Fixed possible admin notices duplication when activating/deactivating or
+  installing add-ons from the page Add-ons & more.

--- a/includes/admin/class.llms.admin.notices.php
+++ b/includes/admin/class.llms.admin.notices.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -18,11 +18,18 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Notices {
 
 	/**
-	 * Array of messages to display
+	 * Array of messages to display.
 	 *
-	 * @var  array
+	 * @var array
 	 */
 	private static $notices = array();
+
+	/**
+	 * Array of messages already displayed in the current request.
+	 *
+	 * @var array
+	 */
+	private static $printed_notices = array();
 
 	/**
 	 * Static constructor
@@ -342,16 +349,22 @@ class LLMS_Admin_Notices {
 	}
 
 	/**
-	 * Output all saved notices
+	 * Output all saved notices.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Made sure to print the notices only once.
 	 *
 	 * @return void
 	 */
 	public static function output_notices() {
-		foreach ( self::get_notices() as $notice_id ) {
+
+		$notices_to_print = array_diff( self::get_notices(), self::$printed_notices );
+
+		foreach ( $notices_to_print as $notice_id ) {
 			self::output_notice( $notice_id );
+			self::$printed_notices[] = $notice_id;
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
## Description
Fixes #2340 

## How has this been tested?
manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

