### PR TITLE
Fix warning for themes without sidebar.php template

### DIFF
--- a/.changelogs/fix-sidebar-fse.yml
+++ b/.changelogs/fix-sidebar-fse.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#2488"
-entry: Fixed warning for themes without sidebar.php template.
+entry: Don't include WordPress default sidebar.php template when using a block theme.

--- a/.changelogs/fix-sidebar-fse.yml
+++ b/.changelogs/fix-sidebar-fse.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2488"
+entry: Fixed warning for themes without sidebar.php template.

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Templates
  *
  * @since Unknown
- * @since [version] Fix warning for themes without sidebar.php template.
+ * @since [version] Don't include WordPress default sidebar.php template when using a block theme.
  * @version [version]
  */
 

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -5,9 +5,12 @@
  * @package LifterLMS/Templates
  *
  * @since Unknown
- * @version Unknown
+ * @since [version] Fix warning for themes without sidebar.php template.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
 
-get_sidebar( 'llms_shop' );
+if ( ABSPATH . WPINC . '/theme-compat/sidebar.php' !== locate_template( array( 'sidebar-llms_shop', 'sidebar.php' ) ) ) {
+	get_sidebar( 'llms_shop' );
+}

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -11,6 +11,12 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ABSPATH . WPINC . '/theme-compat/sidebar.php' !== locate_template( array( 'sidebar-llms_shop', 'sidebar.php' ) ) ) {
-	get_sidebar( 'llms_shop' );
+$core_fallback     = ABSPATH . WPINC . '/theme-compat/sidebar.php';
+$sidebar_templates = array( 'sidebar-llms_shop.php', 'sidebar.php' );
+
+// Return early if using block theme with no sidebar template.
+if ( wp_is_block_theme() && $core_fallback === locate_template( $sidebar_templates ) ) {
+	return;
 }
+
+get_sidebar( 'llms_shop' );


### PR DESCRIPTION
## Description

Fixes warning for themes without sidebar.php template.

Fixes #2488

## How has this been tested?

Manually

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

