### PR TITLE
Adding nonce to course clone link

### DIFF
--- a/.changelogs/fix_clone-csrf.yml
+++ b/.changelogs/fix_clone-csrf.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: Added nonce for course clone link. (Thanks, Dhabaleshwar Das)

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -59,7 +59,7 @@ class LLMS_Admin_Post_Tables {
 				),
 				admin_url( 'edit.php' )
 			);
-			$actions['llms-clone'] = '<a href="' . esc_url( $url ) . '">' . __( 'Clone', 'lifterlms' ) . '</a>';
+			$actions['llms-clone'] = '<a href="' . esc_url( wp_nonce_url( $url, 'llms_clone_post', 'llms_clone_post_nonce' ) ) . '">' . __( 'Clone', 'lifterlms' ) . '</a>';
 		}
 
 		if ( current_user_can( 'edit_course', $post->ID ) && post_type_supports( $post->post_type, 'llms-export-post' ) ) {
@@ -84,6 +84,7 @@ class LLMS_Admin_Post_Tables {
 	 * @since 3.3.0
 	 * @since 3.33.1 Use `llms_filter_input` to access `$_GET` and `$_POST` data.
 	 * @since 3.33.1 Use `edit_course` cap instead of `edit_post` cap.
+	 * @since [version] Adding nonce to course clone links
 	 *
 	 * @return void
 	 */
@@ -135,6 +136,9 @@ class LLMS_Admin_Post_Tables {
 				break;
 
 			case 'llms-clone-post':
+				if ( ! wp_verify_nonce( sanitize_key( $_GET['llms_clone_post_nonce'] ), 'llms_clone_post' ) ) {
+					wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
+				}
 				$r = $post->clone_post();
 				if ( is_wp_error( $r ) ) {
 					LLMS_Admin_Notices::flash_notice( $r->get_error_message(), 'error' );


### PR DESCRIPTION
## Description
Adding nonce to course clone link

## How has this been tested?
Manually by visiting the url without the nonce, or with a different nonce key.

## Types of changes
Security fix

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

