### PR TITLE
Set the default date format of lifterlms_course_info to be the site date format.

### DIFF
--- a/.changelogs/2903-shortcode-date-format-does-not-match.yml
+++ b/.changelogs/2903-shortcode-date-format-does-not-match.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: changed
+links:
+  - "#2903"
+entry: Change default date display format of lifterlms_course_info used in
+  settings like Enrollment Start and End Date to match the site date format.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -422,13 +422,19 @@ class LLMS_Shortcodes {
 	 * @return string
 	 */
 	public static function course_info( $atts ) {
+
+		$default_type = '';
+		if ( isset( $atts['key'] ) && false !== strpos( $atts['key'], '_date' ) ) {
+			$default_type = 'date';
+		}
+
 		extract(
 			shortcode_atts(
 				array(
-					'date_format' => 'F j, Y', // If $type is date, a custom date format can be supplied.
+					'date_format' => get_option( 'date_format' ), // If $type is date, a custom date format can be supplied.
 					'id'          => get_the_ID(),
 					'key'         => '',
-					'type'        => '', // Can either be: date, price or empty string.
+					'type'        => $default_type, // Can either be: date, price or empty string.
 				),
 				$atts,
 				'lifterlms_course_info'


### PR DESCRIPTION

## Description

Fixes #2903

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
![CleanShot 2025-04-07 at 7  33 57@2x](https://github.com/user-attachments/assets/f0154b91-ab34-4bff-9930-dab9a87491b3)

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

