### PR TITLE
Improved individual order formatting

### DIFF
--- a/.changelogs/fix_order-formatting.yml
+++ b/.changelogs/fix_order-formatting.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Improved formatting of the individual order page.

--- a/assets/scss/frontend/_student-dashboard.scss
+++ b/assets/scss/frontend/_student-dashboard.scss
@@ -75,6 +75,7 @@
 		border: 1px solid $color-border;
 		border-spacing: 0;
 		width: 100%;
+		margin: 10px 0;
 
 		thead {
 			display: none;
@@ -160,35 +161,13 @@
 		.llms-change-password { display: none; }
 	}
 
-	.order-primary {
-
-		@media all and ( min-width: 600px ) {
-			float: left;
-			width: 68%;
-		}
-
+	.order-primary, .order-secondary {
+		width: 100%;
 	}
+
 	.order-secondary {
-
-		@media all and ( min-width: 600px ) {
-			float: left;
-			width: 32%;
-		}
-
-		form {
-			margin-bottom: 0;
-		}
-
-	}
-
-	// stack columns when alternate layout declared via filter
-	@media all and ( min-width: 600px ) {
-		.llms-view-order.llms-stack-cols {
-			.order-primary,
-			.order-secondary {
-				float: none;
-				width: 100%;
-			}
+		.llms-form-field {
+			padding: 10px 0;
 		}
 	}
 

--- a/templates/checkout/form-switch-source.php
+++ b/templates/checkout/form-switch-source.php
@@ -37,7 +37,7 @@ if ( 'llms-active' === $status ) {
 	llms_form_field(
 		array(
 			'columns'     => 12,
-			'classes'     => 'llms-button-secondary',
+			'classes'     => 'llms-button-primary',
 			'id'          => 'llms_update_payment_method',
 			'value'       => 'llms-pending-cancel' === $status ? __( 'Reactivate Subscription', 'lifterlms' ) : __( 'Update Payment Method', 'lifterlms' ),
 			'last_column' => true,

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -29,7 +29,7 @@ defined( 'ABSPATH' ) || exit;
 			</thead>
 			<tbody>
 			<?php foreach ( $orders['orders'] as $order ) : ?>
-				<tr class="llms-order-item <?php echo esc_attr( $order->get( 'status' ) ); ?>" id="llms-order-<?php esc_attr( $order->get( 'id' ) ); ?>">
+				<tr class="llms-order-item <?php echo esc_attr( $order->get( 'status' ) ); ?>" id="llms-order-<?php echo esc_attr( $order->get( 'id' ) ); ?>">
 					<td data-label="<?php esc_attr_e( 'Order', 'lifterlms' ); ?>: ">
 						<a href="<?php echo esc_url( $order->get_view_link() ); ?>">#<?php echo esc_html( $order->get( 'id' ) ); ?></a>
 						<span class="llms-status <?php echo esc_attr( $order->get( 'status' ) ); ?>"><?php echo esc_html( $order->get_status_name() ); ?></span>


### PR DESCRIPTION

## Description

Improved formatting of the individual order screen. Single column instead of float left/right with a 32% width right column.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1772" height="2614" alt="CleanShot 2025-07-14 at 9  43 16@2x" src="https://github.com/user-attachments/assets/bc804878-b202-44ff-8d1a-a3aa1173be3f" />
<img width="2508" height="2174" alt="CleanShot 2025-07-14 at 9  43 36@2x" src="https://github.com/user-attachments/assets/4a1277fa-9e5d-40ca-806f-50cb5bb8dcb3" />
<img width="2638" height="2578" alt="CleanShot 2025-07-14 at 9  44 08@2x" src="https://github.com/user-attachments/assets/220abac6-541d-4ec8-b4ed-174ffbdb20ed" />


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

