### PR TITLE
Issue 2325 Armed Forces "States" not an option for addresses

### DIFF
--- a/.changelogs/issue_2325.yml
+++ b/.changelogs/issue_2325.yml
@@ -4,5 +4,5 @@ comment: added missing armed forces options to adresse's states dropdown in
   checkout form
 links:
   - "#2325"
-entry: Added missing armed forces options to adresse's states dropdown in
-  checkout form.
+entry: Added missing armed forces options to the State dropdown in the
+  Billing information form.

--- a/.changelogs/issue_2325.yml
+++ b/.changelogs/issue_2325.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: fixed
+comment: added missing armed forces options to adresse's states dropdown in
+  checkout form
+links:
+  - "#2325"
+entry: Added missing armed forces options to adresse's states dropdown in
+  checkout form.

--- a/languages/states.php
+++ b/languages/states.php
@@ -5067,10 +5067,13 @@ return array(
 		'W'   => __( 'Western Region', 'lifterlms' ),
 	),
 	'UM' => array(),
-	'US' => array(
-		'AL' => __( 'Alabama', 'lifterlms' ),
-		'AK' => __( 'Alaska', 'lifterlms' ),
-		'AS' => __( 'American Samoa', 'lifterlms' ),
+    'US' => array(
+        'AA' => __( 'Armed Forces (AA)', 'lifterlms' ),
+        'AE' => __( 'Armed Forces (AE)', 'lifterlms' ),
+        'AL' => __( 'Alabama', 'lifterlms' ),
+        'AK' => __( 'Alaska', 'lifterlms' ),
+        'AP' => __( 'Armed Forces (AP)', 'lifterlms' ),
+        'AS' => __( 'American Samoa', 'lifterlms' ),
 		'AZ' => __( 'Arizona', 'lifterlms' ),
 		'AR' => __( 'Arkansas', 'lifterlms' ),
 		'CA' => __( 'California', 'lifterlms' ),

--- a/languages/states.php
+++ b/languages/states.php
@@ -5073,6 +5073,7 @@ return array(
 		'AS' => __( 'American Samoa', 'lifterlms' ),
 		'AZ' => __( 'Arizona', 'lifterlms' ),
 		'AR' => __( 'Arkansas', 'lifterlms' ),
+		// Armed Forces manually added, see https://github.com/gocodebox/lifterlms/issues/2325.
 		'AA' => __( 'Armed Forces (Americas)', 'lifterlms' ),
 		'AE' => __( 'Armed Forces (Europe, Canada, Africa, Middle East)', 'lifterlms' ),
 		'AP' => __( 'Armed Forces (Pacific)', 'lifterlms' ),

--- a/languages/states.php
+++ b/languages/states.php
@@ -32,7 +32,7 @@
  * @see llms_get_states()
  *
  * @since 5.0.0
- * @version 6.10.0
+ * version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -5067,15 +5067,15 @@ return array(
 		'W'   => __( 'Western Region', 'lifterlms' ),
 	),
 	'UM' => array(),
-    'US' => array(
-        'AA' => __( 'Armed Forces (AA)', 'lifterlms' ),
-        'AE' => __( 'Armed Forces (AE)', 'lifterlms' ),
-        'AL' => __( 'Alabama', 'lifterlms' ),
-        'AK' => __( 'Alaska', 'lifterlms' ),
-        'AP' => __( 'Armed Forces (AP)', 'lifterlms' ),
-        'AS' => __( 'American Samoa', 'lifterlms' ),
+	'US' => array(
+		'AL' => __( 'Alabama', 'lifterlms' ),
+		'AK' => __( 'Alaska', 'lifterlms' ),
+		'AS' => __( 'American Samoa', 'lifterlms' ),
 		'AZ' => __( 'Arizona', 'lifterlms' ),
 		'AR' => __( 'Arkansas', 'lifterlms' ),
+		'AA' => __( 'Armed Forces (Americas)', 'lifterlms' ),
+		'AE' => __( 'Armed Forces (Europe, Canada, Africa, Middle East)', 'lifterlms' ),
+		'AP' => __( 'Armed Forces (Pacific)', 'lifterlms' ),
 		'CA' => __( 'California', 'lifterlms' ),
 		'CO' => __( 'Colorado', 'lifterlms' ),
 		'CT' => __( 'Connecticut', 'lifterlms' ),


### PR DESCRIPTION

## Description
Added Armed Forces "States" options to States Array.

Fixes #2325 

## How has this been tested?
Manually

## Screenshots
<img width="853" alt="image" src="https://user-images.githubusercontent.com/1678457/233173024-e4a26292-db0d-4ca5-b41e-02540435171a.png">

## Types of changes
Bug Fix. Adds missing stastes to dropdown

## Checklist:
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

