### PR TITLE
Update payment method updates

### DIFF
--- a/.changelogs/update-payment-method-updates.yml
+++ b/.changelogs/update-payment-method-updates.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: changed
+links:
+  - "#2957"
+entry: Changes button text when updating a payment method,depending on whether
+  it's a payment gateway with an external payment page.

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -195,7 +195,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 				'safe' => false,
 			)
 		);
-
 	}
 
 	/**
@@ -226,7 +225,17 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		do_action( 'llms_dispatch_notification_processors' );
 
 		return $data;
+	}
 
+	/**
+	 * Whether the payment details are entered on an external payment page, or entered inline with the checkout form.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool
+	 */
+	public function is_external_payment_entry() {
+		return false;
 	}
 
 	/**
@@ -270,7 +279,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param string $gateway_id        The payment gateway ID.
 		 */
 		return apply_filters( 'llms_get_gateway_admin_description', $this->admin_description, $this->id );
-
 	}
 
 	/**
@@ -291,7 +299,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param string $gateway_id  The payment gateway ID.
 		 */
 		return apply_filters( 'llms_get_gateway_admin_title', $this->admin_title, $this->id );
-
 	}
 
 	/**
@@ -408,7 +415,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param string  $gateway_id The payment gateway ID.
 		 */
 		return apply_filters( 'llms_get_gateway_settings_fields', $fields, $this->id );
-
 	}
 
 	/**
@@ -475,7 +481,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param LLMS_Order $order    The order object.
 		 */
 		return esc_url( apply_filters( 'lifterlms_completed_transaction_redirect', $redirect, $order ) );
-
 	}
 
 	/**
@@ -615,7 +620,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		}
 
 		return sprintf( '<a href="%1$s" target="_blank">%2$s</a>', $url, $item_value );
-
 	}
 
 	/**
@@ -663,7 +667,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		}
 
 		return array_merge( $strings, $this->retrieve_secure_strings() );
-
 	}
 
 	/**
@@ -896,7 +899,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		}
 
 		remove_filter( 'llms_secure_strings', array( $this, 'get_secure_strings' ), 10, 2 );
-
 	}
 
 	/**
@@ -939,7 +941,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param string $gateway_id Payment gateway ID.
 		 */
 		return apply_filters( "llms_get_gateway_{$key}", $val, $this->id );
-
 	}
 
 	/**
@@ -1029,7 +1030,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		$gateway_strings = apply_filters( 'llms_get_gateway_secure_strings', $gateway_strings, $this->id );
 
 		return array_values( array_unique( $gateway_strings ) );
-
 	}
 
 	/**
@@ -1053,7 +1053,6 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -1080,5 +1079,4 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 */
 		return apply_filters( 'llms_can_gateway_process_access_plan', $plan || $order, $plan, $order, $this->id );
 	}
-
 }

--- a/templates/checkout/form-switch-source.php
+++ b/templates/checkout/form-switch-source.php
@@ -83,11 +83,11 @@ if ( 'llms-active' === $status ) {
 
 		<?php elseif ( $confirm && $gateway ) : ?>
 
-			<div class="llms-payment-method">
+			<div class="llms-payment-method llms-payment-gateway <?php echo esc_attr( $confirm ); ?>">
 				<?php do_action( 'lifterlms_checkout_confirm_before_payment_method', $gateway->get_id(), 'switch' ); ?>
 				<span class="llms-gateway-title"><span class="llms-label"><?php esc_html_e( 'Payment Method:', 'lifterlms' ); ?></span> <?php echo esc_html( $gateway->get_title() ); ?></span>
 				<?php if ( $gateway->get_icon() ) : ?>
-					<span class="llms-gateway-icon"><?php echo wp_kses_post( $gateway->get_icon() ); ?></span>
+					<span class="llms-gateway-icon llms-description"><?php echo wp_kses_post( $gateway->get_icon() ); ?></span>
 				<?php endif; ?>
 				<?php if ( $gateway->get_description() ) : ?>
 					<div class="llms-gateway-description"><?php echo wp_kses_post( wpautop( wptexturize( $gateway->get_description() ) ) ); ?></div>
@@ -104,17 +104,21 @@ if ( 'llms-active' === $status ) {
 		<input name="llms_switch_action" type="hidden" value="<?php echo esc_attr( $order->get_switch_source_action() ); ?>">
 
 		<?php
-		llms_form_field(
-			array(
-				'columns'     => 12,
-				'classes'     => 'llms-button-primary',
-				'id'          => 'llms_save_payment_method',
-				'value'       => $submit_text,
-				'last_column' => true,
-				'required'    => false,
-				'type'        => 'submit',
-			)
-		);
+		if ( apply_filters( 'llms_show_switch_save_payment_method_button', true, $order ) ) :
+
+			llms_form_field(
+				array(
+					'columns'     => 12,
+					'classes'     => 'llms-button-primary',
+					'id'          => 'llms_save_payment_method',
+					'value'       => $submit_text,
+					'last_column' => true,
+					'required'    => false,
+					'type'        => 'submit',
+				)
+			);
+
+		endif;
 		?>
 
 	</div>

--- a/templates/checkout/form-switch-source.php
+++ b/templates/checkout/form-switch-source.php
@@ -16,16 +16,23 @@
  */
 defined( 'ABSPATH' ) || exit;
 
-$status  = $order->get( 'status' );
-$gateway = llms()->payment_gateways()->get_gateway_by_id( $confirm );
-$plan    = llms_get_post( $order->get( 'plan_id' ) );
+$status        = $order->get( 'status' );
+$gateway       = llms()->payment_gateways()->get_gateway_by_id( $confirm );
+$order_gateway = llms()->payment_gateways()->get_gateway_by_id( $order->get( 'payment_gateway' ) );
+$plan          = llms_get_post( $order->get( 'plan_id' ) );
 if ( ! $plan ) {
 	return;
 }
 if ( 'llms-active' === $status ) {
-	$submit_text = __( 'Save Payment Method', 'lifterlms' );
+	if ( $order_gateway && $order_gateway->is_external_payment_entry() ) {
+		$submit_text = __( 'Save and Continue', 'lifterlms' );
+	} else {
+		$submit_text = __( 'Save Payment Method', 'lifterlms' );
+	}
 } elseif ( 'llms-pending-cancel' === $status ) {
 	$submit_text = __( 'Reactivate Subscription', 'lifterlms' );
+} elseif ( $order_gateway && $order_gateway->is_external_payment_entry() ) {
+	$submit_text = __( 'Save and Continue', 'lifterlms' );
 } else {
 	$submit_text = __( 'Save and Pay Now', 'lifterlms' );
 }


### PR DESCRIPTION
## Description
Renames the button to "Save and Continue" for both an overdue amount, and when switching the payment method, if using Stripe Checkout. Needs the updated version of the Stripe gateway add-on to have an effect.

Fixes #2957

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1384" height="1418" alt="CleanShot 2025-07-11 at 11  23 34@2x" src="https://github.com/user-attachments/assets/ed1045bc-61d2-4a4f-baa9-6e14a7817fba" />
<img width="1442" height="1166" alt="CleanShot 2025-07-11 at 11  23 18@2x" src="https://github.com/user-attachments/assets/5900eef3-2c79-4a76-83bc-db627d14129d" />
<img width="1402" height="690" alt="CleanShot 2025-07-11 at 12  07 05@2x" src="https://github.com/user-attachments/assets/959dd309-9647-44f4-ad61-136dce6daa46" />


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

