### PR TITLE
Avoid JS error in the webui popover script

### DIFF
--- a/.changelogs/fix_2678-js-error.yml
+++ b/.changelogs/fix_2678-js-error.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2678"
+entry: Avoids JS error on the front-end.

--- a/assets/vendor/webui-popover/jquery.webui-popover.js
+++ b/assets/vendor/webui-popover/jquery.webui-popover.js
@@ -20,7 +20,13 @@
             factory(window.jQuery);
         }
     }(function($) {
-        // Create the defaults once
+		// verify that LLMS.l10n.translate is defined before using it to get the Close label
+		var closeLabel = 'Close';
+		if ( 'undefined' !== typeof LLMS && 'undefined' !== typeof LLMS.l10n && 'undefined' !== typeof LLMS.l10n.translate ) {
+			closeLabel = LLMS.l10n.translate( 'Close' );
+		}
+
+		// Create the defaults once
         var pluginName = 'webuiPopover';
         var pluginClass = 'webui-popover';
         var pluginType = 'webui.popover';
@@ -56,7 +62,7 @@
             template: '<div class="webui-popover">' +
                 '<div class="webui-arrow"></div>' +
                 '<div class="webui-popover-inner">' +
-                '<a href="#" aria-label="' + LLMS.l10n.translate( 'Close' ) + '" class="close"></a>' +
+                '<a href="#" aria-label="' + closeLabel + '" class="close"></a>' +
                 '<h3 class="webui-popover-title"></h3>' +
                 '<div class="webui-popover-content"><i class="icon-refresh"></i> <p>&nbsp;</p></div>' +
                 '</div>' +

--- a/assets/vendor/webui-popover/jquery.webui-popover.js
+++ b/assets/vendor/webui-popover/jquery.webui-popover.js
@@ -20,7 +20,6 @@
             factory(window.jQuery);
         }
     }(function($) {
-		// verify that LLMS.l10n.translate is defined before using it to get the Close label
 		var closeLabel = 'Close';
 		if ( 'undefined' !== typeof LLMS && 'undefined' !== typeof LLMS.l10n && 'undefined' !== typeof LLMS.l10n.translate ) {
 			closeLabel = LLMS.l10n.translate( 'Close' );


### PR DESCRIPTION

## Description
Checks that LLMS.l10n.translate is defined, otherwise use a default 'Close' aria label.

Fixes #2678 

## How has this been tested?
Manually

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

