### PR TITLE
Switch to Edit link beside engagements 

### DIFF
--- a/.changelogs/fix_view-button-engagement-1.yml
+++ b/.changelogs/fix_view-button-engagement-1.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#2962"
+entry: Avoid duplicated buttons when changing the Engagement Type when editing
+  an engagement.

--- a/.changelogs/fix_view-button-engagement.yml
+++ b/.changelogs/fix_view-button-engagement.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#2961"
+entry: Fix link beside selected engagement when editing an engagement.

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -981,9 +981,9 @@
 					var id = $( this ).val();
 					if ( id ) {
 						if ( editBtn ) {
-							$btn.attr( 'href', window.llms.admin_url + 'post.php?action=edit&post=' + id ).show();
+							$btn.attr( 'href', window.llms.admin_url + 'post.php?action=edit&post=' + parseInt( id )  ).show();
 						} else {
-							$btn.attr( 'href', window.llms.home_url + '/?p=' + id ).show();
+							$btn.attr( 'href', window.llms.home_url + '/?p=' + parseInt( id ) ).show();
 						}
 					} else {
 						$btn.hide();

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -970,24 +970,28 @@
 				return;
 			}
 
-			// add a "View" button to see what the selected page looks like
-			var msg  = editBtn ? LLMS.l10n.translate( 'Edit' ) : LLMS.l10n.translate( 'View' ),
-				$btn = $( '<a class="llms-button-secondary small" style="margin-left:5px;" target="_blank" href="#">' + msg + ' <i class="fa fa-external-link" aria-hidden="true"></i></a>' );
-			$el.next( '.select2' ).after( $btn );
+			// add a "View" button to see what the selected page looks like, if it doesn't already exist.
+			$btn = $el.next('.select2').next( 'a.llms-button-secondary' );
+			if ( ! $btn.length ) {
+				var msg  = editBtn ? LLMS.l10n.translate( 'Edit' ) : LLMS.l10n.translate( 'View' ),
+					$btn = $( '<a class="llms-button-secondary small" style="margin-left:5px;" target="_blank" href="#">' + msg + ' <i class="fa fa-external-link" aria-hidden="true"></i></a>' );
+				$el.next( '.select2' ).after( $btn );
 
-			$el.on( 'change', function() {
-				var id = $( this ).val();
-				if ( id ) {
-					if ( editBtn ) {
-						$btn.attr( 'href', window.llms.admin_url + 'post.php?action=edit&post=' + id ).show();
+				$el.on( 'change', function() {
+					var id = $( this ).val();
+					if ( id ) {
+						if ( editBtn ) {
+							$btn.attr( 'href', window.llms.admin_url + 'post.php?action=edit&post=' + id ).show();
+						} else {
+							$btn.attr( 'href', window.llms.home_url + '/?p=' + id ).show();
+						}
 					} else {
-						$btn.attr( 'href', window.llms.home_url + '/?p=' + id ).show();
+						$btn.hide();
 					}
-				} else {
-					$btn.hide();
-				}
-			} ).trigger( 'change' );
+				} );
+			}
 
+			$el.trigger( 'change' );
 		};
 
 		/**

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -971,7 +971,7 @@
 			}
 
 			// add a "View" button to see what the selected page looks like
-			var msg  = LLMS.l10n.translate( 'View' ),
+			var msg  = editBtn ? LLMS.l10n.translate( 'Edit' ) : LLMS.l10n.translate( 'View' ),
 				$btn = $( '<a class="llms-button-secondary small" style="margin-left:5px;" target="_blank" href="#">' + msg + ' <i class="fa fa-external-link" aria-hidden="true"></i></a>' );
 			$el.next( '.select2' ).after( $btn );
 

--- a/assets/js/private/llms-metaboxes.js
+++ b/assets/js/private/llms-metaboxes.js
@@ -959,7 +959,8 @@
 		this.post_select = function( $el ) {
 
 			var multi = 'multiple' === $el.attr( 'multiple' ),
-				noViewBtn = $el.attr( 'data-no-view-button' );
+				noViewBtn = $el.attr( 'data-no-view-button' ),
+				editBtn = $el.attr( 'data-edit-button' );
 
 			$el.llmsPostsSelect2( {
 				width: multi || noViewBtn ? '100%' : '65%',
@@ -977,7 +978,11 @@
 			$el.on( 'change', function() {
 				var id = $( this ).val();
 				if ( id ) {
-					$btn.attr( 'href', window.llms.home_url + '/?p=' + id ).show();
+					if ( editBtn ) {
+						$btn.attr( 'href', window.llms.admin_url + 'post.php?action=edit&post=' + id ).show();
+					} else {
+						$btn.attr( 'href', window.llms.home_url + '/?p=' + id ).show();
+					}
 				} else {
 					$btn.hide();
 				}

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
@@ -33,7 +33,6 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 			'llms_engagement',
 		);
 		$this->priority = 'high';
-
 	}
 
 	/**
@@ -194,6 +193,7 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				'allow_clear' => true,
 				'placeholder' => __( 'Select an Engagement', 'lifterlms' ),
 				'post-type'   => $default,
+				'edit-button' => true,
 			),
 			'id'              => $this->prefix . 'engagement',
 			'label'           => __( 'Select an Engagement', 'lifterlms' ),
@@ -217,7 +217,6 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				'fields' => $fields,
 			),
 		);
-
 	}
 
 	/**
@@ -341,7 +340,5 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 		}
 
 		update_post_meta( $post_id, $this->prefix . 'engagement_trigger_post', $val );
-
 	}
-
 }


### PR DESCRIPTION
## Description
Show edit link instead of a broken View link.

Also avoid multiple buttons showing if Engagement Type is changed.

Fixes #2961 and #2962

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3660" height="1680" alt="CleanShot 2025-07-14 at 4  06 08@2x" src="https://github.com/user-attachments/assets/e34c99dd-2ec1-4c8e-9f10-cb359aee24ad" />

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

