### PR TITLE
Use stripslashes_deep for array setting.

### DIFF
--- a/.changelogs/use-stripslashes-deep-array-setting.yml
+++ b/.changelogs/use-stripslashes-deep-array-setting.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Handle possible array of arrays in admin settings.

--- a/includes/admin/class.llms.admin.settings.php
+++ b/includes/admin/class.llms.admin.settings.php
@@ -918,7 +918,7 @@ class LLMS_Admin_Settings {
 		}
 
 		if ( is_array( $option_value ) ) {
-			$option_value = array_map( 'stripslashes', $option_value );
+			$option_value = stripslashes_deep( $option_value );
 		} elseif ( ! is_null( $option_value ) ) {
 			$option_value = stripslashes( $option_value );
 		}


### PR DESCRIPTION
## Description
Avoid errors if there is a setting with an array of array value.

## How has this been tested?
Manually

Ensure the main Settings page and other sub-pages load correctly, and can save new setting values.

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

