### PR TITLE
Removed check for validating Visibility options

### DIFF
--- a/.changelogs/issue_190.yml
+++ b/.changelogs/issue_190.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#190"
+entry: Removed `in_array()` check for `llms_get_product_visibility_options()`
+  when options are added via filter.

--- a/includes/models/model.llms.product.php
+++ b/includes/models/model.llms.product.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 6.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -378,6 +378,7 @@ class LLMS_Product extends LLMS_Post_Model {
 	 *
 	 * @since 3.6.0
 	 * @since 3.37.17 Use `in_array` with strict comparison.
+	 * @since [version] Removed `in_array` check for `llms_get_product_visibility_options()`.
 	 *
 	 * @param string $visibility Visibility term name.
 	 * @return void

--- a/includes/models/model.llms.product.php
+++ b/includes/models/model.llms.product.php
@@ -383,9 +383,6 @@ class LLMS_Product extends LLMS_Post_Model {
 	 * @return void
 	 */
 	public function set_catalog_visibility( $visibility ) {
-		if ( ! in_array( $visibility, array_keys( llms_get_product_visibility_options() ), true ) ) {
-			return;
-		}
 		wp_set_object_terms( $this->get( 'id' ), $visibility, 'llms_product_visibility', false );
 	}
 


### PR DESCRIPTION
## Description
Fixes issue when the visibility options are coming via add_filter on Gutenberg Post. Based on https://github.com/gocodebox/lifterlms-blocks/pull/192

Fixes [lifterlms-blocks#190](https://github.com/gocodebox/lifterlms-blocks/issues/190)

## How has this been tested?
Manually.

## Types of changes
Bug fix.

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

