### PR TITLE
Added Block setting and Shortcode attribute to display Student Account Dashboard as stacked or columns

### DIFF
--- a/.changelogs/dashboard-adjust-for-columns.yml
+++ b/.changelogs/dashboard-adjust-for-columns.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: Added attribute 'layout' to My Account block and shortcode to display
+  content as columns or stacked.

--- a/assets/scss/frontend/_student-dashboard.scss
+++ b/assets/scss/frontend/_student-dashboard.scss
@@ -3,37 +3,47 @@
 	.llms-sd-nav {}
 
 	.llms-sd-title {
-		margin: 25px 0;
+		margin: 0 0 25px 0;
 	}
 
 	.llms-sd-items { // ul
 		@extend %clearfix;
 		list-style-type: none;
-		margin: 0;
+		margin: 0 0 25px 0;
 		padding: 0;
 	}
-		.llms-sd-item { // li
-			float: left;
-			list-style-type: none;
-			margin: 0;
-			padding: 0;
 
-			&:last-child {
-				.llms-sep {
-					display: none;
-				}
-			}
+	.llms-sd-item { // li
+		float: left;
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
 
+		&:last-child {
 			.llms-sep {
-				color: #333;
-				margin: 0 5px;
+				display: none;
 			}
 		}
 
+		.llms-sep {
+			color: #333;
+			margin: 0 5px;
+		}
+	}
+
 	.llms-sd-section {
-		margin-bottom: 25px;
+		margin-bottom: 40px;
+
+		.llms-sd-section-title:first-child {
+			margin: 0 0 10px 0;
+		}
+
 		.llms-sd-section-footer {
 			margin-top: 10px;
+
+			a.llms-button-secondary {
+				display: inline-block;
+			}
 		}
 	}
 
@@ -103,7 +113,7 @@
 		}
 
 		@media all and ( min-width: 600px ) {
-			&.transactions th:first-child  {width: auto; }
+			&.transactions th:first-child {width: auto; }
 		}
 
 	}
@@ -176,6 +186,52 @@
 	 */
 	.llms-loop-list {
 		margin: 0 -10px;
+	}
+
+}
+
+.llms-sd-layout-columns {
+	align-items: start;
+
+	@media all and ( min-width: 600px ) {
+		display: grid;
+		grid-gap: 25px;
+		grid-template-areas: "nav header" "nav tab";
+		grid-template-columns: 200px 1fr;
+		grid-template-rows: auto 1fr;
+	}
+
+	.llms-sd-nav {
+		grid-area: nav;
+
+		.llms-sd-items {
+
+			@media all and ( min-width: 600px ) {
+				.llms-sd-item {
+					display: block;
+					float: none;
+
+					a {
+						display: block;
+						padding: 10px 0;
+					}
+
+					.llms-sep {
+						display: none;
+					}
+				}
+			}
+
+		}
+
+	}
+
+	.llms-sd-header {
+		grid-area: header;
+	}
+
+	.llms-sd-tab {
+		grid-area: tab;
 	}
 
 }

--- a/assets/scss/frontend/_student-dashboard.scss
+++ b/assets/scss/frontend/_student-dashboard.scss
@@ -190,48 +190,51 @@
 
 }
 
