### PR TITLE
Updating state/province requirement for countries with no states/provinces/etc

### DIFF
--- a/.changelogs/fix_countries-with-no-states.yml
+++ b/.changelogs/fix_countries-with-no-states.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixing checkout for countries that have no states/provinces/regions listed.

--- a/languages/countries-address-info.php
+++ b/languages/countries-address-info.php
@@ -38,12 +38,12 @@ defined( 'ABSPATH' ) || exit;
 return array(
 	'AD' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'AE' => array(
 		'city'     => false,
-		'state'    => __( 'Emirate', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'AF' => array(
@@ -53,7 +53,7 @@ return array(
 	),
 	'AG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'AI' => array(
@@ -68,7 +68,7 @@ return array(
 	),
 	'AM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'AO' => array(
@@ -113,17 +113,17 @@ return array(
 	),
 	'AZ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BA' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BB' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'BD' => array(
@@ -138,7 +138,7 @@ return array(
 	),
 	'BF' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BG' => array(
@@ -168,12 +168,12 @@ return array(
 	),
 	'BM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BN' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BO' => array(
@@ -183,7 +183,7 @@ return array(
 	),
 	'BQ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal Code', 'lifterlms' ),
 	),
 	'BR' => array(
@@ -193,12 +193,12 @@ return array(
 	),
 	'BS' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Island', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'BT' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BV' => array(
@@ -208,12 +208,12 @@ return array(
 	),
 	'BW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'BY' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'BZ' => array(
@@ -238,12 +238,12 @@ return array(
 	),
 	'CF' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'CG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'CH' => array(
@@ -253,7 +253,7 @@ return array(
 	),
 	'CI' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'CK' => array(
@@ -268,7 +268,7 @@ return array(
 	),
 	'CM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'CN' => array(
@@ -293,7 +293,7 @@ return array(
 	),
 	'CV' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Island', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'CW' => array(
@@ -323,7 +323,7 @@ return array(
 	),
 	'DJ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'DK' => array(
@@ -333,7 +333,7 @@ return array(
 	),
 	'DM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'DO' => array(
@@ -368,7 +368,7 @@ return array(
 	),
 	'ER' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'ES' => array(
@@ -388,7 +388,7 @@ return array(
 	),
 	'FJ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'FK' => array(
@@ -398,7 +398,7 @@ return array(
 	),
 	'FM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'ZIP code', 'lifterlms' ),
 	),
 	'FO' => array(
@@ -413,7 +413,7 @@ return array(
 	),
 	'GA' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'GB' => array(
@@ -423,12 +423,12 @@ return array(
 	),
 	'GD' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'GE' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'GF' => array(
@@ -458,12 +458,12 @@ return array(
 	),
 	'GM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'GN' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'GP' => array(
@@ -473,7 +473,7 @@ return array(
 	),
 	'GQ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'GR' => array(
@@ -498,12 +498,12 @@ return array(
 	),
 	'GW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'GY' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'HK' => array(
@@ -528,7 +528,7 @@ return array(
 	),
 	'HT' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'HU' => array(
@@ -568,7 +568,7 @@ return array(
 	),
 	'IQ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'IR' => array(
@@ -598,7 +598,7 @@ return array(
 	),
 	'JO' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'JP' => array(
@@ -613,17 +613,17 @@ return array(
 	),
 	'KG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'KH' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'KI' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Island', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'KM' => array(
@@ -638,7 +638,7 @@ return array(
 	),
 	'KP' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'KR' => array(
@@ -658,7 +658,7 @@ return array(
 	),
 	'KZ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'LA' => array(
@@ -673,7 +673,7 @@ return array(
 	),
 	'LC' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'LI' => array(
@@ -693,12 +693,12 @@ return array(
 	),
 	'LS' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'LT' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'LU' => array(
@@ -708,12 +708,12 @@ return array(
 	),
 	'LV' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'LY' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'MA' => array(
@@ -723,7 +723,7 @@ return array(
 	),
 	'MC' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MD' => array(
@@ -733,7 +733,7 @@ return array(
 	),
 	'ME' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MF' => array(
@@ -743,32 +743,32 @@ return array(
 	),
 	'MG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MH' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'ZIP code', 'lifterlms' ),
 	),
 	'MK' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'ML' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'MM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MN' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MO' => array(
@@ -788,7 +788,7 @@ return array(
 	),
 	'MR' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'MS' => array(
@@ -803,17 +803,17 @@ return array(
 	),
 	'MU' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MV' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MX' => array(
@@ -843,7 +843,7 @@ return array(
 	),
 	'NE' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'NF' => array(
@@ -878,7 +878,7 @@ return array(
 	),
 	'NR' => array(
 		'city'     => false,
-		'state'    => __( 'District', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'NU' => array(
@@ -893,7 +893,7 @@ return array(
 	),
 	'OM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'PA' => array(
@@ -913,7 +913,7 @@ return array(
 	),
 	'PG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'PH' => array(
@@ -968,7 +968,7 @@ return array(
 	),
 	'QA' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'RE' => array(
@@ -988,7 +988,7 @@ return array(
 	),
 	'RU' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'RW' => array(
@@ -998,22 +998,22 @@ return array(
 	),
 	'SA' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'SB' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'SC' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Island', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'SD' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'SE' => array(
@@ -1048,12 +1048,12 @@ return array(
 	),
 	'SL' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'SM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'SN' => array(
@@ -1063,22 +1063,22 @@ return array(
 	),
 	'SO' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'SR' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Province', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'SS' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal Code', 'lifterlms' ),
 	),
 	'ST' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'SV' => array(
@@ -1088,17 +1088,17 @@ return array(
 	),
 	'SX' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal Code', 'lifterlms' ),
 	),
 	'SY' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'SZ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'TC' => array(
@@ -1118,7 +1118,7 @@ return array(
 	),
 	'TG' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TH' => array(
@@ -1128,7 +1128,7 @@ return array(
 	),
 	'TJ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'TK' => array(
@@ -1138,22 +1138,22 @@ return array(
 	),
 	'TL' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'TN' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'TO' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TR' => array(
@@ -1163,17 +1163,17 @@ return array(
 	),
 	'TT' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TV' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'Island', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'TZ' => array(
@@ -1208,7 +1208,7 @@ return array(
 	),
 	'UZ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'VA' => array(
@@ -1218,7 +1218,7 @@ return array(
 	),
 	'VC' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'VE' => array(
@@ -1243,7 +1243,7 @@ return array(
 	),
 	'VU' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'WF' => array(
@@ -1253,7 +1253,7 @@ return array(
 	),
 	'WS' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'XK' => array(
@@ -1263,7 +1263,7 @@ return array(
 	),
 	'YE' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'YT' => array(
@@ -1283,7 +1283,7 @@ return array(
 	),
 	'ZW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 );

--- a/languages/countries-address-info.php
+++ b/languages/countries-address-info.php
@@ -798,7 +798,7 @@ return array(
 	),
 	'MT' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'MU' => array(

--- a/languages/countries-address-info.php
+++ b/languages/countries-address-info.php
@@ -218,7 +218,7 @@ return array(
 	),
 	'BZ' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'CA' => array(
@@ -233,7 +233,7 @@ return array(
 	),
 	'CD' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'CF' => array(
@@ -288,7 +288,7 @@ return array(
 	),
 	'CU' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'CV' => array(
@@ -308,7 +308,7 @@ return array(
 	),
 	'CY' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'Postal code', 'lifterlms' ),
 	),
 	'CZ' => array(
@@ -628,7 +628,7 @@ return array(
 	),
 	'KM' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'KN' => array(
@@ -958,7 +958,7 @@ return array(
 	),
 	'PW' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => __( 'ZIP code', 'lifterlms' ),
 	),
 	'PY' => array(
@@ -1108,7 +1108,7 @@ return array(
 	),
 	'TD' => array(
 		'city'     => __( 'City', 'lifterlms' ),
-		'state'    => __( 'State / Region', 'lifterlms' ),
+		'state'    => false,
 		'postcode' => false,
 	),
 	'TF' => array(


### PR DESCRIPTION

## Description
Countries with no states/provinces/region/etc listed in states.php have the State dropdown listed. However if they are not listed with `state` as `false` in `countries-address-info.php` then checkout will fail.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

