### PR TITLE
Show setup wizard after activation via Add New Plugin screen

### DIFF
--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -596,7 +596,7 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_sessions` (
 
 		// Trigger first time run redirect.
 		if ( ( is_null( $version ) || is_null( $db_version ) ) || 'no' === get_option( 'lifterlms_first_time_setup', 'no' ) ) {
-			set_transient( '_llms_first_time_setup_redirect', 'yes', 30 );
+			update_option( '_llms_first_time_setup_redirect', 'yes', false );
 		}
 
 		self::run_db_updates( $db_version );
@@ -731,9 +731,9 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_sessions` (
 	 */
 	public static function wizard_redirect() {
 
-		if ( get_transient( '_llms_first_time_setup_redirect' ) ) {
+		if ( 'yes' === get_option( '_llms_first_time_setup_redirect', 'no' ) ) {
 
-			delete_transient( '_llms_first_time_setup_redirect' );
+			update_option( '_llms_first_time_setup_redirect', 'no' );
 
 			if ( ( ! empty( $_GET['page'] ) && in_array( $_GET['page'], array( 'llms-setup' ), true ) ) || is_network_admin() || isset( $_GET['activate-multi'] ) || apply_filters( 'llms_prevent_automatic_wizard_redirect', false ) ) {
 				return;


### PR DESCRIPTION

## Description
The current method of using a transient to decide if a redirect should happen isn't reliable since a transient could disappear after creation. With WP 6.5 using AJAX for plugin activations, it needs to be reliably around longer. 

Fixes #2622 

## How has this been tested?
Manually

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

