### PR TITLE
Add warning icon to possibly misconfigured access plans

### DIFF
--- a/.changelogs/access-plans-with-warnings.yml
+++ b/.changelogs/access-plans-with-warnings.yml
@@ -2,4 +2,4 @@ significance: patch
 type: changed
 entry: When a notice is shown for an access plan on the course edit screen (e.g.
   When using the WooCommerce integration and no product has been associated to
-  the access plan), also display a warning icon next to the access plan title.
+  the access plan.) Also display a warning icon next to the access plan title.

--- a/.changelogs/access-plans-with-warnings.yml
+++ b/.changelogs/access-plans-with-warnings.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: changed
+entry: When a notice is shown for an access plan on the course edit screen (e.g.
+  When using the WooCommerce integration and no product has been associated to
+  the access plan), also display a warning icon next to the access plan title.

--- a/assets/js/llms-metabox-product.js
+++ b/assets/js/llms-metabox-product.js
@@ -1,11 +1,12 @@
 /**
- * Product Options MetaBox
- * Displays on Course & Membership Post Types
+ * Product Options MetaBox.
+ *
+ * Displays on Course & Membership Post Types.
  *
  * @since 3.0.0
  * @since 3.30.3 Unknown.
  * @since 3.36.3 Fixed conflicts with the Classic Editor block.
- * @version 3.36.3
+ * @version [version]
  */
 ( function( $ ) {
 
@@ -43,12 +44,15 @@
 		this.validation_class = 'llms-invalid';
 
 		/**
-		 * Initialize
+		 * Initialize.
 		 *
-		 * @param   bool skip_dep_checks if true, skips dependency checks.
-		 * @return  void
-		 * @since   3.0.0
-		 * @version 3.29.3
+		 * @param bool skip_dep_checks If true, skips dependency checks.
+		 *
+		 * @since 3.0.0
+		 * @since 3.29.3 Unknown.
+		 * @since [version] Check on whether access plans require attention.
+		 *
+		 * @return {Void}
 		 */
 		this.init = function( skip_dep_checks ) {
 
@@ -63,7 +67,12 @@
 
 			if ( ! $mb.length ) {
 				return;
-			} else if ( skip_dep_checks ) {
+			}
+
+			// Check whether the warning icon should be displayed.
+			self.requiresAttention();
+
+			if ( skip_dep_checks ) {
 				self.bind();
 				return;
 			}
@@ -105,13 +114,12 @@
 		};
 
 		/**
-		 * Bind DOM Events
+		 * Bind DOM Events.
 		 *
-		 * @since  3.0.0
-		 * @since  3.30.0 Add checkout redirect fields events.
-		 * @version 3.30.0
+		 * @since 3.0.0
+		 * @since 3.30.0 Add checkout redirect fields events.
 		 *
-		 * @return void
+		 * @return {Void}
 		 */
 		this.bind = function() {
 
@@ -318,6 +326,24 @@
 			} );
 
 		};
+
+		/**
+		 * Checks whether the access plan requires attention, e.g. because it contains notices.
+		 *
+		 * And if so adds the class `llms-needs-attention` to the access plan.
+		 *
+		 * @since [version]
+		 *
+		 * @return {Void}
+		 */
+		this.requiresAttention = function() {
+			var self = this;
+			self.$plans.find( '.llms-access-plan' ).each(
+				function() {
+					$(this).toggleClass( 'llms-needs-attention', $(this).find('p.notice').length > 0 );
+				}
+			);
+		}
 
 		/**
 		 * Handle physical deletion of a plan element

--- a/assets/scss/admin/metaboxes/_llms-metabox.scss
+++ b/assets/scss/admin/metaboxes/_llms-metabox.scss
@@ -196,6 +196,12 @@
 			&.dashicons-no:hover {
 				color: $color-danger;
 			}
+			&.dashicons-warning.medium-danger {
+				&,
+				&:hover {
+					color: $color-orange;
+				}
+			}
 		}
 
 	}

--- a/assets/scss/admin/metaboxes/_metabox-product.scss
+++ b/assets/scss/admin/metaboxes/_metabox-product.scss
@@ -31,11 +31,12 @@
 				display: inline;
 			}
 		}
-
+		.llms-needs-attention .dashicons-warning.medium-danger {
+			display: inline;
+		}
 		.dashicons-warning {
 			display: none;
 		}
-
 	}
 
 	.llms-access-plan {
@@ -66,7 +67,9 @@
 			color: $color-danger;
 			margin-left: 3px;
 		}
-
+		.notice {
+			margin-left: 0;
+		}
 	}
 
 }

--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -9,6 +9,8 @@
  * @since 3.31.0 Change sale_price input from text to number to ensure min value validation is properly enforced by browsers.
  * @since 3.37.18 Don't localize the price "step" html attribute.
  * @since 4.14.0 Get the access plan's raw content to display it in the wp_editor.
+ * @since [version] Added another icon for possible issues with the access plan configuration.
+ * @version [version]
  *
  * @var LLMS_Course      $course                     LLMS_Course.
  * @var array            $checkout_redirection_types Checkout redirect setting options.
@@ -56,6 +58,9 @@ if ( ! isset( $plan ) ) {
 			<?php endif; ?>
 		</h3>
 		<div class="d-1of2 d-right">
+			<span class="tip--top-left" data-tip="<?php esc_attr_e( 'This access plan requires attention for possible misconfigurations', 'lifterlms' ); ?>">
+				<span class="dashicons dashicons-warning medium-danger"></span>
+			</span>
 			<span class="tip--top-left" data-tip="<?php esc_attr_e( 'Errors were found during access plan validation', 'lifterlms' ); ?>">
 				<span class="dashicons dashicons-warning"></span>
 			</span>

--- a/includes/admin/views/access-plans/metabox.php
+++ b/includes/admin/views/access-plans/metabox.php
@@ -2,7 +2,7 @@
 /**
  * Product Options Admin Metabox HTML
  *
- * @package  LifterLMS/Admin/Views
+ * @package LifterLMS/Admin/Views
  *
  * @since 3.0.0
  * @since 6.0.0 Fix closing tag inside the `llms-no-plans-msg` div element.


### PR DESCRIPTION
## Description
This PR adds an icon next to the Access Plans title in their metabox, and shows it when there are notices related to the access plan.
Notices are printed when, e.g., using the WooCommerce integration, there's no valid WooCommerce product associated to the access plan (e.g. the product has been removed), or when using the new PayPal API a recurring access plan doesn't respect the limits PayPal set on the interval between payments.

The reason why we add an icon is that Access Plans meta-boxes are collapsible, and they're actually collapsed when reloaded after saving, so the warning might be printed but you won't notice it. 

## How has this been tested?
manually

## Screenshots <!-- if applicable -->
![Schermata 2023-07-16 alle 13 49 44](https://github.com/gocodebox/lifterlms/assets/7689242/5dcae95a-2df2-4dbe-838a-804a1cf0c761)
![Schermata 2023-07-16 alle 13 58 12](https://github.com/gocodebox/lifterlms/assets/7689242/e3e8644b-3208-445d-a337-93f762e5c9b1)

## Types of changes
UX Enhancement

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

