### PR TITLE
Course Builder: Correctly get/set (and track changes of) Backbone's model properties which are objects.

### DIFF
--- a/.changelogs/builder-model-object-properties.yml
+++ b/.changelogs/builder-model-object-properties.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: dev
+entry: "Course Builder: Correctly get/set (and track changes of) Backbone's
+  model properties which are objects."

--- a/assets/js/builder/Models/_Utilities.js
+++ b/assets/js/builder/Models/_Utilities.js
@@ -1,8 +1,8 @@
 /**
- * Utility functions for Models
+ * Utility functions for Models.
  *
- * @since    3.16.0
- * @version  3.17.1
+ * @since 3.16.0
+ * @version [version]
  */
 define( [], function() {
 
@@ -11,11 +11,71 @@ define( [], function() {
 		fields: [],
 
 		/**
-		 * Retrieve the edit post link for the current model
+		 * Override Backbone `set` method.
 		 *
-		 * @return   string
-		 * @since    3.16.0
-		 * @version  3.16.0
+		 * Takes into account attributes of the form object[prop].
+		 *
+		 * @since [version]
+		 *
+		 * @param {Mixed} attr The attribute to be set.
+		 * @param {Mixed} val  The value to set.
+		 */
+		set: function ( attr, val ) {
+
+			if ( 'string' === typeof attr ) {
+
+				const matches = attr.match( /(.*?)\[(.*?)\]/ );
+				if ( matches && 3 === matches.length ) {
+
+					const
+						realAttr   = matches[1],
+						currentVal = Backbone.Model.prototype.get.call( this, realAttr );
+
+					var newVal = undefined !== currentVal ? currentVal : {};
+
+					newVal[ matches[2] ] = val;
+
+					arguments[0] = realAttr;
+					arguments[1] = newVal;
+
+				}
+			}
+
+			// Continue with Backbone default `set` behavior.
+			Backbone.Model.prototype.set.apply( this, arguments );
+
+		},
+
+		/**
+		 * Override Backbone `get` method.
+		 *
+		 * Takes into account attributes of the form object[prop].
+		 *
+		 * @since [version]
+		 *
+		 * @param {Mixed} attr The attribute name.
+		 */
+		get: function( attr ) {
+
+			const matches = attr.match( /(.*?)\[(.*?)\]/ );
+			if ( matches && 3 === matches.length ) {
+				const val = Backbone.Model.prototype.get.call( this, matches[1] );
+				if ( val && undefined !== val[ matches[2] ] ) {
+					return val[ matches[2] ];
+				}
+			}
+
+			// Continue with Backbone default `get` behavior.
+			return Backbone.Model.prototype.get.call( this, attr );
+
+		},
+
+		/**
+		 * Retrieve the edit post link for the current model.
+		 *
+		 * @since 3.16.0
+		 *
+		 * @return string
 		 */
 		get_edit_post_link: function() {
 

--- a/assets/js/builder/vendor/backbone.trackit.js
+++ b/assets/js/builder/vendor/backbone.trackit.js
@@ -1,8 +1,11 @@
-//
-// backbone.trackit - 0.1.0
-// The MIT License
-// Copyright (c) 2013 The New York Times, CMS Group, Matthew DeLambo <delambo@gmail.com>
-//
+/**
+ * backbone.trackit - 0.1.0
+ *
+ * The MIT License
+ * Copyright (c) 2013 The New York Times, CMS Group, Matthew DeLambo <delambo@gmail.com>
+ *
+ * @since [version] Added support for deep models (attributes that are objects themselves).
+ */
 (function() {
 
 	// Unsaved Record Keeping
@@ -132,8 +135,14 @@
 			return changed;
 		},
 
+		/**
+		 * Reset tracking.
+		 *
+		 * @since [version] Added support for deep models (attributes that are objects themselves),
+		 *                  by using `_.deepClone` in place of `_.clone`.
+		 */
 		_resetTracking: function() {
-			this._originalAttrs = _.clone(this.attributes);
+			this._originalAttrs = _.deepClone(this.attributes);
 			this._unsavedChanges = {};
 		},
 


### PR DESCRIPTION
## Description
This will allow getting and setting model properties which are objects. E.g.
```
model.get( 'object[key]' );
```
and 
```
model.set( 'object[key]', value );
```
The latter happens when we have an input of the kind:
`<input data-attribute="object[key]" name="object[key]"... >`
(the `name` it's not mandatory but we'll keep it for formal correctness)

## How has this been tested?
manually with advanced quizzes, assignments, and advanced videos add-on, making sure no regressions were introduced (hopefully), and with advanced quizzes question bank feature were we want to use a property that it's actually an object storing multiple `<key, value>`.

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix/New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

