### PR TITLE
Fixing CSS for changing the number of columns in the loop grid.

### DIFF
--- a/.changelogs/fix_change-loop-columns.yml
+++ b/.changelogs/fix_change-loop-columns.yml
@@ -1,0 +1,6 @@
+significance: patch
+type: fixed
+links:
+  - "#3101"
+entry: Fix lifterlms_loop_columns filter styling to change the number of columns
+  in a loop (ie. Course Catalog).

--- a/assets/scss/frontend/_loop.scss
+++ b/assets/scss/frontend/_loop.scss
@@ -23,7 +23,7 @@
 	@media all and (min-width: 600px) {
 		$cols: 1;
 		@while $cols <= 6 {
-			&.cols-#{$cols} .llms-loop-item {
+			&.cols-#{$cols} {
 				grid-template-columns: repeat($cols, minmax(0, 1fr));
 			}
 			$cols: $cols + 1;


### PR DESCRIPTION

## Description
[This snippet](https://lifterlms.com/docs/can-change-number-columns-displayed-course-membership-catalog/) didn't work after the "match height" javascript was removed from the course / membership listing in favour of display grid. This fixes it.

It still worked with Sky Pilot since it uses display: flex and sets the column width.

Fixes #3101 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1568" height="1688" alt="CleanShot 2026-03-04 at 09 46 54@2x" src="https://github.com/user-attachments/assets/15f0c48d-0baa-483e-8ad0-1d8cdbada76d" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

