### PR TITLE
Avoid text wrapping in buttons

### DIFF
--- a/.changelogs/fix_wrapping-buttons.yml
+++ b/.changelogs/fix_wrapping-buttons.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2820"
+entry: Avoid wrapping of the text of buttons.

--- a/assets/scss/_includes/_buttons.scss
+++ b/assets/scss/_includes/_buttons.scss
@@ -17,6 +17,7 @@
 	padding: 12px 24px;
 	position: relative;
 	transition: all .5s ease;
+	white-space: nowrap;
 
 	&:disabled {
 		opacity: 0.5;


### PR DESCRIPTION

## Description
Similar styling to avoid wrapping of text in buttons to WP. May cause buttons to wrap when they didn't before in certain situations on the front-end if the text is long (ie. other languages).

Fixes #2820 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2024-12-20 at 10  24 46@2x](https://github.com/user-attachments/assets/8dfdfd21-0294-48f3-9447-94c43afa1675)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

