### PR TITLE
PHP 8.2 and WP 6.4 compatibility fixes

### DIFF
--- a/.changelogs/php82-1.yml
+++ b/.changelogs/php82-1.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: dev
+entry: Improved some unit tests compatibility with PHP 8.2.

--- a/.changelogs/php82-2.yml
+++ b/.changelogs/php82-2.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+entry: Improved compatibility with WordPress 6.4 by using
+  `traverse_and_serialize_blocks` in place of the deprecated
+  `_inject_theme_attribute_in_block_template_content`.

--- a/.changelogs/php82.yml
+++ b/.changelogs/php82.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: "PHP 8.2 compatibility fix: Fixed creation of dynamic property
+  `LLMS_Meta_Box_Access::$_saved`."

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "woocommerce/action-scheduler": "3.5.4"
   },
   "require-dev": {
-    "lifterlms/lifterlms-tests": "^3.3.1",
+    "lifterlms/lifterlms-tests": "^4.1.1",
     "lifterlms/lifterlms-cs": "dev-trunk"
   },
   "archive": {

--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -153,6 +153,15 @@ abstract class LLMS_Admin_Metabox {
 	private $version = 1;
 
 	/**
+	 * Used to prevent save action from running
+	 * multiple times on a single load.
+	 *
+	 * @since [version]
+	 * @var bool
+	 */
+	private $_saved;
+
+	/**
 	 * Constructor.
 	 *
 	 * Configure the metabox and automatically add required actions.

--- a/includes/class-llms-block-templates.php
+++ b/includes/class-llms-block-templates.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 5.8.0
- * @version 7.2.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -351,6 +351,7 @@ class LLMS_Block_Templates {
 	 *
 	 * @since 5.8.0
 	 * @since 5.9.0 Allow template directory override when the block template comes from an add-on.
+	 * @since [version] Use `traverse_and_serialize_blocks` in place of deprecated (since wp 6.4.0) `_inject_theme_attribute_in_block_template_content`
 	 *
 	 * @param string $template_file Template file path.
 	 * @param string $template_slug Template slug.
@@ -372,7 +373,9 @@ class LLMS_Block_Templates {
 		$template                 = new WP_Block_Template();
 		$template->id             = $theme ? $theme . '//' . $template_slug : $namespace . '//' . $template_slug;
 		$template->theme          = $theme ? $theme : $namespace;
-		$template->content        = _inject_theme_attribute_in_block_template_content( $template_content );
+		$template->content        = function_exists( 'traverse_and_serialize_blocks' ) ?
+			traverse_and_serialize_blocks( parse_blocks( $template_content ), '_inject_theme_attribute_in_template_part_block' ) :
+			_inject_theme_attribute_in_block_template_content( $template_content );
 		$template->source         = $theme ? 'theme' : 'plugin'; // Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
 		$template->slug           = $template_slug;
 		$template->type           = 'wp_template';

--- a/tests/phpunit/unit-tests/class-llms-test-post-types.php
+++ b/tests/phpunit/unit-tests/class-llms-test-post-types.php
@@ -6,6 +6,7 @@
  *
  * @since 3.13.0
  * @since 5.5.0 Addedd tests for deprecated filters of the type "lifterlms_register_post_type_${prefixed_post_type_name}".
+ * @version [version]
  */
 class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 
@@ -272,6 +273,7 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 	 * @preserveGlobalState disabled
 	 *
 	 * @since 5.5.0
+	 * @since [version] Fixed use of deprecated `${var}`.
 	 *
 	 * @return void
 	 */
@@ -280,9 +282,9 @@ class LLMS_Test_Post_Types extends LLMS_UnitTestCase {
 		foreach ( $this->post_types as $post_type ) {
 
 			unregister_post_type( $post_type );
-			add_filter( "lifterlms_register_post_type_${post_type}", '__return_empty_array' );
+			add_filter( "lifterlms_register_post_type_{$post_type}", '__return_empty_array' );
 			LLMS_Post_Types::register_post_type( $post_type, array() );
-			remove_filter( "lifterlms_register_post_type_${post_type}", '__return_empty_array' );
+			remove_filter( "lifterlms_register_post_type_{$post_type}", '__return_empty_array' );
 
 		}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-template.php
@@ -8,7 +8,7 @@
  * @group functions_template
  *
  * @since 4.8.0
- * @version 7.2.0
+ * @version [version]
  */
 class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
@@ -35,15 +35,21 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test llms_get_template_override_directories() when only parent theme override dir is present
+	 * Test `llms_get_template_override_directories()` when only parent theme override dir is present.
 	 *
 	 * @since 4.8.0
+	 * @since [version] Clear cache globals `$wp_template_path` since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_template_override_directories_only_parent_theme() {
-		$original_template = get_option( 'template', '' );
+
+		global $wp_template_path;
+		$original_template = get_option( 'template' );
+
 		update_option( 'template', 'fake_parent' );
+		$wp_template_path = null;
+
 		$this->_create_theme_override_directory( 'fake_parent' );
 		$template_directories = llms_get_template_override_directories();
 
@@ -56,22 +62,29 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		$this->_delete_theme_override_directory( 'fake_parent' );
 		update_option( 'template', $original_template );
+		$wp_template_path = null;
 	}
 
 	/**
-	 * Test llms_get_template_override_directories() when parent and child theme override dir are present
+	 * Test llms_get_template_override_directories() when parent and child theme override dir are present.
 	 *
 	 * @since 4.8.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_template_override_directories_parent_and_child_theme() {
+
+		global $wp_template_path, $wp_stylesheet_path;
+
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
 		update_option( 'stylesheet', 'fake_child' );
 		$this->_create_theme_override_directory( 'fake_parent' );
 		$this->_create_theme_override_directory( 'fake_child' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		$template_directories = llms_get_template_override_directories();
 
@@ -85,23 +98,31 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
 	/**
-	 * Test llms_get_template_override_directories() when parent and child theme are present but only parent overrides
+	 * Test llms_get_template_override_directories() when parent and child theme are present but only parent overrides.
 	 *
 	 * @since 4.8.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_template_override_directories_parent_and_child_theme_parent_overrides() {
+
+		global $wp_template_path, $wp_stylesheet_path;
+
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
 		update_option( 'stylesheet', 'fake_child' );
 		$this->_create_theme_override_directory( 'fake_parent' );
 		$this->_create_theme_override_directory( 'fake_child' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		rmdir(  get_theme_root() . '/fake_child/lifterlms' );
 
@@ -116,23 +137,31 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
 	/**
-	 * Test llms_get_template_override_directories() when parent and child theme are present but only child overrides
+	 * Test llms_get_template_override_directories() when parent and child theme are present but only child overrides.
 	 *
 	 * @since 4.8.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_template_override_directories_parent_and_child_theme_child_overrides() {
+
+		global $wp_template_path, $wp_stylesheet_path;
+
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
 		update_option( 'stylesheet', 'fake_child' );
 		$this->_create_theme_override_directory( 'fake_parent' );
 		$this->_create_theme_override_directory( 'fake_child' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		rmdir(  get_theme_root() . '/fake_parent/lifterlms' );
 
@@ -147,23 +176,31 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
 	/**
-	 * Test llms_get_template_override_directories() when parent and child theme are present but none of them overrides
+	 * Test llms_get_template_override_directories() when parent and child theme are present but none of them overrides.
 	 *
 	 * @since 4.8.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_get_template_override_directories_parent_and_child_theme_no_override() {
+
+		global $wp_template_path, $wp_stylesheet_path;
+
 		$original_template   = get_option( 'template', '' );
 		$original_stylesheet = get_option( 'stylesheet', '' );
 		update_option( 'template', 'fake_parent' );
 		update_option( 'stylesheet', 'fake_child' );
 		$this->_create_theme_override_directory( 'fake_parent' );
 		$this->_create_theme_override_directory( 'fake_child' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		rmdir(  get_theme_root() . '/fake_parent/lifterlms' );
 		rmdir(  get_theme_root() . '/fake_child/lifterlms' );
@@ -177,6 +214,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
@@ -184,10 +223,13 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 * Test llms_template_file_path() passing an empty template file.
 	 *
 	 * @since 5.9.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_template_file_path_empty_template_file_passed() {
+
+		global $wp_template_path, $wp_stylesheet_path;
 
 		$this->assertEquals(
 			llms()->plugin_path() . '/templates/',
@@ -203,6 +245,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 		update_option( 'template', 'fake' );
 		update_option( 'stylesheet', 'fake' );
 		$this->_create_theme_override_directory( 'fake' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		$this->assertEquals(
 			get_theme_root() . '/fake/lifterlms/',
@@ -213,6 +257,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
@@ -220,10 +266,13 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 * Test llms_template_file_path() passing a template file that doesn't exist in the theme.
 	 *
 	 * @since 5.9.0
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_template_file_path_template_file_not_in_theme() {
+
+		global $wp_template_path, $wp_stylesheet_path;
 
 		/**
 		 * Simulate the activation of a theme with the templates directory overridden.
@@ -233,6 +282,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 		update_option( 'template', 'fake' );
 		update_option( 'stylesheet', 'fake' );
 		$this->_create_theme_override_directory( 'fake' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		$this->assertEquals(
 			llms()->plugin_path() . '/templates/single-certificate.php',
@@ -243,6 +294,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
@@ -251,10 +304,14 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 *
 	 * @since 5.9.0
 	 * @since 7.2.0 Stop expecting leading slash added to absolute paths.
+	 * @since [version] Clear cache globals `$wp_template_path`, `$wp_stylesheet_path' since WP 6.4.
 	 *
 	 * @return void
 	 */
 	public function test_llms_template_file_path_template_directory_absolute() {
+
+		global $wp_template_path, $wp_stylesheet_path;
+
 		$this->_delete_theme_override_directory( 'fake' );
 
 		$this->assertEquals(
@@ -271,6 +328,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 		update_option( 'stylesheet', 'fake' );
 		$this->_create_theme_override_directory( 'fake' );
 		wp_cache_delete( 'theme-override-directories', 'llms_template_functions' );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 		$this->assertEquals(
 			get_theme_root() . '/fake/lifterlms/',
@@ -281,6 +340,8 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 
 		update_option( 'template', $original_template );
 		update_option( 'stylesheet', $original_stylesheet );
+		$wp_template_path = null;
+		$wp_stylesheet_path = null;
 
 	}
 
@@ -288,7 +349,7 @@ class LLMS_Test_Functions_Template extends LLMS_UnitTestCase {
 	 * Creates a theme and override lifterlms template directory.
 	 *
 	 * @since 4.8.0
-	 * @since 5.9.0 always remove the theme directory if it already exists.
+	 * @since 5.9.0 Always remove the theme directory if it already exists.
 	 *
 	 * @param string $theme_dir_name Theme directory name.
 	 * @return void

--- a/tests/phpunit/unit-tests/processors/class-llms-test-processors.php
+++ b/tests/phpunit/unit-tests/processors/class-llms-test-processors.php
@@ -29,6 +29,7 @@ class LLMS_Test_Processors extends LLMS_Unit_Test_Case {
 	 * @since 5.0.0
 	 * @since 5.3.0 Rename `_instance` property to `instance`.
 	 * @since 6.0.0 Removed testing of the removed `LLMS_Processors::$_instance` property.
+	 * @since [version] Removed testing of mock property.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -37,13 +38,11 @@ class LLMS_Test_Processors extends LLMS_Unit_Test_Case {
 	 */
 	public function test_instance() {
 
-		$this->main->fake = 'mock';
 		$this->assertEquals( $this->main, LLMS_Processors::instance() );
 
 		LLMS_Unit_Test_Util::set_private_property( $this->main, 'instance', null );
 		$new_instance = LLMS_Processors::instance();
 		$this->assertInstanceOf( 'LLMS_Processors', $new_instance );
-		$this->assertTrue( ! isset( $new_instance->fake ) );
 
 	}
 


### PR DESCRIPTION
## Description
Fix all PHP 8.2 and WP 6.4 compatibility issues.
still some deprecation warnings to fix.

## How has this been tested?
manually and unit tests

## Screenshots <!-- if applicable -->

## Types of changes
enhancement

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

