### PR TITLE
Fix favorite template

### DIFF
--- a/.changelogs/fix_favorite-template.yml
+++ b/.changelogs/fix_favorite-template.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+attributions:
+  - "@DAnn2012"
+entry: Fixing aria label output for course favorites.

--- a/templates/course/favorite.php
+++ b/templates/course/favorite.php
@@ -51,14 +51,14 @@ $can_mark_favorite = $lesson && ( ( $student && $student->is_enrolled( $lesson->
 		<?php if ( $is_favorite ) : ?>
 
 			<?php /* Translators: %s: lesson title */ ?>
-			<button aria-label="<?php esc_attr_e( sprintf( __( 'Toggle favorite for lesson %s', 'lifterlms' ), get_the_title( $lesson->get( 'id' ) ) ), 'lifterlms' ); ?>" data-action="unfavorite" aria-pressed="true" data-type="lesson" data-id="<?php echo esc_attr( $lesson->get( 'id' ) ); ?>" class="llms-unfavorite-btn">
+			<button aria-label="<?php echo esc_attr( sprintf( __( 'Toggle favorite for lesson %s', 'lifterlms' ), get_the_title( $lesson->get( 'id' ) ) ) ); ?>" data-action="unfavorite" aria-pressed="true" data-type="lesson" data-id="<?php echo esc_attr( $lesson->get( 'id' ) ); ?>" class="llms-unfavorite-btn">
 				<i class="fa fa-heart llms-heart-btn" aria-hidden="true"></i>
 			</button>
 
 		<?php else : ?>
 
 			<?php /* Translators: %s: lesson title */ ?>
-			<button aria-label="<?php esc_attr_e( sprintf( __( 'Toggle favorite for lesson %s', 'lifterlms' ), get_the_title( $lesson->get( 'id' ) ) ), 'lifterlms' ); ?>" data-action="favorite" aria-pressed="false" data-type="lesson" data-id="<?php echo esc_attr( $lesson->get( 'id' ) ); ?>" class="llms-favorite-btn">
+			<button aria-label="<?php echo esc_attr( sprintf( __( 'Toggle favorite for lesson %s', 'lifterlms' ), get_the_title( $lesson->get( 'id' ) ) ) ); ?>" data-action="favorite" aria-pressed="false" data-type="lesson" data-id="<?php echo esc_attr( $lesson->get( 'id' ) ); ?>" class="llms-favorite-btn">
 				<i class="fa fa-heart-o llms-heart-btn" aria-hidden="true"></i>
 			</button>
 


### PR DESCRIPTION

## Description
Fixes incorrect use of esc_attr_e()

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

