### PR TITLE
Use options instead of transients for saving the notice delay

### DIFF
--- a/.changelogs/fix_use-options-for-notice-delay.yml
+++ b/.changelogs/fix_use-options-for-notice-delay.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2767"
+entry: Using a more reliable method of keeping LifterLMS notices dismissed.

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -220,7 +220,7 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 		LLMS_Admin_Notices::delete_notice( 'test-remind', 'remind' );
 
 		$this->assertEquals( array(), LLMS_Admin_Notices::get_notice( 'test-remind' ) );
-		$this->assertEquals( 'yes', get_transient( 'llms_admin_notice_test-remind_delay' ) );
+		$this->assertTrue( is_numeric( get_option( 'llms_admin_notice_test-remind_delay' ) ) && time() < get_option( 'llms_admin_notice_test-remind_delay' ) );
 		$this->assertSame( 1, did_action( 'lifterlms_remind_test-remind_notice' ) );
 
 
@@ -263,7 +263,7 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 		LLMS_Admin_Notices::delete_notice( 'test-dismiss', 'hide' );
 
 		$this->assertEquals( array(), LLMS_Admin_Notices::get_notice( 'test-dismiss' ) );
-		$this->assertEquals( 'yes', get_transient( 'llms_admin_notice_test-dismiss_delay' ) );
+		$this->assertTrue( is_numeric( get_option( 'llms_admin_notice_test-dismiss_delay' ) && time() < get_option( 'llms_admin_notice_test-dismiss_delay' ) ) );
 		$this->assertSame( 1, did_action( 'lifterlms_hide_test-dismiss_notice' ) );
 
 	}

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-notices.php
@@ -263,7 +263,7 @@ class LLMS_Test_Admin_Notices extends LLMS_Unit_Test_Case {
 		LLMS_Admin_Notices::delete_notice( 'test-dismiss', 'hide' );
 
 		$this->assertEquals( array(), LLMS_Admin_Notices::get_notice( 'test-dismiss' ) );
-		$this->assertTrue( is_numeric( get_option( 'llms_admin_notice_test-dismiss_delay' ) && time() < get_option( 'llms_admin_notice_test-dismiss_delay' ) ) );
+		$this->assertTrue( is_numeric( get_option( 'llms_admin_notice_test-dismiss_delay' ) ) && time() < get_option( 'llms_admin_notice_test-dismiss_delay' ) );
 		$this->assertSame( 1, did_action( 'lifterlms_hide_test-dismiss_notice' ) );
 
 	}


### PR DESCRIPTION

## Description
Using options avoids the delay transient being removed and the notice appearing again before it's supposed to.

Fixes #2767 

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

