### PR TITLE
Make the settings panel for the lesson appear when Add New Lesson clicked

### DIFF
--- a/.changelogs/fix_new-lesson-selected-course-builder.yml
+++ b/.changelogs/fix_new-lesson-selected-course-builder.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2855"
+entry: Open the lesson panel after adding a new lesson in the Course Builder.

--- a/assets/js/builder/Views/Lesson.js
+++ b/assets/js/builder/Views/Lesson.js
@@ -43,8 +43,8 @@ define( [
 		 * @version  3.16.12
 		 */
 		events: _.defaults( {
-			'click .edit-lesson': 'open_lesson_editor',
-			'click .llms-headline': 'open_lesson_editor',
+			'click .edit-lesson': 'edit_lesson',
+			'click .llms-headline': 'edit_lesson',
 			'click .edit-quiz': 'open_quiz_editor',
 			'click .edit-assignment': 'open_assignment_editor',
 			'click .section-prev': 'section_prev',
@@ -88,7 +88,7 @@ define( [
 			this.listenTo( this.model, 'change', this.render );
 
 			Backbone.pubSub.on(  'lesson-selected', this.on_select, this );
-			Backbone.pubSub.on(  'new-lesson-added', this.on_select, this );
+			Backbone.pubSub.on(  'new-lesson-added', this.maybe_open_editor, this );
 
 		},
 
@@ -139,16 +139,25 @@ define( [
 		 * @since    3.16.0
 		 * @version  3.27.0
 		 */
-		open_lesson_editor: function( event ) {
+		edit_lesson: function( event ) {
 
 			if ( event ) {
 				event.preventDefault();
 			}
 
+			this.open_lesson_editor();
+		},
+
+		open_lesson_editor: function() {
 			Backbone.pubSub.trigger( 'lesson-selected', this.model, 'lesson' );
 			this.model.set( '_selected', true );
 			this.set_hash( false );
+		},
 
+		maybe_open_editor: function( model ) {
+			if ( this.model.id === model.id ) {
+				this.open_lesson_editor();
+			}
 		},
 
 		/**

--- a/assets/js/builder/Views/LessonEditor.js
+++ b/assets/js/builder/Views/LessonEditor.js
@@ -118,6 +118,8 @@ define( [
 
 				this.render_points_percentage();
 
+				this.$('.llms-editable-title').focus();
+
 				return this;
 
 			},


### PR DESCRIPTION

## Description

Also make the "title" input of the lesson focused.

Fixes #2855 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/af5a5312-e71c-4b61-ab81-f1c9d0040be0

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

