### PR TITLE
Add `$tab` additional param to 'lifterlms_reporting_tab_cap' filter hook

### DIFF
--- a/.changelogs/add_additional_param_to_filter_hook_lifterlms_reporting_tab_cap.yml
+++ b/.changelogs/add_additional_param_to_filter_hook_lifterlms_reporting_tab_cap.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: dev
+links:
+  - "#2468"
+attributions:
+  - "@sapayth"
+entry: Added the parameter `$tab` (ID/slug of the tab) to the filter
+  `lifterlms_reporting_tab_cap`.

--- a/.changelogs/add_additional_param_to_filter_hook_lifterlms_reporting_tab_cap.yml
+++ b/.changelogs/add_additional_param_to_filter_hook_lifterlms_reporting_tab_cap.yml
@@ -4,5 +4,5 @@ links:
   - "#2468"
 attributions:
   - "@sapayth"
-entry: Added the parameter `$tab` (ID/slug of the tab) to the filter
-  `lifterlms_reporting_tab_cap`.
+entry: Added the parameter `$tab` (ID/slug of the tab) to the 
+  `lifterlms_reporting_tab_cap` filter hook.

--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -357,7 +357,7 @@ class LLMS_Admin_Reporting {
 			$cap = 'view_others_lifterlms_reports';
 		}
 
-		return apply_filters( 'lifterlms_reporting_tab_cap', $cap );
+		return apply_filters( 'lifterlms_reporting_tab_cap', $cap, $tab );
 	}
 
 	/**

--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Admin/Reporting/Classes
  *
  * @since 3.2.0
- * @version 6.11.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -344,6 +344,7 @@ class LLMS_Admin_Reporting {
 	 * within the view.
 	 *
 	 * @since 3.19.4
+	 * @since [version] Use `in_array()` with strict type comparison.
 	 *
 	 * @param string $tab ID/slug of the tab.
 	 * @return string
@@ -353,10 +354,19 @@ class LLMS_Admin_Reporting {
 		$tab = is_null( $tab ) ? self::get_current_tab() : $tab;
 
 		$cap = 'view_lifterlms_reports';
-		if ( in_array( $tab, array( 'sales', 'enrollments' ) ) ) {
+		if ( in_array( $tab, array( 'sales', 'enrollments' ), true ) ) {
 			$cap = 'view_others_lifterlms_reports';
 		}
 
+		/**
+		 * Filters the WP capability required to access a reporting tab.
+		 *
+		 * @since 3.19.4
+		 * @since [version] Added the `$tab` parameter.
+		 *
+		 * @param string      $cap The required WP capability.
+		 * @param string|null $tab ID/slug of the tab.
+		 */
 		return apply_filters( 'lifterlms_reporting_tab_cap', $cap, $tab );
 	}
 


### PR DESCRIPTION
### Add $tab additional param to 'lifterlms_reporting_tab_cap' filter hook

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
Added a new `$tab` param to the filter hook `lifterlms_reporting_tab_cap`

Fixes #2468 

## How has this been tested?
Manually tested on WordPress `v6.2.2`

## Screenshots <!-- if applicable -->

## Types of changes
New feature

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

