### PR TITLE
Change display format of datepickers to match the date format of the site

### DIFF
--- a/.changelogs/datepicker-display-format-site-format.yml
+++ b/.changelogs/datepicker-display-format-site-format.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: changed
+links:
+  - "#2447"
+entry: Display date pickers in the site date format, but save the data in the
+  previous format.

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -279,6 +279,15 @@
 				minDate: minDate,
 				altField: altField,
 				altFormat: altFormat
+			} ).on( "keyup", function() {
+				var date;
+				try {
+					date = $.datepicker.parseDate( $.datepicker._defaults.dateFormat, this.value );
+				} catch ( e ) { }
+
+				if ( !date && altField ) {
+					$( altField ).val( "" );
+				}
 			} );
 		}
 

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -269,12 +269,16 @@
 		 */
 		this.bind_datepicker = function( $el ) {
 			var format  = $el.attr( 'data-format' ) || 'mm/dd/yy',
+				altFormat = $el.attr( 'data-alt-format' ) || '',
+				altField = $el.attr( 'data-alt-field' ) || '',
 				maxDate = $el.attr( 'data-max-date' ) || null,
 				minDate = $el.attr( 'data-min-date' ) || null;
 			$el.datepicker( {
 				dateFormat: format,
 				maxDate: maxDate,
 				minDate: minDate,
+				altField: altField,
+				altFormat: altFormat
 			} );
 		}
 

--- a/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
+++ b/includes/admin/post-types/meta-boxes/fields/llms.class.meta.box.date.php
@@ -31,13 +31,65 @@ class LLMS_Metabox_Date_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 		$_field = wp_parse_args(
 			$_field,
 			array(
-				'date_format' => 'mm/dd/yy', // jQuery datepicker formats (http://api.jqueryui.com/datepicker/#utility-formatDate).
-				'date_max'    => '',
-				'date_min'    => '',
+				'date_format'        => 'mm/dd/yy', // jQuery datepicker formats (http://api.jqueryui.com/datepicker/#utility-formatDate).
+				'date_max'           => '',
+				'date_min'           => '',
+				'date_displayformat' => $this->php_to_jquery_date_format( get_option( 'date_format' ) ),
 			)
 		);
 
 		$this->field = $_field;
+	}
+
+	function php_to_jquery_date_format( $php_format ) {
+		$replacements = array(
+			// Day
+			'd' => 'dd',
+			'D' => 'D',
+			'j' => 'd',
+			'l' => 'DD',
+			// Month
+			'm' => 'mm',
+			'n' => 'm',
+			'M' => 'M',
+			'F' => 'MM',
+			// Year
+			'Y' => 'yy',
+			'y' => 'y',
+		);
+
+		return strtr( $php_format, $replacements );
+	}
+
+	function jquery_date_to_php_format( $js_format ) {
+		// Mapping of jQuery UI Datepicker tokens to PHP date format tokens
+		$replacements = array(
+			// Year tokens
+			'yy' => 'Y',  // 4-digit year
+			'y'  => 'y',  // 2-digit year
+
+			// Month tokens
+			'mm' => 'm',  // Month with leading zero
+			'm'  => 'n',  // Month without leading zero
+			'MM' => 'F',  // Full month name
+			'M'  => 'M',  // Short month name
+
+			// Day tokens
+			'dd' => 'd',  // Day with leading zero
+			'd'  => 'j',  // Day without leading zero
+			'DD' => 'l',  // Full day name
+			'D'  => 'D',   // Short day name
+		);
+
+		// Sort keys descending by length to avoid partial replacements.
+		uksort(
+			$replacements,
+			function ( $a, $b ) {
+				return strlen( $b ) - strlen( $a );
+			}
+		);
+
+		return strtr( $js_format, $replacements );
 	}
 
 	/**
@@ -79,12 +131,27 @@ class LLMS_Metabox_Date_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 		global $post;
 
 		parent::output(); ?>
-
+		<?php
+		// Convert the meta value into display format.
+		$js_display_date = '';
+		if ( ! empty( $this->meta ) ) {
+			$meta_date       = DateTime::createFromFormat( $this->jquery_date_to_php_format( $this->field['date_format'] ), $this->meta );
+			$js_display_date = $meta_date->format( $this->jquery_date_to_php_format( $this->field['date_displayformat'] ) );
+		}
+		?>
+		<input type="hidden"
+				id="<?php echo esc_attr( $this->field['id'] ); ?>_alt_datefield"
+				name="<?php echo esc_attr( $this->field['id'] ); ?>"
+				value="<?php echo ! empty( $this->meta ) ? esc_attr( $this->meta ) : ''; ?>"
+			<?php if ( isset( $this->field['required'] ) && $this->field['required'] ) : ?>
+				required="required"
+			<?php endif; ?>
+		/>
 		<input type="text"
-			name="<?php echo esc_attr( $this->field['id'] ); ?>"
+			name="<?php echo esc_attr( $this->field['id'] ); ?>_datepicker"
 			id="<?php echo esc_attr( $this->field['id'] ); ?>"
 			class="<?php echo esc_attr( $this->field['class'] ); ?>"
-			value="<?php echo ! empty( $this->meta ) ? esc_attr( $this->meta ) : ''; ?>"
+			value="<?php echo ! empty( $this->meta ) ? esc_attr( $js_display_date ) : ''; ?>"
 			size="30"
 			<?php if ( isset( $this->field['required'] ) && $this->field['required'] ) : ?>
 			required="required"
@@ -92,9 +159,16 @@ class LLMS_Metabox_Date_Field extends LLMS_Metabox_Field implements Meta_Box_Fie
 			<?php if ( isset( $this->field['placeholder'] ) ) : ?>
 			placeholder="<?php echo esc_attr( $this->field['placeholder'] ); ?>"
 			<?php endif; ?>
-			<?php
-				echo wp_kses_post( $this->get_data_attrs() );
-				?>
+			data-format="<?php echo esc_attr( $this->field['date_displayformat'] ); ?>"
+			data-alt-format="<?php echo esc_attr( $this->field['date_format'] ); ?>"
+			<?php if ( ! empty( $this->field['date_max'] ) ) : ?>
+				data-max-date="<?php echo esc_attr( $this->field['date_max'] ); ?>"
+			<?php endif; ?>
+			<?php if ( ! empty( $this->field['date_min'] ) ) : ?>
+				data-min-date="<?php echo esc_attr( $this->field['date_min'] ); ?>"
+			<?php endif; ?>
+			data-alt-field="#<?php echo esc_attr( $this->field['id'] ); ?>_alt_datefield"
+
 		/>
 		<?php
 		parent::close_output();


### PR DESCRIPTION
## Description

- [ ] Need to handle when the alt field is cleared, to also clear the hidden input value

POC for having a datepicker that shows the format of the site, but saves using a hidden input in the previous format.

Fixes #2447

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

