### PR TITLE
Fix/select2 error in editor

### DIFF
--- a/.changelogs/fix_select2-error-in-editor.yml
+++ b/.changelogs/fix_select2-error-in-editor.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2925"
+entry: Avoid console error when saving access plans when a free plan is included.

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -1195,6 +1195,10 @@ GROUP BY locations.meta_value";
 		}
 
 		$attrs['type'] = 'hidden';
+		if ( isset( $attrs['classes'] ) && strpos( $attrs['classes'], 'llms-select2' ) !== false ) {
+			// Avoids trying to register the select2 script when the field is a hidden field vs. select field.
+			$attrs['classes'] = str_replace( 'llms-select2', '', $attrs['classes'] );
+		}
 		return $attrs;
 	}
 


### PR DESCRIPTION

## Description

Avoids console error when access plans are saved when a free plan is included.

Fixes #2925

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

