### PR TITLE
Disable copy protection for input and textarea fields.

### DIFF
--- a/.changelogs/enhancement_disable-copy-protection-for-fields.yml
+++ b/.changelogs/enhancement_disable-copy-protection-for-fields.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Now allows copying of text in input and textarea elements, even if copy
+  protection is enabled.

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -101,11 +101,18 @@ class LLMS_Frontend_Assets {
 				document.dispatchEvent( new Event( type ) );
 			}
 			document.addEventListener( 'copy', function( event ) {
+				// Allow copying if the target is an input or textarea element
+				if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') {
+					return; // Let the default copy behavior proceed
+				}
+				
+				// Prevent copying outside input/textarea elements
 				event.preventDefault();
 				event.clipboardData.setData( 'text/plain', '<?php echo esc_html__( 'Copying is not allowed.', 'lifterlms' ); ?>' );
 				dispatchEvent( 'llms-copy-prevented' );
 			}, false );
 			document.addEventListener( 'contextmenu', function( event ) {
+				// Prevent right-click context menu on images
 				if ( event.target && 'IMG' === event.target.nodeName ) {
 					event.preventDefault();
 					dispatchEvent( 'llms-context-prevented' );


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

The copy protection Javascript has been updated to exclude INPUT and TEXTAREA elements. This will allow users to copy email and address fields and other things in text boxes that typically don't need to have copy protection.

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Manually. Go to the checkout page. Try to copy some text on the page. You will instead have "Copying is not allowed." your clipboard. Now type something into the email field and try to copy that. You will have the actual copied text.

I haven't tested this yet. There is a unit test related to the copy protection feature. It may fail now. We can think about updating or removing that test.

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

