### PR TITLE
Fix possible issue when cloning course with quizzes creted with the advanced quizzes add-on

### DIFF
--- a/.changelogs/fix-clone-advanced-quizzes.yml
+++ b/.changelogs/fix-clone-advanced-quizzes.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed possible issues when cloning a course containing a quiz built with
+  the Advanced Quizzes addon, after disabling it.

--- a/includes/models/model.llms.question.choice.php
+++ b/includes/models/model.llms.question.choice.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 3.16.0
- * @version 3.16.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -216,13 +216,14 @@ class LLMS_Question_Choice {
 	}
 
 	/**
-	 * Set a piece of data by key
+	 * Set a piece of data by key.
 	 *
-	 * @param    string $key  name of the key to set
-	 * @param    mixed  $val  value to set
-	 * @return   self
-	 * @since    3.16.0
-	 * @version  3.16.0
+	 * @since 3.16.0
+	 * @since [version] Check `$type['choices']` is an array before trying to access it as such.
+	 *
+	 * @param string $key Name of the key to set.
+	 * @param mixed  $val Value to set.
+	 * @return self
 	 */
 	public function set( $key, $val ) {
 
@@ -244,10 +245,12 @@ class LLMS_Question_Choice {
 				break;
 
 			case 'marker':
-				$type    = $this->get_question()->get_question_type();
-				$markers = $type['choices']['markers'];
-				if ( ! in_array( $val, $markers ) ) {
-					$val = $markers[0];
+				$type = $this->get_question()->get_question_type();
+				if ( is_array( $type['choices'] ?? false ) ) {
+					$markers = $type['choices']['markers'];
+					if ( ! in_array( $val, $markers ) ) {
+						$val = $markers[0];
+					}
 				}
 				break;
 

--- a/includes/models/model.llms.question.php
+++ b/includes/models/model.llms.question.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 4.4.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -407,17 +407,21 @@ class LLMS_Question extends LLMS_Post_Model {
 	}
 
 	/**
-	 * Retrieve the next marker for question choices
+	 * Retrieve the next marker for question choices.
 	 *
 	 * @since 3.16.0
 	 * @since 3.30.1 Fixed bug which caused the next marker to be 1 index too high.
+	 * @since [version] Check `$type['choices']` is an array before trying to access it as such.
 	 *
 	 * @return string
 	 */
 	protected function get_next_choice_marker() {
 		$next_index = count( $this->get_choices( 'ids', false ) );
 		$type       = $this->get_question_type();
-		$markers    = $type['choices']['markers'];
+		if ( ! is_array( $type['choices'] ?? false ) ) {
+			return false;
+		}
+		$markers = $type['choices']['markers'];
 		return $next_index > count( $markers ) ? false : $markers[ $next_index ];
 	}
 


### PR DESCRIPTION
## Description
Fixes possible issues when cloning a course containing a quiz built with the Advanced Quizzes addon, after disabling it

## How has this been tested?
manually

## Screenshots <!-- if applicable -->

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

