### PR TITLE
Fixed PHP warning when no course/membership catalog page was set

### DIFF
--- a/.changelogs/fix-loop-no_pageid.yml
+++ b/.changelogs/fix-loop-no_pageid.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2496"
+entry: Fixed PHP Warning when no course/membership catalog page was set or if
+  the selected page doesn't exist anymore.

--- a/includes/functions/llms.functions.templates.loop.php
+++ b/includes/functions/llms.functions.templates.loop.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 1.0.0
- * @version 7.1.3
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -34,8 +34,10 @@ if ( ! function_exists( 'lifterlms_get_archive_description' ) ) {
 	 * If content is added to the course/membership catalog page via the WP editor, output it as the archive description before the loop.
 	 *
 	 * @since 4.10.0 Moved from `lifterlms_archive_description()`.
-	 *              Adjusted filter `llms_archive_description` to always run instead of only running if content exists to display,
-	 *              this allows developers to filter the content even when an empty string is returned.
+	 *               Adjusted filter `llms_archive_description` to always run instead of only running if content exists to display,
+	 *               this allows developers to filter the content even when an empty string is returned.
+	 * @since [version] Fixed PHP Warning when no course/membership catalog page was set or if the
+	 *               selected page doesn't exist anymore.
 	 *
 	 * @return string
 	 */
@@ -57,9 +59,9 @@ if ( ! function_exists( 'lifterlms_get_archive_description' ) ) {
 		}
 
 		// If we don't have a description, try to pull it from the page's content area.
-		if ( empty( $content ) && $page_id ) {
+		if ( empty( $content ) && (int) $page_id > 0 ) {
 			$page    = get_post( $page_id );
-			$content = $page->post_content;
+			$content = $page ? $page->post_content : $content;
 		}
 
 		/**


### PR DESCRIPTION
or if the selected page doesn't exist anymore.

## Description
<!-- Please describe what you have changed or added -->

Fixes #2496 

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

