### PR TITLE
Needs id so static var doesn't persist across object.

### DIFF
--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -1046,8 +1046,9 @@ class LLMS_Order extends LLMS_Post_Model {
 
 		// Check the cache.
 		static $cache = array();
-		if ( isset( $cache[$type] ) ) {
-			return $cache[$type];
+		if ( isset( $cache[$this->get( 'id' )] )
+		  && isset( $cache[$this->get( 'id' )][$type] ) ) {
+			return $cache[$this->get( 'id' )][$type];
 		}
 
 		$statuses = array( 'llms-txn-refunded' );
@@ -1088,7 +1089,10 @@ class LLMS_Order extends LLMS_Post_Model {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		// Save to cache.
-		$cache[$type] = floatval( $grosse );
+		if ( ! isset( $cache[$this->get( 'id' )] ) ) {
+			$cache[$this->get( 'id' )] = array();
+		}
+		$cache[$this->get('id')][$type] = floatval( $grosse );
 
 		return $cache[$type];
 	}


### PR DESCRIPTION
The commit here attempted to cache the order total through a static var: https://github.com/gocodebox/lifterlms/commit/482b119658dabb3e62f05579b45d830afd4544c8

However, that static var persists across separate instances of the order object!

Here is an example to demonstrate: 
````
class Test {
    public function echovar()  {
        static $var = 0;
        $var++;
        echo $var;
    }
}

$t1 = new Test();
$t1->echovar(); // echos 1

$t2 = new Test();
$t2->echovar(); // echos 2, we expected 1
````

To fix this, this PR uses the order id in the cache array.

It's still possible that multiple calls to this method before and after tweaking the revenue somehow may result in the wrong cached version being returned, but this doesn't seem to happen in practice. The performance improvement of the orders page is worth it until we find a new way to grab things there.