### PR TITLE
Membership Restriction Fixes: Reverting changes from PR #2572

### DIFF
--- a/.changelogs/revert-membership-restrict-page-changes.yml
+++ b/.changelogs/revert-membership-restrict-page-changes.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2714"
+entry: Reverts changes to restricting pages by membership functionality to avoid
+  conflicts with certain themes and plugins.

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -323,79 +323,50 @@ class LLMS_Template_Loader {
 	 *
 	 * @since 3.0.0
 	 * @since 3.37.10 Added Flag to print notices when landing on the redirected page.
-	 * @since 7.7.0 Added support for multiple memberships warning.
 	 *
 	 * @param array $info Array of restriction info from `llms_page_restricted()`.
 	 * @return void
 	 */
 	public function restricted_by_membership( $info ) {
 
-		$membership_ids = $info['restriction_id'];
+		$membership_id = $info['restriction_id'];
 
 		// Do nothing if we don't have a membership id.
-		if ( ! empty( $membership_ids ) && ( is_array( $membership_ids ) || is_numeric( $membership_ids ) ) ) {
+		if ( ! empty( $membership_id ) && is_numeric( $membership_id ) ) {
+
+			// Instantiate the membership.
+			$membership = new LLMS_Membership( $membership_id );
 
 			$msg      = '';
 			$redirect = '';
 
-			// Check if we're dealing with an array or a numeric for single membership restriction.
-			if ( ( is_array( $membership_ids ) && 1 === count( $membership_ids ) ) || is_numeric( $membership_ids ) ) {
+			if ( 'yes' === $membership->get( 'restriction_add_notice' ) ) {
 
-				// Get the membership.
-				$membership = new LLMS_Membership( is_array( $membership_ids ) ? $membership_ids[0] : $membership_ids );
+				$msg = $membership->get( 'restriction_notice' );
 
-				if ( 'yes' === $membership->get( 'restriction_add_notice' ) ) {
+			}
 
-					$msg = $membership->get( 'restriction_notice' );
+			// Get the redirect based on the redirect type (if set).
+			switch ( $membership->get( 'restriction_redirect_type' ) ) {
 
-				}
+				case 'custom':
+					$redirect = $membership->get( 'redirect_custom_url' );
+					break;
 
-				// Get the redirect based on the redirect type (if set).
-				switch ( $membership->get( 'restriction_redirect_type' ) ) {
+				case 'membership':
+					$redirect = get_permalink( $membership->get( 'id' ) );
+					break;
 
-					case 'custom':
-						$redirect = $membership->get( 'redirect_custom_url' );
-						break;
-
-					case 'membership':
-						$redirect = get_permalink( $membership->get( 'id' ) );
-						break;
-
-					case 'page':
-						$redirect = get_permalink( $membership->get( 'redirect_page_id' ) );
-						// Make sure to print notices in wp pages.
-						$redirect = empty( $msg ) ? $redirect : add_query_arg(
-							array(
-								'llms_print_notices' => 1,
-							),
-							$redirect
-						);
-						break;
-				}
-			} else {
-
-				$restricted_memberships = '';
-				$count                  = 0;
-				$length                 = count( $membership_ids );
-
-				foreach ( $membership_ids as $membership_id ) {
-
-					$restricted_memberships .= do_shortcode( '[lifterlms_membership_link id="' . $membership_id . '"]' );
-					++$count;
-
-					// Adding `, ` or ` or ` depending on the number of memberships.
-					if ( $count < $length - 1 ) {
-						$restricted_memberships .= ', ';
-					} elseif ( $count === $length - 1 ) {
-						$restricted_memberships .= __( ' or ', 'lifterlms' );
-					}
-				}
-
-				// Translators: %s = Membership links.
-				$msg = sprintf(
-					esc_html__( 'You must belong to one of the following memberships to access this content: %s', 'lifterlms' ),
-					wp_kses_post( $restricted_memberships )
-				);
+				case 'page':
+					$redirect = get_permalink( $membership->get( 'redirect_page_id' ) );
+					// Make sure to print notices in wp pages.
+					$redirect = empty( $msg ) ? $redirect : add_query_arg(
+						array(
+							'llms_print_notices' => 1,
+						),
+						$redirect
+					);
+					break;
 
 			}
 
@@ -713,7 +684,6 @@ class LLMS_Template_Loader {
 	 * @since 3.41.1
 	 * @since 4.0.0 Don't pass by reference because it's unnecessary.
 	 * @since 4.10.1 Fixed incorrect position of `true` in `in_array()`.
-	 * @since 7.7.0 Added support for restricted membership IDs array.
 	 *
 	 * @param WP_Post  $post  Post Object.
 	 * @param WP_Query $query Query object.
@@ -761,8 +731,9 @@ class LLMS_Template_Loader {
 
 				$membership_id = $page_restricted['restriction_id'];
 
-				if ( ! empty( $membership_id ) && ( is_array( $membership_id ) || is_numeric( $membership_id ) ) ) {
-					$membership = new LLMS_Membership( is_array( $membership_id ) ? $membership_id[0] : $membership_id );
+				if ( ! empty( $membership_id ) && is_numeric( $membership_id ) ) {
+
+					$membership = new LLMS_Membership( $membership_id );
 
 					if ( 'yes' === $membership->get( 'restriction_add_notice' ) ) {
 						$msg = $membership->get( 'restriction_notice' );

--- a/tests/phpunit/unit-tests/class-llms-test-functions-access.php
+++ b/tests/phpunit/unit-tests/class-llms-test-functions-access.php
@@ -164,13 +164,15 @@ class LLMS_Test_Functions_Access extends LLMS_UnitTestCase {
 
 		update_post_meta( $post_id, '_llms_restricted_levels', $memberships );
 		update_post_meta( $post_id, '_llms_is_restricted', 'yes' );
-		$this->assertEquals( $memberships, llms_is_post_restricted_by_membership( $post_id ) );
-		$this->assertEquals( $memberships, llms_is_post_restricted_by_membership( $post_id, $uid ) );
+
+		$this->assertEquals( $memberships[0], llms_is_post_restricted_by_membership( $post_id ) );
+		$this->assertEquals( $memberships[0], llms_is_post_restricted_by_membership( $post_id, $uid ) );
 
 		$out = llms_is_post_restricted_by_membership( $post_id );
 		$in = llms_is_post_restricted_by_membership( $post_id, $uid );
+
 		$student->enroll( $memberships[1] );
-		$this->assertEquals( $memberships, llms_is_post_restricted_by_membership( $post_id, $uid ) );
+		$this->assertEquals( $memberships[1], llms_is_post_restricted_by_membership( $post_id, $uid ) );
 
 	}
 


### PR DESCRIPTION
## Description
Reverts #2572 

It looks like themes and others have coded against having a single membership ID returned by `llms_is_post_restricted_by_membership()`. Showing multiple membership names is secondary to pages being restricted.

I still believe there are potential bugs here if a membership is deleted, or with the restriction IDs having invalid data (ie. `""`). This will also show only a single membership link vs. an array of multiple memberships a visitor/student could be a member of to access the content.

Fixes #2714 and may fix #2725

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

