### PR TITLE
Fixing broken links to LifterLMS.com and our network of sites

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ All translations to LifterLMS can be made via our GlotPress project at [translat
 
 Anyone can contribute translations. All you need is to login to your wordpress.org account. If you have questions about how to submit translations please refer to the [Translator's Handbook](https://make.wordpress.org/polyglots/handbook/).
 
-We're always seeking Translation Editors who can manage and approve translations for their locale. If you're interested in becoming a translation editor for your locale please submit an application at [translate.lifterlms.com](https://translate.lifterlms.com/become-a-translator/).
+We're always seeking Translation Editors who can manage and approve translations for their locale. If you're interested in becoming a translation editor for your locale please [review the documentation about translations here](https://lifterlms.com/docs/how-can-i-contribute-translations-to-lifterlms/).
 
 
 ### Need Help Getting Started as a Contributor?
@@ -62,6 +62,6 @@ We're always seeking Translation Editors who can manage and approve translations
 A number of resources are available for first time contributors:
 
 + Join our [LifterLMS Community Slack Channel](https://lifterlms.com/slack) and hop into the `#developers` channel. Our core contributors and maintainers are there to help out and answer questions.
-+ Check out the [LifterLMS Contributor's Events Calendar](https://make.lifterlms.com/calendar/events/) for opportunities to interact with other contributors.
++ Check out the [LifterLMS Community Events Calendar](https://lifterlms.com/community-events/) for opportunities to interact with other contributors.
 + Check out [this tutorial](https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github) on how to submit pull requests on GitHub.
 + Grab an issue marked tagged as a [`good first issue`](https://github.com/gocodebox/lifterlms/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ GitHub is for bug reports and contributions only! If you have a support question
 
 + [Changelog](./CHANGELOG.md)
 + User documentation and knowledge base: https://lifterlms.com/docs/
-+ Contributor's blog: https://make.lifterlms.com/docs/
-+ Developer portal: https://developer.lifterlms.com/docs/
++ Contributor's blog: https://make.lifterlms.com/
++ Developer portal: https://developer.lifterlms.com/
 
 
 ### Included Core Packages


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->
There were a few spots in our GitHub readme and Contributing guides that linked to non-existent pages. This PR fixes those links. This does not need a changlog entry in my opinion.
