### PR TITLE
Improve performance when counting course's lessons on the course post list table

### DIFF
--- a/.changelogs/improve-lessons-count-perf.yml
+++ b/.changelogs/improve-lessons-count-perf.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: dev
+entry: Added new `LLMS_Course::get_lessons_count()` method. It can be used in
+  place of `count( LLMS_Course::get_lessons() )` to improve performance.

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.courses.php
@@ -173,8 +173,9 @@ class LLMS_Admin_Post_Table_Courses {
 
 		// Get a count of lessons in the course.
 		$course       = llms_get_post( $post_id );
-		$lessons      = $course->get_lessons( 'ids' );
-		$lesson_count = count( $lessons );
+		$lesson_count = $course->get_lessons_count();
+
+		$column_content = '&ndash;';
 
 		if ( $lesson_count ) {
 
@@ -189,14 +190,12 @@ class LLMS_Admin_Post_Table_Courses {
 			);
 
 			// Translators: %d = Number of lessons in the specified course.
-			$label = sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'lifterlms' ), $lesson_count );
-			echo '<a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
-
-		} else {
-
-			echo '&ndash;';
+			$label          = sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'lifterlms' ), $lesson_count );
+			$column_content = '<a href="' . esc_url( $url ) . '">' . esc_html( $label ) . '</a>';
 
 		}
+
+		echo $column_content;
 
 	}
 

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -5,13 +5,13 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Course model class
+ * LLMS_Course model class.
  *
  * @since 1.0.0
  * @since 3.30.3 Explicitly define class properties.
@@ -295,6 +295,37 @@ class LLMS_Course extends LLMS_Post_Model implements LLMS_Interface_Post_Instruc
 			$ret = array_map( 'llms_get_post', $lessons );
 		}
 		return $ret;
+
+	}
+
+	/**
+	 * Retrieve the number of course's lessons.
+	 *
+	 * This is less expensive than counting the result of {@see LLMS_Course::get_lessons()},
+	 * and should be preferred when you only need to count the number of lessons of a course.
+	 *
+	 * @since [version]
+	 *
+	 * @return int
+	 */
+	public function get_lessons_count() {
+
+		$query = new WP_Query(
+			array(
+				'meta_key'               => '_llms_parent_course',
+				'meta_value'             => $this->get( 'id' ),
+				'post_type'              => 'lesson',
+				'posts_per_page'         => -1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				'fields'                 => 'ids',
+				'orderby'                => 'ID',
+				'order'                  => 'ASC',
+			)
+		);
+
+		return $query->post_count;
 
 	}
 


### PR DESCRIPTION
## Description
About the lessons count in the courses post list table:
The lessons count the way is done right now is not performant:
That is acceptable in most of the cases because we use that on a single course template ecc. But in a list of N courses, that could be pretty expensive if there are many courses with many sections and lessons each.
We’re now using `count( $course->get_lessons('ids') );`, but if you look at how course’s get_lessons() [method works](https://github.com/gocodebox/lifterlms/blob/7.0.1/includes/models/model.llms.course.php#L283), and down the rabbit hole at how section’s get_lessons() [method works](https://github.com/gocodebox/lifterlms/blob/7.0.1/includes/models/model.llms.section.php#L208), you’ll see what I’m talking about.
So I propose this as a viable alternative.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
performance

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

