### PR TITLE
Rename l10n (i18n internationalization / localization) js script

### DIFF
--- a/.changelogs/rename-l18n-js-script.yml
+++ b/.changelogs/rename-l18n-js-script.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2787"
+entry: Renaming front-end javascript translation file not required, as some
+  security scans appear to be deleting it incorrectly.

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ assets/js/*.min.js
 assets/js/llms-metaboxes.js
 blocks/certificate-title/*
 blocks/my-account/*
-includes/class.llms.l10n.js.php
+includes/class.llms.l10n.frontend.php
 languages/lifterlms.pot
 
 # Ignore composer-installed libs.

--- a/.llmsconfig
+++ b/.llmsconfig
@@ -10,7 +10,7 @@
 		"domain": "lifterlms",
 		"dest": "languages/",
 		"jsClassname": "LLMS_L10n_JS",
-		"jsFilename": "class.llms.l10n.js.php",
+		"jsFilename": "class.llms.l10n.frontend.php",
 		"jsSince": "3.17.8",
 		"jsSrc": [ "assets/js/**/*.js", "!assets/js/**/*.min.js", "!assets/js/**/*.js.map" ],
 		"lastTranslator": "Thomas Patrick Levy <help@lifterlms.com>",

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -269,7 +269,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.comments.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.date.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.install.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.l10n.js.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.l10n.frontend.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.nav.menus.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.oembed.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.playnice.php';

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -269,7 +269,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.comments.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.date.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.install.php';
-		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.l10n.frontend.php';
+		include_once LLMS_PLUGIN_DIR . 'includes/class.llms.l10n.frontend.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.nav.menus.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.oembed.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/class.llms.playnice.php';


### PR DESCRIPTION

## Description
Theory that the js file is being flagged incorrectly. Renaming to `.frontend.php` and making it not required.

Refs #2787 

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

