### PR TITLE
Fix award certificate button

### DIFF
--- a/.changelogs/issue_2386.yml
+++ b/.changelogs/issue_2386.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2386"
+entry: Fixed manual certificates awarding broken when using the block editor.

--- a/src/js/util/award-certificate-button/index.js
+++ b/src/js/util/award-certificate-button/index.js
@@ -4,7 +4,7 @@ import { Button, Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 
 // LLMS Deps.
-import { PostSearchControl, UserSearchControl } from '@lifterlms/components/src/search-control';
+import { PostSearchControl, UserSearchControl } from '@lifterlms/components';
 
 // Internal Deps.
 import createAward from './create';


### PR DESCRIPTION
## Description

Fixes #2386
Fixes #2391 

This is what should happen when clicking on the Award Certificate button from Engagements -> Awarded Certificates
![Schermata 2023-03-16 alle 15 12 10](https://user-images.githubusercontent.com/7689242/225645844-9ac63822-e7e4-473f-98c8-8dc2960fb5ed.png)

I broke this feature in https://github.com/gocodebox/lifterlms/commit/57099ec702f53f01d4ca96de5781e3ca0dbb127b#diff-b301bee89bb9076915128b503cf67fcf7f9f3398a9fcd6f2331177f2b06416a6R7

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

