### PR TITLE
Show "Mark Complete" button when quiz requirements are already met

### DIFF
--- a/.changelogs/3092.yml
+++ b/.changelogs/3092.yml
@@ -1,0 +1,7 @@
+significance: patch
+type: fixed
+links:
+  - "#3058"
+attributions:
+  - "@faisalahammad"
+entry: Show "Mark Complete" button when quiz requirements are already met.

--- a/includes/functions/llms-functions-progression.php
+++ b/includes/functions/llms-functions-progression.php
@@ -33,22 +33,47 @@ function llms_allow_lesson_completion( $user_id, $lesson_id, $trigger = '', $arg
 /**
  * Determines whether or not a "Mark Complete" button should be displayed for a given lesson
  *
- * @param   obj $lesson LLMS_Lesson.
- * @return  boolean
- * @since   3.29.0
- * @version 3.29.0
+ * If the lesson has a quiz, the button will only be shown if the current user has
+ * already met the quiz requirements (passed the quiz, or completed at least one attempt
+ * if passing is not required).
+ *
+ * @since 3.29.0
+ * @since [version] Show button when quiz requirements are already met. Fixes issue #3058.
+ *
+ * @param LLMS_Lesson $lesson LLMS_Lesson instance.
+ * @return boolean
  */
 function llms_show_mark_complete_button( $lesson ) {
 
 	$show = true;
 
+	// If a quiz button should be shown, check if user already met quiz requirements.
 	if ( llms_show_take_quiz_button( $lesson ) ) {
 		$show = false;
+
+		// Check if current user has already met quiz requirements.
+		$user_id = get_current_user_id();
+		if ( $user_id && $lesson->is_quiz_enabled() ) {
+			$student = llms_get_student( $user_id );
+			if ( $student ) {
+				$quiz_id = $lesson->get( 'quiz' );
+				$attempt = $student->quizzes()->get_best_attempt( $quiz_id );
+
+				if ( $attempt ) {
+					$passing_required = llms_parse_bool( $lesson->get( 'require_passing_grade' ) );
+					// Show button if: passing not required, OR attempt is passing.
+					if ( ! $passing_required || $attempt->is_passing() ) {
+						$show = true;
+					}
+				}
+			}
+		}
 	}
 
 	return apply_filters( 'llms_show_mark_complete_button', $show, $lesson );
 
 }
+
 
 /**
  * Determines whether or not a "Take Quiz" button should be displayed for a given lesson.

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-progression.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-progression.php
@@ -58,6 +58,144 @@ class LLMS_Test_Functions_Progression extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test llms_show_mark_complete_button() when quiz has not been attempted.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_show_mark_complete_button_quiz_not_attempted() {
+
+		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+		$lesson = $course->get_lessons()[0];
+		$student = $this->factory->student->create_and_get();
+
+		wp_set_current_user( $student->get( 'id' ) );
+		$student->enroll( $course->get( 'id' ) );
+
+		// Quiz exists but no attempts - should not show mark complete.
+		$this->assertFalse( llms_show_mark_complete_button( $lesson ) );
+
+	}
+
+	/**
+	 * Test llms_show_mark_complete_button() when quiz has been passed.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_show_mark_complete_button_quiz_passed() {
+
+		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+		$lesson = $course->get_lessons()[0];
+		$quiz   = $lesson->get_quiz();
+		$student = $this->factory->student->create_and_get();
+
+		wp_set_current_user( $student->get( 'id' ) );
+		$student->enroll( $course->get( 'id' ) );
+
+		// Set passing grade requirement.
+		$lesson->set( 'require_passing_grade', 'yes' );
+		$quiz->set( 'passing_percent', 50 );
+
+		// Simulate a passing quiz attempt.
+		$attempt = LLMS_Quiz_Attempt::init( $quiz->get( 'id' ), $lesson->get( 'id' ), $student->get( 'id' ) );
+		$attempt->start();
+
+		// Get all questions and answer them correctly (100% score).
+		$questions = $attempt->get_questions();
+		foreach ( $questions as $key => $question ) {
+			$questions[ $key ]['answer'] = 'correct_answer';
+			$questions[ $key ]['earned'] = $questions[ $key ]['points'];
+		}
+		$attempt->set_questions( $questions, true );
+		$attempt->end();
+
+		// Quiz passed - should show mark complete button.
+		$this->assertTrue( llms_show_mark_complete_button( $lesson ) );
+
+	}
+
+	/**
+	 * Test llms_show_mark_complete_button() when quiz failed and passing is required.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_show_mark_complete_button_quiz_failed_passing_required() {
+
+		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+		$lesson = $course->get_lessons()[0];
+		$quiz   = $lesson->get_quiz();
+		$student = $this->factory->student->create_and_get();
+
+		wp_set_current_user( $student->get( 'id' ) );
+		$student->enroll( $course->get( 'id' ) );
+
+		// Set passing grade requirement.
+		$lesson->set( 'require_passing_grade', 'yes' );
+		$quiz->set( 'passing_percent', 80 );
+
+		// Simulate a failing quiz attempt (0% score).
+		$attempt = LLMS_Quiz_Attempt::init( $quiz->get( 'id' ), $lesson->get( 'id' ), $student->get( 'id' ) );
+		$attempt->start();
+
+		// Get all questions and answer them incorrectly (0% score).
+		$questions = $attempt->get_questions();
+		foreach ( $questions as $key => $question ) {
+			$questions[ $key ]['answer'] = 'wrong_answer';
+			$questions[ $key ]['earned'] = 0;
+		}
+		$attempt->set_questions( $questions, true );
+		$attempt->end();
+
+		// Quiz failed and passing required - should NOT show mark complete button.
+		$this->assertFalse( llms_show_mark_complete_button( $lesson ) );
+
+	}
+
+	/**
+	 * Test llms_show_mark_complete_button() when quiz failed but passing is NOT required.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_show_mark_complete_button_quiz_failed_passing_not_required() {
+
+		$course = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+		$lesson = $course->get_lessons()[0];
+		$quiz   = $lesson->get_quiz();
+		$student = $this->factory->student->create_and_get();
+
+		wp_set_current_user( $student->get( 'id' ) );
+		$student->enroll( $course->get( 'id' ) );
+
+		// Passing grade is NOT required.
+		$lesson->set( 'require_passing_grade', 'no' );
+		$quiz->set( 'passing_percent', 80 );
+
+		// Simulate a failing quiz attempt (0% score).
+		$attempt = LLMS_Quiz_Attempt::init( $quiz->get( 'id' ), $lesson->get( 'id' ), $student->get( 'id' ) );
+		$attempt->start();
+
+		// Get all questions and answer them incorrectly (0% score).
+		$questions = $attempt->get_questions();
+		foreach ( $questions as $key => $question ) {
+			$questions[ $key ]['answer'] = 'wrong_answer';
+			$questions[ $key ]['earned'] = 0;
+		}
+		$attempt->set_questions( $questions, true );
+		$attempt->end();
+
+		// Quiz failed but passing NOT required - should show mark complete button.
+		$this->assertTrue( llms_show_mark_complete_button( $lesson ) );
+
+	}
+
+	/**
 	 * Test the llms_show_take_quiz_button()
 	 * @return  void
 	 * @since   3.29.0


### PR DESCRIPTION
## Summary

Fixes #3058

This PR allows students to re-mark a lesson as complete after clicking "Mark Incomplete", without needing to retake the quiz. The button is shown only when the student has already met the quiz requirements (passed or attempted based on lesson settings).

---

## Problem

When a lesson has an attached quiz:

1. Student completes the quiz and the lesson is marked complete automatically
2. Student clicks "Mark Incomplete" to reset their progress
3. **Bug:** The "Mark Complete" button disappears. Only the "Take Quiz" button is visible
4. Student is forced to retake the quiz even though they already passed it

This is frustrating for students who want to review a lesson without losing their quiz results.

---

## Root Cause

The `llms_show_mark_complete_button()` function unconditionally returns `false` when a quiz exists:

### Before (Problematic Code)

```php
function llms_show_mark_complete_button( $lesson ) {
    $show = true;

    if ( llms_show_take_quiz_button( $lesson ) ) {
        $show = false;  // Always hides button when quiz exists
    }

    return apply_filters( 'llms_show_mark_complete_button', $show, $lesson );
}
```

The function never checks if the student has already met the quiz requirements. It blindly hides the button whenever a quiz is attached.

---

## Solution

Check if the current user has already met the quiz requirements before hiding the button. This uses the same logic that exists in `quiz_maybe_prevent_lesson_completion()` in the lesson progression controller.

### After (Fixed Code)

```php
function llms_show_mark_complete_button( $lesson ) {
    $show = true;

    // If a quiz button should be shown, check if user already met quiz requirements.
    if ( llms_show_take_quiz_button( $lesson ) ) {
        $show = false;

        // Check if current user has already met quiz requirements.
        $user_id = get_current_user_id();
        if ( $user_id && $lesson->is_quiz_enabled() ) {
            $student = llms_get_student( $user_id );
            if ( $student ) {
                $quiz_id = $lesson->get( 'quiz' );
                $attempt = $student->quizzes()->get_best_attempt( $quiz_id );

                if ( $attempt ) {
                    $passing_required = llms_parse_bool( $lesson->get( 'require_passing_grade' ) );
                    // Show button if: passing not required, OR attempt is passing.
                    if ( ! $passing_required || $attempt->is_passing() ) {
                        $show = true;
                    }
                }
            }
        }
    }

    return apply_filters( 'llms_show_mark_complete_button', $show, $lesson );
}
```

---

## How It Works

The fix adds these checks in order:

1. **Is user logged in?** - Only check for authenticated users
2. **Is quiz enabled?** - Double check the quiz is active
3. **Get best attempt** - Find the student's highest scoring quiz attempt
4. **Check requirements:**
   - If passing grade is NOT required: Show button (any attempt is enough)
   - If passing grade IS required: Show button only if the best attempt is passing

### Decision Table

| Scenario | Before | After |
|----------|--------|-------|
| No quiz attached | Button shown | Button shown |
| Quiz not attempted yet | Button hidden | Button hidden |
| Quiz passed | Button hidden | **Button shown** |
| Quiz failed + passing required | Button hidden | Button hidden |
| Quiz failed + passing NOT required | Button hidden | **Button shown** |
| Unpublished quiz | Button shown | Button shown |

---

## Files Changed

### `includes/functions/llms-functions-progression.php`

- Modified `llms_show_mark_complete_button()` to check quiz completion status
- Updated docblock with new behavior description and version tag

### `tests/phpunit/unit-tests/functions/class-llms-test-functions-progression.php`

Added 4 new test cases:

| Test Method | Description |
|-------------|-------------|
| `test_llms_show_mark_complete_button_quiz_not_attempted` | Quiz exists but no attempts - button should be hidden |
| `test_llms_show_mark_complete_button_quiz_passed` | Quiz passed - button should be shown |
| `test_llms_show_mark_complete_button_quiz_failed_passing_required` | Quiz failed and passing required - button hidden |
| `test_llms_show_mark_complete_button_quiz_failed_passing_not_required` | Quiz failed but passing not required - button shown |

---

## Backward Compatibility

This change is fully backward compatible:

- The `llms_show_mark_complete_button` filter still works as before
- Third-party code using the filter will continue to work
- No changes to function signatures or return types
- No changes to database schema

---

## Performance

The fix adds a database query to fetch the best quiz attempt. This query:

- Only runs when viewing a lesson with an attached quiz
- Only runs for logged-in users
- Uses existing optimized `get_best_attempt()` method
- Has minimal impact since it fetches only 1 record

---

## Testing Instructions

### Manual Testing

1. Create a course with a quiz-enabled lesson
2. Set "Require Passing Grade" to Yes
3. Set passing grade to 50%
4. Enroll as a student and take the quiz (pass with 60%+)
5. Lesson should be marked complete automatically
6. Click "Mark Incomplete" on the lesson
7. **Verify:** "Mark Complete" button should now be visible alongside "Take Quiz"
8. Click "Mark Complete" to re-complete the lesson without retaking quiz

### Automated Tests

```bash
vendor/bin/phpunit tests/phpunit/unit-tests/functions/class-llms-test-functions-progression.php
```

---

## Related

- Original Issue: #3058
- Related Function: `quiz_maybe_prevent_lesson_completion()` in `class.llms.controller.lesson.progression.php`

---

## Note on Assignments

Assignments are provided by LifterLMS add-ons, not the core plugin. The same filter (`llms_show_mark_complete_button`) can be used by add-on developers to implement similar logic for assignments.