### PR TITLE
Switch plan type to Paid by default, allow price to be optional

### DIFF
--- a/.changelogs/fix_filter-on-access-plan-price-required.yml
+++ b/.changelogs/fix_filter-on-access-plan-price-required.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: changed
+links:
+  - "#2794"
+entry: Switches new access plans to Paid by default in the new access plan UI.

--- a/includes/admin/views/access-plans/access-plan.php
+++ b/includes/admin/views/access-plans/access-plan.php
@@ -216,8 +216,8 @@ if ( ! isset( $plan ) ) {
 					</span>
 				</label>
 				<select id="_llms_plans[<?php echo esc_attr( $order ); ?>][is_free]" data-controller-id="llms-is-free" name="_llms_plans[<?php echo esc_attr( $order ); ?>][is_free]"<?php echo ( $plan ) ? '' : ' disabled="disabled"'; ?>>
-					<option value="yes"<?php selected( 'yes', $plan ? $plan->get( 'is_free' ) : '' ); ?>><?php esc_html_e( 'Free', 'lifterlms' ); ?></option>
 					<option value="no"<?php selected( 'no', $plan ? $plan->get( 'is_free' ) : true ); ?>><?php esc_html_e( 'Paid', 'lifterlms' ); ?></option>
+					<option value="yes"<?php selected( 'yes', $plan ? $plan->get( 'is_free' ) : '' ); ?>><?php esc_html_e( 'Free', 'lifterlms' ); ?></option>
 				</select>
 
 			</div>
@@ -233,7 +233,17 @@ if ( ! isset( $plan ) ) {
 							<i class="fa fa-question-circle"></i>
 						</span>
 					</label>
-					<input id="_llms_plans[<?php echo esc_attr( $order ); ?>][price]" class="llms-plan-price" name="_llms_plans[<?php echo esc_attr( $order ); ?>][price]" min="<?php echo esc_attr( $price_step ); ?>" placeholder="<?php echo esc_attr( strip_tags( llms_price( 1000 ) ) ); ?>" required="required" step="<?php echo esc_attr( $price_step ); ?>" type="number"<?php echo ( $plan ? ' value="' . esc_attr( $plan->get( 'price' ) ) . '"' : ' disabled="disabled"' ); ?>>
+					<input
+						id="_llms_plans[<?php echo esc_attr( $order ); ?>][price]"
+						class="llms-plan-price" name="_llms_plans[<?php echo esc_attr( $order ); ?>][price]"
+						placeholder="<?php echo esc_attr( strip_tags( llms_price( 1000 ) ) ); ?>"
+						<?php if ( apply_filters( 'llms_access_plan_price_required', true, $plan ) ) : ?>
+						min="<?php echo esc_attr( $price_step ); ?>"
+						required="required"
+						<?php endif; ?>
+						step="<?php echo esc_attr( $price_step ); ?>"
+						type="number"<?php echo ( $plan ? ' value="' . esc_attr( $plan->get( 'price' ) ) . '"' : ' disabled="disabled"' ); ?>
+					>
 				</div>
 
 				<div class="llms-metabox-field d-1of4">


### PR DESCRIPTION

<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
New access plans are now "paid" by default as they were prior to 7.8

Fixes #2794
Refs https://github.com/gocodebox/lifterlms-integration-woocommerce/issues/176

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

