### PR TITLE
Scroll to top when loading a quiz question

### DIFF
--- a/.changelogs/change_quiz-question-scroll-to-top.yml
+++ b/.changelogs/change_quiz-question-scroll-to-top.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: changed
+entry: Scroll to the top of the quiz UI area when a quiz question is loaded.

--- a/assets/js/llms-quiz.js
+++ b/assets/js/llms-quiz.js
@@ -760,6 +760,13 @@
 
 			$( document ).trigger( 'llms-post-append-question', $html );
 
+			var $quizUi = $( '#llms-quiz-ui' );
+			if ( $quizUi.length ) {
+				$( 'html, body' ).animate( {
+					scrollTop: $quizUi.offset().top - 50
+				}, 300 );
+			}
+
 		},
 
 		/**


### PR DESCRIPTION

## Description

In case there are longer questions, scroll back up to the top of the quiz UI area when a question is loaded.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/ef09f4d3-ea29-4aaf-9f36-5bc25a8bb7ae

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

