### PR TITLE
Add check for lack of source in an image type choice.

### DIFF
--- a/.changelogs/fix_import-empty-picture-choice-question.yml
+++ b/.changelogs/fix_import-empty-picture-choice-question.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#3070"
+entry: Avoid fatal error when importing a course with an empty picture choice
+  question.

--- a/includes/class-llms-generator-courses.php
+++ b/includes/class-llms-generator-courses.php
@@ -629,6 +629,10 @@ class LLMS_Generator_Courses extends LLMS_Abstract_Generator_Posts {
 			return $choice;
 		}
 
+		if ( ! isset( $choice['choice']['src'] ) ) {
+			return $choice;
+		}
+
 		$id = $this->sideload_image( $question_id, $choice['choice']['src'], 'id' );
 		if ( is_wp_error( $id ) ) {
 			return $choice;


### PR DESCRIPTION

## Description

Fixes #3070 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2372" height="652" alt="CleanShot 2026-01-05 at 06 20 16@2x" src="https://github.com/user-attachments/assets/ed2ce85f-225a-41e2-9a93-d0c297d35714" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

