### PR TITLE
Disable failing workflow cron

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,8 +15,8 @@ on:
   workflow_dispatch:
   pull_request:
   # Once daily at 00:00 UTC.
-  schedule:
-    - cron: '0 0 * * *'
+  #schedule:
+  #  - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ 'pull_request' == github.event_name && github.head_ref || github.sha }}


### PR DESCRIPTION
Please disable failing workflow crons so I stop getting nightly notifications for failed work flows.

Thank you <3