### PR TITLE
Allow searching and display of more than 10 categories

### DIFF
--- a/.changelogs/fix_category-course-in-block.yml
+++ b/.changelogs/fix_category-course-in-block.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#3078"
+entry: Allow selection of all categories in the Courses block when there are
+  more than 10 categories.

--- a/src/blocks/courses/index.jsx
+++ b/src/blocks/courses/index.jsx
@@ -29,10 +29,16 @@ const Edit = ( props ) => {
 	const blockProps = useBlockProps();
 	const [ courseTitles, setCourseTitles ] = useState( [] );
 	const [ categoryOptions, setCategoryOptions ] = useState( [] );
+	const [ isLoading, setIsLoading ] = useState( false );
+	const [ searchTerm, setSearchTerm ] = useState( '' );
 
-	useEffect( () => {
+	// Fetch categories from API based on search term.
+	const fetchCategories = ( term, value = '' ) => {
+		setIsLoading( true );
+
+		const searchParam = term ? `&search=${ encodeURIComponent( term ) }` : '';
 		apiFetch( {
-			path: '/wp/v2/course_cat?per_page=100',
+			path: `/wp/v2/course_cat?per_page=10${ searchParam }`,
 		} )
 			.then( ( categories ) => {
 				const options = categories.map( ( category ) => {
@@ -47,7 +53,30 @@ const Edit = ( props ) => {
 					label: __( '- All -', 'lifterlms' ),
 				} );
 
-				setCategoryOptions( options );
+				// If there's a selected value and it's not in the results, fetch it separately.
+				if ( value && !options.some( o => o.value === value ) ) {
+					apiFetch( { path: `/wp/v2/course_cat?slug=${ encodeURIComponent( value ) }` } )
+						.then( ( categories ) => {
+							if ( categories && categories.length > 0 ) {
+								setCategoryOptions( [
+									...options,
+									...categories.map( ( category ) => {
+										return {
+											value: category.slug,
+											label: category.name,
+										};
+									} ),
+								] );
+							} else {
+								setCategoryOptions( options );
+							}
+						} )
+						.catch( () => {
+							setCategoryOptions( options );
+						} );
+				} else {
+					setCategoryOptions( options );
+				}
 			} )
 			.catch( () => {
 				setCategoryOptions( [
@@ -56,8 +85,16 @@ const Edit = ( props ) => {
 						label: __( '- All -', 'lifterlms' ),
 					},
 				] );
+			} )
+			.finally( () => {
+				setIsLoading( false );
 			} );
-	}, [] );
+	};
+
+	useEffect( () => {
+		const timeout = setTimeout( () => fetchCategories( searchTerm, attributes?.category ), 300 );
+		return () => clearTimeout( timeout );
+	}, [ searchTerm, attributes?.category ] );
 
 	const fetchedOptions = usePostOptions();
 	const courseOptions = {};
@@ -99,6 +136,8 @@ const Edit = ( props ) => {
 						onChange={ ( value ) => setAttributes( {
 							category: value,
 						} ) }
+						onFilterValueChange={ setSearchTerm }
+						isLoading={ isLoading }
 						allowReset={ true }
 					/>
 				</PanelRow>

--- a/src/blocks/courses/index.jsx
+++ b/src/blocks/courses/index.jsx
@@ -11,12 +11,13 @@ import {
 	SelectControl,
 	Spinner,
 	ToggleControl,
+	ComboboxControl,
 } from '@wordpress/components';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
 import ServerSideRender from '@wordpress/server-side-render';
+import apiFetch from '@wordpress/api-fetch';
 
 // Internal dependencies.
 import { usePostOptions } from '../../../packages/components/src/post-select';
@@ -27,24 +28,36 @@ const Edit = ( props ) => {
 	const { attributes, setAttributes } = props;
 	const blockProps = useBlockProps();
 	const [ courseTitles, setCourseTitles ] = useState( [] );
+	const [ categoryOptions, setCategoryOptions ] = useState( [] );
 
-	const { categories } = useSelect( ( select ) => {
-		return {
-			categories: select( 'core' )?.getEntityRecords( 'taxonomy', 'course_cat' ),
-		};
+	useEffect( () => {
+		apiFetch( {
+			path: '/wp/v2/course_cat?per_page=100',
+		} )
+			.then( ( categories ) => {
+				const options = categories.map( ( category ) => {
+					return {
+						value: category.slug,
+						label: category.name,
+					};
+				} );
+
+				options.unshift( {
+					value: '',
+					label: __( '- All -', 'lifterlms' ),
+				} );
+
+				setCategoryOptions( options );
+			} )
+			.catch( () => {
+				setCategoryOptions( [
+					{
+						value: '',
+						label: __( '- All -', 'lifterlms' ),
+					},
+				] );
+			} );
 	}, [] );
-
-	const categoryOptions = categories?.map( ( category ) => {
-		return {
-			value: category.slug,
-			label: category.name,
-		};
-	} );
-
-	categoryOptions?.unshift( {
-		value: '',
-		label: __( '- All -', 'lifterlms' ),
-	} );
 
 	const fetchedOptions = usePostOptions();
 	const courseOptions = {};
@@ -77,19 +90,18 @@ const Edit = ( props ) => {
 
 		<InspectorControls>
 			<PanelBody title={ __( 'Courses Settings', 'lifterlms' ) }>
-				{ categoryOptions?.length > 0 && (
-					<PanelRow>
-						<SelectControl
-							label={ __( 'Category', 'lifterlms' ) }
-							help={ __( 'Display courses from a specific Course Category only.', 'lifterlms' ) }
-							value={ attributes?.category }
-							options={ categoryOptions }
-							onChange={ ( value ) => setAttributes( {
-								category: value,
-							} ) }
-						/>
-					</PanelRow>
-				) }
+				<PanelRow>
+					<ComboboxControl
+						label={ __( 'Category', 'lifterlms' ) }
+						help={ __( 'Display courses from a specific Course Category only.', 'lifterlms' ) }
+						value={ attributes?.category || '' }
+						options={ categoryOptions }
+						onChange={ ( value ) => setAttributes( {
+							category: value,
+						} ) }
+						allowReset={ true }
+					/>
+				</PanelRow>
 				<PanelRow>
 					<ToggleControl
 						label={ __( 'Show hidden courses?', 'lifterlms' ) }


### PR DESCRIPTION

## Description

Switch to ComboboxControl and using the WP REST API to fetch the categories.

Fixes #3078 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1830" height="1170" alt="CleanShot 2026-01-12 at 14 44 41@2x" src="https://github.com/user-attachments/assets/cb0eb25f-383c-48ff-be41-73d94466f857" />

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

