### PR TITLE
Making the LifterLMS logo in admin header link to the LifterLMS.com site

### DIFF
--- a/.changelogs/admin-link-to-lifterlms-com.yml
+++ b/.changelogs/admin-link-to-lifterlms-com.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Making the LifterLMS logo link to the LifterLMS.com site.

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 7.1.0
- * @version 7.1.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -32,6 +32,7 @@ class LLMS_Admin_Header {
 	 * Show admin header banner on LifterLMS admin screens.
 	 *
 	 * @since 7.1.0
+	 * @since [version] Making the LifterLMS logo link to the LifterLMS.com site.
 	 *
 	 * @return void
 	 */

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -80,7 +80,7 @@ class LLMS_Admin_Header {
 		if ( ! empty( $show_header ) ) { ?>
 			<header class="llms-header">
 				<div class="llms-inside-wrap">
-					<img class="lifterlms-logo" src="<?php echo llms()->plugin_url(); ?>/assets/images/lifterlms-logo-black.png" alt="<?php esc_attr_e( 'LifterLMS Logo', 'lifterlms' ); ?>">
+					<a href="https://lifterlms.com/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Admin%20Header&utm_content=LifterLMS%20Logo" target="_blank"><img class="lifterlms-logo" src="<?php echo llms()->plugin_url(); ?>/assets/images/lifterlms-logo-black.png" alt="<?php esc_attr_e( 'LifterLMS Logo', 'lifterlms' ); ?>"></a>
 					<div class="llms-meta">
 						<div class="llms-meta-left">
 							<span class="llms-version"><?php echo sprintf( __( 'Version: %s', 'lifterlms' ), llms()->version ); ?></span>
@@ -110,7 +110,7 @@ class LLMS_Admin_Header {
 							}
 							?>
 							<span class="llms-support">
-								<a href="https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Dashboard%20Screen&utm_content=LifterLMS%20Support" target="_blank"><?php esc_html_e( 'Get Support', 'lifterlms' ); ?></a>
+								<a href="https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Admin%20Header&utm_content=LifterLMS%20Support" target="_blank"><?php esc_html_e( 'Get Support', 'lifterlms' ); ?></a>
 							</span>
 						</div>
 					</div>


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description

This is a small update to have our logo be linked to our website in the admin header. This does not warrant a changlog entry in my opinion.

I also had a small fix to the UTM tracking on the Get Support link when that link is in the header - it should use the "utm_medium" Admin Header.
