### PR TITLE
Disable cron for JSUnit tests

### DIFF
--- a/.github/workflows/test-js-unit.yml
+++ b/.github/workflows/test-js-unit.yml
@@ -6,8 +6,8 @@ on:
     paths:
         - src/js/**
   # Once daily at 00:00 UTC.
-  schedule:
-    - cron: '0 0 * * *'
+  # schedule:
+    # - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ 'pull_request' == github.event_name && github.head_ref || github.sha }}


### PR DESCRIPTION
Disables the cron for the JSUnit workflow

This test has been failing for a week or so and sending me notifications
