### PR TITLE
Update to only show the LifterLMS-authored Add Ons on the All section of the Addons and more screen.

### DIFF
--- a/.changelogs/only-lifterlms-add-ons-in-all.yml
+++ b/.changelogs/only-lifterlms-add-ons-in-all.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Only show LifterLMS-authored Addons in All section.

--- a/includes/admin/class.llms.admin.addons.php
+++ b/includes/admin/class.llms.admin.addons.php
@@ -68,7 +68,7 @@ class LLMS_Admin_AddOns {
 		if ( ! $content ) {
 
 			if ( 'all' === $sec ) {
-				$content = $this->data['items'];
+				$content = $this->get_all();
 			} elseif ( 'featured' === $sec ) {
 				$content = $this->get_features();
 			} else {
@@ -107,6 +107,31 @@ class LLMS_Admin_AddOns {
 		}
 
 		return $this->data;
+
+	}
+
+	/**
+	 * Retrieve a list of addons for use on the All section
+	 *
+	 * @return   array
+	 * @since    [version]
+	 * @version  [version]
+	 */
+	private function get_all() {
+
+		$all = array();
+
+		$addons = $this->data['items'];
+
+		foreach ( $addons as $addon ) {
+			// Exclude third-party Addons from the All section.
+			if ( in_array( 'third-party', array_keys( $addon['categories'] ), true ) ) {
+					continue;
+			}
+			$all[] = $addon;
+		}
+
+		return $all;
 
 	}
 


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
The Addons & more screen has an All tab that was showing every product. We spoke internally and want this tab to rather just show the LifterLMS-authored Addons (not include third party).

## How has this been tested?
Tested locally

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

