### PR TITLE
Only enqueue the admin media protection attachment libraries when needed

### DIFF
--- a/.changelogs/enqueue-media-protection-only-with-media-files.yml
+++ b/.changelogs/enqueue-media-protection-only-with-media-files.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#3004"
+entry: Avoid loading the media protection attachment scripts when not needed.

--- a/includes/admin/class.llms.admin.assets.php
+++ b/includes/admin/class.llms.admin.assets.php
@@ -29,6 +29,7 @@ class LLMS_Admin_Assets {
 	public function __construct() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+		add_action( 'wp_enqueue_media', array( $this, 'admin_media' ) );
 		add_action( 'admin_print_styles', array( $this, 'admin_print_styles' ) );
 		add_action( 'admin_print_scripts', array( $this, 'admin_print_scripts' ) );
 		add_action( 'admin_print_footer_scripts', array( $this, 'admin_print_footer_scripts' ) );
@@ -266,7 +267,7 @@ class LLMS_Admin_Assets {
 		wp_register_script( 'llms', LLMS_PLUGIN_URL . 'assets/js/llms' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), LLMS_ASSETS_VERSION, true );
 		wp_register_script( 'llms-admin-scripts', LLMS_PLUGIN_URL . 'assets/js/llms-admin' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'llms', 'llms-select2' ), LLMS_ASSETS_VERSION, true );
 
-		wp_enqueue_script( 'llms-admin-media-protection-attachment-settings', LLMS_PLUGIN_URL . 'assets/js/llms-admin-media-protection-attachment-settings' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'media-views', 'wp-i18n', 'llms-admin-scripts' ), LLMS_ASSETS_VERSION, true );
+		wp_register_script( 'llms-admin-media-protection-attachment-settings', LLMS_PLUGIN_URL . 'assets/js/llms-admin-media-protection-attachment-settings' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery', 'media-views', 'wp-i18n', 'llms-admin-scripts' ), LLMS_ASSETS_VERSION, true );
 
 		if ( $this->is_llms_page() ) {
 
@@ -385,6 +386,20 @@ class LLMS_Admin_Assets {
 			llms()->assets->enqueue_script( 'llms-admin-award-certificate' );
 			wp_enqueue_style( 'wp-editor' );
 		}
+	}
+
+	/**
+	 * Register the media protection scripts when the media is enqueued.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function admin_media() {
+		if ( ! is_admin() ) {
+			return;
+		}
+		wp_enqueue_script( 'llms-admin-media-protection-attachment-settings' );
 	}
 
 	/**


### PR DESCRIPTION

## Description

Fixes #3004 

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

