### PR TITLE
Show correct course title when launching Course Builder immediately after adding course

### DIFF
--- a/.changelogs/fix_course-title-fix-adding-course.yml
+++ b/.changelogs/fix_course-title-fix-adding-course.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2606"
+entry: Show correct course title when launching Course Builder immediately after
+  creating a new course.

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -574,6 +574,8 @@ class LLMS_Admin_Builder {
 					'post_title'  => __( 'New Course', 'lifterlms' ),
 				)
 			);
+
+			$post = get_post( $course_id );
 		}
 
 		$course = llms_get_post( $post );


### PR DESCRIPTION

## Description

Fixes #2606 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1240" alt="Captura de pantalla 2024-04-25 a las 1 50 15 p  m" src="https://github.com/gocodebox/lifterlms/assets/627497/dd5dace8-001e-4e97-b473-bd42002159ea">

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

