### PR TITLE
Fix/paginate links warning

### DIFF
--- a/.changelogs/fix_paginate-links-warning.yml
+++ b/.changelogs/fix_paginate-links-warning.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed warnings from running `wp_kses_post()` on empty `paginate_links()` calls.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -368,20 +368,21 @@ class LLMS_Shortcodes {
 			do_action( 'lifterlms_after_loop' );
 
 			echo '<nav class="llms-pagination">';
-			echo wp_kses_post(
-				paginate_links(
-					array(
-						'base'      => str_replace( 999999, '%#%', esc_url( get_pagenum_link( 999999 ) ) ),
-						'format'    => '?page=%#%',
-						'total'     => $query->max_num_pages,
-						'current'   => max( 1, $args['paged'] ),
-						'prev_next' => true,
-						'prev_text' => '«' . __( 'Previous', 'lifterlms' ),
-						'next_text' => __( 'Next', 'lifterlms' ) . '»',
-						'type'      => 'list',
-					)
+			$pagination = paginate_links(
+				array(
+					'base'      => str_replace( 999999, '%#%', esc_url( get_pagenum_link( 999999 ) ) ),
+					'format'    => '?page=%#%',
+					'total'     => $query->max_num_pages,
+					'current'   => max( 1, $args['paged'] ),
+					'prev_next' => true,
+					'prev_text' => '«' . __( 'Previous', 'lifterlms' ),
+					'next_text' => __( 'Next', 'lifterlms' ) . '»',
+					'type'      => 'list',
 				)
 			);
+			if ( ! empty( $pagination ) ) {
+				echo wp_kses_post( $pagination );
+			}
 			echo '</nav>';
 
 		else :

--- a/templates/myaccount/my-notifications.php
+++ b/templates/myaccount/my-notifications.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
 		<footer class="llms-sd-pagination llms-my-notifications-pagination">
 			<nav class="llms-pagination">
 			<?php
-			echo wp_kses_post( paginate_links(
+			$pagination = paginate_links(
 				array(
 					'base'      => str_replace( 999999, '%#%', esc_url( get_pagenum_link( 999999 ) ) ),
 					'format'    => '?page=%#%',
@@ -39,7 +39,10 @@ defined( 'ABSPATH' ) || exit;
 					'next_text' => __( 'Next', 'lifterlms' ) . ' »',
 					'type'      => 'list',
 				)
-			) );
+			);
+			if ( ! empty( $pagination ) ) {
+				echo wp_kses_post( $pagination );
+			}
 			?>
 			</nav>
 		</footer>


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

A user reported this issue in the 7.7 update on wp .org here: https://wordpress.org/support/topic/preg_replace-passing-null-to-parameter-3-subject/#post-17939000

Our code like `echo wp_kses_post( paginate_links( ... ) );` would sometimes return warnings if the results of the paginate_links call was empty. This is because wp_kses_post called wp_kses, which calls preg_replace at some point down the line, which expects the content being replaced is not empty.

We now set a variable using paginate_links, then check if that result is non empty before echoing and calling wp_kses_post.

## How has this been tested?

Manually loading the memberships and notifications pages of the student dashboard with both pagination and not.

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

