### PR TITLE
Fixed Error output conflict with Yoast Plugin.

### DIFF
--- a/.changelogs/issue_1779.yml
+++ b/.changelogs/issue_1779.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+comment: Yoast plugin was stopping the error output from printing out by taking
+  it as meta description.
+links:
+  - "#1779"
+entry: Fixed error output conflict with Yoast Plugin.

--- a/includes/functions/llms.functions.notice.php
+++ b/includes/functions/llms.functions.notice.php
@@ -7,7 +7,7 @@
  * @package LifterLMS/Functions
  *
  * @since unknown
- * @version 3.14.7
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -147,9 +147,21 @@ function llms_print_notice( $message, $notice_type = 'success' ) {
  *
  * @return  void
  * @since   1.0.0
- * @version 3.14.7
+ * @version [version]
  */
 function llms_print_notices() {
-	echo llms_get_notices();
+	add_action( "the_content", "llms_show_notices" );
+}
+
+/**
+ * Shows all LLMS notices/warnings/errors via `the_content` hook.
+ *
+ * @since [version]
+ *
+ * @param type $content WP Post/Page Content.
+ * @return void
+ */
+function llms_show_notices( $content ) {
+	echo llms_get_notices() . $content;
 	llms_clear_notices();
 }

--- a/includes/functions/llms.functions.notice.php
+++ b/includes/functions/llms.functions.notice.php
@@ -150,7 +150,7 @@ function llms_print_notice( $message, $notice_type = 'success' ) {
  * @version [version]
  */
 function llms_print_notices() {
-	add_action( "the_content", "llms_show_notices" );
+	add_action( 'the_content', 'llms_show_notices' );
 }
 
 /**


### PR DESCRIPTION
## Description
The Yoast plugin stopped the error output from printing out by taking it as a meta description.

Fixes #1779 

## How has this been tested?
Manually.

## Types of changes
Bug fix

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

