### PR TITLE
Use dashboard as default value for navigation link block

### DIFF
--- a/.changelogs/nav-link-block-default.yml
+++ b/.changelogs/nav-link-block-default.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Use dashboard as default value for navigation link block.

--- a/.changelogs/nav-link-block-default.yml
+++ b/.changelogs/nav-link-block-default.yml
@@ -1,3 +1,5 @@
-significance: minor
-type: changed
+significance: patch
+type: fixed
+links:
+  - "#2465"
 entry: Use dashboard as default value for navigation link block.

--- a/.changelogs/nav-link-block-default.yml
+++ b/.changelogs/nav-link-block-default.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#2465"
-entry: Use dashboard as default value for navigation link block.
+entry: Use student dashboard as default value for navigation link block.

--- a/includes/class.llms.nav.menus.php
+++ b/includes/class.llms.nav.menus.php
@@ -387,17 +387,25 @@ class LLMS_Nav_Menus {
 		}
 
 		$items = $this->filter_nav_items( $this->get_nav_items() );
-		$url   = $items[ $block['attrs']['page'] ]['url'] ?? '';
+		$page  = $block['attrs']['page'] ?? 'dashboard';
+
+		if ( ! $page ) {
+			return '';
+		}
+
+		$url = $items[ $page ]['url'] ?? '';
 
 		// Support conditional URLs, e.g. when user logged in or not.
 		if ( ! $url ) {
 			return '';
 		}
 
+		$label = $block['attrs']['label'] ?? $items[ $page ]['label'] ?? '';
+
 		$html  = '<li class="wp-block-navigation-item">';
 		$html .= '<a href="' . esc_url( $url ) . '" class="wp-block-navigation-item__content">';
 		$html .= '<span class="wp-block-navigation-item__label">';
-		$html .= esc_html( $block['attrs']['label'] );
+		$html .= esc_html( $label );
 		$html .= '</span></a></li>';
 
 		return $html;

--- a/src/blocks/navigation-link/block.json
+++ b/src/blocks/navigation-link/block.json
@@ -26,10 +26,12 @@
   "textdomain": "lifterlms",
   "attributes": {
     "label": {
-      "type": "string"
+      "type": "string",
+      "default": "Dashboard"
     },
     "page": {
-      "type": "string"
+      "type": "string",
+      "default": "dashboard"
     },
     "llms_visibility": {
       "type": "string"


### PR DESCRIPTION
## Description

Adds default value (Dashboard) to LLMS Navigation Link block. Previously no default value.

Fixes #2465

## How has this been tested?

Manually

## Types of changes

New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
