### PR TITLE
Avoid escaping text incorrectly.

### DIFF
--- a/.changelogs/fix-form-field-selected-escaping.yml
+++ b/.changelogs/fix-form-field-selected-escaping.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Avoid escaping the selected attribute of a form field select dropdown
+  incorrectly.

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.select.php
@@ -82,18 +82,18 @@ class LLMS_Metabox_Select_Field extends LLMS_Metabox_Field implements Meta_Box_F
 
 				<?php
 				foreach ( $this->field['value'] as $key => $option ) :
-					$selected_text = '';
+					$is_selected = false;
 					if ( is_array( $selected ) ) {
 						if ( in_array( $option['key'], $selected ) ) {
-							$selected_text = ' selected="selected" ';
+							$is_selected = true;
 						}
 					} elseif ( isset( $option['key'] ) && $option['key'] == $selected ) {
-						$selected_text = ' selected="selected" ';
+						$is_selected = true;
 					} elseif ( $key === $selected ) {
-						$selected_text = ' selected="selected" ';
+						$is_selected = true;
 					}
 					?>
-					<option value="<?php echo isset( $option['key'] ) ? esc_attr( $option['key'] ) : esc_attr( $key ); ?>"<?php echo esc_html( $selected_text ); ?>><?php echo isset( $option['title'] ) ? esc_html( $option['title'] ) : esc_html( $option ); ?></option>
+					<option value="<?php echo isset( $option['key'] ) ? esc_attr( $option['key'] ) : esc_attr( $key ); ?>"<?php echo ( $is_selected ? ' selected="selected"' : '' ); ?>><?php echo isset( $option['title'] ) ? esc_html( $option['title'] ) : esc_html( $option ); ?></option>
 
 				<?php endforeach; ?>
 


### PR DESCRIPTION

## Description
Selected dropdown fields had the `selected="selected"` text run through `esc_html` incorrectly.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

![CleanShot 2025-02-18 at 4  02 37](https://github.com/user-attachments/assets/a8919554-4d9c-4267-806a-531abe29a5b6)
![CleanShot 2025-02-18 at 4  01 18](https://github.com/user-attachments/assets/852bf812-80a1-423a-bd39-3c3ca9fd45aa)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

