### PR TITLE
Additional quiz filters and links

### DIFF
--- a/.changelogs/additional-quiz-filters-links.yml
+++ b/.changelogs/additional-quiz-filters-links.yml
@@ -1,0 +1,4 @@
+significance: minor
+type: added
+entry: New tabs to view students who have not yet attempted a quiz, and listing
+  of all quiz attempts for a student.

--- a/includes/admin/reporting/tables/llms.table.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.attempts.php
@@ -66,7 +66,7 @@ class LLMS_Table_Quiz_Attempts extends LLMS_Admin_Table {
 	 *
 	 * @var  boolean
 	 */
-	protected $is_searchable = false;
+	protected $is_searchable = true;
 
 	/**
 	 * Results sort order
@@ -224,6 +224,11 @@ class LLMS_Table_Quiz_Attempts extends LLMS_Admin_Table {
 			'quiz_id'    => $args['quiz_id'],
 			'student_id' => isset( $args['student_id'] ) ? $args['student_id'] : null,
 		);
+
+		// Add search functionality
+		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
+			$query_args['search'] = sanitize_text_field( $args['search'] );
+		}
 
 		if ( 'any' !== $this->filter ) {
 			$query_args['status'] = $this->filter;

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -123,7 +123,7 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 				} else {
 					$value = $last . ', ' . $first;
 				}
-				
+
 				$id = $student->get_id();
 				if ( current_user_can( 'edit_users', $id ) ) {
 					$value = '<a href="' . esc_url( get_edit_user_link( $id ) ) . '">' . $value . '</a>';
@@ -135,24 +135,24 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 				break;
 
 			case 'enrolled_courses':
-				$quiz = llms_get_post( $this->quiz_id );
+				$quiz   = llms_get_post( $this->quiz_id );
 				$course = $quiz ? $quiz->get_course() : false;
-				
+
 				if ( $course ) {
 					$enrollment_date = $student->get_enrollment_date( $course->get( 'id' ) );
-					$value = $enrollment_date ? $enrollment_date : '&mdash;';
+					$value           = $enrollment_date ? $enrollment_date : '&mdash;';
 				} else {
 					$value = '&mdash;';
 				}
 				break;
 
 			case 'status':
-				$quiz = llms_get_post( $this->quiz_id );
+				$quiz   = llms_get_post( $this->quiz_id );
 				$course = $quiz ? $quiz->get_course() : false;
-				
+
 				if ( $course ) {
 					$status = $student->get_enrollment_status( $course->get( 'id' ) );
-					$value = ucfirst( $status );
+					$value  = ucfirst( $status );
 				} else {
 					$value = '&mdash;';
 				}
@@ -210,19 +210,23 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			return;
 		}
 
-		// Get all enrolled students in the course  
-		$enrolled_students = llms_get_enrolled_students( $course->get( 'id' ), array( 'enrolled', 'expired', 'cancelled' ), -1, 0 );
-		
+		// Get all enrolled students in the course
+		// TODO: Run a single query to join enrollments and quiz attempts.
+		$enrolled_students = llms_get_enrolled_students( $course->get( 'id' ), array( 'enrolled', 'expired', 'cancelled' ), 1000, 0 );
+
 		if ( empty( $enrolled_students ) ) {
 			$this->tbody_data = array();
 			return;
 		}
 
 		// Get students who have attempted the quiz
-		$attempted_query = new LLMS_Query_Quiz_Attempt( array(
-			'quiz_id'  => $this->quiz_id,
-			'per_page' => -1,
-		) );
+		$attempted_query = new LLMS_Query_Quiz_Attempt(
+			array(
+				'quiz_id'  => $this->quiz_id,
+				// TODO: Switch to query lack of attempts for students who are enrolled in the course directly.
+				'per_page' => 10000,
+			)
+		);
 
 		$attempted_student_ids = array();
 		if ( $attempted_query->has_results() ) {
@@ -244,21 +248,21 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 
 		// Apply search filter
 		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
-			$search_term = sanitize_text_field( $args['search'] );
+			$search_term  = sanitize_text_field( $args['search'] );
 			$filtered_ids = array();
-			
+
 			foreach ( $non_attempted_student_ids as $student_id ) {
 				$student = llms_get_student( $student_id );
 				if ( $student ) {
-					$name = $student->get( 'display_name' );
+					$name  = $student->get( 'display_name' );
 					$email = $student->get( 'user_email' );
 					$first = $student->get( 'first_name' );
-					$last = $student->get( 'last_name' );
-					
+					$last  = $student->get( 'last_name' );
+
 					if ( stripos( $name, $search_term ) !== false ||
-						 stripos( $email, $search_term ) !== false ||
-						 stripos( $first, $search_term ) !== false ||
-						 stripos( $last, $search_term ) !== false ) {
+						stripos( $email, $search_term ) !== false ||
+						stripos( $first, $search_term ) !== false ||
+						stripos( $last, $search_term ) !== false ) {
 						$filtered_ids[] = $student_id;
 					}
 				}
@@ -290,8 +294,8 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 					$sort_key = '';
 					switch ( $this->orderby ) {
 						case 'name':
-							$first = $student->get( 'first_name' );
-							$last = $student->get( 'last_name' );
+							$first    = $student->get( 'first_name' );
+							$last     = $student->get( 'last_name' );
 							$sort_key = ! empty( $last ) ? $last : $student->get( 'display_name' );
 							break;
 						case 'id':
@@ -304,31 +308,37 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 							$sort_key = $student->get( 'display_name' );
 					}
 					$students_with_data[] = array(
-						'student' => $student,
+						'student'  => $student,
 						'sort_key' => strtolower( $sort_key ),
 					);
 				}
 			}
 
 			// Sort the array
-			usort( $students_with_data, function( $a, $b ) {
-				if ( 'DESC' === $this->order ) {
-					return strcmp( $b['sort_key'], $a['sort_key'] );
+			usort(
+				$students_with_data,
+				function ( $a, $b ) {
+					if ( 'DESC' === $this->order ) {
+						return strcmp( $b['sort_key'], $a['sort_key'] );
+					}
+					return strcmp( $a['sort_key'], $b['sort_key'] );
 				}
-				return strcmp( $a['sort_key'], $b['sort_key'] );
-			});
+			);
 
 			// Extract sorted students
-			$sorted_students = array_map( function( $item ) {
-				return $item['student'];
-			}, $students_with_data );
+			$sorted_students = array_map(
+				function ( $item ) {
+					return $item['student'];
+				},
+				$students_with_data
+			);
 
 			// Pagination
-			$total_results = count( $sorted_students );
-			$this->max_pages = ceil( $total_results / $per );
+			$total_results      = count( $sorted_students );
+			$this->max_pages    = ceil( $total_results / $per );
 			$this->is_last_page = ( $this->current_page >= $this->max_pages );
 
-			$offset = ( $this->current_page - 1 ) * $per;
+			$offset           = ( $this->current_page - 1 ) * $per;
 			$this->tbody_data = array_slice( $sorted_students, $offset, $per );
 		} else {
 			$this->tbody_data = array();
@@ -357,17 +367,17 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 	protected function set_columns() {
 
 		$cols = array(
-			'id' => array(
+			'id'               => array(
 				'exportable' => true,
 				'title'      => __( 'ID', 'lifterlms' ),
 				'sortable'   => true,
 			),
-			'name' => array(
+			'name'             => array(
 				'exportable' => true,
 				'title'      => __( 'Name', 'lifterlms' ),
 				'sortable'   => true,
 			),
-			'email' => array(
+			'email'            => array(
 				'exportable' => true,
 				'title'      => __( 'Email', 'lifterlms' ),
 				'sortable'   => true,
@@ -377,10 +387,10 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 				'title'      => __( 'Enrollment Date', 'lifterlms' ),
 				'sortable'   => false,
 			),
-			'status' => array(
+			'status'           => array(
 				'filterable' => array(
-					'enrolled' => __( 'Enrolled', 'lifterlms' ),
-					'expired'  => __( 'Expired', 'lifterlms' ),
+					'enrolled'  => __( 'Enrolled', 'lifterlms' ),
+					'expired'   => __( 'Expired', 'lifterlms' ),
 					'cancelled' => __( 'Cancelled', 'lifterlms' ),
 				),
 				'exportable' => true,

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -194,7 +194,6 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 		$this->filter   = isset( $args['filter'] ) ? $args['filter'] : $this->get_filter();
 		$this->filterby = isset( $args['filterby'] ) ? $args['filterby'] : $this->get_filterby();
 
-		// Check permissions
 		if ( ! ( current_user_can( 'view_others_lifterlms_reports' ) || ( current_user_can( 'view_lifterlms_reports' ) && current_user_can( 'edit_post', $args['quiz_id'] ) ) ) ) {
 			return;
 		}
@@ -217,14 +216,14 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 		$search_sql = '';
 		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
 			$search_term = sanitize_text_field( $args['search'] );
-			$search_sql = $wpdb->prepare(
-				"AND (
-					u.user_login LIKE %s 
-					OR u.user_email LIKE %s 
+			$search_sql  = $wpdb->prepare(
+				'AND (
+					u.user_login LIKE %s
+					OR u.user_email LIKE %s
 					OR u.display_name LIKE %s
 					OR m_first.meta_value LIKE %s
 					OR m_last.meta_value LIKE %s
-				)",
+				)',
 				'%' . $search_term . '%',
 				'%' . $search_term . '%',
 				'%' . $search_term . '%',
@@ -273,25 +272,25 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 					upm.meta_value as enrollment_status,
 					upm.updated_date as enrollment_date
 				FROM {$wpdb->users} u
-				INNER JOIN {$wpdb->prefix}lifterlms_user_postmeta upm 
-					ON u.ID = upm.user_id 
-					AND upm.post_id = %d 
+				INNER JOIN {$wpdb->prefix}lifterlms_user_postmeta upm
+					ON u.ID = upm.user_id
+					AND upm.post_id = %d
 					AND upm.meta_key = '_status'
 					{$status_sql}
-				LEFT JOIN {$wpdb->usermeta} m_first 
-					ON u.ID = m_first.user_id 
+				LEFT JOIN {$wpdb->usermeta} m_first
+					ON u.ID = m_first.user_id
 					AND m_first.meta_key = 'first_name'
-				LEFT JOIN {$wpdb->usermeta} m_last 
-					ON u.ID = m_last.user_id 
+				LEFT JOIN {$wpdb->usermeta} m_last
+					ON u.ID = m_last.user_id
 					AND m_last.meta_key = 'last_name'
-				LEFT JOIN {$wpdb->prefix}lifterlms_quiz_attempts qa 
-					ON u.ID = qa.student_id 
+				LEFT JOIN {$wpdb->prefix}lifterlms_quiz_attempts qa
+					ON u.ID = qa.student_id
 					AND qa.quiz_id = %d
 				WHERE upm.updated_date = (
-					SELECT MAX(upm2.updated_date) 
-					FROM {$wpdb->prefix}lifterlms_user_postmeta upm2 
-					WHERE upm2.user_id = u.ID 
-					AND upm2.post_id = %d 
+					SELECT MAX(upm2.updated_date)
+					FROM {$wpdb->prefix}lifterlms_user_postmeta upm2
+					WHERE upm2.user_id = u.ID
+					AND upm2.post_id = %d
 					AND upm2.meta_key = '_status'
 				)
 				AND qa.id IS NULL
@@ -310,7 +309,7 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 		$total_results = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
 
 		// Set pagination data
-		$this->max_pages = ceil( $total_results / $per );
+		$this->max_pages    = ceil( $total_results / $per );
 		$this->is_last_page = ( $this->current_page >= $this->max_pages );
 
 		// Convert results to LLMS_Student objects

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -5,7 +5,6 @@
  * @package LifterLMS/Admin/Reporting/Tables/Classes
  *
  * @since [version]
- * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -167,7 +166,7 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 	}
 
 	/**
-	 * Execute a query to retrieve results from the table
+	 * Execute a query to retrieve results from the table.
 	 *
 	 * @since [version]
 	 *
@@ -198,7 +197,6 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			return;
 		}
 
-		// Get the quiz and course
 		$quiz = llms_get_post( $this->quiz_id );
 		if ( ! $quiz ) {
 			return;
@@ -209,10 +207,9 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			return;
 		}
 
-		// Use a single optimized database query
+		// Use a single optimized database query.
 		global $wpdb;
 
-		// Build search WHERE clause
 		$search_sql = '';
 		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
 			$search_term = sanitize_text_field( $args['search'] );
@@ -232,16 +229,12 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			);
 		}
 
-		// Build status WHERE clause
-		$status_sql = '';
 		if ( 'any' !== $this->filter ) {
 			$status_sql = $wpdb->prepare( 'AND upm.meta_value = %s', $this->filter );
 		} else {
 			$status_sql = "AND upm.meta_value IN ('enrolled', 'expired', 'cancelled')";
 		}
 
-		// Build ORDER BY clause
-		$order_sql = '';
 		switch ( $this->orderby ) {
 			case 'name':
 				$order_sql = 'ORDER BY m_last.meta_value ' . $this->order . ', m_first.meta_value ' . $this->order;
@@ -256,10 +249,8 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 				$order_sql = 'ORDER BY u.display_name ' . $this->order;
 		}
 
-		// Calculate offset
 		$offset = ( $this->current_page - 1 ) * $per;
 
-		// Single query to get students enrolled in course who haven't attempted the quiz
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT SQL_CALC_FOUND_ROWS DISTINCT
@@ -305,14 +296,11 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			)
 		);
 
-		// Get total count
 		$total_results = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
 
-		// Set pagination data
 		$this->max_pages    = ceil( $total_results / $per );
 		$this->is_last_page = ( $this->current_page >= $this->max_pages );
 
-		// Convert results to LLMS_Student objects
 		$this->tbody_data = array();
 		if ( ! empty( $results ) ) {
 			foreach ( $results as $result ) {

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -210,138 +210,115 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			return;
 		}
 
-		// Get all enrolled students in the course
-		// TODO: Run a single query to join enrollments and quiz attempts.
-		$enrolled_students = llms_get_enrolled_students( $course->get( 'id' ), array( 'enrolled', 'expired', 'cancelled' ), 1000, 0 );
+		// Use a single optimized database query
+		global $wpdb;
 
-		if ( empty( $enrolled_students ) ) {
-			$this->tbody_data = array();
-			return;
+		// Build search WHERE clause
+		$search_sql = '';
+		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
+			$search_term = sanitize_text_field( $args['search'] );
+			$search_sql = $wpdb->prepare(
+				"AND (
+					u.user_login LIKE %s 
+					OR u.user_email LIKE %s 
+					OR u.display_name LIKE %s
+					OR m_first.meta_value LIKE %s
+					OR m_last.meta_value LIKE %s
+				)",
+				'%' . $search_term . '%',
+				'%' . $search_term . '%',
+				'%' . $search_term . '%',
+				'%' . $search_term . '%',
+				'%' . $search_term . '%'
+			);
 		}
 
-		// Get students who have attempted the quiz
-		$attempted_query = new LLMS_Query_Quiz_Attempt(
-			array(
-				'quiz_id'  => $this->quiz_id,
-				// TODO: Switch to query lack of attempts for students who are enrolled in the course directly.
-				'per_page' => 10000,
+		// Build status WHERE clause
+		$status_sql = '';
+		if ( 'any' !== $this->filter ) {
+			$status_sql = $wpdb->prepare( 'AND upm.meta_value = %s', $this->filter );
+		} else {
+			$status_sql = "AND upm.meta_value IN ('enrolled', 'expired', 'cancelled')";
+		}
+
+		// Build ORDER BY clause
+		$order_sql = '';
+		switch ( $this->orderby ) {
+			case 'name':
+				$order_sql = 'ORDER BY m_last.meta_value ' . $this->order . ', m_first.meta_value ' . $this->order;
+				break;
+			case 'id':
+				$order_sql = 'ORDER BY u.ID ' . $this->order;
+				break;
+			case 'email':
+				$order_sql = 'ORDER BY u.user_email ' . $this->order;
+				break;
+			default:
+				$order_sql = 'ORDER BY u.display_name ' . $this->order;
+		}
+
+		// Calculate offset
+		$offset = ( $this->current_page - 1 ) * $per;
+
+		// Single query to get students enrolled in course who haven't attempted the quiz
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT SQL_CALC_FOUND_ROWS DISTINCT
+					u.ID as user_id,
+					u.user_email,
+					u.display_name,
+					u.user_registered,
+					m_first.meta_value as first_name,
+					m_last.meta_value as last_name,
+					upm.meta_value as enrollment_status,
+					upm.updated_date as enrollment_date
+				FROM {$wpdb->users} u
+				INNER JOIN {$wpdb->prefix}lifterlms_user_postmeta upm 
+					ON u.ID = upm.user_id 
+					AND upm.post_id = %d 
+					AND upm.meta_key = '_status'
+					{$status_sql}
+				LEFT JOIN {$wpdb->usermeta} m_first 
+					ON u.ID = m_first.user_id 
+					AND m_first.meta_key = 'first_name'
+				LEFT JOIN {$wpdb->usermeta} m_last 
+					ON u.ID = m_last.user_id 
+					AND m_last.meta_key = 'last_name'
+				LEFT JOIN {$wpdb->prefix}lifterlms_quiz_attempts qa 
+					ON u.ID = qa.student_id 
+					AND qa.quiz_id = %d
+				WHERE upm.updated_date = (
+					SELECT MAX(upm2.updated_date) 
+					FROM {$wpdb->prefix}lifterlms_user_postmeta upm2 
+					WHERE upm2.user_id = u.ID 
+					AND upm2.post_id = %d 
+					AND upm2.meta_key = '_status'
+				)
+				AND qa.id IS NULL
+				{$search_sql}
+				{$order_sql}
+				LIMIT %d, %d",
+				$course->get( 'id' ),    // Course ID for enrollment check
+				$this->quiz_id,          // Quiz ID for attempt check
+				$course->get( 'id' ),    // Course ID for latest enrollment status
+				$offset,
+				$per
 			)
 		);
 
-		$attempted_student_ids = array();
-		if ( $attempted_query->has_results() ) {
-			foreach ( $attempted_query->get_attempts() as $attempt ) {
-				$student = $attempt->get_student();
-				if ( $student ) {
-					$attempted_student_ids[] = $student->get_id();
-				}
+		// Get total count
+		$total_results = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+		// Set pagination data
+		$this->max_pages = ceil( $total_results / $per );
+		$this->is_last_page = ( $this->current_page >= $this->max_pages );
+
+		// Convert results to LLMS_Student objects
+		$this->tbody_data = array();
+		if ( ! empty( $results ) ) {
+			foreach ( $results as $result ) {
+				$this->tbody_data[] = llms_get_student( $result->user_id );
 			}
-		}
-
-		// Get students who haven't attempted
-		$non_attempted_student_ids = array_diff( $enrolled_students, $attempted_student_ids );
-
-		if ( empty( $non_attempted_student_ids ) ) {
-			$this->tbody_data = array();
-			return;
-		}
-
-		// Apply search filter
-		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
-			$search_term  = sanitize_text_field( $args['search'] );
-			$filtered_ids = array();
-
-			foreach ( $non_attempted_student_ids as $student_id ) {
-				$student = llms_get_student( $student_id );
-				if ( $student ) {
-					$name  = $student->get( 'display_name' );
-					$email = $student->get( 'user_email' );
-					$first = $student->get( 'first_name' );
-					$last  = $student->get( 'last_name' );
-
-					if ( stripos( $name, $search_term ) !== false ||
-						stripos( $email, $search_term ) !== false ||
-						stripos( $first, $search_term ) !== false ||
-						stripos( $last, $search_term ) !== false ) {
-						$filtered_ids[] = $student_id;
-					}
-				}
-			}
-			$non_attempted_student_ids = $filtered_ids;
-		}
-
-		// Apply enrollment status filter
-		if ( 'any' !== $this->filter ) {
-			$filtered_ids = array();
-			foreach ( $non_attempted_student_ids as $student_id ) {
-				$student = llms_get_student( $student_id );
-				if ( $student ) {
-					$status = $student->get_enrollment_status( $course->get( 'id' ) );
-					if ( $status === $this->filter ) {
-						$filtered_ids[] = $student_id;
-					}
-				}
-			}
-			$non_attempted_student_ids = $filtered_ids;
-		}
-
-		// Sort students
-		if ( ! empty( $non_attempted_student_ids ) ) {
-			$students_with_data = array();
-			foreach ( $non_attempted_student_ids as $student_id ) {
-				$student = llms_get_student( $student_id );
-				if ( $student ) {
-					$sort_key = '';
-					switch ( $this->orderby ) {
-						case 'name':
-							$first    = $student->get( 'first_name' );
-							$last     = $student->get( 'last_name' );
-							$sort_key = ! empty( $last ) ? $last : $student->get( 'display_name' );
-							break;
-						case 'id':
-							$sort_key = $student->get_id();
-							break;
-						case 'email':
-							$sort_key = $student->get( 'user_email' );
-							break;
-						default:
-							$sort_key = $student->get( 'display_name' );
-					}
-					$students_with_data[] = array(
-						'student'  => $student,
-						'sort_key' => strtolower( $sort_key ),
-					);
-				}
-			}
-
-			// Sort the array
-			usort(
-				$students_with_data,
-				function ( $a, $b ) {
-					if ( 'DESC' === $this->order ) {
-						return strcmp( $b['sort_key'], $a['sort_key'] );
-					}
-					return strcmp( $a['sort_key'], $b['sort_key'] );
-				}
-			);
-
-			// Extract sorted students
-			$sorted_students = array_map(
-				function ( $item ) {
-					return $item['student'];
-				},
-				$students_with_data
-			);
-
-			// Pagination
-			$total_results      = count( $sorted_students );
-			$this->max_pages    = ceil( $total_results / $per );
-			$this->is_last_page = ( $this->current_page >= $this->max_pages );
-
-			$offset           = ( $this->current_page - 1 ) * $per;
-			$this->tbody_data = array_slice( $sorted_students, $offset, $per );
-		} else {
-			$this->tbody_data = array();
 		}
 	}
 

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -1,0 +1,394 @@
+<?php
+/**
+ * Quiz Non-Attempts Reporting Table
+ *
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Table_Quiz_Non_Attempts class.
+ *
+ * Displays students enrolled in courses containing a quiz but who have not attempted the quiz.
+ *
+ * @since [version]
+ */
+class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
+
+	/**
+	 * Unique ID for the Table
+	 *
+	 * @var  string
+	 */
+	protected $id = 'quiz_non_attempts';
+
+	/**
+	 * Value of the field being filtered by
+	 * Only applicable if $filterby is set
+	 *
+	 * @var  string
+	 */
+	protected $filter = 'any';
+
+	/**
+	 * Field results are filtered by
+	 *
+	 * @var  string
+	 */
+	protected $filterby = 'status';
+
+	/**
+	 * Is the Table Exportable?
+	 *
+	 * @var  boolean
+	 */
+	protected $is_exportable = true;
+
+	/**
+	 * Determine if the table is filterable
+	 *
+	 * @var  boolean
+	 */
+	protected $is_filterable = true;
+
+	/**
+	 * If true, tfoot will add ajax pagination links
+	 *
+	 * @var  boolean
+	 */
+	protected $is_paginated = true;
+
+	/**
+	 * Determine of the table is searchable
+	 *
+	 * @var  boolean
+	 */
+	protected $is_searchable = true;
+
+	/**
+	 * Results sort order
+	 * 'ASC' or 'DESC'
+	 * Only applicable of $orderby is not set
+	 *
+	 * @var  string
+	 */
+	protected $order = 'ASC';
+
+	/**
+	 * Field results are sorted by
+	 *
+	 * @var  string
+	 */
+	protected $orderby = 'name';
+
+	/**
+	 * WP Post ID of the displayed quiz
+	 *
+	 * @var  null
+	 */
+	protected $quiz_id = null;
+
+	/**
+	 * Retrieve data for a cell.
+	 *
+	 * @since [version]
+	 *
+	 * @param string       $key     The column id / key.
+	 * @param LLMS_Student $student LLMS_Student obj.
+	 * @return mixed
+	 */
+	protected function get_data( $key, $student ) {
+
+		switch ( $key ) {
+
+			case 'id':
+				$id = $student->get_id();
+				if ( current_user_can( 'edit_users', $id ) ) {
+					$value = '<a href="' . esc_url( get_edit_user_link( $id ) ) . '">' . $id . '</a>';
+				} else {
+					$value = $id;
+				}
+				break;
+
+			case 'name':
+				$first = $student->get( 'first_name' );
+				$last  = $student->get( 'last_name' );
+
+				if ( ! $first || ! $last ) {
+					$value = $student->get( 'display_name' );
+				} else {
+					$value = $last . ', ' . $first;
+				}
+				
+				$id = $student->get_id();
+				if ( current_user_can( 'edit_users', $id ) ) {
+					$value = '<a href="' . esc_url( get_edit_user_link( $id ) ) . '">' . $value . '</a>';
+				}
+				break;
+
+			case 'email':
+				$value = $student->get( 'user_email' );
+				break;
+
+			case 'enrolled_courses':
+				$quiz = llms_get_post( $this->quiz_id );
+				$course = $quiz ? $quiz->get_course() : false;
+				
+				if ( $course ) {
+					$enrollment_date = $student->get_enrollment_date( $course->get( 'id' ) );
+					$value = $enrollment_date ? $enrollment_date : '&mdash;';
+				} else {
+					$value = '&mdash;';
+				}
+				break;
+
+			case 'status':
+				$quiz = llms_get_post( $this->quiz_id );
+				$course = $quiz ? $quiz->get_course() : false;
+				
+				if ( $course ) {
+					$status = $student->get_enrollment_status( $course->get( 'id' ) );
+					$value = ucfirst( $status );
+				} else {
+					$value = '&mdash;';
+				}
+				break;
+
+			default:
+				$value = $key;
+
+		}// End switch().
+
+		return $value;
+	}
+
+	/**
+	 * Execute a query to retrieve results from the table
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of query args.
+	 * @return void
+	 */
+	public function get_results( $args = array() ) {
+
+		$this->title = __( 'Students Without Quiz Attempts', 'lifterlms' );
+
+		$args = $this->clean_args( $args );
+
+		$this->quiz_id = $args['quiz_id'];
+
+		if ( isset( $args['page'] ) ) {
+			$this->current_page = absint( $args['page'] );
+		}
+
+		$per = apply_filters( 'llms_reporting_' . $this->id . '_per_page', 25 );
+
+		$this->order   = isset( $args['order'] ) ? $args['order'] : $this->order;
+		$this->orderby = isset( $args['orderby'] ) ? $args['orderby'] : $this->orderby;
+
+		$this->filter   = isset( $args['filter'] ) ? $args['filter'] : $this->get_filter();
+		$this->filterby = isset( $args['filterby'] ) ? $args['filterby'] : $this->get_filterby();
+
+		// Check permissions
+		if ( ! ( current_user_can( 'view_others_lifterlms_reports' ) || ( current_user_can( 'view_lifterlms_reports' ) && current_user_can( 'edit_post', $args['quiz_id'] ) ) ) ) {
+			return;
+		}
+
+		// Get the quiz and course
+		$quiz = llms_get_post( $this->quiz_id );
+		if ( ! $quiz ) {
+			return;
+		}
+
+		$course = $quiz->get_course();
+		if ( ! $course ) {
+			return;
+		}
+
+		// Get all enrolled students in the course  
+		$enrolled_students = llms_get_enrolled_students( $course->get( 'id' ), array( 'enrolled', 'expired', 'cancelled' ), -1, 0 );
+		
+		if ( empty( $enrolled_students ) ) {
+			$this->tbody_data = array();
+			return;
+		}
+
+		// Get students who have attempted the quiz
+		$attempted_query = new LLMS_Query_Quiz_Attempt( array(
+			'quiz_id'  => $this->quiz_id,
+			'per_page' => -1,
+		) );
+
+		$attempted_student_ids = array();
+		if ( $attempted_query->has_results() ) {
+			foreach ( $attempted_query->get_attempts() as $attempt ) {
+				$student = $attempt->get_student();
+				if ( $student ) {
+					$attempted_student_ids[] = $student->get_id();
+				}
+			}
+		}
+
+		// Get students who haven't attempted
+		$non_attempted_student_ids = array_diff( $enrolled_students, $attempted_student_ids );
+
+		if ( empty( $non_attempted_student_ids ) ) {
+			$this->tbody_data = array();
+			return;
+		}
+
+		// Apply search filter
+		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
+			$search_term = sanitize_text_field( $args['search'] );
+			$filtered_ids = array();
+			
+			foreach ( $non_attempted_student_ids as $student_id ) {
+				$student = llms_get_student( $student_id );
+				if ( $student ) {
+					$name = $student->get( 'display_name' );
+					$email = $student->get( 'user_email' );
+					$first = $student->get( 'first_name' );
+					$last = $student->get( 'last_name' );
+					
+					if ( stripos( $name, $search_term ) !== false ||
+						 stripos( $email, $search_term ) !== false ||
+						 stripos( $first, $search_term ) !== false ||
+						 stripos( $last, $search_term ) !== false ) {
+						$filtered_ids[] = $student_id;
+					}
+				}
+			}
+			$non_attempted_student_ids = $filtered_ids;
+		}
+
+		// Apply enrollment status filter
+		if ( 'any' !== $this->filter ) {
+			$filtered_ids = array();
+			foreach ( $non_attempted_student_ids as $student_id ) {
+				$student = llms_get_student( $student_id );
+				if ( $student ) {
+					$status = $student->get_enrollment_status( $course->get( 'id' ) );
+					if ( $status === $this->filter ) {
+						$filtered_ids[] = $student_id;
+					}
+				}
+			}
+			$non_attempted_student_ids = $filtered_ids;
+		}
+
+		// Sort students
+		if ( ! empty( $non_attempted_student_ids ) ) {
+			$students_with_data = array();
+			foreach ( $non_attempted_student_ids as $student_id ) {
+				$student = llms_get_student( $student_id );
+				if ( $student ) {
+					$sort_key = '';
+					switch ( $this->orderby ) {
+						case 'name':
+							$first = $student->get( 'first_name' );
+							$last = $student->get( 'last_name' );
+							$sort_key = ! empty( $last ) ? $last : $student->get( 'display_name' );
+							break;
+						case 'id':
+							$sort_key = $student->get_id();
+							break;
+						case 'email':
+							$sort_key = $student->get( 'user_email' );
+							break;
+						default:
+							$sort_key = $student->get( 'display_name' );
+					}
+					$students_with_data[] = array(
+						'student' => $student,
+						'sort_key' => strtolower( $sort_key ),
+					);
+				}
+			}
+
+			// Sort the array
+			usort( $students_with_data, function( $a, $b ) {
+				if ( 'DESC' === $this->order ) {
+					return strcmp( $b['sort_key'], $a['sort_key'] );
+				}
+				return strcmp( $a['sort_key'], $b['sort_key'] );
+			});
+
+			// Extract sorted students
+			$sorted_students = array_map( function( $item ) {
+				return $item['student'];
+			}, $students_with_data );
+
+			// Pagination
+			$total_results = count( $sorted_students );
+			$this->max_pages = ceil( $total_results / $per );
+			$this->is_last_page = ( $this->current_page >= $this->max_pages );
+
+			$offset = ( $this->current_page - 1 ) * $per;
+			$this->tbody_data = array_slice( $sorted_students, $offset, $per );
+		} else {
+			$this->tbody_data = array();
+		}
+	}
+
+	/**
+	 * Define the structure of arguments used to pass to the get_results method
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function set_args() {
+		return array(
+			'quiz_id' => ! empty( $this->quiz_id ) ? $this->quiz_id : ( isset( $_GET['quiz_id'] ) ? absint( $_GET['quiz_id'] ) : null ),
+		);
+	}
+
+	/**
+	 * Define the structure of the table
+	 *
+	 * @return array
+	 * @since [version]
+	 */
+	protected function set_columns() {
+
+		$cols = array(
+			'id' => array(
+				'exportable' => true,
+				'title'      => __( 'ID', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'name' => array(
+				'exportable' => true,
+				'title'      => __( 'Name', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'email' => array(
+				'exportable' => true,
+				'title'      => __( 'Email', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'enrolled_courses' => array(
+				'exportable' => true,
+				'title'      => __( 'Enrollment Date', 'lifterlms' ),
+				'sortable'   => false,
+			),
+			'status' => array(
+				'filterable' => array(
+					'enrolled' => __( 'Enrolled', 'lifterlms' ),
+					'expired'  => __( 'Expired', 'lifterlms' ),
+					'cancelled' => __( 'Cancelled', 'lifterlms' ),
+				),
+				'exportable' => true,
+				'title'      => __( 'Status', 'lifterlms' ),
+				'sortable'   => false,
+			),
+		);
+
+		return $cols;
+	}
+}

--- a/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
@@ -109,14 +109,14 @@ class LLMS_Table_Student_Quiz_Attempts extends LLMS_Admin_Table {
 				$quiz = $attempt->get_quiz();
 				if ( $quiz ) {
 					$value = $quiz->get( 'title' );
-					
+
 					// Add link to quiz attempts if user has permission
 					if ( current_user_can( 'edit_post', $quiz->get( 'id' ) ) ) {
-						$url = LLMS_Admin_Reporting::get_current_tab_url(
+						$url   = LLMS_Admin_Reporting::get_current_tab_url(
 							array(
-								'tab'        => 'quizzes',
-								'stab'       => 'attempts',
-								'quiz_id'    => $quiz->get( 'id' ),
+								'tab'     => 'quizzes',
+								'stab'    => 'attempts',
+								'quiz_id' => $quiz->get( 'id' ),
 							)
 						);
 						$value = '<a href="' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
@@ -127,28 +127,20 @@ class LLMS_Table_Student_Quiz_Attempts extends LLMS_Admin_Table {
 				break;
 
 			case 'course':
-				$quiz = $attempt->get_quiz();
+				$value = '&mdash;';
+				$quiz  = $attempt->get_quiz();
 				if ( $quiz ) {
 					$course = $quiz->get_course();
 					if ( $course ) {
-						$value = $course->get( 'title' );
-						
-						// Add link to course if user has permission
-						if ( current_user_can( 'edit_post', $course->get( 'id' ) ) ) {
-							$url = LLMS_Admin_Reporting::get_current_tab_url(
-								array(
-									'tab'        => 'courses',
-									'stab'       => 'overview',
-									'course_id'  => $course->get( 'id' ),
-								)
-							);
-							$value = '<a href="' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
-						}
-					} else {
-						$value = __( '[Deleted Course]', 'lifterlms' );
+						$url   = LLMS_Admin_Reporting::get_current_tab_url(
+							array(
+								'tab'       => 'courses',
+								'stab'      => 'overview',
+								'course_id' => $course->get( 'id' ),
+							)
+						);
+						$value = '<a href="' . esc_url( $url ) . '">' . esc_html( $course->get( 'title' ) ) . '</a>';
 					}
-				} else {
-					$value = '&ndash;';
 				}
 				break;
 
@@ -253,17 +245,17 @@ class LLMS_Table_Student_Quiz_Attempts extends LLMS_Admin_Table {
 			// For search, we'll need to get quiz IDs that match the search term
 			global $wpdb;
 			$search_term = sanitize_text_field( $args['search'] );
-			
+
 			$quiz_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts} 
-					WHERE post_type = 'llms_quiz' 
+					"SELECT ID FROM {$wpdb->posts}
+					WHERE post_type = 'llms_quiz'
 					AND post_status = 'publish'
 					AND post_title LIKE %s",
 					'%' . $search_term . '%'
 				)
 			);
-			
+
 			if ( ! empty( $quiz_ids ) ) {
 				$query_args['quiz_id'] = $quiz_ids;
 			} else {

--- a/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
@@ -242,27 +242,7 @@ class LLMS_Table_Student_Quiz_Attempts extends LLMS_Admin_Table {
 
 		// Add search functionality
 		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
-			// For search, we'll need to get quiz IDs that match the search term
-			global $wpdb;
-			$search_term = sanitize_text_field( $args['search'] );
-
-			$quiz_ids = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->posts}
-					WHERE post_type = 'llms_quiz'
-					AND post_status = 'publish'
-					AND post_title LIKE %s",
-					'%' . $search_term . '%'
-				)
-			);
-
-			if ( ! empty( $quiz_ids ) ) {
-				$query_args['quiz_id'] = $quiz_ids;
-			} else {
-				// No matching quizzes, return empty results
-				$this->tbody_data = array();
-				return;
-			}
+			$query_args['search'] = $args['search'];
 		}
 
 		if ( 'any' !== $this->filter ) {

--- a/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.student.quiz.attempts.php
@@ -1,0 +1,360 @@
+<?php
+/**
+ * Student Quiz Attempts Reporting Table
+ *
+ * @package LifterLMS/Admin/Reporting/Tables/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Table_Student_Quiz_Attempts class.
+ *
+ * Displays all quiz attempts for a specific student across all courses.
+ *
+ * @since [version]
+ */
+class LLMS_Table_Student_Quiz_Attempts extends LLMS_Admin_Table {
+
+	/**
+	 * Unique ID for the Table
+	 *
+	 * @var  string
+	 */
+	protected $id = 'student_quiz_attempts';
+
+	/**
+	 * Value of the field being filtered by
+	 * Only applicable if $filterby is set
+	 *
+	 * @var  string
+	 */
+	protected $filter = 'any';
+
+	/**
+	 * Field results are filtered by
+	 *
+	 * @var  string
+	 */
+	protected $filterby = 'grade';
+
+	/**
+	 * Is the Table Exportable?
+	 *
+	 * @var  boolean
+	 */
+	protected $is_exportable = true;
+
+	/**
+	 * Determine if the table is filterable
+	 *
+	 * @var  boolean
+	 */
+	protected $is_filterable = true;
+
+	/**
+	 * If true, tfoot will add ajax pagination links
+	 *
+	 * @var  boolean
+	 */
+	protected $is_paginated = true;
+
+	/**
+	 * Determine of the table is searchable
+	 *
+	 * @var  boolean
+	 */
+	protected $is_searchable = true;
+
+	/**
+	 * Results sort order
+	 * 'ASC' or 'DESC'
+	 * Only applicable of $orderby is not set
+	 *
+	 * @var  string
+	 */
+	protected $order = 'DESC';
+
+	/**
+	 * Field results are sorted by
+	 *
+	 * @var  string
+	 */
+	protected $orderby = 'id';
+
+	/**
+	 * Student ID for the displayed student
+	 *
+	 * @var  null
+	 */
+	protected $student_id = null;
+
+	/**
+	 * Retrieve data for a cell.
+	 *
+	 * @since [version]
+	 *
+	 * @param string            $key     The column id / key.
+	 * @param LLMS_Quiz_Attempt $attempt LLMS_Quiz_Attempt obj.
+	 * @return mixed
+	 */
+	protected function get_data( $key, $attempt ) {
+
+		switch ( $key ) {
+
+			case 'quiz':
+				$quiz = $attempt->get_quiz();
+				if ( $quiz ) {
+					$value = $quiz->get( 'title' );
+					
+					// Add link to quiz attempts if user has permission
+					if ( current_user_can( 'edit_post', $quiz->get( 'id' ) ) ) {
+						$url = LLMS_Admin_Reporting::get_current_tab_url(
+							array(
+								'tab'        => 'quizzes',
+								'stab'       => 'attempts',
+								'quiz_id'    => $quiz->get( 'id' ),
+							)
+						);
+						$value = '<a href="' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
+					}
+				} else {
+					$value = __( '[Deleted Quiz]', 'lifterlms' );
+				}
+				break;
+
+			case 'course':
+				$quiz = $attempt->get_quiz();
+				if ( $quiz ) {
+					$course = $quiz->get_course();
+					if ( $course ) {
+						$value = $course->get( 'title' );
+						
+						// Add link to course if user has permission
+						if ( current_user_can( 'edit_post', $course->get( 'id' ) ) ) {
+							$url = LLMS_Admin_Reporting::get_current_tab_url(
+								array(
+									'tab'        => 'courses',
+									'stab'       => 'overview',
+									'course_id'  => $course->get( 'id' ),
+								)
+							);
+							$value = '<a href="' . esc_url( $url ) . '">' . esc_html( $value ) . '</a>';
+						}
+					} else {
+						$value = __( '[Deleted Course]', 'lifterlms' );
+					}
+				} else {
+					$value = '&ndash;';
+				}
+				break;
+
+			case 'lesson':
+				$quiz = $attempt->get_quiz();
+				if ( $quiz ) {
+					$lesson = $quiz->get_lesson();
+					if ( $lesson ) {
+						$value = $lesson->get( 'title' );
+					} else {
+						$value = __( '[Deleted Lesson]', 'lifterlms' );
+					}
+				} else {
+					$value = '&ndash;';
+				}
+				break;
+
+			case 'attempt':
+				$value = '#' . $attempt->get( $key );
+				break;
+
+			case 'grade':
+				$value      = $attempt->get( $key ) ? $attempt->get( $key ) . '%' : '0%';
+				$additional = $attempt->l10n( 'status' );
+				if ( $attempt->can_be_resumed() && $attempt->is_last_attempt() ) {
+					$additional .= ' - ' . esc_html__( 'Can be resumed', 'lifterlms' );
+				}
+				$value .= ' (' . $additional . ')';
+				break;
+
+			case 'start_date':
+			case 'end_date':
+				$value = '&ndash;';
+				$date  = $attempt->get( $key );
+				if ( $date ) {
+					$value = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $date ) );
+				}
+				break;
+
+			case 'id':
+				$value = sprintf( '%2$d (%1$s)', $attempt->get_key(), $attempt->get( 'id' ) );
+
+				$url = LLMS_Admin_Reporting::get_current_tab_url(
+					array(
+						'tab'        => 'quizzes',
+						'stab'       => 'attempts',
+						'quiz_id'    => $attempt->get( 'quiz_id' ),
+						'attempt_id' => $attempt->get( 'id' ),
+					)
+				);
+
+				$value = '<a href="' . esc_url( $url ) . '">' . $value . '</a>';
+				break;
+
+			default:
+				$value = $key;
+
+		}// End switch().
+
+		return $value;
+	}
+
+	/**
+	 * Execute a query to retrieve results from the table
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args Array of query args.
+	 * @return void
+	 */
+	public function get_results( $args = array() ) {
+
+		$this->title = __( 'Quiz Attempts', 'lifterlms' );
+
+		$args = $this->clean_args( $args );
+
+		$this->student_id = $args['student_id'];
+
+		if ( isset( $args['page'] ) ) {
+			$this->current_page = absint( $args['page'] );
+		}
+
+		$per = apply_filters( 'llms_reporting_' . $this->id . '_per_page', 25 );
+
+		$this->order   = isset( $args['order'] ) ? $args['order'] : $this->order;
+		$this->orderby = isset( $args['orderby'] ) ? $args['orderby'] : $this->orderby;
+
+		$this->filter   = isset( $args['filter'] ) ? $args['filter'] : $this->get_filter();
+		$this->filterby = isset( $args['filterby'] ) ? $args['filterby'] : $this->get_filterby();
+
+		$query_args = array(
+			'sort'       => array(
+				$this->orderby => $this->order,
+			),
+			'page'       => $this->current_page,
+			'per_page'   => $per,
+			'student_id' => $this->student_id,
+		);
+
+		// Add search functionality
+		if ( isset( $args['search'] ) && ! empty( $args['search'] ) ) {
+			// For search, we'll need to get quiz IDs that match the search term
+			global $wpdb;
+			$search_term = sanitize_text_field( $args['search'] );
+			
+			$quiz_ids = $wpdb->get_col(
+				$wpdb->prepare(
+					"SELECT ID FROM {$wpdb->posts} 
+					WHERE post_type = 'llms_quiz' 
+					AND post_status = 'publish'
+					AND post_title LIKE %s",
+					'%' . $search_term . '%'
+				)
+			);
+			
+			if ( ! empty( $quiz_ids ) ) {
+				$query_args['quiz_id'] = $quiz_ids;
+			} else {
+				// No matching quizzes, return empty results
+				$this->tbody_data = array();
+				return;
+			}
+		}
+
+		if ( 'any' !== $this->filter ) {
+			$query_args['status'] = $this->filter;
+		}
+
+		// Check permissions
+		if ( ! current_user_can( 'view_others_lifterlms_reports' ) && ! llms_current_user_can( 'view_lifterlms_reports', $this->student_id ) ) {
+			return;
+		}
+
+		$query = new LLMS_Query_Quiz_Attempt( $query_args );
+
+		$this->max_pages    = $query->get_max_pages();
+		$this->is_last_page = $query->is_last_page();
+
+		$this->tbody_data = $query->get_attempts();
+	}
+
+	/**
+	 * Define the structure of arguments used to pass to the get_results method
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	public function set_args() {
+		return array(
+			'student_id' => ! empty( $this->student_id ) ? $this->student_id : ( isset( $_GET['student_id'] ) ? absint( $_GET['student_id'] ) : null ),
+		);
+	}
+
+	/**
+	 * Define the structure of the table
+	 *
+	 * @return array
+	 * @since [version]
+	 */
+	protected function set_columns() {
+
+		$cols = array(
+			'id'         => array(
+				'exportable' => true,
+				'title'      => __( 'ID', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'quiz'       => array(
+				'exportable' => true,
+				'title'      => __( 'Quiz', 'lifterlms' ),
+				'sortable'   => false,
+			),
+			'course'     => array(
+				'exportable' => true,
+				'title'      => __( 'Course', 'lifterlms' ),
+				'sortable'   => false,
+			),
+			'lesson'     => array(
+				'exportable' => true,
+				'title'      => __( 'Lesson', 'lifterlms' ),
+				'sortable'   => false,
+			),
+			'attempt'    => array(
+				'exportable' => true,
+				'title'      => __( 'Attempt #', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'grade'      => array(
+				'filterable' => llms_get_quiz_attempt_statuses(),
+				'exportable' => true,
+				'title'      => __( 'Grade', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'start_date' => array(
+				'exportable' => true,
+				'title'      => __( 'Start Date', 'lifterlms' ),
+				'sortable'   => true,
+			),
+			'end_date'   => array(
+				'exportable' => true,
+				'title'      => __( 'End Date', 'lifterlms' ),
+				'sortable'   => true,
+			),
+		);
+
+		return $cols;
+	}
+}

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.quizzes.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.quizzes.php
@@ -83,8 +83,9 @@ class LLMS_Admin_Reporting_Tab_Quizzes {
 			$tabs = apply_filters(
 				'llms_reporting_tab_quiz_tabs',
 				array(
-					'overview' => __( 'Overview', 'lifterlms' ),
-					'attempts' => __( 'Attempts', 'lifterlms' ),
+					'overview'     => __( 'Overview', 'lifterlms' ),
+					'attempts'     => __( 'Attempts', 'lifterlms' ),
+					'non-attempts' => __( 'Students Without Attempts', 'lifterlms' ),
 				)
 			);
 

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
@@ -119,7 +119,6 @@ class LLMS_Admin_Reporting_Tab_Students {
 					'achievements'           => __( 'Achievements', 'lifterlms' ),
 					'certificates'           => __( 'Certificates', 'lifterlms' ),
 					'quiz_attempts'          => __( 'Quiz Attempts', 'lifterlms' ),
-					'assignment_submissions' => __( 'Assignment Submissions', 'lifterlms' ),
 				)
 			);
 

--- a/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
+++ b/includes/admin/reporting/tabs/class.llms.admin.reporting.tab.students.php
@@ -113,11 +113,13 @@ class LLMS_Admin_Reporting_Tab_Students {
 			$tabs = apply_filters(
 				'llms_reporting_tab_student_tabs',
 				array(
-					'information'  => __( 'Information', 'lifterlms' ),
-					'courses'      => __( 'Courses', 'lifterlms' ),
-					'memberships'  => __( 'Memberships', 'lifterlms' ),
-					'achievements' => __( 'Achievements', 'lifterlms' ),
-					'certificates' => __( 'Certificates', 'lifterlms' ),
+					'information'            => __( 'Information', 'lifterlms' ),
+					'courses'                => __( 'Courses', 'lifterlms' ),
+					'memberships'            => __( 'Memberships', 'lifterlms' ),
+					'achievements'           => __( 'Achievements', 'lifterlms' ),
+					'certificates'           => __( 'Certificates', 'lifterlms' ),
+					'quiz_attempts'          => __( 'Quiz Attempts', 'lifterlms' ),
+					'assignment_submissions' => __( 'Assignment Submissions', 'lifterlms' ),
 				)
 			);
 

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -168,6 +168,8 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 			$joins .= " LEFT JOIN {$wpdb->users} u ON qa.student_id = u.ID";
 			$joins .= " LEFT JOIN {$wpdb->usermeta} um_first ON u.ID = um_first.user_id AND um_first.meta_key = 'first_name'";
 			$joins .= " LEFT JOIN {$wpdb->usermeta} um_last ON u.ID = um_last.user_id AND um_last.meta_key = 'last_name'";
+			// Add in posts of type llms_quiz for search functionality
+			$joins .= " LEFT JOIN {$wpdb->posts} p ON qa.quiz_id = p.ID AND p.post_type = 'llms_quiz'";
 		}
 
 		return $joins;
@@ -237,7 +239,9 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 					OR u.display_name LIKE %s
 					OR um_first.meta_value LIKE %s
 					OR um_last.meta_value LIKE %s
+					OR p.post_title LIKE %s
 				)',
+				'%' . $search . '%',
 				'%' . $search . '%',
 				'%' . $search . '%',
 				'%' . $search . '%',

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -64,12 +64,12 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 			'attempt'        => null,
 			'exclude'        => array(),
 			'can_be_resumed' => null,
+			'search'         => '',
 		);
 
 		$args = wp_parse_args( $args, parent::get_default_args() );
 
 		return apply_filters( $this->get_filter( 'default_args' ), $args );
-
 	}
 
 	/**
@@ -96,7 +96,6 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 		}
 
 		return apply_filters( $this->get_filter( 'get_attempts' ), $attempts );
-
 	}
 
 	/**
@@ -131,7 +130,6 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 				$this->arguments[ $key ] = array_intersect( $valid_statuses, $this->arguments[ $key ] );
 			}
 		}
-
 	}
 
 	/**
@@ -146,12 +144,33 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		return "SELECT SQL_CALC_FOUND_ROWS id
-				FROM {$wpdb->prefix}lifterlms_quiz_attempts
-				{$this->sql_where()}
-				{$this->sql_orderby()}
-				{$this->sql_limit()};";
+		$select = 'SELECT SQL_CALC_FOUND_ROWS qa.id';
+		$from   = "FROM {$wpdb->prefix}lifterlms_quiz_attempts qa";
+		$joins  = $this->sql_joins();
 
+		return "{$select} {$from} {$joins} {$this->sql_where()} {$this->sql_orderby()} {$this->sql_limit()};";
+	}
+
+	/**
+	 * SQL "joins" clause for the query.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function sql_joins() {
+		global $wpdb;
+
+		$joins = '';
+
+		// Join users table for search functionality
+		if ( $this->get( 'search' ) ) {
+			$joins .= " LEFT JOIN {$wpdb->users} u ON qa.student_id = u.ID";
+			$joins .= " LEFT JOIN {$wpdb->usermeta} um_first ON u.ID = um_first.user_id AND um_first.meta_key = 'first_name'";
+			$joins .= " LEFT JOIN {$wpdb->usermeta} um_last ON u.ID = um_last.user_id AND um_last.meta_key = 'last_name'";
+		}
+
+		return $joins;
 	}
 
 	/**
@@ -174,42 +193,59 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 			$ids = $this->get( $key );
 			if ( $ids ) {
 				$prepared = implode( ',', $ids );
-				$sql     .= " AND {$key} IN ({$prepared})";
+				$sql     .= " AND qa.{$key} IN ({$prepared})";
 			}
 		}
 
 		// Add attempt lookup.
 		$val = $this->get( 'attempt' );
 		if ( '' !== $val ) {
-			$sql .= $wpdb->prepare( ' AND attempt = %d', $val );
+			$sql .= $wpdb->prepare( ' AND qa.attempt = %d', $val );
 		}
 
 		// Add attempt exclude.
 		$exclude = $this->get( 'exclude' );
 		if ( $exclude ) {
 			$prepared = implode( ',', $exclude );
-			$sql     .= " AND id NOT IN ({$prepared})";
+			$sql     .= " AND qa.id NOT IN ({$prepared})";
 		}
 
 		$status = $this->get( 'status' );
 		if ( $status ) {
 			$prepared = implode( ',', array_map( array( $this, 'escape_and_quote_string' ), $status ) );
-			$sql     .= " AND status IN ({$prepared})";
+			$sql     .= " AND qa.status IN ({$prepared})";
 		}
 
 		$status_exclude = $this->get( 'status_exclude' );
 		if ( $status_exclude ) {
 			$prepared = implode( ',', array_map( array( $this, 'escape_and_quote_string' ), $status_exclude ) );
-			$sql     .= " AND status NOT IN ({$prepared})";
+			$sql     .= " AND qa.status NOT IN ({$prepared})";
 		}
 
 		$can_be_resumed = $this->get( 'can_be_resumed' );
 		if ( '' !== $can_be_resumed ) {
-			$sql .= $wpdb->prepare( ' AND can_be_resumed = %d', $can_be_resumed );
+			$sql .= $wpdb->prepare( ' AND qa.can_be_resumed = %d', $can_be_resumed );
+		}
+
+		$search = $this->get( 'search' );
+		if ( $search ) {
+			$search = $wpdb->esc_like( $search );
+			$sql   .= $wpdb->prepare(
+				' AND (
+					u.user_login LIKE %s
+					OR u.user_email LIKE %s
+					OR u.display_name LIKE %s
+					OR um_first.meta_value LIKE %s
+					OR um_last.meta_value LIKE %s
+				)',
+				'%' . $search . '%',
+				'%' . $search . '%',
+				'%' . $search . '%',
+				'%' . $search . '%',
+				'%' . $search . '%'
+			);
 		}
 
 		return apply_filters( $this->get_filter( 'where' ), $sql, $this );
-
 	}
-
 }

--- a/templates/admin/reporting/tabs/quizzes/attempts.php
+++ b/templates/admin/reporting/tabs/quizzes/attempts.php
@@ -26,10 +26,26 @@ if ( isset( $_GET['attempt_id'] ) ) {
 
 } else {
 
+	// Display link to non-attempts view
+	$quiz_id = llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT );
+	$non_attempts_url = LLMS_Admin_Reporting::get_current_tab_url(
+		array(
+			'tab'    => 'quizzes',
+			'stab'   => 'non-attempts',
+			'quiz_id' => $quiz_id,
+		)
+	);
+	
+	echo '<div style="margin-bottom: 20px;">';
+	echo '<a href="' . esc_url( $non_attempts_url ) . '" class="button button-secondary">';
+	echo esc_html__( 'View Students Without Attempts', 'lifterlms' );
+	echo '</a>';
+	echo '</div>';
+
 	$table = new LLMS_Table_Quiz_Attempts();
 	$table->get_results(
 		array(
-			'quiz_id' => llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT ),
+			'quiz_id' => $quiz_id,
 		)
 	);
 	$table->output_table_html();

--- a/templates/admin/reporting/tabs/quizzes/attempts.php
+++ b/templates/admin/reporting/tabs/quizzes/attempts.php
@@ -26,26 +26,10 @@ if ( isset( $_GET['attempt_id'] ) ) {
 
 } else {
 
-	// Display link to non-attempts view
-	$quiz_id = llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT );
-	$non_attempts_url = LLMS_Admin_Reporting::get_current_tab_url(
-		array(
-			'tab'    => 'quizzes',
-			'stab'   => 'non-attempts',
-			'quiz_id' => $quiz_id,
-		)
-	);
-	
-	echo '<div style="margin-bottom: 20px;">';
-	echo '<a href="' . esc_url( $non_attempts_url ) . '" class="button button-secondary">';
-	echo esc_html__( 'View Students Without Attempts', 'lifterlms' );
-	echo '</a>';
-	echo '</div>';
-
 	$table = new LLMS_Table_Quiz_Attempts();
 	$table->get_results(
 		array(
-			'quiz_id' => $quiz_id,
+			'quiz_id' => llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT ),
 		)
 	);
 	$table->output_table_html();

--- a/templates/admin/reporting/tabs/quizzes/non-attempts.php
+++ b/templates/admin/reporting/tabs/quizzes/non-attempts.php
@@ -14,26 +14,10 @@ if ( ! is_admin() ) {
 	exit;
 }
 
-// Display link back to regular attempts view
-$quiz_id = llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT );
-$attempts_url = LLMS_Admin_Reporting::get_current_tab_url(
-	array(
-		'tab'    => 'quizzes',
-		'stab'   => 'attempts',
-		'quiz_id' => $quiz_id,
-	)
-);
-
-echo '<div style="margin-bottom: 20px;">';
-echo '<a href="' . esc_url( $attempts_url ) . '" class="button button-secondary">';
-echo esc_html__( '← Back to Quiz Attempts', 'lifterlms' );
-echo '</a>';
-echo '</div>';
-
 $table = new LLMS_Table_Quiz_Non_Attempts();
 $table->get_results(
 	array(
-		'quiz_id' => $quiz_id,
+		'quiz_id' => llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT ),
 	)
 );
 $table->output_table_html();

--- a/templates/admin/reporting/tabs/quizzes/non-attempts.php
+++ b/templates/admin/reporting/tabs/quizzes/non-attempts.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Single Quiz Tab: Non-Attempts Subtab
+ *
+ * @package LifterLMS/Templates/Admin
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! is_admin() ) {
+	exit;
+}
+
+// Display link back to regular attempts view
+$quiz_id = llms_filter_input( INPUT_GET, 'quiz_id', FILTER_SANITIZE_NUMBER_INT );
+$attempts_url = LLMS_Admin_Reporting::get_current_tab_url(
+	array(
+		'tab'    => 'quizzes',
+		'stab'   => 'attempts',
+		'quiz_id' => $quiz_id,
+	)
+);
+
+echo '<div style="margin-bottom: 20px;">';
+echo '<a href="' . esc_url( $attempts_url ) . '" class="button button-secondary">';
+echo esc_html__( '← Back to Quiz Attempts', 'lifterlms' );
+echo '</a>';
+echo '</div>';
+
+$table = new LLMS_Table_Quiz_Non_Attempts();
+$table->get_results(
+	array(
+		'quiz_id' => $quiz_id,
+	)
+);
+$table->output_table_html();

--- a/templates/admin/reporting/tabs/students/quiz_attempts.php
+++ b/templates/admin/reporting/tabs/students/quiz_attempts.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Single Student View: Quiz Attempts Tab
+ *
+ * @package LifterLMS/Templates/Admin
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! is_admin() ) {
+	exit;
+}
+
+$table = new LLMS_Table_Student_Quiz_Attempts();
+$table->get_results(
+	array(
+		'student_id' => $student->get_id(),
+	)
+);
+$table->output_table_html();

--- a/templates/admin/reporting/tabs/students/student.php
+++ b/templates/admin/reporting/tabs/students/student.php
@@ -55,6 +55,15 @@ if ( ! is_admin() ) {
 					'student' => $student,
 				)
 			);
+
+			/**
+			 * Allow add-ons to provide content for student tabs.
+			 *
+			 * @since [version]
+			 *
+			 * @param LLMS_Student $student LLMS_Student instance.
+			 */
+			do_action( 'llms_reporting_student_tab_' . $current_tab . '_content', $student );
 			?>
 		</section>
 


### PR DESCRIPTION

## Description
Additional view to list and export students who have not attempted a quiz yet. Also adds a tab to list all attempts for a single student.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2654" height="2136" alt="CleanShot 2025-08-27 at 11 26 35@2x" src="https://github.com/user-attachments/assets/bf340c43-c51e-48c5-b447-fe41ffb3c0de" />
<img width="2622" height="1262" alt="CleanShot 2025-08-27 at 11 26 56@2x" src="https://github.com/user-attachments/assets/1f821593-9413-4171-837d-5014ac6c74f0" />

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

