### PR TITLE
Fixes: https://github.com/gocodebox/lifterlms/issues/2348

### DIFF
--- a/includes/admin/reporting/tables/llms.table.students.php
+++ b/includes/admin/reporting/tables/llms.table.students.php
@@ -331,7 +331,10 @@ class LLMS_Table_Students extends LLMS_Admin_Table {
 			case 'billing_zip':
 			case 'billing_country':
 			case 'phone':
-				$value = $student->get( $key );
+				$value = strval( $student->get( $key ) );
+				if ( is_numeric( $value ) ) {
+					$value = "'" . $value;
+				}
 				break;
 
 			default:


### PR DESCRIPTION
 * Add a comma before value if that value is numeric. It works like a charm for google spreadsheet, in some excel it just add the comma before the 0. 

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
adds an apostrofe before the value in case the value is numeric

Fixes #

https://github.com/gocodebox/lifterlms/issues/2348

## How has this been tested?
Tested manually with google spreadsheet and libreoffice. @actuallyakash  tested in Ms excel (thanks) 
## Screenshots 

![image](https://user-images.githubusercontent.com/1678457/226632825-6847eb28-e4fa-400c-93ca-e96f5dd2cf4d.png)
![image](https://user-images.githubusercontent.com/1678457/226632853-7ec90403-78e7-435c-b620-fe1f9334e5d8.png)


## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

