### PR TITLE
Update blocks to 2.5.8

### DIFF
--- a/.changelogs/chore_update-blocks-258.yml
+++ b/.changelogs/chore_update-blocks-258.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Update version of the Blocks library to avoid having an unsaved changes
+  prompt appear after updating an access plan on a course.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "php": ">=7.4",
     "composer/installers": "~1.9.0",
     "deliciousbrains/wp-background-processing": "1.0.2",
-    "lifterlms/lifterlms-blocks": "2.5.7",
+    "lifterlms/lifterlms-blocks": "2.5.8",
     "lifterlms/lifterlms-cli": "0.0.4",
     "lifterlms/lifterlms-helper": "3.5.4",
     "lifterlms/lifterlms-rest": "1.0.2",


### PR DESCRIPTION

## Description
Fix for the "unsaved changes" prompt appearing after updating an access plan on a course.

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

