### PR TITLE
Fix registration shortcode address states countries not working

### DIFF
--- a/.changelogs/fix_registration-shortcode-address-states-countries-not-working.yml
+++ b/.changelogs/fix_registration-shortcode-address-states-countries-not-working.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2779"
+entry: Fix for the lifterlms_registration shortcode not working on certain
+  themes on a separate page.

--- a/includes/shortcodes/class.llms.shortcode.registration.php
+++ b/includes/shortcodes/class.llms.shortcode.registration.php
@@ -47,6 +47,7 @@ class LLMS_Shortcode_Registration extends LLMS_Shortcode {
 		llms()->assets->enqueue_style( 'llms-select2-styles' );
 
 		if ( ! wp_script_is( 'llms' ) ) {
+			// If the main LifterLMS script isn't enqueued, adding inline script below will fail.
 			llms()->assets->enqueue_script( 'llms' );
 		}
 

--- a/includes/shortcodes/class.llms.shortcode.registration.php
+++ b/includes/shortcodes/class.llms.shortcode.registration.php
@@ -45,6 +45,11 @@ class LLMS_Shortcode_Registration extends LLMS_Shortcode {
 		 */
 		llms()->assets->enqueue_script( 'llms-select2' );
 		llms()->assets->enqueue_style( 'llms-select2-styles' );
+
+		if ( ! wp_script_is( 'llms' ) ) {
+			llms()->assets->enqueue_script( 'llms' );
+		}
+
 		wp_add_inline_script(
 			'llms',
 			"window.llms.address_info = '" . wp_json_encode( llms_get_countries_address_info() ) . "';"
@@ -53,9 +58,7 @@ class LLMS_Shortcode_Registration extends LLMS_Shortcode {
 		ob_start();
 		include llms_get_template_part_contents( 'global/form', 'registration' );
 		return ob_get_clean();
-
 	}
-
 }
 
 return LLMS_Shortcode_Registration::instance();


### PR DESCRIPTION

## Description
Ensure `llms` is enqueued before adding inline script for it.

Fixes #2779

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

![CleanShot 2024-10-22 at 11  49 45@2x](https://github.com/user-attachments/assets/5676cda5-1e25-47e7-9121-3f0a5149557e)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

