### PR TITLE
Added helper function for floating values shown in average column in reporting.

### DIFF
--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: changed
+comment: Added a helper function for returning precision with filter for
+  floating values in the reporting section for quizzes and assignment's average
+  column.
+entry: Added helper function for precision for floating values in reporting section.

--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,4 +1,4 @@
-significance: minor
+significance: patch
 type: dev
 comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter `lifterlms_floats_rounding_precision` for rounding off floating values in the reporting section for quizzes average column.
 links:

--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,8 +1,7 @@
 significance: minor
 type: dev
 comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter for
-  rounding off floating values in the reporting section for quizzes and
-  assignment's average column.
+  rounding off floating values in the reporting section for quizzes average column.
 links:
   - "#2237"
 entry: Added helper function `llms_get_floats_rounding_precision()` to return precision for rounding off floating

--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,7 +1,6 @@
 significance: minor
 type: dev
-comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter for
-  rounding off floating values in the reporting section for quizzes average column.
+comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter `lifterlms_reporting_average_precision` for rounding off floating values in the reporting section for quizzes average column.
 links:
   - "#2237"
 entry: Added helper function `llms_get_floats_rounding_precision()` to return precision for rounding off floating

--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,7 +1,7 @@
 significance: minor
 type: dev
-comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter `lifterlms_reporting_average_precision` for rounding off floating values in the reporting section for quizzes average column.
+comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter `lifterlms_floats_rounding_precision` for rounding off floating values in the reporting section for quizzes average column.
 links:
   - "#2237"
 entry: Added helper function `llms_get_floats_rounding_precision()` to return precision for rounding off floating
-  values in reporting section.
+  values with filter hook `lifterlms_floats_rounding_precision` to filter precision value for reporting section.

--- a/.changelogs/issue_2237.yml
+++ b/.changelogs/issue_2237.yml
@@ -1,6 +1,9 @@
-significance: patch
-type: changed
-comment: Added a helper function for returning precision with filter for
-  floating values in the reporting section for quizzes and assignment's average
-  column.
-entry: Added helper function for precision for floating values in reporting section.
+significance: minor
+type: dev
+comment: Added a helper function `llms_get_floats_rounding_precision()` for returning precision with filter for
+  rounding off floating values in the reporting section for quizzes and
+  assignment's average column.
+links:
+  - "#2237"
+entry: Added helper function `llms_get_floats_rounding_precision()` to return precision for rounding off floating
+  values in reporting section.

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -292,9 +292,6 @@ function llms_merge_code_button( $target = 'content', $echo = true, $codes = arr
 /**
  * Retrieve the precision for round function for floating values.
  *
- * The function returns precision to round off the decimal values
- * for 'average' column in reporting tables.
- *
  * @since [version]
  *
  * @return int

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Functions
  *
  * @since 3.0.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -286,5 +286,35 @@ function llms_merge_code_button( $target = 'content', $echo = true, $codes = arr
 	}
 
 	return $html;
+
+}
+
+/**
+ * Retrieve the precision for round function for floating values.
+ *
+ * The function returns precision to round off the decimal values
+ * for 'average' column in reporting tables.
+ *
+ * @since [version]
+ *
+ * @return int
+ */
+function llms_get_floats_rounding_precision() {
+
+	// Used `static` to store precision value so `apply_filters()` run only once per request.
+	static $precision = null;
+
+	if ( is_null( $precision ) ) {
+		/**
+		 * Filters the precision for round function for floating values.
+		 *
+		 * @since [version]
+		 *
+		 * @param int $precision Precision for round function for floating values.
+		 */
+		$precision = apply_filters( 'lifterlms_reporting_average_precision', 2 );
+	}
+
+	return $precision;
 
 }

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -312,7 +312,7 @@ function llms_get_floats_rounding_precision() {
 		 *
 		 * @param int $precision Precision for round function for floating values.
 		 */
-		$precision = apply_filters( 'lifterlms_reporting_average_precision', 2 );
+		$precision = apply_filters( 'lifterlms_floats_rounding_precision', 2 );
 	}
 
 	return $precision;

--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
  * @since 3.16.0
- * @version 6.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -146,6 +146,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 	 *               ID column displays as plain text if the quiz is not editable and directs to the quiz within the course builder when it is.
 	 * @since 4.2.0 Added a deep check on whether the quiz is associated to a lesson.
 	 * @since 6.0.0 Don't access `LLMS_Query_Quiz_Attempt` properties directly.
+	 * @since [version] Added `round()` method for 'average' column values with precision from `llms_get_floats_rounding_precision()` helper.
 	 *
 	 * @param string $key  The column id / key.
 	 * @param mixed  $data Object / array of data that the function can use to extract the data.
@@ -199,7 +200,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 						$grade += $attempt->get( 'grade' );
 					}
 
-					$value = round( $grade / $attempts, llms_get_reporting_round_precision() ) . '%';
+					$value = round( $grade / $attempts, llms_get_floats_rounding_precision() ) . '%';
 
 				}
 

--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -199,7 +199,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 						$grade += $attempt->get( 'grade' );
 					}
 
-					$value = round( $grade / $attempts, 3 ) . '%';
+					$value = round( $grade / $attempts, llms_get_reporting_round_precision() ) . '%';
 
 				}
 

--- a/includes/functions/llms-functions-content.php
+++ b/includes/functions/llms-functions-content.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.25.1
- * @version [version]
+ * @version 4.17.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -109,24 +109,6 @@ function llms_get_post_sales_page_content( $post, $default = '' ) {
 	 * @param string  $default Default content used when no override content can be found.
 	 */
 	return apply_filters( 'llms_post_sales_page_content', $content, $post, $default );
-
-}
-
-/**
- * Retrieve the decimal value for average column in Reporting.
- *
- * By default the database return floating-point values and  function
- * percision to round off the decimal value.
- *
- * @since [version]
- *
- * @return int
- */
-function llms_get_reporting_round_precision() {
-
-	$precision = apply_filters( 'lifterlms_average_decimal', 1 );
-
-	return $precision;
 
 }
 

--- a/includes/functions/llms-functions-content.php
+++ b/includes/functions/llms-functions-content.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.25.1
- * @version 4.17.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -109,6 +109,24 @@ function llms_get_post_sales_page_content( $post, $default = '' ) {
 	 * @param string  $default Default content used when no override content can be found.
 	 */
 	return apply_filters( 'llms_post_sales_page_content', $content, $post, $default );
+
+}
+
+/**
+ * Retrieve the decimal value for average column in Reporting.
+ *
+ * By default the database return floating-point values and  function
+ * percision to round off the decimal value.
+ *
+ * @since [version]
+ *
+ * @return int
+ */
+function llms_get_reporting_round_precision() {
+
+	$precision = apply_filters( 'lifterlms_average_decimal', 1 );
+
+	return $precision;
 
 }
 


### PR DESCRIPTION
## Description
Added a helper function for returning precision with a filter for floating values in the reporting section for quizzes and assignment's average column.

Fixes #2237

## How has this been tested?
Manually.

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

