### PR TITLE
[@lifterlms/scripts] Fix transpiling lifterlms

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -1,11 +1,16 @@
 @lifterlms/scripts CHANGELOG
 ============================
+Unreleased
+----------
+
++ Allow the whole `@lifterlms` package to be transpiled by babel during builds.
+
 
 v4.0.0 - 2022-08-11
 -------------------
 
 + **[Breaking]** Upgrade `@wordpress/scripts` to [23.6.0](https://github.com/WordPress/gutenberg/blob/trunk/packages/scripts/CHANGELOG.md#2360-2022-07-27).
-+ **[Breaking]** Removes the webpack copy plugin responsible for copying `block.json` files from the `src/` directory to the `${outputDir}/blocks` directory. 
++ **[Breaking]** Removes the webpack copy plugin responsible for copying `block.json` files from the `src/` directory to the `${outputDir}/blocks` directory.
 + Added a blocks-specific webpack config: `./config/blocks-webpack.config.js`.
 + Ignore `lodash` as an undefined dependency when using `config/.eslintrc.js`.
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -4,7 +4,7 @@
  * @package
  *
  * @since Unknown
- * @version 4.0.0
+ * @version [version]
  */
 
 // Deps.
@@ -157,6 +157,29 @@ function setupPlugins( plugins, css, prefix, cleanAfterEveryBuildPatterns ) {
 }
 
 /**
+ * Allow babel transpilation for the whole `@lifterlms` package.
+ *
+ * By default the WordPress' webpack config excludes all the packages
+ * in `node_modules/` from being transpiled by babel.
+ * With this we allow the whole `@lifterlms` package to be transpiled by babel during builds.
+ *
+ * @since [version]
+ *
+ * @param {Object[]} config Webpack config.
+ * @return {Object[]}
+ */
+function allowBabelTranspilation( config ) {
+	config.module.rules = config.module.rules.filter( ( rule ) => {
+		if ( rule.exclude && '/node_modules/' === rule.exclude.toString() &&
+				rule.use[0].loader.indexOf('node_modules/babel-loader') ) {
+			rule.exclude = /node_modules\/(?!\@lifterlms\/)/;
+		}
+		return rule;
+	});
+	return config;
+}
+
+/**
  * Generates a Webpack config object.
  *
  * This is opinionated based on our opinions for directory structure.
@@ -171,6 +194,7 @@ function setupPlugins( plugins, css, prefix, cleanAfterEveryBuildPatterns ) {
  * @since 1.2.1 Reduce method size by using helper methods
  * @since 1.2.3 Add a configurable source file path option and set the default to `src/` instead of `assets/src`.
  * @since 2.1.0 Add configuration option added to the CleanWebpackPlugin.
+ * @since [version] Parse the original WordPress' config to allow babel transpilation for the whole `@lifterlms` package.
  *
  * @param {Object}   options                              Configuration options.
  * @param {string[]} options.css                          Array of CSS file slugs.
@@ -192,7 +216,7 @@ module.exports = (
 	}
 ) => {
 	return {
-		...config,
+		...allowBabelTranspilation( config ),
 		entry: setupEntry( js, srcPath ),
 		output: {
 			filename: `js/${ prefix }[name].js`,

--- a/src/js/util/award-certificate-button/index.js
+++ b/src/js/util/award-certificate-button/index.js
@@ -4,7 +4,7 @@ import { Button, Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 // LLMS Deps.
-import { PostSearchControl, UserSearchControl } from '../../../../packages/components/src/search-control';
+import { PostSearchControl, UserSearchControl } from '@lifterlms/components/src/search-control';
 
 // Internal Deps.
 import createAward from './create';


### PR DESCRIPTION
## Description

Fixes the issue we found when running the build:
```
ERROR in ./node_modules/@lifterlms/components/src/search-control/base-search-control.js 185:2
Module parse failed: Unexpected token (185:2)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| 
| 	return (
> 		<StyledBaseControl { ...{ id, label } }>
| 			<Select
| 				{ ...{
 @ ./node_modules/@lifterlms/components/src/search-control/index.js 1:0-54 5:0-67
 @ ./src/js/util/award-certificate-button/index.js 9:0-95 65:105-122 73:38-55
 @ ./src/js/util/index.js 2:0-79 2:0-79
 @ ./src/js/admin-award-certificate.js 7:0-48 68:23-45

```
that brought us to the following fix (hack):
https://github.com/gocodebox/lifterlms/commit/1f664a8dd1e2c3d53711f71a84cd725da22219f7

The issue, as @seothemes noted on slack, is that one of the imported files contains JSX code rather than simple JS and it didn't get correctly transpiled by babel. The reason for this "transpilation" failure is that the default WordPress' webpack config excludes from transpilation all the packes in `node_modules` (assuming they already transpiled).
With this PR we remove the `node_modules/@lifterlms` from the exclusion path, so the whole `@lifterlms` package gets correctly transpiled during builds.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

