### PR TITLE
Improve analytics widgets permissions management.

### DIFF
--- a/.changelogs/better-analytics-widgets-1.yml
+++ b/.changelogs/better-analytics-widgets-1.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: dev
+entry: Added new filter hook `llms_can_analytics_widget_be_processed`
+  that will allow to filter wheteher or not an analytics widgegt can 
+  be processed/disoplayed.

--- a/.changelogs/better-analytics-widgets.yml
+++ b/.changelogs/better-analytics-widgets.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: changed
+entry: Made sure only who can `view_others_lifterlms_reports` will be able to
+  see the analytics widget content in the WordPress admin.

--- a/assets/js/llms-analytics.js
+++ b/assets/js/llms-analytics.js
@@ -7,23 +7,28 @@
  * @since 3.36.3 Added the `allow_clear` paramater when initializiing the `llmsStudentSelect2`.
  * @since 4.3.3 Legends will automatically display on top of the chart.
  * @since 4.5.1 Show sales reporting currency symbol based on LifterLMS site options.
- * @version 7.2.0
+ * @version [version]
  *
  */( function( $, undefined ) {
 
 	window.llms = window.llms || {};
 
 	/**
-	 * LifterLMS Admin Analytics
+	 * LifterLMS Admin Analytics.
 	 *
 	 * @since 3.0.0
 	 * @since 3.5.0 Unknown
 	 * @since 4.5.1 Added `opts` parameter.
+	 * @since [verison] Early bail if no `#llms-analytics-json` is available.
 	 *
 	 * @param {Object} options Options object.
 	 * @return {Object} Class instance.
 	 */
 	var Analytics = function( opts ) {
+
+		if ( ! $( '#llms-analytics-json' ).length ) {
+			return;
+		}
 
 		this.charts_loaded = false;
 		this.data          = {};
@@ -55,13 +60,13 @@
 		};
 
 		/**
-		 * Bind DOM events
+		 * Bind DOM events.
 		 *
 		 * @since 3.0.0
 		 * @since 3.36.3 Added the `allow_clear` paramater when initializiing the `llmsStudentSelect2`.
 		 * @since 7.2.0 Added check for datepicker before initializing.
 		 *
-		 * @return void
+		 * @return {Void}
 		 */
 		this.bind = function() {
 
@@ -194,7 +199,7 @@
 			var self = this;
 
 			this.$widgets.each( function() {
-
+				console.log($(this));
 				self.load_widget( $( this ) );
 
 			} );
@@ -202,13 +207,14 @@
 		};
 
 		/**
-		 * Load a specific widget
+		 * Load a specific widget.
 		 *
 		 * @since 3.0.0
 		 * @since 7.2.0 Change h1 tag to .llms-widget-content.
+		 * @since [version] Append `_ajax_nonce` to the ajax data packet.
 		 *
-		 * @param obj $widget The jQuery selector of the widget element.
-		 * @return void
+		 * @param {Object} $widget The jQuery selector of the widget element.
+		 * @return {Void}
 		 */
 		this.load_widget = function( $widget ) {
 
@@ -229,6 +235,7 @@
 					courses: self.query.current_courses,
 					memberships: self.query.current_memberships,
 					students: self.query.current_students,
+					_ajax_nonce: window.llms.ajax_nonce,
 				},
 				method: 'POST',
 				timeout: self.timeout,

--- a/assets/js/llms-analytics.js
+++ b/assets/js/llms-analytics.js
@@ -199,9 +199,7 @@
 			var self = this;
 
 			this.$widgets.each( function() {
-				console.log($(this));
 				self.load_widget( $( this ) );
-
 			} );
 
 		};

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Abstracts/Classes
  *
  * @since 3.0.0
- * @version 4.0.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -333,6 +333,57 @@ abstract class LLMS_Analytics_Widget {
 			$this->message = $wpdb->last_error;
 
 		}
+
+	}
+
+	/**
+	 * Whether or not the current widget can be processed/displayed.
+	 *
+	 * @since [version]
+	 *
+	 * @return true|WP_Error True if the widget can be processed, `WP_Error` otherwise.
+	 */
+	protected function _can_be_processed() {
+
+		$can_be_processed = true;
+		if ( ! current_user_can( 'view_others_lifterlms_reports' ) ) {
+			$can_be_processed = new WP_Error(
+				WP_Http::FORBIDDEN, // 403.
+				esc_html__( 'You are not authorized to access the requested widget', 'lifterlms' )
+			);
+		}
+
+		return $can_be_processed;
+	}
+
+	/**
+	 * Whether or not the current widget can be processed/displayed.
+	 *
+	 * @since [version]
+	 *
+	 * @return true|WP_Error
+	 */
+	public function can_be_processed() {
+
+		$widget_name = str_replace(
+			array( 'llms_analytics_', '_widget' ),
+			'',
+			strtolower( get_class( $this ) )
+		);
+
+		/**
+		 * Whether or not the current widget can be processed/displayed.
+		 *
+		 * @param true|WP_Error         True if the widget can be processed, `WP_Error` otherwise.
+		 * @param string                The widget name
+		 * @param LLMS_Analytics_Widget The instance extending `LLMS_Analytics_Widget`.
+		 */
+		return apply_filters(
+			'llms_can_analytics_widget_be_processed',
+			$this->_can_be_processed(),
+			$widget_name,
+			$this
+		);
 
 	}
 

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -375,7 +375,7 @@ abstract class LLMS_Analytics_Widget {
 		 * Whether or not the current widget can be processed/displayed.
 		 *
 		 * @param true|WP_Error         True if the widget can be processed, `WP_Error` otherwise.
-		 * @param string                The widget name
+		 * @param string                The widget name.
 		 * @param LLMS_Analytics_Widget The instance extending `LLMS_Analytics_Widget`.
 		 */
 		return apply_filters(

--- a/includes/abstracts/abstract.llms.analytics.widget.php
+++ b/includes/abstracts/abstract.llms.analytics.widget.php
@@ -343,7 +343,7 @@ abstract class LLMS_Analytics_Widget {
 	 *
 	 * @return true|WP_Error True if the widget can be processed, `WP_Error` otherwise.
 	 */
-	protected function _can_be_processed() {
+	protected function _can_be_processed() { // phpcs:ignore -- PSR2.Methods.MethodDeclaration.Underscore.
 
 		$can_be_processed = true;
 		if ( ! current_user_can( 'view_others_lifterlms_reports' ) ) {
@@ -387,6 +387,14 @@ abstract class LLMS_Analytics_Widget {
 
 	}
 
+	/**
+	 * Output widget.
+	 *
+	 * @since 3.0.0
+	 * @since [version] Use `wp_json_encode` in place of the deprecated `json_encode`.
+	 *
+	 * @return void
+	 */
 	public function output() {
 
 		$this->set_query();
@@ -399,7 +407,7 @@ abstract class LLMS_Analytics_Widget {
 		}
 
 		header( 'Content-Type: application/json' );
-		echo json_encode( $this );
+		echo wp_json_encode( $this );
 		wp_die();
 
 	}

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
@@ -25,7 +25,7 @@ class LLMS_Analytics_Widget_Ajax {
 	 * @since 3.16.8 Unknown.
 	 * @since 3.35.0 Sanitize `$_REQUEST` data.
 	 * @since 6.0.0 Removed loading of class files that don't instantiate their class in favor of autoloading.
-	 * @since [version] Ajax call are now handled by `LLMS_Analytics_Widget_Ajax::handle()` method.
+	 * @since [version] Ajax calls are now handled by `LLMS_Analytics_Widget_Ajax::handle()` method.
 	 *
 	 * @return void
 	 */

--- a/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
+++ b/includes/admin/reporting/widgets/class.llms.analytics.widget.ajax.php
@@ -78,7 +78,7 @@ class LLMS_Analytics_Widget_Ajax {
 		$method = str_replace(
 			'llms_widget_',
 			'',
-			sanitize_text_field( wp_unslash( $_REQUEST['action'] ) )
+			sanitize_text_field( wp_unslash( $_REQUEST['action'] ?? '' ) )
 		);
 		$class  = 'LLMS_Analytics_' . ucwords( $method ) . '_Widget';
 
@@ -89,7 +89,7 @@ class LLMS_Analytics_Widget_Ajax {
 		$widget           = new $class();
 		$can_be_processed = $widget->can_be_processed();
 
-		if ( is_wp_error( $can_be_processed) ) {
+		if ( is_wp_error( $can_be_processed ) ) {
 			wp_send_json_error( $can_be_processed );
 			wp_die();
 		}


### PR DESCRIPTION
## Description
- checks ajax referrer when handling ajax request to show an analytics widget
- checks user permissions so to make sure only users with the correct capability can view them (`view_others_lifterlms_reports`)

## How has this been tested?
manually with different kind of user roles.

## Types of changes
Enhancement

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

