### PR TITLE
Fix currently enrolled students count on course overview reporting

### DIFF
--- a/.changelogs/remove-calc-found-rows-course-enrollment.yml
+++ b/.changelogs/remove-calc-found-rows-course-enrollment.yml
@@ -1,0 +1,6 @@
+significance: minor
+type: fixed
+links:
+  - "#3073"
+entry: Fix count of currently enrolled students in the Course overview reporting
+  for certain hosts and number of students.

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -174,7 +174,11 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	 */
 	protected function sql_select_columns( $select_columns = '*' ) {
 
-		if ( ! $this->get( 'no_found_rows' ) ) {
+		if ( $this->get( 'count_only' ) ) {
+			$select_columns = 'COUNT(*), ' . $select_columns;
+		}
+
+		if ( ! $this->get( 'count_only' ) && ! $this->get( 'no_found_rows' ) ) {
 			$select_columns = 'SQL_CALC_FOUND_ROWS ' . $select_columns;
 		}
 

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -174,10 +174,6 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	 */
 	protected function sql_select_columns( $select_columns = '*' ) {
 
-		if ( $this->get( 'count_only' ) ) {
-			$select_columns = 'COUNT(*), ' . $select_columns;
-		}
-
 		if ( ! $this->get( 'count_only' ) && ! $this->get( 'no_found_rows' ) ) {
 			$select_columns = 'SQL_CALC_FOUND_ROWS ' . $select_columns;
 		}
@@ -237,6 +233,11 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	 */
 	protected function sql_orderby() {
 		$sql = '';
+
+		// No point in ordering if we're just counting.
+		if ( $this->get( 'count_only' ) ) {
+			return $sql;
+		}
 
 		$sort = $this->get( 'sort' );
 		if ( $sort ) {

--- a/includes/abstracts/llms-abstract-query.php
+++ b/includes/abstracts/llms-abstract-query.php
@@ -315,7 +315,16 @@ abstract class LLMS_Abstract_Query {
 	 */
 	public function get_found_results() {
 		if ( $this->get( 'count_only' ) ) {
+			$results = $this->get_results();
 
+			if ( ! is_array( $results ) || ! count( $results ) || ! isset( $results[0] ) || ! property_exists( $results[0], 'total' ) ) {
+				/* Translators: %s - name of class. */
+				error_log( sprintf( __( '[LifterLMS] Found results with count_only has no result rows in %s.', 'lifterlms' ), get_class( $this ) ) );
+
+				return 0;
+			}
+
+			return intval( $results[0]->total );
 		}
 
 		return $this->found_results;

--- a/includes/abstracts/llms-abstract-query.php
+++ b/includes/abstracts/llms-abstract-query.php
@@ -314,19 +314,6 @@ abstract class LLMS_Abstract_Query {
 	 * @return int
 	 */
 	public function get_found_results() {
-		if ( $this->get( 'count_only' ) ) {
-			$results = $this->get_results();
-
-			if ( ! is_array( $results ) || ! count( $results ) || ! isset( $results[0] ) || ! property_exists( $results[0], 'total' ) ) {
-				/* Translators: %s - name of class. */
-				error_log( sprintf( __( '[LifterLMS] Found results with count_only has no result rows in %s.', 'lifterlms' ), get_class( $this ) ) );
-
-				return 0;
-			}
-
-			return intval( $results[0]->total );
-		}
-
 		return $this->found_results;
 	}
 
@@ -334,7 +321,7 @@ abstract class LLMS_Abstract_Query {
 	 * Get the total number of pages available for the given query.
 	 *
 	 * If the query was instantiated with `$no_found_rows=true` this will always
-	 * return `0`.
+	 * return `0`, unless `$count_only=true`.
 	 *
 	 * Retrieves the value of the protected property `$max_pages`.
 	 *
@@ -588,5 +575,25 @@ abstract class LLMS_Abstract_Query {
 			$this->set( $arg, $val );
 
 		}
+	}
+
+	public function get_count_only_result() {
+		$results = $this->get_results();
+		if ( ! is_array( $results ) || ! count( $results ) || ! isset( $results[0] ) || ! property_exists(
+			$results[0],
+			'total'
+		) ) {
+			/* Translators: %s - name of class. */
+			error_log(
+				sprintf(
+					__( '[LifterLMS] Found results with count_only has no result rows in %s.', 'lifterlms' ),
+					get_class( $this )
+				)
+			);
+
+			return 0;
+		}
+
+		return intval( $results[0]->total );
 	}
 }

--- a/includes/abstracts/llms-abstract-query.php
+++ b/includes/abstracts/llms-abstract-query.php
@@ -129,7 +129,6 @@ abstract class LLMS_Abstract_Query {
 		$this->setup_args();
 
 		$this->query();
-
 	}
 
 	/**
@@ -148,7 +147,6 @@ abstract class LLMS_Abstract_Query {
 			$this->found_results = $this->found_results();
 			$this->max_pages     = absint( ceil( $this->found_results / $this->get( 'per_page' ) ) );
 		}
-
 	}
 
 	/**
@@ -170,8 +168,8 @@ abstract class LLMS_Abstract_Query {
 			'sort'             => array(),
 			'suppress_filters' => false,
 			'no_found_rows'    => false,
+			'count_only'       => false,
 		);
-
 	}
 
 	/**
@@ -275,7 +273,6 @@ abstract class LLMS_Abstract_Query {
 		 * @param array $allowed_fields Default arguments.
 		 */
 		return apply_filters( "llms_{$this->id}_query_allowed_sort_fields", $allowed_fields );
-
 	}
 
 	/**
@@ -302,7 +299,6 @@ abstract class LLMS_Abstract_Query {
 		 * @param array $args Array of default arguments to set up the query with.
 		 */
 		return apply_filters( "llms_{$this->id}_query_get_default_args", $this->default_arguments() );
-
 	}
 
 	/**
@@ -318,6 +314,10 @@ abstract class LLMS_Abstract_Query {
 	 * @return int
 	 */
 	public function get_found_results() {
+		if ( $this->get( 'count_only' ) ) {
+
+		}
+
 		return $this->found_results;
 	}
 
@@ -375,7 +375,6 @@ abstract class LLMS_Abstract_Query {
 		 * @param array $results Array of results retrieved by the query.
 		 */
 		return apply_filters( "llms_{$this->id}_query_get_results", $this->results );
-
 	}
 
 	/**
@@ -474,7 +473,6 @@ abstract class LLMS_Abstract_Query {
 		$this->results = $this->perform_query();
 
 		$this->count_results();
-
 	}
 
 	/**
@@ -501,7 +499,6 @@ abstract class LLMS_Abstract_Query {
 
 		// Remove empty values.
 		return array_values( array_filter( $ids ) );
-
 	}
 
 	/**
@@ -528,7 +525,6 @@ abstract class LLMS_Abstract_Query {
 		}
 
 		return $sort;
-
 	}
 
 	/**
@@ -583,7 +579,5 @@ abstract class LLMS_Abstract_Query {
 			$this->set( $arg, $val );
 
 		}
-
 	}
-
 }

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -169,21 +169,29 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			$vars[] = $search;
 		}
 
+		$limit_clause = '';
 		if ( ! $this->get( 'count_only' ) ) {
-			$vars[] = $this->get_skip();
-			$vars[] = $this->get( 'per_page' );
+			$vars[]       = $this->get_skip();
+			$vars[]       = $this->get( 'per_page' );
+			$limit_clause = 'LIMIT %d, %d';
+		}
+
+		$count_wrapper_start = $count_wrapper_end = '';
+		if ( $this->get( 'count_only' ) ) {
+			$count_wrapper_start = 'SELECT COUNT(*) AS total FROM (';
+			$count_wrapper_end   = ') as t';
 		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.
 		$sql = $wpdb->prepare(
-			"SELECT {$this->sql_select()}
+			"{$count_wrapper_start}SELECT {$this->sql_select()}
 			FROM {$wpdb->users} AS u
 			{$this->sql_joins()}
 			{$this->sql_search()}
 			{$this->sql_having()}
 			{$this->sql_orderby()}
-			" . ( ! $this->get( 'count_only' ) ? 'LIMIT %d, %d' : '' ) . ';',
+			{$limit_clause}{$count_wrapper_end};",
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -182,8 +182,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			$count_wrapper_end   = ') as t';
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.
 		$sql_query = "{$count_wrapper_start}SELECT {$this->sql_select()}
 			FROM {$wpdb->users} AS u
 			{$this->sql_joins()}
@@ -197,6 +195,8 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			return $sql_query;
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.
 		$sql = $wpdb->prepare(
 			$sql_query,
 			$vars

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -62,7 +62,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
 		 */
 		return apply_filters( 'llms_student_query_default_args', $args, $this );
-
 	}
 
 	/**
@@ -100,7 +99,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
 		 */
 		return apply_filters( 'llms_student_query_get_students', $students, $this );
-
 	}
 
 	/**
@@ -146,7 +144,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			}
 		}
 		$this->arguments['post_id'] = $post_ids;
-
 	}
 
 	/**
@@ -172,8 +169,10 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			$vars[] = $search;
 		}
 
-		$vars[] = $this->get_skip();
-		$vars[] = $this->get( 'per_page' );
+		if ( ! $this->get( 'count_only' ) ) {
+			$vars[] = $this->get_skip();
+			$vars[] = $this->get( 'per_page' );
+		}
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.
@@ -184,13 +183,12 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 			{$this->sql_search()}
 			{$this->sql_having()}
 			{$this->sql_orderby()}
-			LIMIT %d, %d;",
+			" . ( ! $this->get( 'count_only' ) ? 'LIMIT %d, %d' : '' ) . ';',
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		return $sql;
-
 	}
 
 	/**
@@ -294,7 +292,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
 		 */
 		return apply_filters( 'llms_student_query_join', $sql, $this );
-
 	}
 
 	/**
@@ -334,7 +331,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
 		 */
 		return apply_filters( 'llms_student_query_search', $sql, $this );
-
 	}
 
 	/**
@@ -392,7 +388,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 		 * @param LLMS_Student_Query $student_query Instance of LLMS_Student_Query.
 		 */
 		return apply_filters( 'llms_student_query_select', $sql, $this );
-
 	}
 
 	/**
@@ -416,7 +411,6 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		$sql = $wpdb->prepare( $sql, $statuses ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		return "{$column} IN ( {$sql} )";
-
 	}
 
 	/**
@@ -449,5 +443,4 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 				ORDER BY updated_date DESC
 				LIMIT 1";
 	}
-
 }

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -184,14 +184,21 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.
-		$sql = $wpdb->prepare(
-			"{$count_wrapper_start}SELECT {$this->sql_select()}
+		$sql_query = "{$count_wrapper_start}SELECT {$this->sql_select()}
 			FROM {$wpdb->users} AS u
 			{$this->sql_joins()}
 			{$this->sql_search()}
 			{$this->sql_having()}
 			{$this->sql_orderby()}
-			{$limit_clause}{$count_wrapper_end};",
+			{$limit_clause}{$count_wrapper_end};";
+
+		if ( empty( $vars ) ) {
+			// If we don't have placeholders, we can't use prepare().
+			return $sql_query;
+		}
+
+		$sql = $wpdb->prepare(
+			$sql_query,
 			$vars
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -423,7 +423,7 @@ class LLMS_Course extends LLMS_Post_Model implements LLMS_Interface_Post_Instruc
 				)
 			);
 
-			$count = $query->get_found_results();
+			$count = $query->get_count_only_result();
 
 			// Cache result for later use.
 			$this->set( 'enrolled_students', $count );

--- a/includes/models/model.llms.course.php
+++ b/includes/models/model.llms.course.php
@@ -413,12 +413,13 @@ class LLMS_Course extends LLMS_Post_Model implements LLMS_Interface_Post_Instruc
 
 			$query = new LLMS_Student_Query(
 				array(
-					'post_id'  => $this->get( 'id' ),
-					'statuses' => array( 'enrolled' ),
-					'per_page' => 1,
-					'sort'     => array(
+					'post_id'    => $this->get( 'id' ),
+					'statuses'   => array( 'enrolled' ),
+					'per_page'   => 1,
+					'sort'       => array(
 						'id' => 'ASC',
 					),
+					'count_only' => true,
 				)
 			);
 

--- a/includes/processors/class.llms.processor.course.data.php
+++ b/includes/processors/class.llms.processor.course.data.php
@@ -83,7 +83,6 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 	 * @return void|null
 	 */
 	public function dispatch_calc( $course_id ) {
-
 		$this->log( sprintf( 'Course data calculation dispatched for course %d.', $course_id ) );
 
 		// Make sure we have a course.
@@ -100,25 +99,29 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 		// Retrieve args.
 		$args = $this->get_student_query_args( $course_id );
 
-		// Get total number of pages.
+		// Get the results for the current set of arguments.
 		$query = new LLMS_Student_Query( $args );
 
 		// No students in the course, run task completion.
-		if ( ! $query->get_found_results() ) {
+		if ( ! $query->get_number_results() ) {
 			return $this->task_complete( $course, $this->get_task_data(), true );
 		}
 
-		// Get the total number of students as a separate query. If the query fails store best guess with the SQL_CALC_FOUND_ROWS result.
+		// Get the total number of students as a separate query since deprecating SQL_CALC_FOUND_ROWS usage.
 		$count_query = new LLMS_Student_Query( array_merge( $args, array( 'count_only' => true ) ) );
-		$course->set( 'enrolled_students', ( $count_query->get_found_results() ? $count_query->get_found_results() : $query->get_found_results() ) );
+		if ( ! $count_query->get_count_only_result() ) {
+			return $this->task_complete( $course, $this->get_task_data(), true );
+		}
+		$course->set( 'enrolled_students', $count_query->get_count_only_result() );
 
 		// Throttle processing.
-		if ( $this->maybe_throttle( $query->get_found_results(), $course_id ) ) {
+		if ( $this->maybe_throttle( $count_query->get_count_only_result(), $course_id ) ) {
 			return $this->dispatch_calc_throttled( $course_id );
 		}
 
 		// Add each page to the queue.
-		while ( $args['page'] <= $query->get_max_pages() ) {
+		$max_pages = absint( ceil( $count_query->get_count_only_result() / $args['per_page'] ) );
+		while ( $args['page'] <= $max_pages ) {
 			$this->push_to_queue( $args );
 			++$args['page'];
 		}
@@ -165,13 +168,14 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 		return apply_filters(
 			'llms_data_processor_course_data_student_query_args',
 			array(
-				'post_id'  => $course_id,
-				'statuses' => array( 'enrolled' ),
-				'page'     => 1,
-				'per_page' => 100,
-				'sort'     => array(
+				'post_id'       => $course_id,
+				'statuses'      => array( 'enrolled' ),
+				'page'          => 1,
+				'per_page'      => 100,
+				'sort'          => array(
 					'id' => 'ASC',
 				),
+				'no_found_rows' => true,
 			),
 			$this
 		);

--- a/includes/processors/class.llms.processor.course.data.php
+++ b/includes/processors/class.llms.processor.course.data.php
@@ -108,8 +108,9 @@ class LLMS_Processor_Course_Data extends LLMS_Abstract_Processor {
 			return $this->task_complete( $course, $this->get_task_data(), true );
 		}
 
-		// Store the total number of students right away.
-		$course->set( 'enrolled_students', $query->get_found_results() );
+		// Get the total number of students as a separate query. If the query fails store best guess with the SQL_CALC_FOUND_ROWS result.
+		$count_query = new LLMS_Student_Query( array_merge( $args, array( 'count_only' => true ) ) );
+		$course->set( 'enrolled_students', ( $count_query->get_found_results() ? $count_query->get_found_results() : $query->get_found_results() ) );
 
 		// Throttle processing.
 		if ( $this->maybe_throttle( $query->get_found_results(), $course_id ) ) {


### PR DESCRIPTION

## Description

Wraps query in a SELECT COUNT(*) instead of using the deprecated SQL_CALC_FOUND_ROWS.

Fixes #3073 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3634" height="1402" alt="CleanShot 2026-01-06 at 12 46 18@2x" src="https://github.com/user-attachments/assets/30a9f44d-b8b5-4752-a8f8-f9c2311f8879" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

