### PR TITLE
Fix fatal error that occurred when viewing quiz attempts with deleted questions.

### DIFF
--- a/.changelogs/fix_quiz-attempt-with-deleted-question.yml
+++ b/.changelogs/fix_quiz-attempt-with-deleted-question.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: deprecated
+entry: Fixed issues with viewing quiz attempts when questions were deleted.

--- a/templates/quiz/results-attempt-questions-list.php
+++ b/templates/quiz/results-attempt-questions-list.php
@@ -24,8 +24,8 @@ defined( 'ABSPATH' ) || exit;
 		$quiz_question = $attempt_question->get_question();
 		if ( ! $quiz_question ) { // Question missing/deleted.
 			?>
-		<li class="llms-quiz-attempt-question type--<?php echo esc_attr( $quiz_question->get( 'question_type' ) ); ?> status--<?php echo esc_attr( $attempt_question->get_status() ); ?> <?php echo $attempt_question->is_correct() ? 'correct' : 'incorrect'; ?>"
-			data-question-id="<?php echo esc_attr( $quiz_question->get( 'id' ) ); ?>"
+		<li class="llms-quiz-attempt-question type--deleted status--<?php echo esc_attr( $attempt_question->get_status() ); ?> <?php echo $attempt_question->is_correct() ? 'correct' : 'incorrect'; ?>"
+			data-question-id="<?php echo esc_attr( $attempt_question->get( 'id' ) ); ?>"
 			data-grading-manual="<?php echo $attempt_question->can_be_manually_graded() ? 'yes' : 'no'; ?>"
 			data-points="<?php echo esc_attr( $attempt_question->get( 'points' ) ); ?>"
 			data-points-curr="<?php echo esc_attr( $attempt_question->get( 'earned' ) ); ?>">
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 				<span class="toggle-answer">
 					<h3 class="llms-question-title"><?php esc_html_e( 'This question has been deleted', 'lifterlms' ); ?></h3>
 					<span class="llms-points">
-						<?php if ( $quiz_question->get( 'points' ) ) : ?>
+						<?php if ( $attempt_question->get( 'points' ) ) : ?>
 							<?php echo esc_html( sprintf( __( '%1$d / %2$d points', 'lifterlms' ), $attempt_question->get( 'earned' ), $attempt_question->get( 'points' ) ) ); ?>
 						<?php endif; ?>
 					</span>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->

Viewing quiz attempts when questions were deleted would throw a fatal error:

> PHP Fatal error:  Uncaught Error: Call to a member function get() on null in ...\wp-content\plugins\lifterlms\templates\quiz\results-attempt-questions-list.php

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

To recreate the issue:
* Create a quiz with 2 questions.
* Complete the quiz from the frontend.
* Delete 1 of the questions.
* Go to LifterLMS > Reports > Quizzes
* Click on the quiz, then Click on Attempts.

## Types of changes
This issue was introduced by accident in the work to add the quiz resume feature. Some code was incorrectly updated to get data from the $question variable instead of the $attempt_question variable.

Note: Since `$attempt_question->get('question_type')` is always null, we instead add `type--deleted` as a css class on the li element instead of trying to find the type.

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

