### PR TITLE
Pagination fix to return false only on Dashboard (fixes bug for Social Learning)

### DIFF
--- a/.changelogs/pagination-fix.yml
+++ b/.changelogs/pagination-fix.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Adjusted `llms_modify_dashboard_pagination_links_disable` filter to
+  return false only on Dashboard page.

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.0.0
- * @version 7.1.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -919,11 +919,12 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard_wrapper_open' ) ) 
 endif;
 
 /**
- * Modify the pagination links displayed on endpoints using the default LLMS loop
+ * Modify the pagination links displayed on endpoints using the default LLMS loop.
  *
  * @since 3.24.0
  * @since 3.26.3 Unknown.
  * @since 6.3.0 Fixed pagination when using plain permalinks.
+ * @since [version] Made sure the pagination links is not altered when not in the LifterLMS dashboard context.
  *
  * @param string $link Default link.
  * @return string
@@ -936,8 +937,10 @@ function llms_modify_dashboard_pagination_links( $link ) {
 	 * Resolves compatibility issues with LifterLMS WooCommerce.
 	 *
 	 * @since unknown
+	 * @since [version] Defaults to `false` only on the LifterLMS dashboard context, while `true` elsewhere.
 	 *
-	 * @param bool   $disable Whether or not the dashboard pagination links should be disabled. Default `false`.
+	 * @param bool   $disable Whether or not the dashboard pagination links should be disabled.
+	 *                        Default `false` in the LifterLMS dashboard context, `true` elsewhere.
 	 * @param string $link    The default link.
 	 */
 	if ( apply_filters( 'llms_modify_dashboard_pagination_links_disable', ! is_page( llms_get_page_id( 'myaccount' ) ), $link ) ) {

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -940,7 +940,7 @@ function llms_modify_dashboard_pagination_links( $link ) {
 	 * @param bool   $disable Whether or not the dashboard pagination links should be disabled. Default `false`.
 	 * @param string $link    The default link.
 	 */
-	if ( apply_filters( 'llms_modify_dashboard_pagination_links_disable', false, $link ) ) {
+	if ( apply_filters( 'llms_modify_dashboard_pagination_links_disable', ! is_page( llms_get_page_id( 'myaccount' ) ), $link ) ) {
 		return $link;
 	}
 


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description

This update changes the default return value of the `llms_modify_dashboard_pagination_links_disable` filter. The filter previously always returned false. In this update, we return true by default unless we are on the LifterLMS Student Dashboard page.

<!-- Please describe what you have changed or added -->

Fixes #2441

## How has this been tested?
This has been tested locally with Social Learning Add-on, on the Course Directory page, and on the Student Dashboard > My Courses page.

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

