### PR TITLE
[Fix] Check clone nonce before use & tabs vs spaces, fixing some E2E tests

### DIFF
--- a/includes/admin/class-llms-admin-plugins.php
+++ b/includes/admin/class-llms-admin-plugins.php
@@ -35,7 +35,7 @@ class LLMS_Admin_Plugins {
 	public function plugin_action_links( $links ) {
 		$new_links = array(
 			'dashboard' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-dashboard' ) ) . '">' . __( 'Dashboard', 'lifterlms' ) . '</a>',
-			'settings' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-settings' ) ) . '">' . __( 'Settings', 'lifterlms' ) . '</a>'
+			'settings' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-settings' ) ) . '">' . __( 'Settings', 'lifterlms' ) . '</a>',
 		);
 
 		$links = array_merge( $new_links, $links );
@@ -48,9 +48,9 @@ class LLMS_Admin_Plugins {
 	public function plugin_row_meta( $links, $file ) {
 		if ( plugin_basename( LLMS_PLUGIN_DIR . '/lifterlms.php' ) === $file ) {
 			$row_meta = array(
-			    'docs'    => '<a href="' . esc_url( 'https://lifterlms.com/docs/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Documentation' ) . '" aria-label="' . esc_attr__( 'Docs', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Documentation', 'lifterlms' ) . '</a>',
-			    'support' => '<a href="' . esc_url( 'https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Support' ) . '" aria-label="' . esc_attr__( 'Support', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Support', 'lifterlms' ) . '</a>',
-			    'pricing' => '<a href="' . esc_url( 'https://lifterlms.com/pricing/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Premium%20Plans' ) . '" aria-label="' . esc_attr__( 'Premium Plans', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Premium Plans', 'lifterlms' ) . '</a>',
+				'docs'      => '<a href="' . esc_url( 'https://lifterlms.com/docs/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Documentation' ) . '" aria-label="' . esc_attr__( 'Docs', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Documentation', 'lifterlms' ) . '</a>',
+				'support'   => '<a href="' . esc_url( 'https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Support' ) . '" aria-label="' . esc_attr__( 'Support', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Support', 'lifterlms' ) . '</a>',
+				'pricing'   => '<a href="' . esc_url( 'https://lifterlms.com/pricing/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Premium%20Plans' ) . '" aria-label="' . esc_attr__( 'Premium Plans', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Premium Plans', 'lifterlms' ) . '</a>',
 			);
 
 			$links = array_merge( $links, $row_meta );

--- a/includes/admin/class-llms-admin-plugins.php
+++ b/includes/admin/class-llms-admin-plugins.php
@@ -25,39 +25,39 @@ class LLMS_Admin_Plugins {
 	 * @return void
 	 */
 	public function __construct() {
-        add_filter( 'plugin_action_links_' . plugin_basename( LLMS_PLUGIN_DIR . '/lifterlms.php' ), array( $this, 'plugin_action_links' ) );
-        add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
+		add_filter( 'plugin_action_links_' . plugin_basename( LLMS_PLUGIN_DIR . '/lifterlms.php' ), array( $this, 'plugin_action_links' ) );
+		add_filter( 'plugin_row_meta', array( $this, 'plugin_row_meta' ), 10, 2 );
 	}
 
 	/**
-     * Add links to the plugins page.
-     */
-    public function plugin_action_links( $links ) {
-        $new_links = array(
-            'dashboard' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-dashboard' ) ) . '">' . __( 'Dashboard', 'lifterlms' ) . '</a>',
-            'settings' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-settings' ) ) . '">' . __( 'Settings', 'lifterlms' ) . '</a>'
-        );
+	 * Add links to the plugins page.
+	 */
+	public function plugin_action_links( $links ) {
+		$new_links = array(
+			'dashboard' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-dashboard' ) ) . '">' . __( 'Dashboard', 'lifterlms' ) . '</a>',
+			'settings' => '<a href="' . esc_url( admin_url( 'admin.php?page=llms-settings' ) ) . '">' . __( 'Settings', 'lifterlms' ) . '</a>'
+		);
 
-        $links = array_merge( $new_links, $links );
-        return $links;
-    }
+		$links = array_merge( $new_links, $links );
+		return $links;
+	}
 
-    /**
-     * Add links to plugin description.
-     */
-    public function plugin_row_meta( $links, $file ) {
-        if ( plugin_basename( LLMS_PLUGIN_DIR . '/lifterlms.php' ) === $file ) {
-            $row_meta = array(
-                'docs'    => '<a href="' . esc_url( 'https://lifterlms.com/docs/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Documentation' ) . '" aria-label="' . esc_attr__( 'Docs', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Documentation', 'lifterlms' ) . '</a>',
-                'support' => '<a href="' . esc_url( 'https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Support' ) . '" aria-label="' . esc_attr__( 'Support', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Support', 'lifterlms' ) . '</a>',
-                'pricing' => '<a href="' . esc_url( 'https://lifterlms.com/pricing/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Premium%20Plans' ) . '" aria-label="' . esc_attr__( 'Premium Plans', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Premium Plans', 'lifterlms' ) . '</a>',
-            );
+	/**
+	 * Add links to plugin description.
+	 */
+	public function plugin_row_meta( $links, $file ) {
+		if ( plugin_basename( LLMS_PLUGIN_DIR . '/lifterlms.php' ) === $file ) {
+			$row_meta = array(
+			    'docs'    => '<a href="' . esc_url( 'https://lifterlms.com/docs/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Documentation' ) . '" aria-label="' . esc_attr__( 'Docs', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Documentation', 'lifterlms' ) . '</a>',
+			    'support' => '<a href="' . esc_url( 'https://lifterlms.com/my-account/my-tickets/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Support' ) . '" aria-label="' . esc_attr__( 'Support', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Support', 'lifterlms' ) . '</a>',
+			    'pricing' => '<a href="' . esc_url( 'https://lifterlms.com/pricing/?utm_source=LifterLMS%20Plugin&utm_medium=Plugins%20Screen&utm_campaign=Plugin%20to%20Sale&utm_content=Premium%20Plans' ) . '" aria-label="' . esc_attr__( 'Premium Plans', 'lifterlms' ) . '" target="_blank">' . esc_html__( 'Premium Plans', 'lifterlms' ) . '</a>',
+			);
 
-            $links = array_merge( $links, $row_meta );
-        }
+			$links = array_merge( $links, $row_meta );
+		}
 
-        return $links;
-    }
+		return $links;
+	}
 }
 
 return new LLMS_Admin_Plugins();

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -136,7 +136,7 @@ class LLMS_Admin_Post_Tables {
 				break;
 
 			case 'llms-clone-post':
-				if ( ! wp_verify_nonce( sanitize_key( $_GET['llms_clone_post_nonce'] ), 'llms_clone_post' ) ) {
+				if ( ! isset( $_GET['llms_clone_post_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_GET['llms_clone_post_nonce'] ), 'llms_clone_post' ) ) {
 					wp_die( __( 'You are not authorized to perform this action on the current post.', 'lifterlms' ) );
 				}
 				$r = $post->clone_post();

--- a/packages/llms-e2e-test-utils/src/create-access-plan.js
+++ b/packages/llms-e2e-test-utils/src/create-access-plan.js
@@ -44,7 +44,7 @@ export async function createAccessPlan( {
 		);
 	}
 
-	await clickAndWait( '#llms-save-access-plans' );
+	await page.click( '#llms-save-access-plans' );
 
 	await page.waitForSelector(
 		`${ selector }:nth-last-child(2) .llms-plan-link`,

--- a/packages/llms-e2e-test-utils/src/import-course.js
+++ b/packages/llms-e2e-test-utils/src/import-course.js
@@ -27,7 +27,8 @@ export async function importCourse(
 
 	await visitAdminPage( 'admin.php', 'page=llms-import' );
 
-	await page.click( 'button.page-title-action' );
+	// Upload button
+	await page.click( '.llms-setting-group.top button.llms-button-primary' );
 
 	const inputSelector = 'input[name="llms_import"]';
 	await page.waitForSelector( inputSelector );

--- a/packages/llms-e2e-test-utils/src/visit-post-permalink.js
+++ b/packages/llms-e2e-test-utils/src/visit-post-permalink.js
@@ -8,9 +8,7 @@ import { toggleSidebarPanel } from './toggle-sidebar-panel';
  * @return {Promise} A promise representing the link click.
  */
 export async function visitPostPermalink() {
-	await toggleSidebarPanel( 'Permalink' );
-
-	const SELECTOR = 'a.edit-post-post-link__link';
+	const SELECTOR = '.edit-post-header__settings a[aria-label="View Certificate Template"]';
 
 	await page.waitForSelector( SELECTOR );
 	const permalink = await page.$eval( SELECTOR, ( el ) => el.href );

--- a/tests/e2e/tests/engagements/__snapshots__/certificates.test.js.snap
+++ b/tests/e2e/tests/engagements/__snapshots__/certificates.test.js.snap
@@ -44,42 +44,6 @@ exports[`Engagements/Certificates Awarded should award a certificate on user reg
 </div>"
 `;
 
-exports[`Engagements/Certificates Legacy should be able to edit legacy certificates in the classic editor 1`] = `
-"<div class=\\"llms-certificate-container\\" style=\\"width:800px; height:616px;\\">
-	<img src=\\"/wp-content/plugins/lifterlms/assets/images/default-certificate.png\\" style=\\"margin-bottom:-616px;\\" alt=\\"Certificate Background\\" class=\\"certificate-background\\">
-	<div id=\\"certificate-999\\" class=\\"post-999 llms_my_certificate type-llms_my_certificate status-publish hentry\\">
-
-		<div class=\\"llms-summary\\">
-
-			
-			
-			<h1>Template-V1</h1>
-			<p>Legacy Template</p>
-
-			
-		</div>
-	</div>
-</div>"
-`;
-
-exports[`Engagements/Certificates Legacy should be able to migrate a legacy certificates to the block editor 1`] = `
-"<div class=\\"llms-certificate-wrapper\\">
-	<div id=\\"certificate-999\\" class=\\"llms-certificate-container cert-template-v2 post-999 llms_my_certificate type-llms_my_certificate status-publish hentry\\">
-
-		
-		
-		
-<p>Legacy Template</p>
-
-
-
-<p></p>
-
-		
-	</div>
-</div>"
-`;
-
 exports[`Engagements/Certificates Templates can reset blocks to the default template 1`] = `
 Array [
   Object {


### PR DESCRIPTION
## Description

Adds check for new clone nonce before use

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

