### PR TITLE
Filter for whether to send notification to a subscriber

### DIFF
--- a/.changelogs/notification-filter.yml
+++ b/.changelogs/notification-filter.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: dev
+entry: Adding hookable filter for notification sending.

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -499,7 +499,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 				 *
 				 * @since [version]
 				 */
-				if ( ! apply_filters( 'llms_send_notification_to_subscriber', true, $this, $subscriber, $this->post_id ) ) {
+				if ( ! apply_filters( 'llms_send_notification_to_subscriber', true, $this, $subscriber, $type, $this->post_id ) ) {
 					continue;
 				}
 

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -499,7 +499,7 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 				 *
 				 * @since [version]
 				 */
-				if ( ! apply_filters( 'llms_send_notification_to_subscriber', true, $this, $subscriber ) ) {
+				if ( ! apply_filters( 'llms_send_notification_to_subscriber', true, $this, $subscriber, $this->post_id ) ) {
 					continue;
 				}
 

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -162,7 +162,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		}
 
 		return self::$_instances[ $class ];
-
 	}
 
 	/**
@@ -175,7 +174,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	private function __construct() {
 
 		$this->add_actions();
-
 	}
 
 	/**
@@ -190,7 +188,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		foreach ( $this->action_hooks as $hook ) {
 			add_action( $hook, array( $this, 'action_callback' ), $this->action_accepted_args, $this->action_priority );
 		}
-
 	}
 
 	/**
@@ -245,7 +242,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -269,7 +265,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		$notification->set( 'trigger_id', $this->id );
 
 		return llms()->notifications()->get_view( $notification );
-
 	}
 
 	/**
@@ -356,7 +351,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 			$arr['enabled'] = $enabled;
 			return $arr;
 		}
-
 	}
 
 	/**
@@ -462,7 +456,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		);
 
 		return $query->has_results();
-
 	}
 
 	/**
@@ -480,7 +473,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -502,9 +494,16 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 
 		foreach ( $this->get_subscriptions() as $subscriber => $types ) {
 			foreach ( $types as $type ) {
+				/**
+				 * Filter to determine if a notification should be sent to a subscriber.
+				 *
+				 * @since [version]
+				 */
+				if ( ! apply_filters( 'llms_send_notification_to_subscriber', true, $this, $subscriber ) ) {
+					continue;
+				}
 
 				$this->send_one( $type, $subscriber, $force );
-
 			}
 		}
 
@@ -515,7 +514,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		 * This happens when receipts are triggered in bulk by action scheduler.
 		 */
 		$this->unset_subscriptions();
-
 	}
 
 	/**
@@ -569,7 +567,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		}
 
 		return $id;
-
 	}
 
 	/**
@@ -641,7 +638,6 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 		}
 
 		$this->subscriptions[ $subscriber ] = $subscriptions;
-
 	}
 
 	/**
@@ -667,5 +663,4 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	public function unset_subscriptions() {
 		$this->subscriptions = array();
 	}
-
 }


### PR DESCRIPTION
## Description
Adding a new filter so notifications can be programmatically turned off. For example, to only send enrollment notifications for memberships and not courses:

```
add_filter(
	'llms_send_notification_to_subscriber',
	function ( $send, $notification, $subscriber, $type, $post_id ) {
		if ( 'enrollment' === $notification->id && 'llms_membership' !== get_post_type( $post_id ) ) {
			$send = false;
		}

		return $send;
	},
	10,
	5
);
```

## How has this been tested?
Manually

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