-.llms-sd-layout-columns {
-	align-items: start;
+.logged-in {
+	.llms-sd-layout-columns {
+		align-items: start;
 
-	@media all and ( min-width: 600px ) {
-		display: grid;
-		grid-gap: 25px;
-		grid-template-areas: "nav header" "nav tab";
-		grid-template-columns: 200px 1fr;
-		grid-template-rows: auto 1fr;
-	}
+		@media all and ( min-width: 600px ) {
+			display: grid;
+			grid-gap: 25px;
+			grid-template-areas: "nav header" "nav tab";
+			grid-template-columns: 200px 1fr;
+			grid-template-rows: auto 1fr;
+		}
 
-	.llms-sd-nav {
-		grid-area: nav;
+		.llms-sd-nav {
+			grid-area: nav;
 
-		.llms-sd-items {
+			.llms-sd-items {
 
-			@media all and ( min-width: 600px ) {
-				.llms-sd-item {
-					display: block;
-					float: none;
-
-					a {
+				@media all and ( min-width: 600px ) {
+					.llms-sd-item {
 						display: block;
-						padding: 10px 0;
-					}
+						float: none;
 
-					.llms-sep {
-						display: none;
+						a {
+							display: block;
+							padding: 10px 0;
+						}
+
+						.llms-sep {
+							display: none;
+						}
 					}
 				}
+
 			}
 
 		}
 
-	}
+		.llms-sd-header {
+			grid-area: header;
+		}
 
-	.llms-sd-header {
-		grid-area: header;
-	}
+		.llms-sd-tab {
+			grid-area: tab;
+		}
 
-	.llms-sd-tab {
-		grid-area: tab;
 	}
 
 }

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -286,7 +286,7 @@ class LLMS_Install {
 					'docs_url'     => 'https://lifterlms.com/docs/checkout-page/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Wizard&utm_content=LifterLMS%20Checkout%20Page',
 				),
 				array(
-					'content'      => '[lifterlms_my_account]',
+					'content'      => '[lifterlms_my_account layout="columns"]',
 					'option'       => 'lifterlms_myaccount_page_id',
 					'slug'         => 'dashboard',
 					'title'        => __( 'Dashboard', 'lifterlms' ),

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -286,7 +286,7 @@ class LLMS_Install {
 					'docs_url'     => 'https://lifterlms.com/docs/checkout-page/?utm_source=LifterLMS%20Plugin&utm_campaign=Plugin%20to%20Sale&utm_medium=Wizard&utm_content=LifterLMS%20Checkout%20Page',
 				),
 				array(
-					'content'      => '[lifterlms_my_account layout="columns"]',
+					'content'      => '[lifterlms_my_account]',
 					'option'       => 'lifterlms_myaccount_page_id',
 					'slug'         => 'dashboard',
 					'title'        => __( 'Dashboard', 'lifterlms' ),

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -29,6 +29,7 @@ if ( ! function_exists( 'lifterlms_student_dashboard' ) ) {
 		$options = wp_parse_args(
 			$options,
 			array(
+				'layout'         => 'stacked',
 				'login_redirect' => get_permalink( llms_get_page_id( 'myaccount' ) ),
 			)
 		);
@@ -36,11 +37,13 @@ if ( ! function_exists( 'lifterlms_student_dashboard' ) ) {
 		/**
 		 * Fires before the student dashboard output.
 		 *
-		 * @since Unknown
+		 * @since [version]
+		 *
+		 * @param string $layout The layout of the dashboard.
 		 *
 		 * @hooked lifterlms_template_student_dashboard_wrapper_open - 10
 		 */
-		do_action( 'lifterlms_before_student_dashboard' );
+		do_action( 'lifterlms_before_student_dashboard', $options['layout'] );
 
 		/**
 		 * Filters whether or not to display the student dashboard
@@ -1014,12 +1017,15 @@ if ( ! function_exists( 'lifterlms_template_student_dashboard_wrapper_open' ) ) 
 	 *
 	 * @since 3.0.0
 	 * @since 3.10.0 Unknown.
+	 * @since [version]
+	 *
+	 * @param string $layout Dashboard layout. Accepts "stacked" (default) or "columns".
 	 *
 	 * @return void
 	 */
-	function lifterlms_template_student_dashboard_wrapper_open() {
+	function lifterlms_template_student_dashboard_wrapper_open( $layout ) {
 		$current = LLMS_Student_Dashboard::get_current_tab( 'slug' );
-		echo '<div class="llms-student-dashboard ' . $current . '" data-current="' . $current . '">';
+		echo '<div class="llms-student-dashboard ' . $current . ' llms-sd-layout-' . esc_attr( $layout ) . '" data-current="' . $current . '">';
 	}
 endif;
 

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -29,7 +29,7 @@ if ( ! function_exists( 'lifterlms_student_dashboard' ) ) {
 		$options = wp_parse_args(
 			$options,
 			array(
-				'layout'         => 'stacked',
+				'layout'         => 'columns',
 				'login_redirect' => get_permalink( llms_get_page_id( 'myaccount' ) ),
 			)
 		);

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -132,7 +132,8 @@ if ( ! function_exists( 'lifterlms_student_dashboard' ) ) {
 			 *
 			 * @since unknown
 			 *
-			 * @hooked lifterlms_template_student_dashboard_header - 10
+			 * @hooked lifterlms_template_student_dashboard_navigation - 10
+			 * @hooked lifterlms_template_student_dashboard_header - 20
 			 */
 			do_action( 'lifterlms_before_student_dashboard_content' );
 

--- a/includes/llms.template.hooks.php
+++ b/includes/llms.template.hooks.php
@@ -167,14 +167,14 @@ add_action( 'lifterlms_single_question_after_summary', 'lifterlms_template_quest
 /**
  * Student Dashboard
  *
- * @since Unknown
+ * @since [version]
  */
 add_action( 'lifterlms_before_student_dashboard', 'lifterlms_template_student_dashboard_wrapper_open', 10 );
+add_action( 'lifterlms_before_student_dashboard', 'lifterlms_template_student_dashboard_navigation', 20 );
 
 add_action( 'lifterlms_before_student_dashboard_content', 'lifterlms_template_student_dashboard_header', 10 );
 
-add_action( 'lifterlms_student_dashboard_header', 'lifterlms_template_student_dashboard_navigation', 10 );
-add_action( 'lifterlms_student_dashboard_header', 'lifterlms_template_student_dashboard_title', 20 );
+add_action( 'lifterlms_student_dashboard_header', 'lifterlms_template_student_dashboard_title', 10 );
 
 add_action( 'lifterlms_student_dashboard_index', 'lifterlms_template_student_dashboard_my_courses', 10 );
 add_action( 'lifterlms_student_dashboard_index', 'lifterlms_template_student_dashboard_my_achievements', 20 );

--- a/includes/llms.template.hooks.php
+++ b/includes/llms.template.hooks.php
@@ -170,9 +170,9 @@ add_action( 'lifterlms_single_question_after_summary', 'lifterlms_template_quest
  * @since [version]
  */
 add_action( 'lifterlms_before_student_dashboard', 'lifterlms_template_student_dashboard_wrapper_open', 10 );
-add_action( 'lifterlms_before_student_dashboard', 'lifterlms_template_student_dashboard_navigation', 20 );
 
-add_action( 'lifterlms_before_student_dashboard_content', 'lifterlms_template_student_dashboard_header', 10 );
+add_action( 'lifterlms_before_student_dashboard_content', 'lifterlms_template_student_dashboard_navigation', 10 );
+add_action( 'lifterlms_before_student_dashboard_content', 'lifterlms_template_student_dashboard_header', 20 );
 
 add_action( 'lifterlms_student_dashboard_header', 'lifterlms_template_student_dashboard_title', 10 );
 

--- a/includes/shortcodes/class.llms.shortcode.my.account.php
+++ b/includes/shortcodes/class.llms.shortcode.my.account.php
@@ -46,6 +46,7 @@ class LLMS_Shortcode_My_Account {
 
 		$atts = shortcode_atts(
 			array(
+				'layout'         => 'stacked',
 				'login_redirect' => null,
 			),
 			$atts,

--- a/includes/shortcodes/class.llms.shortcode.my.account.php
+++ b/includes/shortcodes/class.llms.shortcode.my.account.php
@@ -46,7 +46,7 @@ class LLMS_Shortcode_My_Account {
 
 		$atts = shortcode_atts(
 			array(
-				'layout'         => 'stacked',
+				'layout'         => 'columns',
 				'login_redirect' => null,
 			),
 			$atts,

--- a/src/blocks/my-account/block.json
+++ b/src/blocks/my-account/block.json
@@ -7,6 +7,9 @@
   "description": "Outputs the login, registration, dashboard, profile and reset password templates.",
   "textdomain": "lifterlms",
   "attributes": {
+    "layout": {
+      "type": "string"
+    },
     "login_redirect": {
       "type": "string"
     },

--- a/src/blocks/my-account/index.jsx
+++ b/src/blocks/my-account/index.jsx
@@ -4,6 +4,7 @@ import {
 	PanelBody,
 	PanelRow,
 	TextControl,
+	SelectControl,
 	Disabled, Spinner,
 } from '@wordpress/components';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
@@ -38,6 +39,19 @@ const Edit = ( props ) => {
 	return <>
 		<InspectorControls>
 			<PanelBody title={ __( 'My Account Settings', 'lifterlms' ) }>
+				<PanelRow>
+					<SelectControl
+						label={ __( 'Layout', 'lifterlms' ) }
+						options={ [
+							{ label: __( 'Columns', 'lifterlms' ), value: 'columns' },
+							{ label: __( 'Stacked', 'lifterlms' ), value: 'stacked' },
+						] }
+						value={ attributes.layout }
+						onChange={ ( value ) => setAttributes( {
+							layout: value,
+						} ) }
+					/>
+				</PanelRow>
 				<PanelRow>
 					<TextControl
 						label={ __( 'Login redirect URL', 'lifterlms' ) }

--- a/templates/myaccount/form-redeem-voucher.php
+++ b/templates/myaccount/form-redeem-voucher.php
@@ -18,16 +18,21 @@ defined( 'ABSPATH' ) || exit;
 
 <?php do_action( 'lifterlms_before_redeem_voucher' ); ?>
 
-<form action="" method="POST">
+<form action="" method="POST" class="llms-voucher-form">
 
-	<p class="form-row form-row-first">
-		<label for="llms-voucher-code"><?php _e( 'Voucher Code', 'lifterlms' ); ?></label>
-		<input id="llms-voucher-code" type="text" placeholder="<?php _e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" required="required">
-	</p>
+	<div class="llms-form-fields">
+		<div class="form-row form-row-first llms-form-field type-text llms-cols-6 llms-is-required">
+			<label for="llms-voucher-code"><?php _e( 'Voucher Code', 'lifterlms' ); ?></label>
+			<input id="llms-voucher-code" type="text" placeholder="<?php _e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" class="llms-field-input" required="required">
+		</div>
+	</div>
 
-	<button id="llms-redeem-voucher-submit" type="submit"><?php _ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
-
-	<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
+	<footer class="llms-form-fields">
+		<div class="llms-form-field type-submit llms-cols-3 llms-cols-last"">
+			<button id="llms-redeem-voucher-submit" type="submit" class="llms-field-button llms-button-action"><?php _ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
+		</div>
+		<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
+	</footer>
 
 </form>
 

--- a/templates/myaccount/header.php
+++ b/templates/myaccount/header.php
@@ -5,6 +5,7 @@
  * @package LifterLMS/Templates
  *
  * @since    3.14.0
+ * @since    [version]
  * @version  3.14.0
  */
 
@@ -15,8 +16,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<?php
 	/**
-	 * @hooked lifterlms_template_my_account_navigation - 10
-	 * @hooked lifterlms_template_student_dashboard_title - 20
+	 * @hooked lifterlms_template_student_dashboard_title - 10
 	 */
 	do_action( 'lifterlms_student_dashboard_header' );
 	?>


### PR DESCRIPTION
## Description
Now allowing people to define a shortcode attribute 'layout' for our Student Dashboard / My Account page shortcode OR for the My Account block.

The attribute accepts 'columns' or 'stacked'. Stacked will maintain the current appearance of the My Account page where the navigation is above the content of the tab.

Columns will display the layout with the navigation in the left column. We can provide people with CSS recipes to have the columns swapped so the nav is on the right side.  I feel this is better than supporting more options for the layout attribute, but I am open to it. It isn't a lot of effort to change this to "Navigation Location: Top | Left | Right".

This update also includes adding proper core LifterLMS forms CSS selectors to the "Redeem a Voucher" tab of the My Account page so that the form field and buttons are in line with other forms throughout the frontend.

## How has this been tested?
Locally

Note: We should test a bit more with Kadence and Astra - right now they are looking fine when the default attribute is set to stacked. Kadence will not look good with the attribute "columns" since our CSS is getting mixed up with the styling in their customizations
.
Sky Pilot will also need an update. I am going to do that PR and make it dependent on this update being released.

## Screenshots <!-- if applicable -->
![Screenshot 2024-05-08 at 7 26 30 AM](https://github.com/gocodebox/lifterlms/assets/5312875/f464addb-b4d4-4a7a-a641-44c70d8009aa)
![Screenshot 2024-05-08 at 7 34 47 AM](https://github.com/gocodebox/lifterlms/assets/5312875/e74ba363-4551-481b-9c76-2a73c874fda8)

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

