### PR TITLE
Added filter for updating text when not enrolled in any course

### DIFF
--- a/.changelogs/issue_2365-1.yml
+++ b/.changelogs/issue_2365-1.yml
@@ -1,0 +1,9 @@
+significance: patch
+type: changed
+comment: Added hook `lifterlms_dashboard_memberships_not_enrolled_text` for
+  updating text when user is not enrolled in any membership.
+links:
+  - "#2396"
+entry: Added `lifterlms_dashboard_memberships_not_enrolled_text` filter hook to
+  allow altering the message displaying on the dashboard when the current user
+  is not enrolled in any memberships.

--- a/.changelogs/issue_2365-1.yml
+++ b/.changelogs/issue_2365-1.yml
@@ -1,7 +1,7 @@
 significance: patch
-type: changed
+type: dev
 comment: Added hook `lifterlms_dashboard_memberships_not_enrolled_text` for
-  updating text when user is not enrolled in any membership.
+  updating text when user is not enrolled in any memberships.
 links:
   - "#2396"
 entry: Added `lifterlms_dashboard_memberships_not_enrolled_text` filter hook to

--- a/.changelogs/issue_2365.yml
+++ b/.changelogs/issue_2365.yml
@@ -1,7 +1,7 @@
 significance: patch
-type: changed
+type: dev
 comment: Added filter to change the text to be displayed when the student is not
   enrolled in any courses.
 links:
   - "#2396"
-entry: Added lifterlms_dashboard_courses_not_enrolled_text filter hook to allow altering the message displaying on the dashboard when the current user is not enrolled in any courses.
+entry: Added `lifterlms_dashboard_courses_not_enrolled_text` filter hook to allow altering the message displaying on the dashboard when the current user is not enrolled in any courses.

--- a/.changelogs/issue_2365.yml
+++ b/.changelogs/issue_2365.yml
@@ -4,4 +4,4 @@ comment: Added filter to change the text to be displayed when the student is not
   enrolled in any courses.
 links:
   - "#2396"
-entry: Added Filter for No Course Enrollement text.
+entry: Added lifterlms_dashboard_courses_not_enrolled_text filter hook to allow altering the message displaying on the dashboard when the current user is not enrolled in any courses.

--- a/.changelogs/issue_2365.yml
+++ b/.changelogs/issue_2365.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: changed
+comment: Added filter to change the text to be displayed when the student is not
+  enrolled in any courses.
+links:
+  - "#2396"
+entry: Added Filter for No Course Enrollement text.

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.0.0
- * @version 6.3.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -162,6 +162,7 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 	 * @since 3.26.3 Unknown.
 	 * @since 3.37.15 Added secondary sorting by `post_title` when the primary sort is `menu_order`.
 	 * @since 6.3.0 Fix paged query not working when using plain permalinks.
+	 * @since [version] Added filter for filtering 'Not enrolled text'.
 	 *
 	 * @param LLMS_Student $student Optional. LLMS_Student (current student if none supplied). Default `null`.
 	 * @param bool         $preview Optional. If true, outputs a short list of courses (based on dashboard_recent_courses filter). Default `false`.
