### PR TITLE
Fix/plugin checks 3

### DIFF
--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -280,10 +280,10 @@ abstract class LLMS_Admin_Metabox {
 		echo '<div class="llms-mb-container">';
 		// only show tabbed navigation when there's more than 1 tab.
 		if ( $this->total_tabs > 1 ) {
-			echo '<nav class="llms-nav-tab-wrapper llms-nav-style-tabs"><ul class="tabs llms-nav-items">' . $this->navigation . '</ul></nav>';
+			echo '<nav class="llms-nav-tab-wrapper llms-nav-style-tabs"><ul class="tabs llms-nav-items">' . wp_kses_post( $this->navigation ) . '</ul></nav>';
 		}
 		do_action( 'llms_metabox_before_content', $this->id );
-		echo $this->content;
+		echo wp_kses_post( $this->content );
 		do_action( 'llms_metabox_after_content', $this->id );
 		echo '</div>';
 		wp_nonce_field( 'lifterlms_save_data', 'lifterlms_meta_nonce' );
@@ -310,7 +310,7 @@ abstract class LLMS_Admin_Metabox {
 			if ( is_wp_error( $error ) ) {
 				$error = $error->get_error_message();
 			}
-			echo '<div id="lifterlms_errors" class="error"><p>' . $error . '</p></div>';
+			echo '<div id="lifterlms_errors" class="error"><p>' . wp_kses_post( $error ) . '</p></div>';
 		}
 
 		delete_option( $this->error_opt_key );

--- a/includes/abstracts/abstract.llms.admin.metabox.php
+++ b/includes/abstracts/abstract.llms.admin.metabox.php
@@ -283,7 +283,8 @@ abstract class LLMS_Admin_Metabox {
 			echo '<nav class="llms-nav-tab-wrapper llms-nav-style-tabs"><ul class="tabs llms-nav-items">' . wp_kses_post( $this->navigation ) . '</ul></nav>';
 		}
 		do_action( 'llms_metabox_before_content', $this->id );
-		echo wp_kses_post( $this->content );
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped via process_fields().
+		echo $this->content;
 		do_action( 'llms_metabox_after_content', $this->id );
 		echo '</div>';
 		wp_nonce_field( 'lifterlms_save_data', 'lifterlms_meta_nonce' );

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -412,9 +412,9 @@ class LLMS_Admin_Assets {
 		';
 
 		echo '<script type="text/javascript">window.LLMS = window.LLMS || {};</script>';
-		
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_js_strings returns json_encoded strings.
-		echo '<script type="text/javascript">window.LLMS.l10n = window.LLMS.l10n || {}; window.LLMS.l10n.strings = ' . LLMS_L10n::get_js_strings( true ) . ';</script>';
+		echo '<script type="text/javascript">window.LLMS.l10n = window.LLMS.l10n || {}; window.LLMS.l10n.strings = ' . wp_json_encode( LLMS_L10n::get_js_strings( false ) ) . ';</script>';
 
 		$forms = LLMS_Forms::instance()->get_post_type();
 

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -412,6 +412,8 @@ class LLMS_Admin_Assets {
 		';
 
 		echo '<script type="text/javascript">window.LLMS = window.LLMS || {};</script>';
+		
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- get_js_strings returns json_encoded strings.
 		echo '<script type="text/javascript">window.LLMS.l10n = window.LLMS.l10n || {}; window.LLMS.l10n.strings = ' . LLMS_L10n::get_js_strings( true ) . ';</script>';
 
 		$forms = LLMS_Forms::instance()->get_post_type();

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -608,7 +608,7 @@ class LLMS_Admin_Builder {
 					echo self::get_template(
 						$template,
 						array(
-							'course_id' => $course_id,
+							'course_id' => $course_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						)
 					);
 				}

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -604,13 +604,14 @@ class LLMS_Admin_Builder {
 				);
 
 				foreach ( $templates as $template ) {
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the template file.
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
 					echo self::get_template(
 						$template,
 						array(
-							'course_id' => $course_id, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							'course_id' => $course_id,
 						)
 					);
+					// phpcs:enable
 				}
 
 				?>

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -370,14 +370,12 @@ class LLMS_Admin_Settings {
 
 			case 'button':
 				$name = isset( $field['name'] ) ? $field['name'] : 'save';
-
+				echo '<tr valign="top" class="' . esc_attr( $disabled_class ) . '"><th><label for="' . esc_attr( $field['id'] ) . '">' . esc_html( $field['title'] ) . '</label>';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $tooltip escaped in set_field_descriptions().
-				echo '<tr valign="top" class="' . esc_attr( $disabled_class ) . '"><th>
-            		<label for="' . esc_attr( $field['id'] ) . '">' . esc_html( $field['title'] ) . '</label>
-						' . $tooltip . '
-            	</th>';
+				echo $tooltip;
+				echo '</th>';
 
-				echo '<td class="forminp forminp-' . sanitize_title( $field['type'] ) . '">';
+				echo '<td class="forminp forminp-' . esc_attr( sanitize_title( $field['type'] ) ) . '">';
 				echo '<div id="llms-form-wrapper">';
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $description escaped in set_field_descriptions().
 				echo $description . '<br><br>';
@@ -402,7 +400,7 @@ class LLMS_Admin_Settings {
 						<label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['title'] ); ?></label>
 						<?php echo $tooltip; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in set_field_descriptions(). ?>
 					</th>
-					<td class="forminp forminp-<?php echo sanitize_title( $field['type'] ); ?>">
+					<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $field['type'] ) ); ?>">
 						<div id="<?php echo esc_attr( $field['id'] ); ?>"><?php echo wp_kses_post( $field['value'] ); ?></div>
 					</td>
 				</tr>
@@ -503,9 +501,9 @@ class LLMS_Admin_Settings {
 						<label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['title'] ); ?></label>
 						<?php echo $tooltip; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in set_field_descriptions. ?>
 					</th>
-					<td class="forminp forminp-<?php echo sanitize_title( $field['type'] ); ?>">
+					<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $field['type'] ) ); ?>">
 						<select
