### PR TITLE
Add new action on the free enroll form for use with turnstile or others

### DIFF
--- a/.changelogs/free-enroll-fields-action.yml
+++ b/.changelogs/free-enroll-fields-action.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: dev
+entry: Adds a new action so Turnstile or other captchas can be added without
+  editing the free-enroll-form.php template directly.

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -35,6 +35,8 @@ if ( ! $uid || empty( $plan ) || ! $plan->has_free_checkout() ) {
 	<input name="form" type="hidden" value="free_enroll">
 	<input name="llms_agree_to_terms" type="hidden" value="yes">
 
+	<?php do_action( 'lifterlms_after_free_enroll_fields' ); ?>
+
 	<button class="llms-button-action button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
 
 </form>


### PR DESCRIPTION

## Description
Adds a new action so Turnstile or other captchas can be added without editing the free-enroll-form.php template directly.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2025-04-01 at 1  53 54@2x](https://github.com/user-attachments/assets/c6507c39-1133-4fdc-b43d-76fb8308b49c)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

