### PR TITLE
Added functionality to disable retake of quiz.

### DIFF
--- a/.changelogs/disable-retake.yml
+++ b/.changelogs/disable-retake.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added functionality to disable quiz retake after a passed attempt.

--- a/assets/js/builder/Models/Quiz.js
+++ b/assets/js/builder/Models/Quiz.js
@@ -50,7 +50,8 @@ define( [
 		 * New lesson defaults.
 		 *
 		 * @since 3.16.0
-		 * @since 7.4.0 Added filter for filtering defaults.
+		 * @since 3.16.6 Unknown.
+		 * @since [version] Added filter for filtering defaults, `can_be_resumed` and `disable_retake` property.
 		 *
 		 * @return {Object}
 		 */
@@ -74,6 +75,8 @@ define( [
 				random_answers: 'no',
 				time_limit: 30,
 				show_correct_answer: 'no',
+				can_be_resumed: 'no',
+				disable_retake: 'no',
 
 				questions: [],
 

--- a/assets/js/builder/Schemas/Quiz.js
+++ b/assets/js/builder/Schemas/Quiz.js
@@ -2,8 +2,9 @@
  * Quiz Schema.
  *
  * @since 3.17.6
- * @since 7.4.0 Added upsell for Question Bank and condition in `random_questions` schema.
- * @version 7.4.0
+ * @since 3.24.0 Unknown.
+ * @since [version] Added upsell for Question Bank, condition in `random_questions` schema, 'can_be_resumed' and `disable_retake` option.
+ * @version [version]
  */
 define( [], function() {
 
@@ -71,6 +72,13 @@ define( [], function() {
 						condition: function() {
 							return 'yes' === this.get( 'question_bank' ) ? false : true;
 						}
+			},
+					{
+						attribute: 'disable_retake',
+						id: 'disable-retake',
+						label: LLMS.l10n.translate( 'Disable Retake' ),
+						tip: LLMS.l10n.translate( 'Prevent quiz retake after student passed the quiz.' ),
+						type: 'switch',
 			},
 				], [
 					{


### PR DESCRIPTION
## Description
Admin can disable the quiz retaking ability for a student when the student gets a passed attempt. Can be enabled from the quiz builder.

## How has this been tested?
Manually.

## Types of changes
<!-- What types of changes does your code introduce?  -->
New feature

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

