### PR TITLE
Fix confirmation toggle and course info heading default

### DIFF
--- a/.changelogs/fix-confirmation-toggle-and-course-info-heading-default-1.yml
+++ b/.changelogs/fix-confirmation-toggle-and-course-info-heading-default-1.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: changed
+entry: Course Information header is now h2 instead of h3 by default, for
+  accessibility in heading order.

--- a/.changelogs/fix-confirmation-toggle-and-course-info-heading-default.yml
+++ b/.changelogs/fix-confirmation-toggle-and-course-info-heading-default.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2646"
+entry: Can now deactivate the Confirmation field for blocks like E-mail address
+  and Password in forms.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "php": ">=7.4",
     "composer/installers": "~1.9.0",
     "deliciousbrains/wp-background-processing": "1.0.2",
-    "lifterlms/lifterlms-blocks": "2.5.8",
+    "lifterlms/lifterlms-blocks": "2.5.9",
     "lifterlms/lifterlms-cli": "0.0.4",
     "lifterlms/lifterlms-helper": "3.5.4",
     "lifterlms/lifterlms-rest": "1.0.2",


### PR DESCRIPTION

## Description
Can now disable the "confirmation" toggle for blocks like Email address and User Password.

Also changes Course Information block header from h3 to h2 by default, to have the correct heading over.

Fixes #2646 and https://github.com/gocodebox/lifterlms-blocks/issues/243

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/f8eebe1d-8109-4324-891d-0359c1548709)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

