### PR TITLE
Avoid using deprecated mb_convert_encoding

### DIFF
--- a/.changelogs/fix_mb_convert_encoding_replace.yml
+++ b/.changelogs/fix_mb_convert_encoding_replace.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2672"
+entry: Removes use of deprecated mb_convert_encoding().

--- a/includes/class-llms-dom-document.php
+++ b/includes/class-llms-dom-document.php
@@ -109,7 +109,6 @@ class LLMS_DOM_Document {
 		libxml_use_internal_errors( $libxml_state );
 
 		return is_wp_error( $this->error ) && $this->error->has_errors() ? $this->error : true;
-
 	}
 
 	/**
@@ -122,18 +121,17 @@ class LLMS_DOM_Document {
 	public function dom() {
 
 		return $this->dom;
-
 	}
 
 	/**
-	 * Load the HTML string in the DOMDocument using mb_convert_econding
+	 * Load the HTML string in the DOMDocument using htmlspecialchars_decode( htmlentities() ) as mb_convert_encoding() is deprecated.
 	 *
 	 * @since 4.13.0
 	 *
 	 * @return void
 	 */
 	private function load_with_mb_convert_encoding() {
-		if ( ! $this->dom->loadHTML( mb_convert_encoding( $this->source, 'HTML-ENTITIES', 'UTF-8' ) ) ) {
+		if ( ! $this->dom->loadHTML( htmlspecialchars_decode( htmlentities( $this->source ) ) ) ) {
 			$this->error = new WP_Error( 'llms-dom-document-error', __( 'DOMDocument XML Error encountered.', 'lifterlms' ), libxml_get_errors() );
 		}
 	}
@@ -156,7 +154,5 @@ class LLMS_DOM_Document {
 		if ( $meta ) {
 			$meta->parentNode->removeChild( $meta ); // phpcs:ignore: WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		}
-
 	}
-
 }


### PR DESCRIPTION

## Description
Avoids mb_convert_encoding warning with a video on a course.

Fixes #2672 

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

