### PR TITLE
Fix cs and docs

### DIFF
--- a/.changelogs/fix-cs-docs.yml
+++ b/.changelogs/fix-cs-docs.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: deprecated
+entry: Deprecated methods `LLMS_Admin_Notices_Core::sidebar_support()` and
+  `LLMS_Admin_Notices_Core::clear_sidebar_notice()`.

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -56,7 +56,10 @@ class LLMS_Admin_Header {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
-		if ( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) {
+		if (
+			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
+			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
+		) {
 			$show_header = true;
 		}
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -55,7 +55,7 @@ class LLMS_Admin_Header {
 		// Show header on our settings pages.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
 			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
 			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
@@ -63,6 +63,7 @@ class LLMS_Admin_Header {
 			$show_header = true;
 		}
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 
 		// Exclude the wizard.
 		if ( ! empty( $_GET['page'] ) && 'llms-setup' === $_GET['page'] ) {

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -11,14 +11,14 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin Header UI
+ * Admin Header UI.
  *
  * @since [version]
  */
 class LLMS_Admin_Header {
 
 	/**
-	 * Constructor
+	 * Constructor.
 	 *
 	 * @since [version]
 	 *
@@ -32,6 +32,8 @@ class LLMS_Admin_Header {
 	 * Show admin header banner on LifterLMS admin screens.
 	 *
 	 * @since [version]
+	 *
+	 * @return void
 	 */
 	public function admin_header() {
 
@@ -42,24 +44,31 @@ class LLMS_Admin_Header {
 		$current_screen = get_current_screen();
 
 		// Show header on our custom post types in admin, but not on the block editor.
-		if ( isset( $current_screen->post_type ) &&
-			in_array( $current_screen->post_type, array( 'course', 'lesson', 'llms_review', 'llms_membership', 'llms_engagement', 'llms_order', 'llms_coupon', 'llms_voucher', 'llms_form', 'llms_achievement', 'llms_my_achievement', 'llms_certificate', 'llms_my_certificate', 'llms_email' ), true ) && 
-			$current_screen->is_block_editor === false ) {
+		if (
+			isset( $current_screen->post_type ) &&
+			in_array( $current_screen->post_type, array( 'course', 'lesson', 'llms_review', 'llms_membership', 'llms_engagement', 'llms_order', 'llms_coupon', 'llms_voucher', 'llms_form', 'llms_achievement', 'llms_my_achievement', 'llms_certificate', 'llms_my_certificate', 'llms_email' ), true ) &&
+			false === $current_screen->is_block_editor
+		) {
 			$show_header = true;
 		}
 
 		// Show header on our settings pages.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if ( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) {
 			$show_header = true;
 		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Exclude the wizard.
-		if ( ! empty( $_GET['page' ] ) && $_GET['page'] === 'llms-setup' ) {
+		if ( ! empty( $_GET['page'] ) && 'llms-setup' === $_GET['page'] ) {
 			$show_header = false;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Don't show header on the Course Builder.
-		if ( $current_screen->base === 'admin_page_llms-course-builder' ) {
+		if ( 'admin_page_llms-course-builder' === $current_screen->base ) {
 			$show_header = false;
 		}
 
@@ -74,27 +83,27 @@ class LLMS_Admin_Header {
 						</div>
 						<div class="llms-meta-right">
 							<?php
-								// Show a license link in header if we aren't on the Add-ons screen.
-								$screen = get_current_screen();
-								if ( $screen->id !== 'lifterlms_page_llms-add-ons' ) {
-									?>
-									<span class="llms-license">
-										<?php
-											// Get active keys for this site.
-											$my_keys = llms_helper_options()->get_license_keys();
-
-											if ( empty( $my_keys ) ) {
-												$license_class = 'llms-license-none';
-												$license_label = __( 'No License', 'lifterlms' );
-											} else {
-												$license_class = 'llms-license-active';
-												$license_label = __( 'My License Keys', 'lifterlms' );
-											}
-										?>
-										<a class="<?php echo esc_attr( $license_class ); ?>" href="<?php echo esc_url( admin_url( 'admin.php?page=llms-add-ons' ) ); ?>"><?php echo esc_html( $license_label ); ?></a>
-									</span>
+							// Show a license link in header if we aren't on the Add-ons screen.
+							$screen = get_current_screen();
+							if ( 'lifterlms_page_llms-add-ons' !== $screen->id ) {
+								?>
+								<span class="llms-license">
 									<?php
-								}
+									// Get active keys for this site.
+									$my_keys = llms_helper_options()->get_license_keys();
+
+									if ( empty( $my_keys ) ) {
+										$license_class = 'llms-license-none';
+										$license_label = __( 'No License', 'lifterlms' );
+									} else {
+										$license_class = 'llms-license-active';
+										$license_label = __( 'My License Keys', 'lifterlms' );
+									}
+									?>
+									<a class="<?php echo esc_attr( $license_class ); ?>" href="<?php echo esc_url( admin_url( 'admin.php?page=llms-add-ons' ) ); ?>"><?php echo esc_html( $license_label ); ?></a>
+								</span>
+								<?php
+							}
 							?>
 							<span class="llms-support">
 								<a href="https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Dashboard%20Screen&utm_content=LifterLMS%20Support" target="_blank"><?php esc_html_e( 'Get Support', 'lifterlms' ); ?></a>

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -68,7 +68,7 @@ class LLMS_Admin_Header {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Don't show header on the Course Builder.
-		if ( 'admin_page_llms-course-builder' === $current_screen->base ) {
+		if ( isset( $current_screen->base ) && 'admin_page_llms-course-builder' === $current_screen->base ) {
 			$show_header = false;
 		}
 

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -5,13 +5,13 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.24.0
- * @version 4.14.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin review request
+ * Admin review request.
  *
  * Handles UI updates to the admin panel which request users to rate & review the
  * LifterLMS plugin on WordPress.org.
@@ -39,9 +39,10 @@ class LLMS_Admin_Review {
 	}
 
 	/**
-	 * On LifterLMS admin screens replace the default footer text with a review request
+	 * On LifterLMS admin screens replace the default footer text with a review request.
 	 *
 	 * @since 3.24.0
+	 * @since [version] Show footer on our custom post types in admin, but not on the block editor.
 	 *
 	 * @param string $text Default footer text.
 	 * @return string
@@ -51,24 +52,31 @@ class LLMS_Admin_Review {
 		global $current_screen;
 
 		// Show footer on our custom post types in admin, but not on the block editor.
-		if ( isset( $current_screen->post_type ) &&
+		if (
+			isset( $current_screen->post_type ) &&
 			in_array( $current_screen->post_type, array( 'course', 'lesson', 'llms_review', 'llms_membership', 'llms_engagement', 'llms_order', 'llms_coupon', 'llms_voucher', 'llms_form', 'llms_achievement', 'llms_my_achievement', 'llms_certificate', 'llms_my_certificate', 'llms_email' ), true ) &&
-			$current_screen->is_block_editor === false ) {
+			false === $current_screen->is_block_editor
+		) {
 			$show_footer = true;
 		}
 
 		// Show footer on our settings pages.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if ( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) {
 			$show_footer = true;
 		}
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// Exclude the wizard.
-		if ( ! empty( $_GET['page' ] ) && $_GET['page'] === 'llms-setup' ) {
+		if ( ! empty( $_GET['page'] ) && 'llms-setup' === $_GET['page'] ) {
 			$show_header = false;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Don't show footer on the Course Builder.
-		if ( $current_screen->base === 'admin_page_llms-course-builder' ) {
+		if ( 'admin_page_llms-course-builder' === $current_screen->base ) {
 			$show_footer = false;
 		}
 

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -71,12 +71,12 @@ class LLMS_Admin_Review {
 
 		// Exclude the wizard.
 		if ( ! empty( $_GET['page'] ) && 'llms-setup' === $_GET['page'] ) {
-			$show_header = false;
+			$show_footer = false;
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		// Don't show footer on the Course Builder.
-		if ( 'admin_page_llms-course-builder' === $current_screen->base ) {
+		if ( isset( $current_screen->base ) && 'admin_page_llms-course-builder' === $current_screen->base ) {
 			$show_footer = false;
 		}
 

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -63,7 +63,7 @@ class LLMS_Admin_Review {
 		// Show footer on our settings pages.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
 			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
 			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
@@ -71,6 +71,7 @@ class LLMS_Admin_Review {
 			$show_footer = true;
 		}
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 
 		// Exclude the wizard.
 		if ( ! empty( $_GET['page'] ) && 'llms-setup' === $_GET['page'] ) {

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -64,7 +64,10 @@ class LLMS_Admin_Review {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- No nonce verification needed here
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
-		if ( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) {
+		if (
+			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
+			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
+		) {
 			$show_footer = true;
 		}
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.5.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -42,9 +42,9 @@ class LLMS_Admin_AddOns {
 
 		$section = 'all';
 
-		if ( isset( $_GET['page'] ) && 'llms-dashboard' === $_GET['page'] ) {
+		if ( isset( $_GET['page'] ) && 'llms-dashboard' === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$section = 'featured';
-		} elseif ( isset( $_GET['section'] ) ) {
+		} elseif ( isset( $_GET['section'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$section = llms_filter_input_sanitize_string( INPUT_GET, 'section' );
 		}
 
@@ -80,11 +80,13 @@ class LLMS_Admin_AddOns {
 	}
 
 	/**
-	 * Retrieve remote json data
+	 * Retrieve remote json data.
 	 *
-	 * @return   null|WP_Error
-	 * @since    3.5.0
-	 * @version  3.22.2
+	 * @since 3.5.0
+	 * @since 3.22.2 Unknown.
+	 * @since [version] Use strict comparisons for `in_array()`.
+	 *
+	 * @return array|WP_Error
 	 */
 	private function get_data() {
 
@@ -148,13 +150,14 @@ class LLMS_Admin_AddOns {
 	}
 
 	/**
-	 * Get a random product from a category that doesn't exist in the list of excluded product ids
+	 * Get a random product from a category that doesn't exist in the list of excluded product ids.
 	 *
-	 * @param    string $cat       category slug
-	 * @param    array  $excludes  list of product ids to exclude
-	 * @return   array|false
-	 * @since    3.22.0
-	 * @version  3.22.0
+	 * @since 3.22.0
+	 * @since [version] Use strict comparisons for `in_array()`.
+	 *
+	 * @param  string $cat      Category slug.
+	 * @param  array  $excludes List of product ids to exclude.
+	 * @return array|false
 	 */
 	public function get_product_from_cat( $cat, $excludes ) {
 
@@ -177,12 +180,13 @@ class LLMS_Admin_AddOns {
 	}
 
 	/**
-	 * Retrieve products for a specific category
+	 * Retrieve products for a specific category.
 	 *
-	 * @param    string $cat  category slug
-	 * @return   array
-	 * @since    3.22.0
-	 * @version  3.22.0
+	 * @since 3.22.0
+	 * @since [version] Use strict comparisons for `in_array()`.
+	 *
+	 * @param string $cat Category slug.
+	 * @return array
 	 */
 	private function get_products_for_cat( $cat, $include_bundles = true ) {
 

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 6.10.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -203,7 +203,7 @@ class LLMS_Admin_Assets {
 	}
 
 	/**
-	 * Enqueue scripts
+	 * Enqueue scripts.
 	 *
 	 * @since 1.0.0
 	 * @since 3.22.0 Unknown.
@@ -216,6 +216,8 @@ class LLMS_Admin_Assets {
 	 *              Add `llms-admin-forms` on the forms post table screen.
 	 * @since 5.5.0 Use `LLMS_Assets` for the enqueue of `llms-admin-add-ons`.
 	 * @since 6.0.0 Enqueue certificate and achievement related js in `llms_my_certificate`, `llms_my_achievement` post types as well.
+	 * @since [version] Enqueue `postbox` script on the new dashboard page.
+	 *
 	 * @return void
 	 */
 	public function admin_scripts() {

--- a/includes/admin/class.llms.admin.menus.php
+++ b/includes/admin/class.llms.admin.menus.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 7.0.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/class.llms.admin.notices.core.php
+++ b/includes/admin/class.llms.admin.notices.core.php
@@ -5,13 +5,13 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Manage core admin notices class
+ * Manage core admin notices class.
  *
  * @since 3.0.0
  * @since 6.0.0 Removed the deprecated `LLMS_Admin_Notices_Core::check_staging()` method.
@@ -19,10 +19,11 @@ defined( 'ABSPATH' ) || exit;
 class LLMS_Admin_Notices_Core {
 
 	/**
-	 * Constructor
+	 * Init.
 	 *
 	 * @since 3.0.0
 	 * @since 3.14.8 Add handler for removing dismissed notices.
+	 * @since [version] Do not add a callback to remove sidebar notice on `switch_theme` anymore.
 	 *
 	 * @return void
 	 */
@@ -36,12 +37,13 @@ class LLMS_Admin_Notices_Core {
 	}
 
 	/**
-	 * Add actions on different hooks depending on the current screen
+	 * Add actions on different hooks depending on the current screen.
 	 *
 	 * Adds later for LLMS Settings screens to accommodate for settings that are updated later in the load cycle.
 	 *
 	 * @since 3.0.0
 	 * @since 4.12.0 Remove hook for deprecated `check_staging()` notice.
+	 * @since [version] Do not add a callback to show the missing sidebar support anymore.
 	 *
 	 * @return void
 	 */
@@ -120,6 +122,75 @@ class LLMS_Admin_Notices_Core {
 
 		}
 
+	}
+
+	/**
+	 * Check theme support for LifterLMS Sidebars.
+	 *
+	 * @since 3.0.0
+	 * @since 3.7.4 Unknown.
+	 * @since 4.5.0 Use strict comparison for `in_array()`.
+	 * @deprecated [version]
+	 *
+	 * @return void
+	 */
+	public static function sidebar_support() {
+
+		_deprecated_function( __METHOD__, '[version]' );
+
+		$theme = wp_get_theme();
+
+		$id = 'sidebars';
+
+		if ( ! current_theme_supports( 'lifterlms-sidebars' ) && ! in_array( $theme->get_template(), llms_get_core_supported_themes(), true ) ) {
+
+			$msg = sprintf(
+				__( '<strong>The current theme, %1$s, does not declare support for LifterLMS Sidebars.</strong> Course and Lesson sidebars may not work as expected. Please see our %2$sintegration guide%3$s or check out our %4$sLaunchPad%5$s theme which is designed specifically for use with LifterLMS.', 'lifterlms' ),
+				$theme->get( 'Name' ),
+				'<a href="https://lifterlms.com/docs/lifterlms-sidebar-support/?utm_source=notice&utm_medium=product&utm_content=sidebarsupport&utm_campaign=lifterlmsplugin" target="_blank">',
+				'</a>',
+				'<a href="https://lifterlms.com/product/launchpad/?utm_source=notice&utm_medium=product&utm_content=launchpad&utm_campaign=lifterlmsplugin" target="_blank">',
+				'</a>'
+			);
+
+			LLMS_Admin_Notices::add_notice(
+				$id,
+				$msg,
+				array(
+					'dismissible'      => true,
+					'dismiss_for_days' => 730, // @TODO: there should be a "forever" setting here.
+					'remindable'       => false,
+					'type'             => 'warning',
+				)
+			);
+
+		} elseif ( LLMS_Admin_Notices::has_notice( $id ) ) {
+
+			LLMS_Admin_Notices::delete_notice( $id );
+
+		}
+
+	}
+
+	/**
+	 * Removes the current sidebar notice (if present) and clears notice delay transients.
+	 *
+	 * Called when theme is switched.
+	 *
+	 * @since 3.14.7
+	 * @deprecated [version]
+	 *
+	 * @return void
+	 */
+	public static function clear_sidebar_notice() {
+
+		_deprecated_function( __METHOD__, '[version]' );
+
+		if ( LLMS_Admin_Notices::has_notice( 'sidebars' ) ) {
+			LLMS_Admin_Notices::delete_notice( 'sidebars' );
+		} else {
+			delete_transient( 'llms_admin_notice_sidebars_delay' );
+		}
 	}
 
 }

--- a/includes/admin/class.llms.admin.system-report.php
+++ b/includes/admin/class.llms.admin.system-report.php
@@ -5,13 +5,13 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 2.1.0
- * @version 4.13.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Admin System Report Class
+ * Admin System Report Class.
  *
  * @since 2.1.0
  */
@@ -23,7 +23,7 @@ class LLMS_Admin_System_Report {
 	 * @since 2.1.0
 	 * @since 3.0.0 Unknown.
 	 *
-	 * @return   void
+	 * @return void
 	 */
 	public static function output() {
 
@@ -45,10 +45,11 @@ class LLMS_Admin_System_Report {
 	}
 
 	/**
-	 * Output the copy for support box
+	 * Output the copy for support box.
 	 *
 	 * @since 2.1.0
 	 * @since 3.11.2 Unknown.
+	 * @since [version] Style update.
 	 *
 	 * @return void
 	 */
@@ -164,9 +165,10 @@ class LLMS_Admin_System_Report {
 
 
 	/**
-	 * Output the title for an item in the system report
+	 * Output the title for an item in the system report.
 	 *
 	 * @since 3.0.0
+	 * @since [version] Fixed misspelled WordPress.
 	 *
 	 * @param string $key Title.
 	 * @return void
@@ -176,7 +178,7 @@ class LLMS_Admin_System_Report {
 		$key = ucwords( str_replace( '_', ' ', $key ) );
 
 		// Fix for capital P.
-		if ( $key === 'Wordpress' ) {
+		if ( 'Wordpress' === $key ) { // phpcs:ignore WordPress.WP.CapitalPDangit.Misspelled
 			$key = 'WordPress';
 		}
 

--- a/includes/admin/views/dashboard.php
+++ b/includes/admin/views/dashboard.php
@@ -2,10 +2,7 @@
 /**
  * Dashboard Page HTML
  *
- * @package LifterLMS/Admin/Views
- *
  * @since [version]
- * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -62,7 +59,7 @@ add_meta_box(
 				echo llms_get_template(
 					'admin/reporting/tabs/widgets.php',
 					array(
-						'json'        => wp_json_encode(
+						'json'        => json_encode(
 							array(
 								'current_tab'         => 'settings',
 								'current_range'       => 'last-7-days',
@@ -151,10 +148,6 @@ add_meta_box(
 <?php
 /**
  * Callback function for llms_dashboard_welcome meta box.
- *
- * @since [version]
- *
- * @return void
  */
 function llms_dashboard_addons_callback() {
 	/**
@@ -168,10 +161,6 @@ function llms_dashboard_addons_callback() {
 
 /**
  * Callback function for llms_dashboard_quick_links meta box.
- *
- * @since [version]
- *
- * @return void
  */
 function llms_dashboard_quick_links_callback() {
 	?>
@@ -280,10 +269,6 @@ function llms_dashboard_quick_links_callback() {
 
 /**
  * Callback function for llms_dashboard_blog meta box.
- *
- * @since [version]
- *
- * @return void
  */
 function llms_dashboard_blog_callback() {
 
@@ -308,7 +293,7 @@ function llms_dashboard_blog_callback() {
 	?>
 
 	<ul>
-		<?php if ( 0 === $maxitems ) : ?>
+		<?php if ( $maxitems === 0 ) : ?>
 			<li><?php esc_html_e( 'No news found.', 'lifterlms' ); ?></li>
 		<?php else : ?>
 			<?php // Loop through each feed item and display each item as a hyperlink. ?>
@@ -329,10 +314,6 @@ function llms_dashboard_blog_callback() {
 
 /**
  * Callback function for llms_dashboard_podcast meta box.
- *
- * @since [version]
- *
- * @return void
  */
 function llms_dashboard_podcast_callback() {
 
@@ -357,7 +338,7 @@ function llms_dashboard_podcast_callback() {
 	?>
 
 	<ul>
-		<?php if ( 0 === $maxitems ) : ?>
+		<?php if ( $maxitems === 0 ) : ?>
 			<li><?php esc_html_e( 'No news found.', 'lifterlms' ); ?></li>
 		<?php else : ?>
 			<?php // Loop through each feed item and display each item as a hyperlink. ?>

--- a/includes/admin/views/dashboard.php
+++ b/includes/admin/views/dashboard.php
@@ -2,7 +2,10 @@
 /**
  * Dashboard Page HTML
  *
+ * @package LifterLMS/Admin/Views
+ *
  * @since [version]
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -59,7 +62,7 @@ add_meta_box(
 				echo llms_get_template(
 					'admin/reporting/tabs/widgets.php',
 					array(
-						'json'        => json_encode(
+						'json'        => wp_json_encode(
 							array(
 								'current_tab'         => 'settings',
 								'current_range'       => 'last-7-days',
@@ -148,6 +151,10 @@ add_meta_box(
 <?php
 /**
  * Callback function for llms_dashboard_welcome meta box.
+ *
+ * @since [version]
+ *
+ * @return void
  */
 function llms_dashboard_addons_callback() {
 	/**
@@ -161,6 +168,10 @@ function llms_dashboard_addons_callback() {
 
 /**
  * Callback function for llms_dashboard_quick_links meta box.
+ *
+ * @since [version]
+ *
+ * @return void
  */
 function llms_dashboard_quick_links_callback() {
 	?>
@@ -269,6 +280,10 @@ function llms_dashboard_quick_links_callback() {
 
 /**
  * Callback function for llms_dashboard_blog meta box.
+ *
+ * @since [version]
+ *
+ * @return void
  */
 function llms_dashboard_blog_callback() {
 
@@ -293,7 +308,7 @@ function llms_dashboard_blog_callback() {
 	?>
 
 	<ul>
-		<?php if ( $maxitems === 0 ) : ?>
+		<?php if ( 0 === $maxitems ) : ?>
 			<li><?php esc_html_e( 'No news found.', 'lifterlms' ); ?></li>
 		<?php else : ?>
 			<?php // Loop through each feed item and display each item as a hyperlink. ?>
@@ -314,6 +329,10 @@ function llms_dashboard_blog_callback() {
 
 /**
  * Callback function for llms_dashboard_podcast meta box.
+ *
+ * @since [version]
+ *
+ * @return void
  */
 function llms_dashboard_podcast_callback() {
 
@@ -338,7 +357,7 @@ function llms_dashboard_podcast_callback() {
 	?>
 
 	<ul>
-		<?php if ( $maxitems === 0 ) : ?>
+		<?php if ( 0 === $maxitems ) : ?>
 			<li><?php esc_html_e( 'No news found.', 'lifterlms' ); ?></li>
 		<?php else : ?>
 			<?php // Loop through each feed item and display each item as a hyperlink. ?>

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-assets.php
@@ -9,6 +9,8 @@
  * @group assets
  *
  * @since 4.3.3
+ * @since [version] Turn `test_maybe_enqueue_reporting_general_settings_assumed()` into ` test_maybe_enqueue_reporting_dashboard_assumed()`.
+ *              Removed outdated `test_maybe_enqueue_reporting_general_settings_explicit()`.
  */
 class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 
@@ -167,17 +169,17 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test maybe_enqueue_reporting() on the general settings page where analytics are required for the data widgets
+	 * Test maybe_enqueue_reporting() on the dashboard page where analytics are required for the data widgets
 	 *
 	 * This test tests the default "assumed" tab when there's no `tab` set in the $_GET array.
 	 *
-	 * @since 4.3.3
+	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_maybe_enqueue_reporting_general_settings_assumed() {
+	public function test_maybe_enqueue_reporting_dashboard_assumed() {
 
-		$screen = (object) array( 'base' => 'lifterlms_page_llms-settings' );
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-dashboard' );
 
 		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
 
@@ -189,18 +191,18 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test maybe_enqueue_reporting() on the general settings page where analytics are required for the data widgets
+	 * Test maybe_enqueue_reporting() on the dashboard page where analytics are required for the data widgets
 	 *
-	 * This test is the same as test_maybe_enqueue_reporting_general_settings_assumed() except this one explicitly
+	 * This test is the same as test_maybe_enqueue_reporting_dashboard_assumed() except this one explicitly
 	 * tests for the presence of the `tab=general` in the $_GET array.
 	 *
-	 * @since 4.3.3
+	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_maybe_enqueue_reporting_general_settings_explicit() {
+	public function test_maybe_enqueue_reporting_dashbord_explicit() {
 
-		$screen = (object) array( 'base' => 'lifterlms_page_llms-settings' );
+		$screen = (object) array( 'base' => 'lifterlms_page_llms-dashboard' );
 		$this->mockGetRequest( array( 'tab' => 'general' ) );
 
 		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
@@ -213,9 +215,10 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test maybe_enqueue_reporting() on settings tabs other than general, scripts will be registered but not enqueued.
+	 * Test maybe_enqueue_reporting() on settings tabs other than general, scripts will not be registered.
 	 *
 	 * @since 4.3.3
+	 * @since [version] Updated to reflect that `llms-google-charts` and `llms-analytics` are not registered on settings screens.
 	 *
 	 * @return void
 	 */
@@ -226,10 +229,9 @@ class LLMS_Test_Admin_Assets extends LLMS_Unit_Test_Case {
 
 		LLMS_Unit_Test_Util::call_method( $this->main, 'maybe_enqueue_reporting', array( $screen ) );
 
-		$this->assertAssetIsRegistered( 'script', 'llms-google-charts' );
-		$this->assertAssetIsRegistered( 'script', 'llms-analytics' );
+		$this->assertAssetNotRegistered( 'script', 'llms-google-charts' );
+		$this->assertAssetNotRegistered( 'script', 'llms-analytics' );
 
-		$this->assertAssetNotEnqueued( 'script', 'llms-analytics' );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-import.php
@@ -534,15 +534,16 @@ class LLMS_Test_Admin_Import extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test output() method
+	 * Test output() method.
 	 *
 	 * @since 4.7.0
+	 * @since [version] Mark-up update.
 	 *
 	 * @return void
 	 */
 	public function test_output() {
 
-		$this->assertOutputContains( '<div class="wrap lifterlms llms-import-export">', array( $this->import, 'output' ) );
+		$this->assertOutputContains( '<div class="wrap lifterlms lifterlms-settings llms-import-export">', array( $this->import, 'output' ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-review.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-review.php
@@ -8,6 +8,7 @@
  * @group admin_reviews
  *
  * @since 3.24.0
+ * @version [version]
  */
 class LLMS_Test_Admin_Review extends LLMS_UnitTestCase {
 
@@ -54,16 +55,17 @@ class LLMS_Test_Admin_Review extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test admin_footer() when it's supposed to display
+	 * Test admin_footer() when it's supposed to display.
 	 *
 	 * @since 4.14.0
+	 * @since [version] Updated expected text.
 	 *
 	 * @return void
 	 */
 	public function test_admin_footer_screen_on_lifterlms_screen() {
 
 		set_current_screen( 'lifterlms' );
-		$this->assertEquals( 'Please rate <strong>LifterLMS</strong> <a href="https://wordpress.org/support/plugin/lifterlms/reviews/?filter=5#new-post" target="_blank" rel="noopener noreferrer">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="https://wordpress.org/support/plugin/lifterlms/reviews/?filter=5#new-post" target="_blank" rel="noopener">WordPress.org</a> to help us spread the word. Thank you from the LifterLMS team!', $this->main->admin_footer( 'fake' ) );
+		$this->assertEquals( 'Please rate <strong>LifterLMS</strong> <a class="llms-rating-stars" href="https://wordpress.org/support/plugin/lifterlms/reviews/?filter=5#new-post" target="_blank" rel="noopener noreferrer">&#9733;&#9733;&#9733;&#9733;&#9733;</a> on <a href="https://wordpress.org/support/plugin/lifterlms/reviews/?filter=5#new-post" target="_blank" rel="noopener">WordPress.org</a> to help us spread the word. Thank you from the LifterLMS team!', $this->main->admin_footer( 'fake' ) );
 		set_current_screen( 'front' );
 
 	}
@@ -233,7 +235,7 @@ class LLMS_Test_Admin_Review extends LLMS_UnitTestCase {
 
 		$output = $this->get_output( array( $this->main, 'maybe_show_notice' ) );
 
-		$this->assertStringContains( '<div class="notice notice-info is-dismissible llms-review-notice">', $output );
+		$this->assertStringContains( '<div class="notice notice-info is-dismissible llms-admin-notice llms-review-notice">', $output );
 
 	}
 


### PR DESCRIPTION
Small update mostly to fix some minor coding standard/doc standard issues (error and warnings - and while there fixing some old cs issues as well) about to be introduced in the pending release (#2321).

Most important though, look at the commit https://github.com/gocodebox/lifterlms/pull/2351/commits/4d05a6eaa5f9918e05b888899421f611947abd7f.
We cannot really delete public methods on a minor version, even if it's highly unlikely anybody used them.
Also we want to deprecate them first, on a minor version, so that we can remove them on the next major version.

Also fixed some tests that broke after the recent codebase updates.

I reverted the changes to admin/views/dashboard.php as they are addressed in https://github.com/gocodebox/lifterlms/pull/2360 so to avoid conflicts.