### PR TITLE
Fix limit plus resume quizzes

### DIFF
--- a/.changelogs/fix_limit-plus-resume-quizzes.yml
+++ b/.changelogs/fix_limit-plus-resume-quizzes.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2865"
+entry: Allow quiz question to be retrieved even if attempt limit reached when
+  resuming a quiz.

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -792,7 +792,7 @@ class LLMS_AJAX_Handler {
 		$attempt         = $student_quizzes->get_attempt_by_key( $attempt_key );
 
 		// Don't allow the question to be retrieved if the attempt is not open or can't be resumed.
-		if ( ! $attempt || ( ( ! $attempt->can_be_resumed() || ! $attempt->get_quiz()->can_be_resumed() ) && ! $attempt->get_quiz()->is_open() ) || ( $attempt->get_quiz()->can_be_resumed() && ! $attempt->can_be_resumed() ) ) {
+		if ( ! $attempt || ( ! $attempt->get_quiz()->is_open() && ( ! $attempt->get_quiz()->can_be_resumed() || ! $attempt->can_be_resumed() ) ) ) {
 			$err->add( 500, __( 'There was an error retrieving the question. Please return to the lesson and try again.', 'lifterlms' ) );
 			return $err;
 		}

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -792,7 +792,7 @@ class LLMS_AJAX_Handler {
 		$attempt         = $student_quizzes->get_attempt_by_key( $attempt_key );
 
 		// Don't allow the question to be retrieved if the attempt is not open or can't be resumed.
-		if ( ! $attempt || ! $attempt->get_quiz()->is_open() || ( $attempt->get_quiz()->can_be_resumed() && ! $attempt->can_be_resumed() ) ) {
+		if ( ! $attempt || ( ( ! $attempt->can_be_resumed() || ! $attempt->get_quiz()->can_be_resumed() ) && ! $attempt->get_quiz()->is_open() ) || ( $attempt->get_quiz()->can_be_resumed() && ! $attempt->can_be_resumed() ) ) {
 			$err->add( 500, __( 'There was an error retrieving the question. Please return to the lesson and try again.', 'lifterlms' ) );
 			return $err;
 		}


### PR DESCRIPTION

## Description

If an attempt exists then the error should fire only when the quiz isn’t open and either the attempt or the quiz isn’t resumable.

Fixes #2865

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

