### PR TITLE
Logic to verify the terms page exists for adding to email

### DIFF
--- a/.changelogs/fix-terms-empty-link-emails.yml
+++ b/.changelogs/fix-terms-empty-link-emails.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed logic to validate that the terms page exists before adding to email
+  footer.

--- a/templates/emails/footer.php
+++ b/templates/emails/footer.php
@@ -13,6 +13,10 @@ $mailer = llms()->mailer();
 $terms = false;
 if ( 'yes' === get_option( 'lifterlms_registration_require_agree_to_terms', 'no' ) ) {
 	$terms = get_option( 'lifterlms_terms_page_id', false );
+	// Unset terms if the page is not published.
+	if ( $terms && 'publish' !== get_post_status( $terms ) ) {
+		$terms = false;
+	}
 }
 ?>
 								</td>


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
There are edge cases where the terms link is a page that doesn't exist, but the logic in the email template still tried to add it as a link.

## How has this been tested?
Locally.

## Screenshots <!-- if applicable -->
Fixes: 
![Password-Reset-for-Academy-kim-lifterlms-com-codeBOX-Mail](https://github.com/gocodebox/lifterlms/assets/5312875/500fc3fb-d824-4fa6-8b90-b3331660a300)


## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

