### PR TITLE
Let's use strpos instead of str_starts_with to avoid fatal errors

### DIFF
--- a/.changelogs/issue_2415.yml
+++ b/.changelogs/issue_2415.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2415"
+entry: Using `strpos()` instead of `str_starts_with()` for compatibility.

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 7.1.0
- * @version 7.1.2
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +33,7 @@ class LLMS_Admin_Header {
 	 *
 	 * @since 7.1.0
 	 * @since 7.1.2 Making the LifterLMS logo link to the LifterLMS.com site.
+	 * @since [version] Using strpos instead of str_starts_with for compatibility.
 	 *
 	 * @return void
 	 */
@@ -58,8 +59,8 @@ class LLMS_Admin_Header {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
-			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) !== false ) ||
-			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) !== false )
+			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) === 0 ) ||
+			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) === 0 )
 		) {
 			$show_header = true;
 		}

--- a/includes/admin/class-llms-admin-header.php
+++ b/includes/admin/class-llms-admin-header.php
@@ -58,8 +58,8 @@ class LLMS_Admin_Header {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
-			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
-			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
+			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) !== false ) ||
+			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) !== false )
 		) {
 			$show_header = true;
 		}

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -65,8 +65,8 @@ class LLMS_Admin_Review {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
-			( ! empty( $_GET['page'] ) && str_starts_with( $_GET['page'], 'llms-' ) ) ||
-			( ! empty( $current_screen->id ) && str_starts_with( $current_screen->id, 'lifterlms' ) )
+			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) !== false ) ||
+			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) !== false )
 		) {
 			$show_footer = true;
 		}

--- a/includes/admin/class-llms-admin-review.php
+++ b/includes/admin/class-llms-admin-review.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Classes
  *
  * @since 3.24.0
- * @version 7.1.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -43,6 +43,7 @@ class LLMS_Admin_Review {
 	 *
 	 * @since 3.24.0
 	 * @since 7.1.0 Show footer on our custom post types in admin, but not on the block editor.
+	 * @since [version] Using strpos instead of str_starts_with for compatibility.
 	 *
 	 * @param string $text Default footer text.
 	 * @return string
@@ -65,8 +66,8 @@ class LLMS_Admin_Review {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- No sanitization needed here, we're not gonna use this value other than for checks
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- No unslash needed here, we're not gonna use this value other than for checks
 		if (
-			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) !== false ) ||
-			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) !== false )
+			( ! empty( $_GET['page'] ) && strpos( $_GET['page'], 'llms-' ) === 0 ) ||
+			( ! empty( $current_screen->id ) && strpos( $current_screen->id, 'lifterlms' ) === 0 )
 		) {
 			$show_footer = true;
 		}


### PR DESCRIPTION
Even though `str_starts_with()` should be available when using our minimum recommended versions of PHP and WP, using `strpos(...) !== false` is easy enough and avoids fatal errors for some of our users.

In general, we want to avoid using new functions, methods, and features of PHP/WP until we have too. We don't want to go too far out of our way to support older versions, but if the required change is small, won't hinder our development, and is not at risk of being deprecated, we should lean toward using the older code to maximize compatibility.

This is a different stance than the LifterLMS dev team has taken in the past.

## Description
<!-- Please describe what you have changed or added -->

Fixes #2415

## How has this been tested?
Locally. After the change, the LifterLMS admin header and footer are still loading properly on pages they should and not loading on pages they shouldn't.

## Types of changes
Bug Fix

## Checklist:
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

