### PR TITLE
Added post ID parameter to the post title filter.

### DIFF
--- a/.changelogs/issue_2191.yml
+++ b/.changelogs/issue_2191.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#2322"
-entry: Added missing `$post_id` parameter to the Post Title filter.
+entry: Added missing `$post_id` parameter to the Post Title filter when retrieving a form title.

--- a/.changelogs/issue_2191.yml
+++ b/.changelogs/issue_2191.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2322"
+entry: Added missing `$post_id` parameter to the Post Title filter.

--- a/includes/functions/llms-functions-forms.php
+++ b/includes/functions/llms-functions-forms.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions/Forms
  *
  * @since 5.0.0
- * @version 5.10.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -76,6 +76,7 @@ function llms_get_form_html( $location, $args = array() ) {
  *
  * @since 5.0.0
  * @since 5.10.0 Return specific form title for checkout forms and free access plans.
+ * @since [version] Added 3rd missing `$post_id` parameter for the Post Title Filter.
  *
  * @param string $location Form location, one of: "checkout", "registration", or "account".
  * @param array  $args Additional arguments passed to the short-circuit filter in `LLMS_Forms->get_form_post()`.
@@ -90,7 +91,7 @@ function llms_get_form_title( $location, $args = array() ) {
 
 	return 'checkout' === $location && isset( $args['plan'] ) && $args['plan']->is_free()
 		?
-		apply_filters( 'the_title', get_post_meta( $post->ID, '_llms_form_title_free_access_plans', true ) )
+		apply_filters( 'the_title', get_post_meta( $post->ID, '_llms_form_title_free_access_plans', true ), $post->ID )
 		:
 		get_the_title( $post->ID );
 


### PR DESCRIPTION
## Description
Post Title filter in `llms_get_form_title()` function was conflicting with the My Calendar Plugin due to missing post ID parameter. 

Fixes #2332

## How has this been tested?
Manually.

## Types of changes
Bug fix.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

