### PR TITLE
Add `LLMS_ASSETS_VERSION` constant for cache busting

### DIFF
--- a/.changelogs/add-version-constant.yml
+++ b/.changelogs/add-version-constant.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added `LLMS_ASSETS_VERSION` constant for cache busting.

--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -136,18 +136,19 @@ final class LifterLMS {
 		llms_maybe_define_constant( 'LLMS_LOG_DIR', $upload_dir['basedir'] . '/llms-logs/' );
 		llms_maybe_define_constant( 'LLMS_TMP_DIR', $upload_dir['basedir'] . '/llms-tmp/' );
 
+		// If we're loading in debug mode.
+		$script_debug = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
+		$wp_debug     = defined( 'WP_DEBUG' ) && WP_DEBUG;
+
+		// If debugging, load the unminified version otherwise load minified.
 		if ( ! defined( 'LLMS_ASSETS_SUFFIX' ) ) {
-
-			// If we're loading in debug mode.
-			$debug = ( defined( 'SCRIPT_DEBUG' ) ) ? SCRIPT_DEBUG : false;
-
-			// If debugging, load the unminified version otherwiser load minified.
-			$min = ( $debug ) ? '' : '.min';
-
-			define( 'LLMS_ASSETS_SUFFIX', $min );
-
+			define( 'LLMS_ASSETS_SUFFIX', $script_debug ? '' : '.min' );
 		}
 
+		// If debugging, use time for asset version otherwise use plugin version.
+		if ( ! defined( 'LLMS_ASSETS_VERSION' ) ) {
+			define( 'LLMS_ASSETS_VERSION', ( $script_debug || $wp_debug ) ? time() : $this->version );
+		}
 	}
 
 	/**

--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Main
  *
  * @since 1.0.0
- * @version 6.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -123,6 +123,7 @@ final class LifterLMS {
 	 * @since 3.17.8 Added `LLMS_PLUGIN_URL` && `LLMS_ASSETS_SUFFIX`.
 	 * @since 4.0.0 Moved definitions of `LLMS_PLUGIN_FILE` and `LLMS_PLUGIN_DIR` to the main `lifterlms.php` file.
 	 *              Use `llms_maybe_define_constant()` to reduce code complexity.
+	 * @since [version] Added `LLMS_ASSETS_VERSION` constant.
 	 *
 	 * @return void
 	 */

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 1.0.0
- * @version 7.1.1
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -179,12 +179,13 @@ class LLMS_Admin_Assets {
 	 * @since 3.35.0 Explicitly set asset versions.
 	 * @since 5.0.0 Use `LLMS_Assets` for registration/enqueue of styles.
 	 * @since 5.5.0 Use `LLMS_Assets` for the enqueue of `llms-addons`.
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
 	 *
 	 * @return void
 	 */
 	public function admin_styles() {
 
-		wp_enqueue_style( 'llms-admin-styles', LLMS_PLUGIN_URL . 'assets/css/admin' . LLMS_ASSETS_SUFFIX . '.css', array(), llms()->version );
+		wp_enqueue_style( 'llms-admin-styles', LLMS_PLUGIN_URL . 'assets/css/admin' . LLMS_ASSETS_SUFFIX . '.css', array(), LLMS_ASSETS_VERSION );
 		wp_style_add_data( 'llms-admin-styles', 'rtl', 'replace' );
 		wp_style_add_data( 'llms-admin-styles', 'suffix', LLMS_ASSETS_SUFFIX );
 
@@ -217,6 +218,7 @@ class LLMS_Admin_Assets {
 	 * @since 5.5.0 Use `LLMS_Assets` for the enqueue of `llms-admin-add-ons`.
 	 * @since 6.0.0 Enqueue certificate and achievement related js in `llms_my_certificate`, `llms_my_achievement` post types as well.
 	 * @since 7.1.0 Enqueue `postbox` script on the new dashboard page.
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
 	 *
 	 * @return void
 	 */
@@ -227,12 +229,12 @@ class LLMS_Admin_Assets {
 
 		if ( 'widgets' === $screen->id ) {
 
-			wp_enqueue_script( 'llms-widget-syllabus', LLMS_PLUGIN_URL . 'assets/js/llms-widget-syllabus' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+			wp_enqueue_script( 'llms-widget-syllabus', LLMS_PLUGIN_URL . 'assets/js/llms-widget-syllabus' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 
 		}
 
 		llms()->assets->register_script( 'llms-select2' );
-		wp_register_script( 'llms-metaboxes', LLMS_PLUGIN_URL . 'assets/js/llms-metaboxes' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-datepicker', 'llms-admin-scripts', 'llms-select2' ), llms()->version, true );
+		wp_register_script( 'llms-metaboxes', LLMS_PLUGIN_URL . 'assets/js/llms-metaboxes' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-datepicker', 'llms-admin-scripts', 'llms-select2' ), LLMS_ASSETS_VERSION, true );
 
 		if ( ( post_type_exists( $screen->id ) && post_type_supports( $screen->id, 'llms-membership-restrictions' ) ) || 'dashboard_page_llms-setup' === $screen->id ) {
 			wp_enqueue_script( 'llms-metaboxes' );
@@ -247,12 +249,12 @@ class LLMS_Admin_Assets {
 			)
 		);
 		if ( in_array( $screen->id, $tables, true ) ) {
-			wp_register_script( 'llms-admin-tables', LLMS_PLUGIN_URL . 'assets/js/llms-admin-tables' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+			wp_register_script( 'llms-admin-tables', LLMS_PLUGIN_URL . 'assets/js/llms-admin-tables' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			wp_enqueue_script( 'llms-admin-tables' );
 		}
 
-		wp_register_script( 'llms', LLMS_PLUGIN_URL . 'assets/js/llms' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
-		wp_register_script( 'llms-admin-scripts', LLMS_PLUGIN_URL . 'assets/js/llms-admin' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-select2' ), llms()->version, true );
+		wp_register_script( 'llms', LLMS_PLUGIN_URL . 'assets/js/llms' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
+		wp_register_script( 'llms-admin-scripts', LLMS_PLUGIN_URL . 'assets/js/llms-admin' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-select2' ), LLMS_ASSETS_VERSION, true );
 
 		if ( $this->is_llms_page() ) {
 
@@ -266,40 +268,40 @@ class LLMS_Admin_Assets {
 			wp_register_style( 'jquery-ui-flick', LLMS_PLUGIN_URL . 'assets/vendor/jquery-ui-flick/jquery-ui-flick' . LLMS_ASSETS_SUFFIX . '.css', array(), '1.11.2' );
 			wp_enqueue_style( 'jquery-ui-flick' );
 
-			wp_enqueue_script( 'llms-ajax', LLMS_PLUGIN_URL . 'assets/js/llms-ajax' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+			wp_enqueue_script( 'llms-ajax', LLMS_PLUGIN_URL . 'assets/js/llms-ajax' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 
 			wp_enqueue_media();
 
 			if ( 'course' === $post_type ) {
 
-				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 
 			if ( 'course' === $post_type || 'llms_membership' === $post_type ) {
 
-				wp_enqueue_script( 'llms-metabox-students', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-students' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms-select2' ), llms()->version, true );
-				wp_enqueue_script( 'llms-metabox-product', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-product' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), llms()->version, true );
-				wp_enqueue_script( 'llms-metabox-instructors', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-instructors' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-students', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-students' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms-select2' ), LLMS_ASSETS_VERSION, true );
+				wp_enqueue_script( 'llms-metabox-product', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-product' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS_ASSETS_VERSION, true );
+				wp_enqueue_script( 'llms-metabox-instructors', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-instructors' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS_ASSETS_VERSION, true );
 
 			}
 
 			if ( 'lesson' === $post_type ) {
-				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 			if ( in_array( $post_type, array( 'llms_certificate', 'llms_my_certificate' ), true ) ) {
 
-				wp_enqueue_script( 'llms-metabox-certificate', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-certificate' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-certificate', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-certificate' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 			if ( in_array( $post_type, array( 'llms_achievement', 'llms_my_achievement' ), true ) ) {
 
-				wp_enqueue_script( 'llms-metabox-achievement', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-achievement' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-achievement', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-achievement' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 			if ( 'llms_membership' === $post_type ) {
-				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-fields', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-fields' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 			if ( 'llms_voucher' === $post_type ) {
 
-				wp_enqueue_script( 'llms-metabox-voucher', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-voucher' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+				wp_enqueue_script( 'llms-metabox-voucher', LLMS_PLUGIN_URL . 'assets/js/llms-metabox-voucher' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			}
 
 			$this->maybe_enqueue_reporting( $screen );
@@ -316,7 +318,7 @@ class LLMS_Admin_Assets {
 		if ( 'lifterlms_page_llms-settings' === $screen->id ) {
 
 			wp_enqueue_media();
-			wp_enqueue_script( 'llms-admin-settings', LLMS_PLUGIN_URL . 'assets/js/llms-admin-settings' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-sortable' ), llms()->version, true );
+			wp_enqueue_script( 'llms-admin-settings', LLMS_PLUGIN_URL . 'assets/js/llms-admin-settings' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-sortable' ), LLMS_ASSETS_VERSION, true );
 
 		} elseif ( 'admin_page_llms-course-builder' === $screen->id ) {
 
@@ -324,14 +326,14 @@ class LLMS_Admin_Assets {
 
 			wp_enqueue_editor();
 
-			wp_enqueue_style( 'llms-builder-styles', LLMS_PLUGIN_URL . 'assets/css/builder' . LLMS_ASSETS_SUFFIX . '.css', array( 'llms-quill-bubble' ), llms()->version, 'screen' );
+			wp_enqueue_style( 'llms-builder-styles', LLMS_PLUGIN_URL . 'assets/css/builder' . LLMS_ASSETS_SUFFIX . '.css', array( 'llms-quill-bubble' ), LLMS_ASSETS_VERSION, 'screen' );
 			wp_style_add_data( 'llms-builder-styles', 'rtl', 'replace' );
 			wp_style_add_data( 'llms-builder-styles', 'suffix', LLMS_ASSETS_SUFFIX );
 
 			wp_enqueue_style( 'webui-popover', LLMS_PLUGIN_URL . 'assets/vendor/webui-popover/jquery.webui-popover' . LLMS_ASSETS_SUFFIX . '.css', array(), '1.2.15' );
 			wp_style_add_data( 'webui-popover', 'suffix', LLMS_ASSETS_SUFFIX );
 
-			wp_enqueue_script( 'webui-popover', LLMS_PLUGIN_URL . 'assets/vendor/webui-popover/jquery.webui-popover' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+			wp_enqueue_script( 'webui-popover', LLMS_PLUGIN_URL . 'assets/vendor/webui-popover/jquery.webui-popover' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 			wp_enqueue_style( 'llms-datetimepicker', LLMS_PLUGIN_URL . 'assets/vendor/datetimepicker/jquery.datetimepicker.min.css', array(), '1.3.4' );
 			wp_enqueue_script( 'llms-datetimepicker', LLMS_PLUGIN_URL . 'assets/vendor/datetimepicker/jquery.datetimepicker.full' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), '1.3.4', true );
 
@@ -339,7 +341,7 @@ class LLMS_Admin_Assets {
 				wp_enqueue_script( 'heartbeat' );
 			}
 
-			wp_enqueue_script( 'llms-builder', LLMS_PLUGIN_URL . 'assets/js/llms-builder' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable', 'backbone', 'underscore', 'post', 'llms-quill' ), llms()->version, true );
+			wp_enqueue_script( 'llms-builder', LLMS_PLUGIN_URL . 'assets/js/llms-builder' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'jquery-ui-sortable', 'jquery-ui-draggable', 'backbone', 'underscore', 'post', 'llms-quill' ), LLMS_ASSETS_VERSION, true );
 
 		} elseif ( 'lifterlms_page_llms-add-ons' === $screen->id ) {
 			llms()->assets->enqueue_script( 'llms-addons' );
@@ -452,6 +454,7 @@ class LLMS_Admin_Assets {
 	 *
 	 * @since 4.3.3
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
 	 *
 	 * @param WP_Sreen $screen Screen object from WP `get_current_screen()`.
 	 * @return void
@@ -463,7 +466,7 @@ class LLMS_Admin_Assets {
 			$current_tab = llms_filter_input( INPUT_GET, 'tab' );
 
 			wp_register_script( 'llms-google-charts', LLMS_PLUGIN_URL . 'assets/js/vendor/gcharts-loader.min.js', array(), '2019-09-04', false );
-			wp_register_script( 'llms-analytics', LLMS_PLUGIN_URL . 'assets/js/llms-analytics' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-admin-scripts', 'llms-google-charts' ), llms()->version, true );
+			wp_register_script( 'llms-analytics', LLMS_PLUGIN_URL . 'assets/js/llms-analytics' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-admin-scripts', 'llms-google-charts' ), LLMS_ASSETS_VERSION, true );
 
 			// Dashboard page where we have analytics widgets.
 			if ( 'lifterlms_page_llms-dashboard' === $screen->base ) {
@@ -475,7 +478,7 @@ class LLMS_Admin_Assets {
 				if ( in_array( $current_tab, array( 'enrollments', 'sales' ), true ) ) {
 					wp_enqueue_script( 'llms-analytics' );
 				} elseif ( 'quizzes' === $current_tab && 'attempts' === llms_filter_input( INPUT_GET, 'stab' ) ) {
-					wp_enqueue_script( 'llms-quiz-attempt-review', LLMS_PLUGIN_URL . 'assets/js/llms-quiz-attempt-review' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS()->version, true );
+					wp_enqueue_script( 'llms-quiz-attempt-review', LLMS_PLUGIN_URL . 'assets/js/llms-quiz-attempt-review' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms' ), LLMS_ASSETS_VERSION, true );
 				}
 			}
 		}

--- a/includes/class-llms-assets.php
+++ b/includes/class-llms-assets.php
@@ -15,7 +15,7 @@
  * @package LifterLMS/Classes
  *
  * @since 4.4.0
- * @version 7.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -44,7 +44,9 @@ class LLMS_Assets {
 	protected $debugging_assets = false;
 
 	/**
-	 * List of default asset definitions
+	 * List of default asset definitions.
+	 *
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for default asset version.
 	 *
 	 * @var array[]
 	 */
@@ -55,7 +57,7 @@ class LLMS_Assets {
 			'base_url'     => LLMS_PLUGIN_URL,
 			'suffix'       => LLMS_ASSETS_SUFFIX,
 			'dependencies' => array(),
-			'version'      => LLMS_VERSION,
+			'version'      => LLMS_ASSETS_VERSION,
 		),
 		// Script specific defaults.
 		'script' => array(
@@ -261,7 +263,7 @@ class LLMS_Assets {
 	 *     @type string   $extension    The filename extension for the asset. Defaults to `.js` for scripts and `.css` for styles.
 	 *     @type string   $suffix       The file suffix for the asset, for example `.min` for minified files. Defaults to `LLMS_ASSETS_SUFFIX`.
 	 *     @type string[] $dependencies An array of asset handles the asset depends on. These assets do not necessarily need to be assets defined by LifterLMS, for example WP Core scripts, such as `jquery`, can be used.
-	 *     @type string   $version      The asset version. Defaults to `LLMS_VERSION`.
+	 *     @type string   $version      The asset version. Defaults to `LLMS_ASSETS_VERSION`.
 	 *     @type string   $package_id   An ID used to identify the originating plugin or theme that defined the asset.
 	 *     @type boolean  $in_footer    (For `script` assets only) Whether or not the script should be output in the footer. Defaults to `true`.
 	 *     @type boolean  $translate    (For `script` assets only) Whether or not script translations should be set. Defaults to `false`.

--- a/tests/phpunit/unit-tests/class-llms-test-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-assets.php
@@ -7,6 +7,8 @@
  * @group assets
  *
  * @since 4.4.0
+ *
+ * @version [version]
  */
 class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 
@@ -395,6 +397,7 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 	 *
 	 * @since 4.4.0
 	 * @since 5.5.0 Add `asset_file`.
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
 	 *
 	 * @return void
 	 */
@@ -405,7 +408,7 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 			'base_url'     => LLMS_PLUGIN_URL,
 			'suffix'       => LLMS_ASSETS_SUFFIX,
 			'dependencies' => array(),
-			'version'      => llms()->version,
+			'version'      => LLMS_ASSETS_VERSION,
 			'extension'    => '.js',
 			'in_footer'    => true,
 			'path'         => 'assets/js',
@@ -421,6 +424,8 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 	 *
 	 * @since 4.4.0
 	 *
+	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
+	 *
 	 * @return void
 	 */
 	public function test_get_defaults_for_styles() {
@@ -430,7 +435,7 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 			'base_url'     => LLMS_PLUGIN_URL,
 			'suffix'       => LLMS_ASSETS_SUFFIX,
 			'dependencies' => array(),
-			'version'      => llms()->version,
+			'version'      => LLMS_ASSETS_VERSION,
 			'extension'    => '.css',
 			'media'        => 'all',
 			'path'         => 'assets/css',

--- a/tests/phpunit/unit-tests/class-llms-test-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-assets.php
@@ -7,7 +7,6 @@
  * @group assets
  *
  * @since 4.4.0
- *
  * @version [version]
  */
 class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
@@ -423,7 +422,6 @@ class LLMS_Test_Assets extends LLMS_Unit_Test_Case {
 	 * Test get_styles()
 	 *
 	 * @since 4.4.0
-	 *
 	 * @since [version] Use `LLMS_ASSETS_VERSION` for asset versions.
 	 *
 	 * @return void


### PR DESCRIPTION
## Description

This PR adds a new `LLMS_ASSETS_VERSION` constant which can be used for cache busting scripts and styles in development.

If either `WP_DEBUG` or `SCRIPT_DEBUG` are true, the current time in milliseconds will be returned, otherwise the plugin version is returned.

## How has this been tested?

Manually

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
