### PR TITLE
Fixes for course based media protection

### DIFF
--- a/assets/scss/admin/_media-protection.scss
+++ b/assets/scss/admin/_media-protection.scss
@@ -4,8 +4,3 @@
 	max-width: 400px;
 	margin: 10px 0;
 }
-
-.media-modal-content .compat-field-llms_media_protection_post .field {
-	width: 100%;
-	margin: 0;
-}

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -28,8 +28,7 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 
 		$selected_product_html = $protection_warning_html = '';
 		$selected_product_id   = get_post_meta( $post->ID, '_llms_media_protection_product_id', true );
-		if ( $selected_product_id ) {
-			$selected_product      = get_post( $selected_product_id );
+		if ( $selected_product_id && ( $selected_product      = get_post( $selected_product_id ) ) ) {
 			$selected_product_html = sprintf( '<option value="%d" selected="selected">%s</option>', $selected_product->ID, $selected_product->post_title );
 		}
 

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -35,14 +35,15 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 		$protector = new LLMS_Media_Protector();
 		if ( ! $protector->is_media_protected( $post->ID ) ) {
 			// translators: %s is a link to the LifterLMS documentation.
-			$protection_warning_html = '<div class="llms-media-protection-warning">' . sprintf( __( 'This media is not protected. If you select a product here, the media will be moved to the protected uploads directory and existing links to the media will no longer work. %1$sLearn More%2$s', 'lifterlms' ), '<a target="_blank" href="https://lifterlms.com/docs/how-protected-media-files-work/">', '</a>' ) . '</div>';
+			$protection_warning_html = '<div class="llms-media-protection-warning">' . sprintf( __( 'This media is not protected. If you select a product here, the media will be moved to the protected uploads directory and existing links to the media will no longer work. %1$sLearn More%2$s', 'lifterlms' ), '<a target="_blank" href="https://lifterlms.com/docs/how-protected-media-files-work/?utm_source=LifterLMS%20Plugin&utm_medium=Media&utm_campaign=Backend%20Help%20Page">', '</a>' ) . '</div>';
 		}
 
 		$form_fields['llms_media_protection_post'] = array(
-			'label' => __( 'LifterLMS Media Protection', 'lifterlms' ),
+			'label' => __( 'LifterLMS Media Protection:', 'lifterlms' ),
 			'input' => 'html',
 			// TODO: Add selected course/membership to the select2 dropdown if known for this attachment post.
 			'html'  => "$protection_warning_html<select id='attachments-" . $post->ID . "-llms_media_protection_post' class='llms-posts-select2' data-no-view-button='true' data-allow_clear='false' data-post-type='course,llms_membership' name='attachments[" . $post->ID . "][llms_media_protection_post]'>$selected_product_html</select>",
+			'helps' => $protector->is_media_protected( $post->ID ) ? sprintf( __( 'Access is restricted to the selected course/membership. %1$sLearn More%2$s', 'lifterlms' ), '<a target="_blank" href="https://lifterlms.com/docs/how-protected-media-files-work/?utm_source=LifterLMS%20Plugin&utm_medium=Media&utm_campaign=Backend%20Help%20Page">', '</a>' ) : '',
 		);
 
 		return $form_fields;

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -173,7 +173,7 @@ class LLMS_Admin_Assets {
 			return true;
 		} elseif ( in_array( $screen->id, array( 'users' ), true ) ) {
 			return true;
-		} elseif ( 'attachment' === $id ) {
+		} elseif ( 'attachment' === $id || 'upload' === $id ) {
 			return true;
 		}
 


### PR DESCRIPTION
## Description

Loading styling when using the media library in Grid view (with modals). Avoid warnings if the product used to protect a media file is deleted.

No PR since these are changes for a feature that hasn't been released yet.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3314" height="1308" alt="CleanShot 2025-07-21 at 2  11 20@2x" src="https://github.com/user-attachments/assets/33db6189-eb44-4f67-8d4c-21375054be60" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