@@ -193,16 +194,19 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 
 		if ( ! $courses['results'] ) {
 
-			/**
-			 * Not enrolled text.
-			 *
-			 * Allows developers to filter the text to be displayed when the student is not enrolled in any courses.
-			 *
-			 * @since [version]
-			 *
-			 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any course.
-			 */
-			printf( '<p>%s</p>', apply_filters( 'lifterlms_not_enrolled_text', __( 'You are not enrolled in any courses.', 'lifterlms' ) ) );
+			printf(
+				'<p>%s</p>',
+				/**
+				 * Not enrolled text.
+				 *
+				 * Allows developers to filter the text to be displayed when the student is not enrolled in any courses.
+				 *
+				 * @since [version]
+				 *
+				 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any course.
+				 */
+				apply_filters( 'lifterlms_not_enrolled_text', esc_html__( 'You are not enrolled in any courses.', 'lifterlms' ) )
+			); 
 
 		} else {
 

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -205,7 +205,7 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 				 *
 				 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any course.
 				 */
-				apply_filters( 'lifterlms_not_enrolled_text', esc_html__( 'You are not enrolled in any courses.', 'lifterlms' ) )
+				apply_filters( 'lifterlms_dashboard_courses_not_enrolled_text', esc_html__( 'You are not enrolled in any courses.', 'lifterlms' ) )
 			);
 
 		} else {
@@ -323,7 +323,7 @@ if ( ! function_exists( 'lifterlms_template_my_memberships_loop' ) ) {
 				 *
 				 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any memberships.
 				 */
-				apply_filters( 'lifterlms_not_enrolled_text', esc_html__( 'You are not enrolled in any memberships.', 'lifterlms' ) )
+				apply_filters( 'lifterlms_dashboard_memberships_not_enrolled_text', esc_html__( 'You are not enrolled in any memberships.', 'lifterlms' ) )
 			);
 
 		} else {

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -206,7 +206,7 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 				 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any course.
 				 */
 				apply_filters( 'lifterlms_not_enrolled_text', esc_html__( 'You are not enrolled in any courses.', 'lifterlms' ) )
-			); 
+			);
 
 		} else {
 
@@ -296,6 +296,7 @@ if ( ! function_exists( 'lifterlms_template_my_memberships_loop' ) ) {
 	 *
 	 * @since 3.14.0
 	 * @since 3.14.8 Unknown.
+	 * @since [version] Added filter for filtering 'Not enrolled text'.
 	 *
 	 * @param LLMS_Student $student Optional. LLMS_Student (current student if none supplied). Default `null`.
 	 * @return void
@@ -311,7 +312,19 @@ if ( ! function_exists( 'lifterlms_template_my_memberships_loop' ) ) {
 
 		if ( ! $memberships ) {
 
-			printf( '<p>%s</p>', __( 'You are not enrolled in any memberships.', 'lifterlms' ) );
+			printf(
+				'<p>%s</p>',
+				/**
+				 * Not enrolled text.
+				 *
+				 * Allows developers to filter the text to be displayed when the student is not enrolled in any memberships.
+				 *
+				 * @since [version]
+				 *
+				 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any memberships.
+				 */
+				apply_filters( 'lifterlms_not_enrolled_text', esc_html__( 'You are not enrolled in any memberships.', 'lifterlms' ) )
+			);
 
 		} else {
 

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -193,6 +193,15 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 
 		if ( ! $courses['results'] ) {
 
+			/**
+			 * Not enrolled text.
+			 *
+			 * Allows developers to filter the text to be displayed when the student is not enrolled in any courses.
+			 *
+			 * @since [version]
+			 *
+			 * @param string $not_enrolled_text The text to be displayed when the student is not enrolled in any course.
+			 */
 			printf( '<p>%s</p>', apply_filters( 'lifterlms_not_enrolled_text', __( 'You are not enrolled in any courses.', 'lifterlms' ) ) );
 
 		} else {

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -193,7 +193,7 @@ if ( ! function_exists( 'lifterlms_template_my_courses_loop' ) ) {
 
 		if ( ! $courses['results'] ) {
 
-			printf( '<p>%s</p>', __( 'You are not enrolled in any courses.', 'lifterlms' ) );
+			printf( '<p>%s</p>', apply_filters( 'lifterlms_not_enrolled_text', __( 'You are not enrolled in any courses.', 'lifterlms' ) ) );
 
 		} else {
 


### PR DESCRIPTION
## Description
Added a filter for updating text when the user is not enrolled in any course.

Fixes #2365 

## How has this been tested?
Manually.

## Screenshots <!-- if applicable -->
A user can use the below filter to update text:

```
function custom_not_enrolled_text( $text ) {
    return __( 'Oops! Looks like you haven\'t signed up for any courses yet.', 'lifterlms' );
}
add_filter( 'lifterlms_not_enrolled_text', 'custom_not_enrolled_text' );
```

![image](https://user-images.githubusercontent.com/18614782/226822219-713f3c53-9ea9-46c2-8e5a-7cc04bb09d10.png)

## Types of changes
Bug Fix.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