-							name="<?php echo $field_name; ?>"
+							name="<?php echo esc_attr( $field_name ); ?>"
 							id="<?php echo esc_attr( $field['id'] ); ?>"
 							style="<?php echo esc_attr( $field['css'] ); ?>"
 							class="<?php echo esc_attr( $field['class'] ); ?>"
@@ -533,7 +531,7 @@ class LLMS_Admin_Settings {
 									selected( $option_value, $key );
 								}
 								?>
-								><?php echo $val; ?></option>
+								><?php echo wp_kses_post( $val ); ?></option>
 								<?php
 							}
 							?>
@@ -562,7 +560,7 @@ class LLMS_Admin_Settings {
 								<li>
 									<label><input
 										name="<?php echo esc_attr( $field['id'] ); ?>"
-										value="<?php echo $key; ?>"
+										value="<?php echo esc_attr( $key ); ?>"
 										type="radio"
 										style="<?php echo esc_attr( $field['css'] ); ?>"
 										class="<?php echo esc_attr( $field['class'] ); ?>"
@@ -619,7 +617,7 @@ class LLMS_Admin_Settings {
 				}
 
 				?>
-					<label for="<?php echo $field['id']; ?>">
+					<label for="<?php echo esc_attr( $field['id'] ); ?>">
 						<input
 							name="<?php echo esc_attr( $field['id'] ); ?>"
 							id="<?php echo esc_attr( $field['id'] ); ?>"
@@ -668,12 +666,12 @@ class LLMS_Admin_Settings {
 						<label for="<?php echo esc_attr( $field['id'] ); ?>"><?php echo esc_html( $field['title'] ); ?></label>
 						<?php echo $tooltip; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in set_field_descriptions. ?>
 					</th>
-					<td class="forminp forminp-<?php echo sanitize_title( $field['type'] ); ?>">
+					<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $field['type'] ) ); ?>">
 
-						<img class="llms-image-field-preview" src="<?php echo $src; ?>">
+						<img class="llms-image-field-preview" src="<?php echo esc_url( $src ); ?>">
 						<button class="llms-button-secondary llms-image-field-upload" data-id="<?php echo esc_attr( $field['id'] ); ?>" type="button">
 							<span class="dashicons dashicons-admin-media"></span>
-							<?php _e( 'Upload', 'lifterlms' ); ?>
+							<?php esc_html_e( 'Upload', 'lifterlms' ); ?>
 						</button>
 						<button class="llms-button-danger llms-image-field-remove<?php echo ( ! $src ) ? ' hidden' : ''; ?>" data-id="<?php echo esc_attr( $field['id'] ); ?>" type="button">
 							<span class="dashicons dashicons-no"></span>
