### PR TITLE
Some cs/doc fixes.

### DIFF
--- a/.changelogs/courses-lesssons-count.yml
+++ b/.changelogs/courses-lesssons-count.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added lessons count column on the Courses post list table.

--- a/.changelogs/lessons-links-builder.yml
+++ b/.changelogs/lessons-links-builder.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: Added link to the course builder for each lesson on the Lessons post list
+  table. Also added a link to either edit or add a quiz.

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/PostTables/Classes
  *
  * @since 3.3.0
- * @version 3.24.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,11 +19,13 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Post_Table_Courses {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
-	 * @return  void
-	 * @since    3.3.0
-	 * @version  3.13.0
+	 * @since 3.3.0
+	 * @since 3.13.0 Unknown.
+	 * @since [version] Added new custom columns.
+	 *
+	 * @return void
 	 */
 	public function __construct() {
 
@@ -134,7 +136,7 @@ class LLMS_Admin_Post_Table_Courses {
 
 
 	/**
-	 * Add Custom course Columns
+	 * Add custom course columns.
 	 *
 	 * @since [version]
 	 *
@@ -144,7 +146,7 @@ class LLMS_Admin_Post_Table_Courses {
 	public function add_columns( $columns ) {
 
 		// Add a new column for Lessons.
-		$new_columns = array();
+		$new_columns            = array();
 		$new_columns['lessons'] = __( 'Lessons', 'lifterlms' );
 
 		// Insert column into third position in existing columns array.
@@ -155,7 +157,7 @@ class LLMS_Admin_Post_Table_Courses {
 
 
 	/**
-	 * Manage content of custom course columns
+	 * Manage content of custom course columns.
 	 *
 	 * @since [version]
 	 *
@@ -165,38 +167,34 @@ class LLMS_Admin_Post_Table_Courses {
 	 */
 	public function manage_columns( $column, $post_id ) {
 
-		switch ( $column ) {
+		if ( 'lessons' !== $column ) {
+			return $column;
+		}
 
-			case 'lessons':
+		// Get a count of lessons in the course.
+		$course       = llms_get_post( $post_id );
+		$lessons      = $course->get_lessons( 'ids' );
+		$lesson_count = count( $lessons );
 
-				// Get a count of lessons in the course.
-				$course = llms_get_post( $post_id );
-				$lessons = $course->get_lessons( 'lessons' );
-				$lesson_count = (int) count( $lessons );
+		if ( $lesson_count ) {
 
-				if ( ! empty( $lesson_count ) ) {
+			// Build the URL to link to lesson post type filtered for course ID.
+			$url = add_query_arg(
+				array(
+					'post_status'           => 'all',
+					'post_type'             => 'lesson',
+					'llms_filter_course_id' => $post_id,
+				),
+				admin_url( 'edit.php' )
+			);
 
-					// Build the URL to link to lesson post type filtered for course ID.
-					$url = add_query_arg(
-						array(
-							'post_status' => 'all',
-							'post_type' => 'lesson',
-							'llms_filter_course_id' => $post_id,
-						),
-						admin_url( 'edit.php' )
-					);
+			// Translators: %d = Number of lessons in the specified course.
+			$label = sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'lifterlms' ), $lesson_count );
+			echo '<a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
 
-					// Translators: %d = Number of lessons in the specified course.
-					$label = sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'lifterlms' ), $lesson_count );
-					echo '<a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
+		} else {
 
-				} else {
-
-					echo '&ndash;';
-
-				}
-
-				break;
+			echo '&ndash;';
 
 		}
 

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.lessons.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.lessons.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/PostTables/Classes
  *
  * @since 3.2.3
- * @version 5.7.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -19,10 +19,11 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Post_Table_Lessons {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @since 3.2.3
 	 * @since 3.12.0 Unknown.
+	 * @since [version] Added links to the course builder.
 	 *
 	 * @return void
 	 */
@@ -39,12 +40,13 @@ class LLMS_Admin_Post_Table_Lessons {
 	}
 
 	/**
-	 * Add course builder edit link
+	 * Add course builder edit link.
 	 *
-	 * @param    array $actions  existing actions
-	 * @param    obj   $post     WP_Post object
-	 * @since    [version]
-	 * @version  [version]
+	 * @since [version]
+	 *
+	 * @param array   $actions Existing actions.
+	 * @param WP_Post $post    Lesson's WP_Post object.
+	 * @return array
 	 */
 	public function add_links( $actions, $post ) {
 
@@ -52,18 +54,18 @@ class LLMS_Admin_Post_Table_Lessons {
 
 			$lesson = llms_get_post( $post->ID );
 			if ( ! $lesson ) {
-				return;
+				return $actions;
 			}
 
 			$course = $lesson->get( 'parent_course' );
-			$url = add_query_arg(
+			$url    = add_query_arg(
 				array(
 					'page'      => 'llms-course-builder',
 					'course_id' => $course,
 				),
 				admin_url( 'admin.php' )
 			);
-			$url  .= sprintf( '#lesson:%d', $post->ID );
+			$url   .= sprintf( '#lesson:%d', $post->ID );
 
 			$actions = array_merge(
 				array(
@@ -79,10 +81,11 @@ class LLMS_Admin_Post_Table_Lessons {
 	}
 
 	/**
-	 * Add Custom lesson Columns
+	 * Add custom lesson columns.
 	 *
 	 * @since 3.2.3
 	 * @since 3.12.0 Unknown.
+	 * @since [version] Quiz column added.
 	 *
 	 * @param array $columns Array of default columns.
 	 * @return array
@@ -95,7 +98,7 @@ class LLMS_Admin_Post_Table_Lessons {
 			'course'  => __( 'Course', 'lifterlms' ),
 			'section' => __( 'Section', 'lifterlms' ),
 			'prereq'  => __( 'Prerequisite', 'lifterlms' ),
-			'quiz'  => __( 'Quiz', 'lifterlms' ),
+			'quiz'    => __( 'Quiz', 'lifterlms' ),
 			'author'  => __( 'Author', 'lifterlms' ),
 			'date'    => __( 'Date', 'lifterlms' ),
 		);
@@ -125,11 +128,12 @@ class LLMS_Admin_Post_Table_Lessons {
 	}
 
 	/**
-	 * Manage content of custom lesson columns
+	 * Manage content of custom lesson columns.
 	 *
 	 * @since 3.2.3
 	 * @since 3.24.0 Unknown.
 	 * @since 5.7.0 Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
+	 * @since [version] Implemented content for the quiz column.
 	 *
 	 * @param string $column  Column key/name.
 	 * @param int    $post_id WP Post ID of the lesson for the row.
@@ -187,14 +191,14 @@ class LLMS_Admin_Post_Table_Lessons {
 
 			case 'quiz':
 				$course = $lesson->get( 'parent_course' );
-				$url = add_query_arg(
+				$url    = add_query_arg(
 					array(
 						'page'      => 'llms-course-builder',
 						'course_id' => $course,
 					),
 					admin_url( 'admin.php' )
 				);
-				$url  .= sprintf( '#lesson:%d:quiz', $post_id );
+				$url   .= sprintf( '#lesson:%d:quiz', $post_id );
 
 				if ( $lesson->has_quiz() ) {
 


### PR DESCRIPTION
Not a big deal, we just merged new code not compliant with our cs/doc standards.
This PR is mostly about:
- fixing spaces (e.g. equal sign alignment)
- added changelog entries (.changelogs/*yml)
- added/fixed functions/files changelog/documentation (https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md)

I haven't changed any logic, just turned a `switch` with only one `case` to a simple `if` statement.
Also, when we only need counting the lessons of a course, but we don't need to retrieve any other information about the lessons, we can use `$course->get_lessons( 'ids' );` rather than `$course->get_lessons( 'lessons' );` because it's a bit more performant (the latter instantiates a whole `LLMS_Lesson` object for each lesson, and we don't need that.)

