### PR TITLE
Fix LifterLMS specific block templates not correctly working on Windows file system

### DIFF
--- a/.changelogs/block-templates-issue-windows-fs.yml
+++ b/.changelogs/block-templates-issue-windows-fs.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed LifterLMS specific block templates not correctly working on Windows
+  file system.

--- a/includes/class-llms-block-templates.php
+++ b/includes/class-llms-block-templates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.8.0
- * @version 5.10.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -475,23 +475,16 @@ class LLMS_Block_Templates {
 	 * @since 5.8.0
 	 * @since 5.9.0 Return empty string if the passed path is not in the configuration.
 	 * @since 5.10.0 Use '/' in favor of DIRECTORY_SEPARATOR to avoid issues on Windows.
+	 * @since [version] Retrieve the slug by using `basename()` which also fixes issues on Windows filesystems.
 	 *
 	 * @param string $path The template's path.
 	 * @return string
 	 */
 	private function generate_template_slug_from_path( $path ) {
 
-		$dirname = $this->block_template_config_property_from_path( $path, 'blocks_dir' );
 		$prefix  = $this->block_template_config_property_from_path( $path, 'slug_prefix' );
 
-		return $dirname ?
-			$prefix . substr(
-				$path,
-				strpos( $path, $dirname . '/' ) + 1 + strlen( $dirname ),
-				-5 // .html
-			)
-			:
-			'';
+		return $prefix . basename( $path, '.html' );
 
 	}
 

--- a/includes/functions/llms.functions.template.php
+++ b/includes/functions/llms.functions.template.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since Unknown
- * @version 5.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -258,6 +258,7 @@ function llms_get_template_override_directories() {
  * Build the plugin's template file path.
  *
  * @since 5.8.0
+ * @since [version] Do not add leading slash to absolute template directory.
  *
  * @param string $template                    Template file name.
  * @param string $template_directory          Template directory relative to the plugin base directory.
@@ -268,8 +269,9 @@ function llms_template_file_path( $template, $template_directory = 'templates', 
 
 	// We have reason to use a LifterLMS template, check if there's an override we should use from a theme / etc...
 	$override           = llms_get_template_override( $template );
-	$template_directory = $template_directory_absolute ? "/{$template_directory}" : llms()->plugin_path() . "/{$template_directory}/";
+	$template_directory = $template_directory_absolute ? $template_directory : llms()->plugin_path() . "/{$template_directory}/";
 	$template_path      = $override ? $override : $template_directory;
+
 	return trailingslashit( $template_path ) . "{$template}";
 
 }

--- a/tests/phpunit/unit-tests/class-llms-test-block-templates.php
+++ b/tests/phpunit/unit-tests/class-llms-test-block-templates.php
@@ -7,7 +7,7 @@
  * @group block_templates
  *
  * @since 5.8.0
- * @since 5.9.0 Added more tests.
+ * @version [version]
  */
 class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 
@@ -124,6 +124,7 @@ class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 	 * Test generate_template_slug_from_path().
 	 *
 	 * @since 5.9.0
+	 * @since [version] Remove unneded tests after switching `generate_template_slug_from_path()` logic to use `basename()`.
 	 *
 	 * @return void
 	 */
@@ -141,41 +142,6 @@ class LLMS_Test_Block_Templates extends LLMS_UnitTestCase {
 				'generate_template_slug_from_path',
 				array(
 					key( $block_templates_config ) . '/template.html',
-				)
-			)
-		);
-
-		// This util is pretty dumb, it expects the block file extension to be 5 chars, dot included, otherwise...
-		$this->assertEquals(
-			reset( $block_templates_config )['slug_prefix'] . 'templat',
-			LLMS_Unit_Test_Util::call_method(
-				$this->main,
-				'generate_template_slug_from_path',
-				array(
-					key( $block_templates_config ) . '/template.htm',
-				)
-			)
-		);
-
-		$this->assertEquals(
-			reset( $block_templates_config )['slug_prefix'] . 'template',
-			LLMS_Unit_Test_Util::call_method(
-				$this->main,
-				'generate_template_slug_from_path',
-				array(
-					key( $block_templates_config ) . '/template12345',
-				)
-			)
-		);
-
-		// If you pass a path which is not in the configuration I expect an empty slug.
-		$this->assertEquals(
-			'',
-			LLMS_Unit_Test_Util::call_method(
-				$this->main,
-				'generate_template_slug_from_path',
-				array(
-					'/whateverpath/template.html',
 				)
 			)
 		);

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
@@ -8,7 +8,7 @@
  * @group functions_template
  *
  * @since 4.8.0
- * @since 5.9.0 Added tests on llms_template_file_path().
+ * @version [version]
  */
 class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
@@ -250,6 +250,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 * Test llms_template_file_path() when passing an absolute template directory (not relative to the plugin dir).
 	 *
 	 * @since 5.9.0
+	 * @since [version] Stop expecting leading slash added to absolute paths.
 	 *
 	 * @return void
 	 */
@@ -258,7 +259,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		$this->assertEquals(
 			'/path/to/absolute/single-certificate.php',
-			llms_template_file_path( 'single-certificate.php', 'path/to/absolute', true )
+			llms_template_file_path( 'single-certificate.php', '/path/to/absolute', true )
 		);
 
 		/**


### PR DESCRIPTION
## Description

Fixes https://github.com/gocodebox/sky-pilot/issues/19

## How has this been tested?
manually on a Windows local server using ([Laragon](https://laragon.org/) - which doesn't use a linux container, so that we're on a Windows fs) and on a Linux local server (Devilbox). Tested the Groups and the Private Site add-on as well (they both have block templates).

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