@@ -711,9 +709,13 @@ class LLMS_Admin_Settings {
 
 				?>
 				<tr valign="top" class="single_select_page">
-					<th><?php echo esc_html( $field['title'] ); ?> <?php echo $tooltip; ?></th>
+					<th><?php echo esc_html( $field['title'] ); ?> <?php echo $tooltip; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in set_field_descriptions.?></th>
 					<td class="forminp">
-						<?php echo str_replace( ' id=', " data-placeholder='" . __( 'Select a page&hellip;', 'lifterlms' ) . "' style='" . $field['css'] . "' class='" . $field['class'] . "' id=", wp_dropdown_pages( $args ) ); ?> <?php echo $description; ?>
+						<?php 
+						// PHPCS ignore reason: This is a dropdown and the output is escaped in wp_dropdown_pages.
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo str_replace( ' id=', " data-placeholder='" . esc_html__( 'Select a page&hellip;', 'lifterlms' ) . "' style='" . esc_attr( $field['css'] ) . "' class='" . esc_attr( $field['class'] ) . "' id=", wp_dropdown_pages( $args ) ); ?>
+						<?php echo wp_kses_post( $description ); ?>
 					</td>
 				</tr>
 				<?php
@@ -739,8 +741,8 @@ class LLMS_Admin_Settings {
 				<tr valign="top" class="single_select_membership">
 					<th><?php echo esc_html( $field['title'] ); ?> <?php echo $tooltip; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in set_field_descriptions. ?></th>
 					<td class="forminp">
-						<select class="<?php echo $args['class']; ?>" style="<?php echo $field['css']; ?>" name="lifterlms_membership_required" id="lifterlms_membership_required">
-							<option value=""> <?php _e( 'None', 'lifterlms' ); ?></option>
+						<select class="<?php echo esc_attr( $args['class'] ); ?>" style="<?php echo esc_attr( $field['css'] ); ?>" name="lifterlms_membership_required" id="lifterlms_membership_required">
+							<option value=""> <?php esc_html_e( 'None', 'lifterlms' ); ?></option>
 							<?php
 							foreach ( $posts as $post ) :
 								setup_postdata( $post );

--- a/includes/admin/llms.functions.admin.php
+++ b/includes/admin/llms.functions.admin.php
@@ -327,7 +327,8 @@ function llms_merge_code_button( $target = 'content', $echo = true, $codes = arr
 	}
 
 	if ( $echo ) {
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped - Escaped in the view file.
+		// PHPCS ignore reason: Escaped in the view file.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo $html;
 	}
 

--- a/includes/admin/post-types/class.llms.post.tables.php
+++ b/includes/admin/post-types/class.llms.post.tables.php
@@ -168,7 +168,7 @@ class LLMS_Admin_Post_Tables {
 		ob_start();
 		?>
 		<span class="llms-post-table-post-filter">
-			<label for="<?php echo $id; ?>" class="screen-reader-text">
+			<label for="<?php echo esc_attr( $id ); ?>" class="screen-reader-text">
 				<?php echo esc_html( $label ); ?>
 			</label>
 			<select
@@ -176,7 +176,7 @@ class LLMS_Admin_Post_Tables {
 				data-allow_clear="true"
 				data-no-view-button="true"
 				data-placeholder="<?php echo esc_attr( $label ); ?>"
-				data-post-type="<?php echo $post_type; ?>"
+				data-post-type="<?php echo esc_attr( $post_type ); ?>"
 				name="<?php echo esc_attr( $name ); ?>"
 				id="<?php echo esc_attr( $id ); ?>"
 			>

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.builder.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.builder.php
@@ -123,7 +123,7 @@ class LLMS_Metabox_Course_Builder extends LLMS_Admin_Metabox {
 
 			<?php if ( $lesson && $section ) : ?>
 
-				<p><strong><?php printf( __( 'Course: %s', 'lifterlms' ), wp_kses_post( $this->get_title_html( $course->get( 'title' ), get_edit_post_link( $course->get( 'id' ) ) ) ) ); ?></strong></p>
+				<p><strong><?php printf( esc_html__( 'Course: %s', 'lifterlms' ), wp_kses_post( $this->get_title_html( $course->get( 'title' ), get_edit_post_link( $course->get( 'id' ) ) ) ) ); ?></strong></p>
 
 				<?php $this->output_section( $section, 'previous' ); ?>
 
@@ -182,7 +182,7 @@ class LLMS_Metabox_Course_Builder extends LLMS_Admin_Metabox {
 					<?php if ( $this->post->ID !== $lesson->get( 'id' ) ) : ?>
 						<?php echo wp_kses_post( $this->get_title_html( $lesson->get( 'title' ), get_edit_post_link( $lesson->get( 'id' ) ) ) ); ?>
 					<?php else : ?>
-						<?php echo $lesson->get( 'title' ); ?>
+						<?php echo wp_kses_post( $lesson->get( 'title' ) ); ?>
 					<?php endif; ?>
 					<a class="tip--top-left" href="<?php echo esc_url( $this->get_builder_url( $lesson->get( 'parent_course' ), $hash ) ); ?>" data-tip="<?php esc_attr_e( 'Edit lesson in builder', 'lifterlms' ); ?>"><i class="fa fa-cog"></i></a>
 					<?php

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.enrollment.php
@@ -107,11 +107,11 @@ class LLMS_Meta_Box_Order_Enrollment extends LLMS_Admin_Metabox {
 		printf( esc_html_x( 'Trigger: %s', 'enrollment trigger', 'lifterlms' ), esc_html( $student->get_enrollment_trigger( $order->get( 'product_id' ) ) ) );
 		echo '</p>';
 
-		echo '<input name="llms_student_old_enrollment_status" type="hidden" value="' . $current_status . '">';
+		echo '<input name="llms_student_old_enrollment_status" type="hidden" value="' . esc_attr( $current_status ) . '">';
 
-		echo '<input name="llms_update_enrollment_status" type="submit" class="llms-button-secondary small" value="' . __( 'Update Status', 'lifterlms' ) . '"> ';
+		echo '<input name="llms_update_enrollment_status" type="submit" class="llms-button-secondary small" value="' . esc_html__( 'Update Status', 'lifterlms' ) . '"> ';
 		if ( $current_status && 'enrolled' !== $current_status ) {
-			echo '<input name="llms_delete_enrollment_status" type="submit" class="llms-button-danger small" value="' . __( 'Delete Enrollment', 'lifterlms' ) . '">';
+			echo '<input name="llms_delete_enrollment_status" type="submit" class="llms-button-danger small" value="' . esc_html__( 'Delete Enrollment', 'lifterlms' ) . '">';
 		}
 	}
 

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.voucher.export.php
@@ -45,7 +45,7 @@ class LLMS_Meta_Box_Voucher_Export {
 
 			<div class="llms-voucher-export-type">
 				<input type="radio" name="llms_voucher_export_type" id="vouchers_only_type" value="vouchers">
-				<label for="vouchers_only_type"><strong><?php _e( 'Vouchers only', 'lifterlms' ); ?></strong></label>
+				<label for="vouchers_only_type"><strong><?php esc_html_e( 'Vouchers only', 'lifterlms' ); ?></strong></label>
 				<p><?php esc_html_e( 'Generates a CSV of voucher codes, uses, and remaining uses.', 'lifterlms' ); ?></p>
 			</div>
 
@@ -63,7 +63,7 @@ class LLMS_Meta_Box_Voucher_Export {
 				<p><?php esc_html_e( 'Send to multiple emails by separating emails addresses with commas.', 'lifterlms' ); ?></p>
 			</div>
 
-			<button type="submit" name="llms_generate_export" value="generate" class="button-primary"><?php _e( 'Generate Export', 'lifterlms' ); ?></button>
+			<button type="submit" name="llms_generate_export" value="generate" class="button-primary"><?php esc_html_e( 'Generate Export', 'lifterlms' ); ?></button>
 			<?php wp_nonce_field( 'lifterlms_csv_export_data', 'lifterlms_export_nonce' ); ?>
 			<div class="clear"></div>
 		</div>

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
@@ -92,7 +92,9 @@ class LLMS_Metabox_Date_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 			<?php if ( isset( $this->field['placeholder'] ) ) : ?>
 			placeholder="<?php echo esc_attr( $this->field['placeholder'] ); ?>"
 			<?php endif; ?>
-			<?php echo $this->get_data_attrs(); ?>
+			<?php
+				echo wp_kses_post( $this->get_data_attrs() );
+				?>
 		/>
 		<?php
 		parent::close_output();

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.number.php
@@ -55,7 +55,7 @@ class LLMS_Metabox_Number_Field extends LLMS_Metabox_Field implements Meta_Box_F
 			max="<?php echo esc_attr( $this->field['max'] ); ?>"
 			<?php endif; ?>
 			name="<?php echo esc_attr( $this->field['id'] ); ?>"
-			id="<?php echo $this->field['id']; ?>"
+			id="<?php echo esc_attr( $this->field['id'] ); ?>"
 			class="<?php echo esc_attr( $this->field['class'] ); ?>"
 			value="<?php echo esc_attr( $this->meta ); ?>"
 			size="30"

--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -329,7 +329,7 @@ endwhile;
 
 			<div class="llms-metabox-field d-1of6" data-controller="llms-trial-offer" data-value-is="yes">
 				<label>&nbsp;</label>
-				<select name="_llms_plans[<?php echo $order; ?>][trial_period]"<?php echo ( $plan ) ? '' : ' disabled="disabled"'; ?>>
+				<select name="_llms_plans[<?php echo esc_attr( $order ); ?>][trial_period]"<?php echo ( $plan ) ? '' : ' disabled="disabled"'; ?>>
 					<option value="year"<?php selected( 'year', ( $plan && 'yes' === $trial_offer ) ? $plan->get( 'trial_period' ) : '' ); ?>><?php esc_html_e( 'year(s)', 'lifterlms' ); ?></option>
 					<option value="month"<?php selected( 'month', ( $plan && 'yes' === $trial_offer ) ? $plan->get( 'trial_period' ) : '' ); ?>><?php esc_html_e( 'month(s)', 'lifterlms' ); ?></option>
 					<option value="week"<?php selected( 'week', ( $plan && 'yes' === $trial_offer ) ? $plan->get( 'trial_period' ) : '' ); ?>><?php esc_html_e( 'week(s)', 'lifterlms' ); ?></option>

--- a/includes/admin/views/builder/lesson.php
+++ b/includes/admin/views/builder/lesson.php
@@ -156,7 +156,7 @@
 
 		);
 
-		// phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped above.
+		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped above.
 		foreach ( $icons as $icon ) :
 			?>
 

--- a/includes/admin/views/metaboxes/view-award-engagement-submit.php
+++ b/includes/admin/views/metaboxes/view-award-engagement-submit.php
@@ -102,7 +102,7 @@ defined( 'ABSPATH' ) || exit;
 			?>
 			<div class="misc-pub-section curtime misc-pub-curtime">
 				<span id="timestamp">
-					<?php wp_kses_post( printf( $stamp, '<b>' . $date . '</b>' ) ); ?>
+					<?php echo wp_kses_post( sprintf( $stamp, '<b>' . $date . '</b>' ) ); ?>
 				</span>
 				<a href="#edit_timestamp" class="edit-timestamp hide-if-no-js" role="button">
 					<span aria-hidden="true"><?php esc_html_e( 'Edit', 'lifterlms' ); ?></span>

--- a/includes/admin/views/metaboxes/view-order-details.php
+++ b/includes/admin/views/metaboxes/view-order-details.php
@@ -104,7 +104,7 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 				</div>
 
 				<div class="llms-metabox-field">
-					<label><?php _e( 'Coupon Discount:', 'lifterlms' ); ?></label>
+					<label><?php esc_html_e( 'Coupon Discount:', 'lifterlms' ); ?></label>
 					<?php echo wp_kses( $order->get_coupon_amount( 'trial' ), LLMS_ALLOWED_HTML_PRICES ); ?>
 					(<?php echo wp_kses( llms_price( $order->get_price( 'coupon_value_trial', array(), 'float' ) * - 1 ), LLMS_ALLOWED_HTML_PRICES ); ?>)
 					[<a href="<?php echo esc_url( get_edit_post_link( $order->get( 'coupon_id' ) ) ); ?>"><?php echo esc_html( $order->get( 'coupon_code' ) ); ?></a>]
@@ -129,7 +129,7 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 
 			<?php if ( $order->has_sale() ) : ?>
 				<div class="llms-metabox-field">
-					<label><?php _e( 'Sale Discount:', 'lifterlms' ); ?></label>
+					<label><?php esc_html_e( 'Sale Discount:', 'lifterlms' ); ?></label>
 					<?php echo wp_kses( $order->get_price( 'sale_price' ), LLMS_ALLOWED_HTML_PRICES ); ?>
 					(<?php echo wp_kses( llms_price( $order->get_price( 'sale_value', array(), 'float' ) * -1 ), LLMS_ALLOWED_HTML_PRICES ); ?>)
 				</div>
@@ -137,7 +137,7 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 
 			<?php if ( $order->has_coupon() ) : ?>
 				<div class="llms-metabox-field">
-					<label><?php _e( 'Coupon Discount:', 'lifterlms' ); ?></label>
+					<label><?php esc_html_e( 'Coupon Discount:', 'lifterlms' ); ?></label>
 					<?php echo wp_kses( $order->get_coupon_amount( 'regular' ), LLMS_ALLOWED_HTML_PRICES ); ?>
 					(<?php echo wp_kses( llms_price( $order->get_price( 'coupon_value', array(), 'float' ) * - 1 ), LLMS_ALLOWED_HTML_PRICES ); ?>)
 					[<a href="<?php echo esc_url( get_edit_post_link( $order->get( 'coupon_id' ) ) ); ?>"><?php echo esc_html( $order->get( 'coupon_code' ) ); ?></a>]
@@ -146,7 +146,7 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 		<?php endif; ?>
 
 		<div class="llms-metabox-field">
-			<label><?php _e( 'Total:', 'lifterlms' ); ?></label>
+			<label><?php esc_html_e( 'Total:', 'lifterlms' ); ?></label>
 			<?php echo wp_kses( $order->get_price( 'total' ), LLMS_ALLOWED_HTML_PRICES ); ?>
 			<?php if ( $order->is_recurring() ) : ?>
 				<?php
@@ -310,9 +310,9 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 				</button>
 			</h4>
 
-			<div class="llms-metabox-field d-1of4" data-gateway-fields='<?php echo wp_json_encode( $switchable_gateway_fields ); ?>' data-llms-editable="payment_gateway" data-llms-editable-options='<?php echo wp_json_encode( $switchable_gateways ); ?>' data-llms-editable-type="select" data-llms-editable-value="<?php echo $order->get( 'payment_gateway' ); ?>">
+			<div class="llms-metabox-field d-1of4" data-gateway-fields='<?php echo wp_json_encode( $switchable_gateway_fields ); ?>' data-llms-editable="payment_gateway" data-llms-editable-options='<?php echo wp_json_encode( $switchable_gateways ); ?>' data-llms-editable-type="select" data-llms-editable-value="<?php echo esc_attr( $order->get( 'payment_gateway' ) ); ?>">
 				<label><?php esc_html_e( 'Name:', 'lifterlms' ); ?></label>
-				<?php echo is_wp_error( $gateway ) ? $order->get( 'payment_gateway' ) : $gateway->get_admin_title(); ?>
+				<?php echo is_wp_error( $gateway ) ? esc_html( $order->get( 'payment_gateway' ) ) : esc_html( $gateway->get_admin_title() ); ?>
 			</div>
 
 			<?php if ( ! is_wp_error( $gateway ) ) : ?>

--- a/includes/class.llms.gateway.manual.php
+++ b/includes/class.llms.gateway.manual.php
@@ -73,7 +73,7 @@ class LLMS_Payment_Gateway_Manual extends LLMS_Payment_Gateway {
 				$order->get( 'payment_gateway' ) === $this->id &&
 				in_array( $order->get( 'status' ), array( 'llms-pending', 'llms-on-hold', true ) )
 			) {
-				echo $this->get_payment_instructions();
+				echo wp_kses_post( $this->get_payment_instructions() );
 			}
 		}
 

--- a/includes/functions/llms-functions-deprecated.php
+++ b/includes/functions/llms-functions-deprecated.php
@@ -324,5 +324,5 @@ add_filter( 'get_post_metadata', 'llms_engagement_handle_deprecated_meta_keys', 
 function _llms_earned_engagement_deprecated_function( $obj, $meta_key, $replacement_msg ) {
 	$classname = get_class( $obj );
 	$keyname   = strtolower( str_replace( 'LLMS_User_', '', $classname ) ) . '_' . $meta_key;
-	_deprecated_function( esc_html( "{$classname} meta key '{$keyname}'" ), '6.0.0', $replacement_msg );
+	_deprecated_function( esc_html( "{$classname} meta key '{$keyname}'" ), '6.0.0', wp_kses_post( $replacement_msg ) );
 }

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -734,7 +734,7 @@ if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 
 		if ( 100 == $progress ) {
 
-			echo '<p class="llms-course-complete-text">' . apply_filters( 'llms_course_continue_button_complete_text', __( 'Course Complete', 'lifterlms' ), $course ) . '</p>';
+			echo '<p class="llms-course-complete-text">' . wp_kses_post( apply_filters( 'llms_course_continue_button_complete_text', __( 'Course Complete', 'lifterlms' ), $course ) ) . '</p>';
 
 		} else {
 

--- a/includes/widgets/class.llms.widget.course.syllabus.php
+++ b/includes/widgets/class.llms.widget.course.syllabus.php
@@ -47,7 +47,6 @@ class LLMS_Widget_Course_Syllabus extends LLMS_Widget {
 
 		$collapse       = ( ! empty( $instance['collapse'] ) ) ? $instance['collapse'] : 0;
 		$toggles        = ( ! empty( $instance['toggles'] ) ) ? $instance['toggles'] : 0;
-		$toggle_display = ( ! $collapse ) ? ' style="display:none;"' : '';
 		?>
 		<p>
 			<input <?php checked( 1, $collapse ); ?> class="checkbox llms-course-outline-collapse" id="<?php echo esc_attr( $this->get_field_id( 'collapse' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'collapse' ) ); ?>" type="checkbox" value="1">
@@ -57,7 +56,7 @@ class LLMS_Widget_Course_Syllabus extends LLMS_Widget {
 			</label>
 		</p>
 
-		<p class="llms-course-outline-toggle-wrapper"<?php echo $toggle_display; ?>>
+		<p class="llms-course-outline-toggle-wrapper"<?php echo ( ! $collapse ) ? ' style="display:none;"' : '';?>>
 			<input <?php checked( 1, $toggles ); ?> class="checkbox" id="<?php echo esc_attr( $this->get_field_id( 'toggles' ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( 'toggles' ) ); ?>" type="checkbox" value="1">
 			<label for="<?php echo esc_attr( $this->get_field_id( 'toggles' ) ); ?>">
 				<?php esc_html_e( 'Display open and close all toggles', 'lifterlms' ); ?><br>

--- a/templates/course/complete-lesson-link.php
+++ b/templates/course/complete-lesson-link.php
@@ -34,7 +34,7 @@ $student = llms_get_student( get_current_user_id() );
 
 		<?php if ( llms_show_mark_complete_button( $lesson ) ) : ?>
 
-			<?php echo apply_filters( 'llms_lesson_complete_text', esc_html__( 'Lesson Complete', 'lifterlms' ) ); ?>
+			<?php echo wp_kses_post( apply_filters( 'llms_lesson_complete_text', esc_html__( 'Lesson Complete', 'lifterlms' ) ) ); ?>
 			<?php do_action( 'llms_after_lesson_complete_text', $lesson ); ?>
 
 			<?php if ( 'yes' === get_option( 'lifterlms_retake_lessons', 'no' ) || apply_filters( 'lifterlms_retake_lesson_' . $lesson->get( 'parent_course' ), false ) ) : ?>
@@ -110,7 +110,7 @@ $student = llms_get_student( get_current_user_id() );
 		<?php do_action( 'llms_before_start_quiz_button' ); ?>
 
 		<a class="llms-button-action auto button" id="llms_start_quiz" href="<?php echo esc_url( get_permalink( $lesson->get( 'quiz' ) ) ); ?>">
-			<?php echo apply_filters( 'lifterlms_start_quiz_button_text', esc_html__( 'Take Quiz', 'lifterlms' ), $lesson->get( 'quiz' ), $lesson ); ?>
+			<?php echo wp_kses_post( apply_filters( 'lifterlms_start_quiz_button_text', esc_html__( 'Take Quiz', 'lifterlms' ), $lesson->get( 'quiz' ), $lesson ) ); ?>
 		</a>
 
 		<?php do_action( 'llms_after_start_quiz_button' ); ?>

--- a/templates/course/lesson-preview.php
+++ b/templates/course/lesson-preview.php
@@ -22,8 +22,8 @@ $restrictions = llms_page_restricted( $lesson->get( 'id' ), get_current_user_id(
 $data_msg     = $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_html( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : '';
 ?>
 
-<div class="llms-lesson-preview<?php echo $lesson->get_preview_classes(); ?>">
-	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? get_permalink( $lesson->get( 'id' ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_html( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
+<div class="llms-lesson-preview<?php echo esc_attr( $lesson->get_preview_classes() ); ?>">
+	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? esc_url( get_permalink( $lesson->get( 'id' ) ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_html( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
 
 		<?php if ( 'course' === get_post_type( get_the_ID() ) ) : ?>
 

--- a/templates/course/lesson-preview.php
+++ b/templates/course/lesson-preview.php
@@ -23,7 +23,7 @@ $data_msg     = $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_htm
 ?>
 
 <div class="llms-lesson-preview<?php echo esc_attr( $lesson->get_preview_classes() ); ?>">
-	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? esc_url( get_permalink( $lesson->get( 'id' ) ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_html( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
+	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? esc_url( get_permalink( $lesson->get( 'id' ) ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_attr( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
 
 		<?php if ( 'course' === get_post_type( get_the_ID() ) ) : ?>
 

--- a/templates/course/meta-wrapper-start.php
+++ b/templates/course/meta-wrapper-start.php
@@ -17,5 +17,5 @@ if ( ! in_array( $title_tag, array( 'h1', 'h2', 'h3', 'h4', 'h5', 'h6' ) ) ) {
 
 <div class="llms-meta-info">
 	<<?php echo esc_html( $title_tag ); ?> class="llms-meta-title">
-		<?php echo apply_filters( 'llms_course_meta_info_title', esc_html_x( 'Course Information', 'course meta info title', 'lifterlms' ) ); ?>
+		<?php echo wp_kses_post( apply_filters( 'llms_course_meta_info_title', esc_html_x( 'Course Information', 'course meta info title', 'lifterlms' ) ) ); ?>
 	</<?php echo esc_html( $title_tag ); ?>>

--- a/templates/emails/header.php
+++ b/templates/emails/header.php
@@ -104,7 +104,7 @@ $header_image = $mailer->get_header_image_src();
 			<!-- END HEADING AREA -->
 			<?php endif; ?>
 
-			<table class="main" style="border-collapse:collapse;color:<?php $mailer->get_css( 'font-color' ); ?>;mso-table-lspace:0pt;mso-table-rspace:0pt;background:#fff;border-radius:<?php echo ! empty( $email_heading ) ? esc_attr( sprintf( '0 0 %1$s %1$s', $mailer->get_css( 'border-radius' ) ) ) : $mailer->get_css( 'border-radius' ); ?>;width:100%;">
+			<table class="main" style="border-collapse:collapse;color:<?php $mailer->get_css( 'font-color' ); ?>;mso-table-lspace:0pt;mso-table-rspace:0pt;background:#fff;border-radius:<?php if ( ! empty( $email_heading ) ) { echo esc_attr( sprintf( '0 0 %1$s %1$s', $mailer->get_css( 'border-radius' ) ) ); } else { $mailer->get_css( 'border-radius' ); } ?>;width:100%;">
 				<tr>
 					<td class="wrapper" style="color:<?php $mailer->get_css( 'font-color' ); ?>;font-family:<?php $mailer->get_css( 'font-family' ); ?>;font-size:<?php $mailer->get_css( 'font-size' ); ?>;vertical-align:top;box-sizing:border-box;padding:20px;">
 						<table border="0" cellpadding="0" cellspacing="0" style="border-collapse:collapse;color:<?php $mailer->get_css( 'font-color' ); ?>;mso-table-lspace:0pt;mso-table-rspace:0pt;width:100%;">

--- a/templates/membership/price.php
+++ b/templates/membership/price.php
@@ -23,7 +23,7 @@ $llms_product = new LLMS_Product( $post->ID );
 
 			<?php if ( 'single' === $option || 'free' === $option ) : ?>
 
-				<h4 class="llms-price"><span><?php echo apply_filters( 'lifterlms_single_payment_text', wp_kses( $llms_product->get_single_price_html(), LLMS_ALLOWED_HTML_PRICES ), $llms_product ); ?></span></h4>
+				<h4 class="llms-price"><span><?php echo wp_kses( apply_filters( 'lifterlms_single_payment_text', $llms_product->get_single_price_html(), $llms_product ), LLMS_ALLOWED_HTML_PRICES ); ?></span></h4>
 
 			<?php elseif ( 'recurring' === $option ) : ?>
 

--- a/templates/myaccount/form-redeem-voucher.php
+++ b/templates/myaccount/form-redeem-voucher.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 		<input id="llms-voucher-code" type="text" placeholder="<?php esc_html_e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" required="required">
 	</p>
 
-	<button id="llms-redeem-voucher-submit" type="submit"><?php esc_html_ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
+	<button id="llms-redeem-voucher-submit" type="submit"><?php echo esc_html_x( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
 
 	<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
 

--- a/templates/myaccount/form-redeem-voucher.php
+++ b/templates/myaccount/form-redeem-voucher.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 		<input id="llms-voucher-code" type="text" placeholder="<?php esc_html_e( 'Voucher Code', 'lifterlms' ); ?>" name="llms_voucher_code" required="required">
 	</p>
 
-	<button id="llms-redeem-voucher-submit" type="submit"><?php esc_html( _ex( 'Submit', 'Voucher Code', 'lifterlms' ) ); ?></button>
+	<button id="llms-redeem-voucher-submit" type="submit"><?php esc_html_ex( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
 
 	<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
 

--- a/templates/myaccount/my-grades.php
+++ b/templates/myaccount/my-grades.php
@@ -25,7 +25,7 @@ llms_print_notices();
 		<tbody>
 		<?php foreach ( $courses as $course ) : ?>
 			<tr>
-				<td><a href="<?php echo esc_url( llms_get_endpoint_url( 'my-grades', $course->get( 'name' ) ) ); ?>"><?php echo $course->get( 'title' ); ?></a></td>
+				<td><a href="<?php echo esc_url( llms_get_endpoint_url( 'my-grades', $course->get( 'name' ) ) ); ?>"><?php echo esc_html( $course->get( 'title' ) ); ?></a></td>
 				<td><?php echo esc_html( $student->get_enrollment_date( $course->get( 'id' ) ) ); ?></td>
 				<td><?php echo wp_kses_post( llms_get_progress_bar_html( $student->get_progress( $course->get( 'id' ) ) ) ); ?></td>
 				<td>

--- a/templates/myaccount/my-notifications.php
+++ b/templates/myaccount/my-notifications.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
 		<footer class="llms-sd-pagination llms-my-notifications-pagination">
 			<nav class="llms-pagination">
 			<?php
-			echo paginate_links(
+			echo wp_kses_post( paginate_links(
 				array(
 					'base'      => str_replace( 999999, '%#%', esc_url( get_pagenum_link( 999999 ) ) ),
 					'format'    => '?page=%#%',
@@ -39,7 +39,7 @@ defined( 'ABSPATH' ) || exit;
 					'next_text' => __( 'Next', 'lifterlms' ) . ' »',
 					'type'      => 'list',
 				)
-			);
+			) );
 			?>
 			</nav>
 		</footer>

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -32,7 +32,7 @@ defined( 'ABSPATH' ) || exit;
 				<tr class="llms-order-item <?php echo esc_attr( $order->get( 'status' ) ); ?>" id="llms-order-<?php esc_attr( $order->get( 'id' ) ); ?>">
 					<td data-label="<?php esc_attr_e( 'Order', 'lifterlms' ); ?>: ">
 						<a href="<?php echo esc_url( $order->get_view_link() ); ?>">#<?php echo esc_html( $order->get( 'id' ) ); ?></a>
-						<span class="llms-status <?php echo $order->get( 'status' ); ?>"><?php echo esc_html( $order->get_status_name() ); ?></span>
+						<span class="llms-status <?php echo esc_attr( $order->get( 'status' ) ); ?>"><?php echo esc_html( $order->get_status_name() ); ?></span>
 					</td>
 					<td data-label="<?php esc_attr_e( 'Date', 'lifterlms' ); ?>: "><?php echo esc_html( $order->get_date( 'date', 'F j, Y' ) ); ?></td>
 					<td data-label="<?php esc_attr_e( 'Expires', 'lifterlms' ); ?>: ">

--- a/templates/myaccount/view-order-information.php
+++ b/templates/myaccount/view-order-information.php
@@ -21,12 +21,12 @@ defined( 'ABSPATH' ) || exit;
 		<tbody>
 			<tr>
 				<th><?php esc_html_e( 'Status', 'lifterlms' ); ?></th>
-				<td><?php echo $order->get_status_name(); ?></td>
+				<td><?php echo esc_html( $order->get_status_name() ); ?></td>
 			</tr>
 
 			<tr>
 				<th><?php esc_html_e( 'Access Plan', 'lifterlms' ); ?></th>
-				<td><?php echo $order->get( 'plan_title' ); ?></td>
+				<td><?php echo esc_html( $order->get( 'plan_title' ) ); ?></td>
 			</tr>
 
 			<tr>

--- a/templates/quiz/results-attempt-questions-list.php
+++ b/templates/quiz/results-attempt-questions-list.php
@@ -77,7 +77,7 @@ foreach ( $attempt->get_question_objects() as $attempt_question ) :
 				<?php if ( llms_parse_bool( $quiz_question->get_quiz()->get( 'show_correct_answer' ) ) ) : ?>
 					<?php if ( in_array( $quiz_question->get_auto_grade_type(), array( 'choices', 'conditional' ) ) ) : ?>
 						<div class="llms-quiz-attempt-answer-section llms-correct-answer">
-							<p class="llms-quiz-results-label correct-answer"><?php _e( 'Correct answer: ', 'lifterlms' ); ?></p>
+							<p class="llms-quiz-results-label correct-answer"><?php esc_html_e( 'Correct answer: ', 'lifterlms' ); ?></p>
 							<?php echo wp_kses_post( $attempt_question->get_correct_answer() ); ?>
 						</div>
 					<?php endif; ?>


### PR DESCRIPTION
More Plugin Check Plugin (PCP) security fixes.

Some of these might have been missed earlier or broken during the merger of other PRs. Some had to have phpcs:ignore type comments tweaked to please the scanners.

For example, sometimes having a `-- explanation` at the end of the comment seemed to break the scanner. Code in the PCP itself seems to use this format to explain the ignores.

```
// PHPCS ignore reason: Content is escaped above.
// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
```
