### PR TITLE
Avoid removing Course access when unenrolling student in membership

### DIFF
--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1491,6 +1491,30 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 
 			// Loop through all the courses and update the enrollment status.
 			foreach ( $courses  as $course_id ) {
+				// See if they should continue to have access to this course via another membership's current auto-enroll settings.
+				$membership_levels    = $this->get_membership_levels();
+				$unenroll_from_course = true;
+
+				foreach ( $membership_levels as $membership_level_id ) {
+					if ( $membership_id === $membership_level_id ) {
+						continue;
+					}
+
+					$membership         = new LLMS_Membership( $membership_level_id );
+					$autoenroll_courses = $membership->get_auto_enroll_courses();
+
+					if ( $autoenroll_courses ) {
+						if ( in_array( $course_id, $autoenroll_courses ) ) {
+							$unenroll_from_course = false;
+							break;
+						}
+					}
+				}
+
+				if ( ! $unenroll_from_course ) {
+					continue;
+				}
+
 				if ( ! $delete ) {
 					$this->unenroll( $course_id, 'membership_' . $membership_id, $status );
 				} else {

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -1505,6 +1505,9 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 
 					if ( $autoenroll_courses ) {
 						if ( in_array( $course_id, $autoenroll_courses ) ) {
+							// Update the enrollment trigger to the membership that is keeping them enrolled in the course.
+							llms_update_user_postmeta( $this->get_id(), $course_id, '_enrollment_trigger', 'membership_' . $membership_level_id, false );
+
 							$unenroll_from_course = false;
 							break;
 						}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
@@ -141,9 +141,18 @@ class LLMS_Test_LLMS_Student extends LLMS_UnitTestCase {
 		$this->student->enroll( $memb_id_2 );
 		$this->assertTrue( $this->student->is_enrolled( $course_id ) );
 		$this->assertTrue( $this->student->is_enrolled( $course_id_2 ) );
+
+		// With no sleep, the enrollment triggers are at the same time, so the test will fail since sorting by updated date returns the first trigger.
+		sleep(1);
+
+		// Unenrolling in the first membership should keep them in course 2, since they have access via membership 2's auto enroll courses.
 		$this->student->unenroll( $memb_id );
 		$this->assertFalse( $this->student->is_enrolled( $course_id ) );
 		$this->assertTrue( $this->student->is_enrolled( $course_id_2 ) );
+
+		// Unenrolling in the second membership should remove them from course 2.
+		$this->student->unenroll( $memb_id_2 );
+		$this->assertFalse( $this->student->is_enrolled( $course_id_2 ) );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
@@ -116,6 +116,37 @@ class LLMS_Test_LLMS_Student extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Enroll student in a two memberships with overlapping courses, and make sure they aren't un-enrolled from the course they should have access to.
+	 *
+	 * @return void
+	 */
+	public function test_auto_enroll_and_unenroll_with_overlapping_courses() {
+		$course_id = $this->factory->post->create( array(
+			'post_type' => 'course',
+		));
+		$course_id_2 = $this->factory->post->create( array(
+			'post_type' => 'course',
+		));
+		$memb_id = $this->factory->post->create( array(
+			'post_type' => 'llms_membership',
+		));
+		$memb_id_2   = $this->factory->post->create( array(
+			'post_type' => 'llms_membership',
+		));
+		$membership = new LLMS_Membership( $memb_id );
+		$membership->add_auto_enroll_courses( array( $course_id, $course_id_2 ) );
+		$membership_2 = new LLMS_Membership( $memb_id_2 );
+		$membership_2->add_auto_enroll_courses( array( $course_id_2 ) );
+		$this->student->enroll( $memb_id );
+		$this->student->enroll( $memb_id_2 );
+		$this->assertTrue( $this->student->is_enrolled( $course_id ) );
+		$this->assertTrue( $this->student->is_enrolled( $course_id_2 ) );
+		$this->student->unenroll( $memb_id );
+		$this->assertFalse( $this->student->is_enrolled( $course_id ) );
+		$this->assertTrue( $this->student->is_enrolled( $course_id_2 ) );
+	}
+
+	/**
 	 * Functional test for the delete_enrollment() method.
 	 *
 	 * @since 3.33.0


### PR DESCRIPTION
## Description

Check the current auto-enroll courses list for other memberships a student is a part of before unenrolling the student from a course.

Note that when a student is unenrolled from a membership, we're only maybe unenrolling them from courses that they *were not already enrolled in* when they were enrolled in the membership. For example:

- Student not enrolled in any courses
- Student enrolled in membership A which auto-enrolls in course A and B
- Student enrolled in membership B which auto-enrolls in course B

Because the student was already enrolled in course A and B, ~there is no new enrollment record created for course B, so they'll never be unenrolled automatically in course B when they are unenrolled from membership B~. This is existing behaviour that would either need a change for what courses we look to remove them from (ie. the current auto-enroll courses list, which may have changed since the student was enrolled in the first place) or creating multiple enrollment triggers that can be checked upon unenrollment in the membership. 
- **Edit: Now creates a new enrollment record for the membership that is keeping them in the course**

Fixes #1861

## How has this been tested?
Manually and via PHPUnit test

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

