### PR TITLE
Course completion pages

### DIFF
--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -184,6 +184,19 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'class' => 'code input-full',
 						'value' => 'test',
 					),
+					array(
+						'label'           => __( 'Course Completion Page', 'lifterlms' ),
+						'class'           => 'llms-select2-post',
+						'data_attributes' => array(
+							'allow-clear' => true,
+							'post-type'   => 'page',
+							'placeholder' => __( 'Select a page', 'lifterlms' ),
+						),
+						'desc'            => sprintf( __( 'This page will be shown to students when they complete the course. %1$sMore Information%2$s', 'lifterlms' ), '<a href="https://lifterlms.com/docs/course-completion-page/" target="_blank">', '</a>' ),
+						'id'              => $this->prefix . 'completion_page_id',
+						'value'           => llms_make_select2_post_array( array( $course->get( 'completion_page_id' ) ) ),
+						'type'            => 'select',
+					),
 				),
 			),
 			array(

--- a/includes/admin/settings/class.llms.settings.courses.php
+++ b/includes/admin/settings/class.llms.settings.courses.php
@@ -34,7 +34,6 @@ class LLMS_Settings_Courses extends LLMS_Settings_Page {
 		add_filter( 'lifterlms_settings_tabs_array', array( $this, 'add_settings_page' ), 20 );
 		add_action( 'lifterlms_settings_' . $this->id, array( $this, 'output' ) );
 		add_action( 'lifterlms_settings_save_' . $this->id, array( $this, 'save' ) );
-
 	}
 
 	/**
@@ -84,6 +83,20 @@ class LLMS_Settings_Courses extends LLMS_Settings_Page {
 					'id'      => 'lifterlms_favorites',
 					'default' => 'yes',
 					'type'    => 'checkbox',
+				),
+
+				array(
+					'class'             => 'llms-select2-post',
+					'custom_attributes' => array(
+						'data-allow-clear' => true,
+						'data-post-type'   => 'page',
+						'data-placeholder' => __( 'Select a page', 'lifterlms' ),
+					),
+					'desc'              => sprintf( __( 'This page will be shown to students when they complete the course. %1$sMore Information%2$s', 'lifterlms' ), '<a href="https://lifterlms.com/docs/course-completion-page/" target="_blank">', '</a>' ),
+					'id'                => 'lifterlms_course_completion_page_id',
+					'options'           => llms_make_select2_post_array( get_option( 'lifterlms_course_completion_page_id', '' ) ),
+					'title'             => __( 'Course Completion', 'lifterlms' ),
+					'type'              => 'select',
 				),
 
 				array(
@@ -156,7 +169,6 @@ class LLMS_Settings_Courses extends LLMS_Settings_Page {
 		$deprecated = apply_filters( 'lifterlms_catalog_settings', array() );
 
 		return array_merge( $course, $deprecated );
-
 	}
 
 	/**
@@ -183,7 +195,6 @@ class LLMS_Settings_Courses extends LLMS_Settings_Page {
 		LLMS_Admin_Settings::output_fields( $settings );
 		add_action( 'shutdown', array( $this, 'flush_rewrite_rules' ) );
 	}
-
 }
 
 return new LLMS_Settings_Courses();

--- a/includes/class-llms-course-completion-page.php
+++ b/includes/class-llms-course-completion-page.php
@@ -1,0 +1,43 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class LLMS_Course_Completion_Page {
+
+	use LLMS_Trait_Singleton;
+
+	public function __construct() {
+		$this->init();
+	}
+
+	protected function init() {
+
+		// Add it as the last action to ensure other handlers of course completion happen first.
+		add_action( 'lifterlms_course_completed', array( $this, 'maybe_redirect_to_course_completion_page' ), 9999, 2 );
+	}
+
+	public function maybe_redirect_to_course_completion_page( $student_id, $related_post_id ) {
+		if ( is_admin() || $student_id !== get_current_user_id() ) {
+			return;
+		}
+
+		$course = new LLMS_Course( $related_post_id );
+
+		if ( ! $course ) {
+			return;
+		}
+
+		if ( $course->get( 'completion_page_id' ) ) {
+			wp_safe_redirect( get_permalink( $course->get( 'completion_page_id' ) ) );
+			exit();
+		}
+
+		if ( get_option( 'lifterlms_course_completion_page_id', '' ) ) {
+			wp_safe_redirect( get_permalink( get_option( 'lifterlms_course_completion_page_id' ) ) );
+			exit();
+		}
+	}
+}
+
+return new LLMS_Course_Completion_Page();

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -319,6 +319,8 @@ class LLMS_Loader {
 
 		// Elementor support.
 		require_once LLMS_PLUGIN_DIR . 'includes/elementor/class-llms-elementor-widgets.php';
+
+		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-course-completion-page.php';
 	}
 
 	/**

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -93,6 +93,7 @@ class LLMS_Course extends LLMS_Post_Model implements LLMS_Interface_Post_Instruc
 		'ignore_lessons'             => 'absint',
 		'days_before_available'      => 'absint',
 		'featured_pricing'           => 'html',
+		'completion_page_id'         => 'absint',
 
 		// Private.
 		'temp_calc_data'             => 'array',


### PR DESCRIPTION

## Description
New global and course-level option to specify a page to redirect upon course completion.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2830" height="2238" alt="CleanShot 2025-12-01 at 11 08 02@2x" src="https://github.com/user-attachments/assets/e0d320ac-0425-4166-97d3-7fceef72b85f" />
<img width="2426" height="930" alt="CleanShot 2025-12-01 at 11 08 36@2x" src="https://github.com/user-attachments/assets/d55e3b10-f1d2-47f0-9d8d-cf9f18c6d97b" />

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

