### PR TITLE
Fixed condition for showing fields for Gutenberg only.

### DIFF
--- a/.changelogs/issue_2174.yml
+++ b/.changelogs/issue_2174.yml
@@ -1,0 +1,9 @@
+significance: patch
+type: fixed
+comment: Added condition for checking if the post is an auto-draft and the
+  Classic Editor is not active when postmeta is not generated for hiding two
+  options for gutenberg editor.
+links:
+  - "#2174"
+entry: Fixed 'Course Length' and 'Difficulty fields' fields visible in Gutenberg
+  Editor which is meant for Classic Editor.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/PostTypes/MetaBoxes/Classes
  *
  * @since 1.0.0
- * @version 5.9.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -39,6 +39,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 	 *
 	 * @since 1.0.0
 	 * @since 3.36.0 Allow some fields to store values with quotes.
+	 * @since [version] Fixed condition for unsetting fields when using Gutenberg.
 	 *
 	 * @return array
 	 */
@@ -356,7 +357,10 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 			),
 		);
 
-		if ( function_exists( 'register_block_type' ) && llms_blocks_is_post_migrated( $this->post->ID ) ) {
+		if (
+			( ! class_exists( 'Classic_Editor' ) && 'auto-draft' === get_post_status( $this->post->ID ) ) ||
+			( function_exists( 'register_block_type' ) && llms_blocks_is_post_migrated( $this->post->ID ) )
+		) {
 			unset( $fields[1]['fields'][0] ); // length.
 			unset( $fields[1]['fields'][1] ); // difficulty.
 		}

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -358,7 +358,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 		);
 
 		$current_screen = get_current_screen();
-		$is_gutenberg   = method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor();
+		$is_gutenberg   = is_object( $current_screen ) && method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor();
 
 		/**
 		 * Remove length and difficulty fields if
@@ -366,8 +366,11 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 		 * - the course is migrated to blocks used in the Gutenberg editor.
 		 */
 		if (
-			( 'auto-draft' === get_post_status( $this->post->ID ) && $is_gutenberg ) ||
-			$is_gutenberg && llms_blocks_is_post_migrated( $this->post->ID )
+			$is_gutenberg &&
+			(
+				'auto-draft' === get_post_status( $this->post->ID ) ||
+				llms_blocks_is_post_migrated( $this->post->ID )
+			)
 		) {
 			unset( $fields[1]['fields'][0] ); // length.
 			unset( $fields[1]['fields'][1] ); // difficulty.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * LLMS_Meta_Box_Course_Options class
+ * LLMS_Meta_Box_Course_Options class.
  *
  * @since 1.0.0
  * @since 3.35.0 Verify nonces and sanitize `$_POST` data.
@@ -40,7 +40,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 	 * @since 1.0.0
 	 * @since 3.36.0 Allow some fields to store values with quotes.
 	 * @since [version] Fixed condition for unsetting fields when using Gutenberg.
-   *                  Replaced outdated URLs to WordPress' documentation about the list of sites you can embed from.
+	 *                  Replaced outdated URLs to WordPress' documentation about the list of sites you can embed from.
 	 *
 	 * @return array
 	 */

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -357,9 +357,17 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 			),
 		);
 
+		$current_screen = get_current_screen();
+		$is_gutenberg   = method_exists( $current_screen, 'is_block_editor' ) && $current_screen->is_block_editor();
+
+		/**
+		 * Remove length and difficulty fields if
+		 * - the course is a new post and the editor is Gutenberg.
+		 * - the course is migrated to blocks used in the Gutenberg editor.
+		 */
 		if (
-			( ! class_exists( 'Classic_Editor' ) && 'auto-draft' === get_post_status( $this->post->ID ) ) ||
-			( function_exists( 'register_block_type' ) && llms_blocks_is_post_migrated( $this->post->ID ) )
+			( 'auto-draft' === get_post_status( $this->post->ID ) && $is_gutenberg ) ||
+			$is_gutenberg && llms_blocks_is_post_migrated( $this->post->ID )
 		) {
 			unset( $fields[1]['fields'][0] ); // length.
 			unset( $fields[1]['fields'][1] ); // difficulty.


### PR DESCRIPTION
## Description
Hides two fields i.e., **Course Length** and **Difficulty** fields when the post is not migrated or the editor is Gutenberg. Those fields are visible only to the classic editor now.

Fixes #2174 

## How has this been tested?
Manually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

