### PR TITLE
Fix error when featured image file doesn't exist

### DIFF
--- a/.changelogs/fix-no-featured-image.yml
+++ b/.changelogs/fix-no-featured-image.yml
@@ -2,5 +2,5 @@ significance: patch
 type: fixed
 links:
   - "#2381"
-entry: Fix bug in llms_featured_img function when featured image file is not
+entry: Fix bug in `llms_featured_img` function when featured image file is not
   available.

--- a/.changelogs/fix-no-featured-image.yml
+++ b/.changelogs/fix-no-featured-image.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2381"
+entry: Fix bug in llms_featured_img function when featured image file is not
+  available.

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -807,8 +807,8 @@ function llms_placeholder_img( $size = 'full' ) {
  *
  * @access public
  *
- * @param int $attachment_id Image attachment ID.
- * @param string|int[] $size Accepts any registered image size name, or an array of width and height values in pixels (in that order). Default 'thumbnail'.
+ * @param int|WP_Post  $post_id Post ID or WP_Post object.
+ * @param string|int[] $size    Accepts any registered image size name, or an array of width and height values in pixels (in that order).
  * @return string
  */
 function llms_featured_img( $post_id, $size ) {
@@ -819,7 +819,16 @@ function llms_featured_img( $post_id, $size ) {
 		$html = '<img src="' . $img[0] . '" alt="' . get_the_title( $post_id ) . '" class="llms-featured-image wp-post-image">';
 	}
 
-	return apply_filters( 'lifterlms_featured_img', $html );
+	/**
+	 * Filters the featured image of a given LifterLMS post.
+	 *
+	 * @since unknown
+	 * @since [version] Added `$post_id` parameter.
+	 *
+	 * @param string $html         HTML img element or empty string if the post has no thumbnail.
+	 * @param int|WP_Post $post_id Post ID or WP_Post object.
+	 */
+	return apply_filters( 'lifterlms_featured_img', $html, $post_id );
 }
 
 /**

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -803,15 +803,19 @@ function llms_placeholder_img( $size = 'full' ) {
  * Get the featured image
  *
  * @access public
+ * @since [version] Fix bug when the featured image file is not available.
  * @return string
  */
 function llms_featured_img( $post_id, $size ) {
-	$img = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), $size );
-	return apply_filters( 'lifterlms_featured_img', '<img src="' . $img[0] . '" alt="' . get_the_title( $post_id ) . '" class="llms-featured-image wp-post-image">' );
+	$img  = wp_get_attachment_image_src( get_post_thumbnail_id( $post_id ), $size );
+	$html = '';
+
+	if ( isset( $img[0] ) ) {
+		$html = '<img src="' . $img[0] . '" alt="' . get_the_title( $post_id ) . '" class="llms-featured-image wp-post-image">';
+	}
+
+	return apply_filters( 'lifterlms_featured_img', $html );
 }
-
-
-
 
 /**
  * Retrieve author name, avatar, and bio

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -825,7 +825,7 @@ function llms_featured_img( $post_id, $size ) {
 	 * @since unknown
 	 * @since [version] Added `$post_id` parameter.
 	 *
-	 * @param string $html         HTML img element or empty string if the post has no thumbnail.
+	 * @param string      $html    HTML img element or empty string if the post has no thumbnail.
 	 * @param int|WP_Post $post_id Post ID or WP_Post object.
 	 */
 	return apply_filters( 'lifterlms_featured_img', $html, $post_id );

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions/Templates
  *
  * @since 1.0.0
- * @version 7.1.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -800,10 +800,15 @@ function llms_placeholder_img( $size = 'full' ) {
 }
 
 /**
- * Get the featured image
+ * Get the featured image.
+ *
+ * @since unknown
+ * @since [version] Fix bug when the featured image file is not available.
  *
  * @access public
- * @since [version] Fix bug when the featured image file is not available.
+ *
+ * @param int $attachment_id Image attachment ID.
+ * @param string|int[] $size Accepts any registered image size name, or an array of width and height values in pixels (in that order). Default 'thumbnail'.
  * @return string
  */
 function llms_featured_img( $post_id, $size ) {


### PR DESCRIPTION
## Description

Fixes issue where a course featured image is set but the file doesn't exist.

Fixes #2381

## How has this been tested?

Manually

## Screenshots

![image](https://user-images.githubusercontent.com/24793388/224229953-b6e757cf-e806-464a-9822-a56f2d6f3d2d.png)

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

