### PR TITLE
Create required pages on activation

### DIFF
--- a/includes/admin/class.llms.admin.setup.wizard.php
+++ b/includes/admin/class.llms.admin.setup.wizard.php
@@ -47,11 +47,6 @@ class LLMS_Admin_Setup_Wizard extends LLMS_Abstract_Admin_Wizard {
 				'save'  => esc_html__( 'Save & Continue', 'lifterlms' ),
 				'skip'  => esc_html__( 'Skip this step', 'lifterlms' ),
 			),
-			'pages'    => array(
-				'title' => esc_html__( 'Page Setup', 'lifterlms' ),
-				'save'  => esc_html__( 'Save & Continue', 'lifterlms' ),
-				'skip'  => esc_html__( 'Skip this step', 'lifterlms' ),
-			),
 			'payments' => array(
 				'title' => esc_html__( 'Payments', 'lifterlms' ),
 				'save'  => esc_html__( 'Save & Continue', 'lifterlms' ),
@@ -181,19 +176,6 @@ class LLMS_Admin_Setup_Wizard extends LLMS_Abstract_Admin_Wizard {
 		}
 
 		return $ret;
-
-	}
-
-	/**
-	 * Save the "Pages" creation step
-	 *
-	 * @since 4.8.0
-	 *
-	 * @return WP_Error|boolean Returns `true` on success otherwise returns a WP_Error.
-	 */
-	protected function save_pages() {
-
-		return LLMS_Install::create_pages() ? true : new WP_Error( 'llms-setup-pages-save', esc_html__( 'There was an error saving your data, please try again.', 'lifterlms' ) );
 
 	}
 

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -596,6 +596,8 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_sessions` (
 		$version    = get_option( 'lifterlms_current_version', null );
 		$db_version = get_option( 'lifterlms_db_version', $version );
 
+		LLMS_Install::create_pages();
+
 		// Trigger first time run redirect.
 		if ( ( is_null( $version ) || is_null( $db_version ) ) || 'no' === get_option( 'lifterlms_first_time_setup', 'no' ) ) {
 			update_option( '_llms_first_time_setup_redirect', 'yes', false );


### PR DESCRIPTION
**NOTE: Verify we also want to create the Course and Membership catalog pages, as this may stop the taxonomy page from working if that's what the user setup**

## Description
Create the four required pages on activation or update, if they don't already exist.

Fixes #2638 

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

