### PR TITLE
Add hook for 3rd party registration validation

### DIFF
--- a/.changelogs/feature_add-hook-for-3rd-party-registration-validation.yml
+++ b/.changelogs/feature_add-hook-for-3rd-party-registration-validation.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: dev
+entry: Adds new llms_before_registration_validation filter for 3rd party open
+  registration validation.

--- a/includes/forms/controllers/class.llms.controller.registration.php
+++ b/includes/forms/controllers/class.llms.controller.registration.php
@@ -28,7 +28,6 @@ class LLMS_Controller_Registration {
 
 		add_action( 'init', array( $this, 'register' ) );
 		add_action( 'lifterlms_user_registered', array( $this, 'voucher' ), 10, 3 );
-
 	}
 
 	/**
@@ -55,7 +54,6 @@ class LLMS_Controller_Registration {
 
 			}
 		}
-
 	}
 
 	/**
@@ -70,6 +68,21 @@ class LLMS_Controller_Registration {
 
 		if ( ! llms_verify_nonce( '_llms_register_person_nonce', 'llms_register_person' ) ) {
 			return;
+		}
+
+		/**
+		 * Allow 3rd parties to perform their own validation prior to standard validation.
+		 *
+		 * If this returns a truthy, we'll stop processing.
+		 *
+		 * The extension should add a notice in addition to returning the truthy.
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $valid Validation status. If `true` ceases registration execution. If `false` checkout proceeds.
+		 */
+		if ( apply_filters( 'llms_before_registration_validation', false ) ) {
+			return false;
 		}
 
 		do_action( 'lifterlms_before_new_user_registration' );
@@ -101,9 +114,7 @@ class LLMS_Controller_Registration {
 			llms_redirect_and_exit( apply_filters( 'lifterlms_registration_redirect', llms_get_page_url( 'myaccount' ) ) );
 
 		}
-
 	}
-
 }
 
 return new LLMS_Controller_Registration();

--- a/includes/forms/controllers/class.llms.controller.registration.php
+++ b/includes/forms/controllers/class.llms.controller.registration.php
@@ -79,7 +79,7 @@ class LLMS_Controller_Registration {
 		 *
 		 * @since [version]
 		 *
-		 * @param boolean $valid Validation status. If `true` ceases registration execution. If `false` checkout proceeds.
+		 * @param boolean $valid Validation status. If `true` ceases registration execution. If `false` registration proceeds.
 		 */
 		if ( apply_filters( 'llms_before_registration_validation', false ) ) {
 			return false;


### PR DESCRIPTION

## Description
Adds a hook to allow for 3rd party validation of the registration form, for example using Cloudflare Turnstyle via the existing `lifterlms_after_registration_fields` hook.

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

