### PR TITLE
Additional lesson preview accessibility

### DIFF
--- a/.changelogs/lesson-preview-accessibility.yml
+++ b/.changelogs/lesson-preview-accessibility.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2827"
+entry: Improved accessibility of the lessons listing on a course page, when a
+  lesson is restricted.

--- a/assets/js/app/llms-lesson-preview.js
+++ b/assets/js/app/llms-lesson-preview.js
@@ -109,7 +109,12 @@ LLMS.LessonPreview = {
 	 */
 	get_tooltip: function( msg ) {
 		var $el = $( '<div class="llms-tooltip" />' );
-		$el.append( '<div class="llms-tooltip-content" aria-hidden="true">' + msg + '</div>' );
+		$el.append(
+			$('<div>', {
+				'class': 'llms-tooltip-content',
+				'aria-hidden': 'true'
+			}).text( msg )
+		);
 		return $el;
 	},
 

--- a/assets/js/app/llms-lesson-preview.js
+++ b/assets/js/app/llms-lesson-preview.js
@@ -109,7 +109,7 @@ LLMS.LessonPreview = {
 	 */
 	get_tooltip: function( msg ) {
 		var $el = $( '<div class="llms-tooltip" />' );
-		$el.append( '<div class="llms-tooltip-content">' + msg + '</div>' );
+		$el.append( '<div class="llms-tooltip-content" aria-hidden="true">' + msg + '</div>' );
 		return $el;
 	},
 

--- a/packages/llms-e2e-test-utils/src/import-course.js
+++ b/packages/llms-e2e-test-utils/src/import-course.js
@@ -2,7 +2,7 @@
 import { clickAndWait } from './click-and-wait';
 
 // External dependencies.
-import { visitAdminPage } from '@wordpress/e2e-test-utils';
+import { visitAdminPage, clickButton } from '@wordpress/e2e-test-utils';
 
 /**
  * Import a course JSON file
@@ -28,7 +28,7 @@ export async function importCourse(
 	await visitAdminPage( 'admin.php', 'page=llms-import' );
 
 	// Upload button
-	await page.click( '.llms-setting-group.top button.llms-button-primary' );
+	await clickButton('Upload');
 
 	const inputSelector = 'input[name="llms_import"]';
 	await page.waitForSelector( inputSelector );
@@ -37,7 +37,7 @@ export async function importCourse(
 	fileUpload.uploadFile( file );
 	await page.waitForTimeout( 1000 );
 
-	await clickAndWait( '#llms-import-file-submit' );
+	await clickButton( 'Import' );
 
 	if ( navigate ) {
 		await clickAndWait( '.llms-admin-notice.notice-success a' );

--- a/templates/course/lesson-preview.php
+++ b/templates/course/lesson-preview.php
@@ -18,12 +18,12 @@
  */
 defined( 'ABSPATH' ) || exit;
 
-$restrictions = llms_page_restricted( $lesson->get( 'id' ), get_current_user_id() );
-$data_msg     = $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_html( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : '';
+$restrictions    = llms_page_restricted( $lesson->get( 'id' ), get_current_user_id() );
+$screenreader_id = 'llms-lesson-description-' . $lesson->get( 'id' ) . '-' . uniqid();
 ?>
 
 <div class="llms-lesson-preview<?php echo esc_attr( $lesson->get_preview_classes() ); ?>">
-	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? esc_url( get_permalink( $lesson->get( 'id' ) ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_attr( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
+	<a class="llms-lesson-link<?php echo $restrictions['is_restricted'] ? ' llms-lesson-link-locked' : ''; ?>" href="<?php echo ( ! $restrictions['is_restricted'] ) ? esc_url( get_permalink( $lesson->get( 'id' ) ) ) : '#llms-lesson-locked'; ?>"<?php echo $restrictions['is_restricted'] ? ' aria-disabled="true" data-tooltip-msg="' . esc_attr( strip_tags( llms_get_restriction_message( $restrictions ) ) ) . '"' : ''; ?>>
 
 		<?php if ( 'course' === get_post_type( get_the_ID() ) ) : ?>
 
@@ -79,6 +79,9 @@ $data_msg     = $restrictions['is_restricted'] ? ' data-tooltip-msg="' . esc_htm
 			</section>
 
 			<?php if ( $restrictions['is_restricted'] ) : ?>
+				<span class="sr-only">
+					<?php echo esc_attr( strip_tags( llms_get_restriction_message( $restrictions ) ) ); ?>
+				</span>
 			<?php endif; ?>
 
 		</div>

--- a/templates/course/lesson-preview.php
+++ b/templates/course/lesson-preview.php
@@ -18,8 +18,7 @@
  */
 defined( 'ABSPATH' ) || exit;
 
-$restrictions    = llms_page_restricted( $lesson->get( 'id' ), get_current_user_id() );
-$screenreader_id = 'llms-lesson-description-' . $lesson->get( 'id' ) . '-' . uniqid();
+$restrictions = llms_page_restricted( $lesson->get( 'id' ), get_current_user_id() );
 ?>
 
 <div class="llms-lesson-preview<?php echo esc_attr( $lesson->get_preview_classes() ); ?>">


### PR DESCRIPTION

## Description

Adds tooltip text as a screen-reader only element and indicates the link is disabled when a lesson cannot be accessed.

Fixes #2827 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/4c8d84ba-3d9c-4843-aefc-18d20f66c30a

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

