### PR TITLE
fix certificate templates with wp 6.3

### DIFF
--- a/.changelogs/certificate-template-spacer-fix.yml
+++ b/.changelogs/certificate-template-spacer-fix.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fix spacer block when creating new certificate templates in WP 6.3.

--- a/includes/schemas/llms-block-templates.php
+++ b/includes/schemas/llms-block-templates.php
@@ -7,13 +7,15 @@
  * @package LifterLMS/Schemas
  *
  * @since 6.0.0
- * @version 6.0.0
+ * @version [version]
  *
  * @see LLMS_Post_Types::get_template().
  * @link https://developer.wordpress.org/block-editor/reference-guides/block-api/block-templates/
  */
 
 defined( 'ABSPATH' ) || exit;
+
+global $wp_version;
 
 $blocks_styles = array(
 	'certificate' => array(
@@ -68,7 +70,7 @@ $blocks_styles = array(
 			),
 		),
 		'spacer' => array(
-			'height' => 100,
+			'height' => version_compare( $wp_version, '6.3', '>=' ) ? '100px' : 100,
 		),
 	),
 );


### PR DESCRIPTION
## Description
Fixes:
> The spacer block is not working both on the editor and frontend when creating a new certificate. Showing error This block has encountered an error and cannot be previewed.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

