### PR TITLE
Fix translation unloading

### DIFF
--- a/.changelogs/fix_translation-unloading.yml
+++ b/.changelogs/fix_translation-unloading.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2807"
+entry: Avoid unloading the textdomain for core translations in case the
+  lifterlms textdomain is used before init (WP 6.7).

--- a/includes/functions/llms-functions-l10n.php
+++ b/includes/functions/llms-functions-l10n.php
@@ -33,7 +33,6 @@ function llms_get_locale( $domain = 'lifterlms' ) {
 	 * @param string $domain The textdomain.
 	 */
 	return apply_filters( 'plugin_locale', $locale, $domain );
-
 }
 
 function llms_l10n_get_safe_directory() {
@@ -52,7 +51,6 @@ function llms_l10n_get_safe_directory() {
 	 * @param string $path Full server path to the safe directory.
 	 */
 	return apply_filters( 'llms_l10n_safe_directory', WP_LANG_DIR . '/lifterlms' );
-
 }
 
 /**
@@ -91,7 +89,9 @@ function llms_load_textdomain( $domain, $plugin_dir = null, $language_dir = null
 	$plugin_dir   = $plugin_dir ? $plugin_dir : LLMS_PLUGIN_DIR;
 	$language_dir = $language_dir ? $language_dir : 'languages';
 
-	unload_textdomain( $domain );
+	if ( 'lifterlms' !== $domain ) {
+		unload_textdomain( $domain );
+	}
 
 	/**
 	 * Load from the custom LifterLMS "safe" directory (if it exists).
@@ -107,7 +107,6 @@ function llms_load_textdomain( $domain, $plugin_dir = null, $language_dir = null
 	 * 2. wp-content/plugins/lifterlms/languages/lifterlms-en_US.mo
 	 */
 	load_plugin_textdomain( $domain, false, sprintf( '%1$s/%2$s', basename( $plugin_dir ), $language_dir ) );
-
 }
 
 /**
@@ -126,19 +125,19 @@ function llms_get_permalink_structure() {
 		// Remove false or empty entries so we can use the default values.
 		array_filter( $saved_permalinks ),
 		array(
-			'course_base' => _x( 'course', 'course url slug', 'lifterlms' ),
-			'courses_base' => _x( 'courses', 'course archive url slug', 'lifterlms' ),
-			'memberships_base' => _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
-			'lesson_base' => _x( 'lesson', 'lesson url slug', 'lifterlms' ),
-			'quiz_base' => _x( 'quiz', 'quiz url slug', 'lifterlms' ),
+			'course_base'               => _x( 'course', 'course url slug', 'lifterlms' ),
+			'courses_base'              => _x( 'courses', 'course archive url slug', 'lifterlms' ),
+			'memberships_base'          => _x( 'memberships', 'membership archive url slug', 'lifterlms' ),
+			'lesson_base'               => _x( 'lesson', 'lesson url slug', 'lifterlms' ),
+			'quiz_base'                 => _x( 'quiz', 'quiz url slug', 'lifterlms' ),
 			'certificate_template_base' => _x( 'certificate-template', 'slug', 'lifterlms' ),
-			'certificate_base' => _x( 'certificate', 'slug', 'lifterlms' ),
-			'course_category_base' => _x( 'course-category', 'slug', 'lifterlms' ),
-			'course_tag_base' => _x( 'course-tag', 'slug', 'lifterlms' ),
-			'course_track_base' => _x( 'course-track', 'slug', 'lifterlms' ),
-			'course_difficulty_base' => _x( 'course-difficulty', 'slug', 'lifterlms' ),
-			'membership_category_base' => _x( 'membership-category', 'slug', 'lifterlms' ),
-			'membership_tag_base' => _x( 'membership-tag', 'slug', 'lifterlms' ),
+			'certificate_base'          => _x( 'certificate', 'slug', 'lifterlms' ),
+			'course_category_base'      => _x( 'course-category', 'slug', 'lifterlms' ),
+			'course_tag_base'           => _x( 'course-tag', 'slug', 'lifterlms' ),
+			'course_track_base'         => _x( 'course-track', 'slug', 'lifterlms' ),
+			'course_difficulty_base'    => _x( 'course-difficulty', 'slug', 'lifterlms' ),
+			'membership_category_base'  => _x( 'membership-category', 'slug', 'lifterlms' ),
+			'membership_tag_base'       => _x( 'membership-tag', 'slug', 'lifterlms' ),
 		)
 	);
 
@@ -149,7 +148,7 @@ function llms_get_permalink_structure() {
 	}
 
 	return $permalinks;
-};
+}
 /**
  * Set the permalink structure and only allow keys we know about.
  *

--- a/includes/functions/llms-functions-l10n.php
+++ b/includes/functions/llms-functions-l10n.php
@@ -89,10 +89,6 @@ function llms_load_textdomain( $domain, $plugin_dir = null, $language_dir = null
 	$plugin_dir   = $plugin_dir ? $plugin_dir : LLMS_PLUGIN_DIR;
 	$language_dir = $language_dir ? $language_dir : 'languages';
 
-	if ( 'lifterlms' !== $domain ) {
-		unload_textdomain( $domain );
-	}
-
 	/**
 	 * Load from the custom LifterLMS "safe" directory (if it exists).
 	 *


### PR DESCRIPTION

## Description
It was mentioned on a related trac ticket that we should not be unloading the textdomain on `init`. This is causing related changes in WP 6.7 to not show the translations if anything uses the `lifterlms` textdomain early.

I believe the `unload_textdomain` was added to fix a conflict with Loco Translate and saving in a certain location. I'm not able to replicate this, so it may no longer be needed. Restricting to just `lifterlms` core for now but we could just remove it for all add-ons too.

Refs #2807

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

