### PR TITLE
Fix lifterlms_membership_link outputting draft or trashed content

### DIFF
--- a/.changelogs/fix_lifterlms-membership-link-outputs-draft-or-trashed-content.yml
+++ b/.changelogs/fix_lifterlms-membership-link-outputs-draft-or-trashed-content.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2724"
+entry: Avoid outputting lifterlms_membership_link content if the membership is
+  not published.

--- a/includes/shortcodes/class.llms.shortcode.membership.link.php
+++ b/includes/shortcodes/class.llms.shortcode.membership.link.php
@@ -40,6 +40,10 @@ class LLMS_Shortcode_Membership_Link extends LLMS_Shortcode {
 	 * @version  3.4.3
 	 */
 	protected function get_output() {
+		if ( 'publish' !== get_post_status( $this->get_attribute( 'id' ) ) ) {
+			return '';
+		}
+
 		return '<a href="' . get_permalink( $this->get_attribute( 'id' ) ) . '">' . $this->get_content() . '</a>';
 	}
 
@@ -65,9 +69,9 @@ class LLMS_Shortcode_Membership_Link extends LLMS_Shortcode {
 	 * @version  3.4.3
 	 */
 	protected function get_default_content( $atts = array() ) {
-		return apply_filters( 'lifterlms_membership_link_text', get_the_title( $this->get_attribute( 'id' ) ), $this->get_attribute( 'id' ) );
+		$default_content = 'publish' === get_post_status( $this->get_attribute( 'id' ) ) ? get_the_title( $this->get_attribute( 'id' ) ) : '';
+		return apply_filters( 'lifterlms_membership_link_text', $default_content, $this->get_attribute( 'id' ) );
 	}
-
 }
 
 return LLMS_Shortcode_Membership_Link::instance();


### PR DESCRIPTION

## Description
Avoid outputting the title and link if the membership isn't published.

Fixes #2724 

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

