### PR TITLE
Improvements on cloning posts

### DIFF
--- a/.changelogs/cloning-issue-with-source.yml
+++ b/.changelogs/cloning-issue-with-source.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Avoid creating a post revision when cloning a course/lesson.

--- a/includes/abstracts/llms-abstract-generator-posts.php
+++ b/includes/abstracts/llms-abstract-generator-posts.php
@@ -176,11 +176,8 @@ abstract class LLMS_Abstract_Generator_Posts {
 			throw new Exception( sprintf( __( 'The class "%s" does not exist.', 'lifterlms' ), $class_name ), self::ERROR_INVALID_POST );
 		}
 
-		// Don't create useless creation on "cloning".
-		$revision_creation_hook_priority = has_action( 'post_updated', 'wp_save_post_revision' );
-		if ( $revision_creation_hook_priority ) {
-			remove_action( 'post_updated', 'wp_save_post_revision', $revision_creation_hook_priority );
-		}
+		// Don't create useless revision on "cloning".
+		add_filter( 'wp_revisions_to_keep', '__return_zero', 999 );
 
 		// Insert the object.
 		$post = new $class_name(
@@ -218,10 +215,8 @@ abstract class LLMS_Abstract_Generator_Posts {
 		$this->sideload_images( $post, $raw );
 		$this->handle_reusable_blocks( $post, $raw );
 
-		// Re-add revision creation action.
-		if ( $revision_creation_hook_priority ) {
-			add_action( 'post_updated', 'wp_save_post_revision', $revision_creation_hook_priority );
-		}
+		// Remove revision prevention.
+		remove_filter( 'wp_revisions_to_keep', '__return_zero', 999 );
 
 		return $post;
 

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -1109,7 +1109,6 @@ class LLMS_Admin_Builder {
 				if ( ! empty( $lesson_data['quiz'] ) && is_array( $lesson_data['quiz'] ) ) {
 					$res['quiz'] = self::update_quiz( $lesson_data['quiz'], $lesson );
 				}
-
 			}
 
 			// Allow 3rd parties to update custom data.

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -1055,11 +1055,8 @@ class LLMS_Admin_Builder {
 
 			} else {
 
-				// Don't create useless creation on "cloning".
-				$revision_creation_hook_priority = has_action( 'post_updated', 'wp_save_post_revision' );
-				if ( $revision_creation_hook_priority && $created ) {
-					remove_action( 'post_updated', 'wp_save_post_revision', $revision_creation_hook_priority );
-				}
+				// Don't create useless revision on "creating".
+				add_filter( 'wp_revisions_to_keep', '__return_zero', 999 );
 
 				/**
 				 * If the parent section was just created the lesson will have a temp id
@@ -1106,12 +1103,11 @@ class LLMS_Admin_Builder {
 					$lesson->set( 'name', sanitize_title( $lesson_data['title'] ) );
 				}
 
+				// Remove revision prevention.
+				remove_filter( 'wp_revisions_to_keep', '__return_zero', 999 );
+
 				if ( ! empty( $lesson_data['quiz'] ) && is_array( $lesson_data['quiz'] ) ) {
 					$res['quiz'] = self::update_quiz( $lesson_data['quiz'], $lesson );
-				}
-
-				if ( $revision_creation_hook_priority && $created ) {
-					add_action( 'post_updated', 'wp_save_post_revision', $revision_creation_hook_priority );
 				}
 
 			}


### PR DESCRIPTION
## Description
Skip adding the `generated_from_id` meta from the original post: this is the case when cloning a cloned post.
Also skip creating revisions.
Revisions creation is skipped on lessons creation/cloning in the course builder as well.

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Enhancement/Bug Fix


## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

