### PR TITLE
Feature: "Any" option for engagement trigger posts

### DIFF
--- a/.changelogs/feature_any-engagement-trigger.yml
+++ b/.changelogs/feature_any-engagement-trigger.yml
@@ -1,0 +1,7 @@
+significance: minor
+type: added
+links:
+  - "#3109"
+entry: Added an explicit 'Any' trigger option for engagements so one engagement
+  can apply to all matching courses, memberships, lessons, quizzes, sections,
+  access plans, or tracks.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.engagement.php
@@ -71,12 +71,14 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				),
 				'id'               => '_faux_engagement_trigger_post_course',
 				'label'            => __( 'Select a Course', 'lifterlms' ),
+				'placeholder'      => __( 'Any Course', 'lifterlms' ),
 			),
 
 			'lesson'           => array(
 				'controller_value' => array( 'lesson_completed' ),
 				'id'               => '_faux_engagement_trigger_post_lesson',
 				'label'            => __( 'Select a Lesson', 'lifterlms' ),
+				'placeholder'      => __( 'Any Lesson', 'lifterlms' ),
 			),
 
 			'llms_access_plan' => array(
@@ -85,6 +87,7 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				),
 				'id'               => '_faux_engagement_trigger_post_access_plan',
 				'label'            => __( 'Select an Access Plan', 'lifterlms' ),
+				'placeholder'      => __( 'Any Access Plan', 'lifterlms' ),
 			),
 
 			'llms_membership'  => array(
@@ -94,6 +97,7 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				),
 				'id'               => '_faux_engagement_trigger_post_membership',
 				'label'            => __( 'Select a Membership', 'lifterlms' ),
+				'placeholder'      => __( 'Any Membership', 'lifterlms' ),
 			),
 
 			'llms_quiz'        => array(
@@ -104,12 +108,14 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				),
 				'id'               => '_faux_engagement_trigger_post_quiz',
 				'label'            => __( 'Select a Quiz', 'lifterlms' ),
+				'placeholder'      => __( 'Any Quiz', 'lifterlms' ),
 			),
 
 			'section'          => array(
 				'controller_value' => array( 'section_completed' ),
 				'id'               => '_faux_engagement_trigger_post_section',
 				'label'            => __( 'Select a Section', 'lifterlms' ),
+				'placeholder'      => __( 'Any Section', 'lifterlms' ),
 			),
 
 		);
@@ -118,11 +124,16 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 
 			$data['controller_value'] = apply_filters( 'llms_engagement_controller_values_' . $post_type, $data['controller_value'] );
 
-			if ( in_array( get_post_meta( $this->post->ID, $this->prefix . 'trigger_type', true ), $data['controller_value'] ) ) {
-				$val = llms_make_select2_post_array( array( get_post_meta( $this->post->ID, $this->prefix . 'engagement_trigger_post', true ) ) );
+			$trigger_post_val = get_post_meta( $this->post->ID, $this->prefix . 'engagement_trigger_post', true );
+			if ( 'any' === $trigger_post_val || empty( $trigger_post_val ) ) {
+				$val = array();
+			} elseif ( in_array( get_post_meta( $this->post->ID, $this->prefix . 'trigger_type', true ), $data['controller_value'] ) ) {
+				$val = llms_make_select2_post_array( array( $trigger_post_val ) );
 			} else {
 				$val = array();
 			}
+
+			$placeholder = isset( $data['placeholder'] ) ? $data['placeholder'] : $data['label'];
 
 			$fields[] = array(
 				'allow_null'       => false,
@@ -131,9 +142,10 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 				'controller_value' => implode( ',', $data['controller_value'] ),
 				'data_attributes'  => array(
 					'allow_clear' => true,
-					'placeholder' => $data['label'],
+					'placeholder' => $placeholder,
 					'post-type'   => $post_type,
 				),
+				'desc'             => __( 'Leave blank to apply to all.', 'lifterlms' ),
 				'id'               => $data['id'],
 				'label'            => $data['label'],
 				'type'             => 'select',
@@ -156,19 +168,24 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 			);
 		}
 
+		$track_selected = get_post_meta( $this->post->ID, $this->prefix . 'engagement_trigger_post', true );
+		if ( 'any' === $track_selected ) {
+			$track_selected = '';
+		}
+
 		$fields[] = array(
-			'allow_null'       => false,
+			'allow_null'       => true,
 			'class'            => 'llms-select2',
 			'controller'       => '#' . $this->prefix . 'trigger_type',
 			'controller_value' => implode( ',', apply_filters( 'llms_engagement_controller_values_track', array( 'course_track_completed' ) ) ),
 			'data_attributes'  => array(
 				'allow_clear' => true,
-				'placeholder' => __( 'Select a Course Track', 'lifterlms' ),
+				'placeholder' => __( 'Any Course Track', 'lifterlms' ),
 			),
 			'id'               => '_faux_engagement_trigger_post_track',
 			'label'            => __( 'Select a Course Track', 'lifterlms' ),
 			'type'             => 'select',
-			'selected'         => get_post_meta( $this->post->ID, $this->prefix . 'engagement_trigger_post', true ),
+			'selected'         => $track_selected,
 			'value'            => $track_options,
 		);
 
@@ -332,6 +349,11 @@ class LLMS_Meta_Box_Engagement extends LLMS_Admin_Metabox {
 		if ( $var ) {
 
 			$val = llms_filter_input_sanitize_string( INPUT_POST, '_faux_engagement_trigger_post_' . $var );
+
+			// An empty trigger post means "any" — store explicitly so the intent is clear.
+			if ( empty( $val ) ) {
+				$val = 'any';
+			}
 
 		} else {
 

--- a/includes/admin/post-types/post-tables/class.llms.admin.post.table.engagements.php
+++ b/includes/admin/post-types/post-tables/class.llms.admin.post.table.engagements.php
@@ -75,7 +75,7 @@ class LLMS_Admin_Post_Table_Engagements {
 				echo isset( $triggers[ $trigger ] ) ? esc_html( $triggers[ $trigger ] ) : esc_html( $trigger );
 
 				$tid = get_post_meta( $post_id, '_llms_engagement_trigger_post', true );
-				if ( $tid ) {
+				if ( $tid && 'any' !== $tid ) {
 
 					echo '<br>';
 
@@ -89,6 +89,10 @@ class LLMS_Admin_Post_Table_Engagements {
 					}
 
 					printf( '<a href="%s">%s (ID# %d)</a>', esc_url( $link ), esc_html( $title ), esc_html( $tid ) );
+
+				} elseif ( 'any' === $tid ) {
+
+					echo '<br><em>' . esc_html__( 'Any', 'lifterlms' ) . '</em>';
 
 				}
 

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -151,7 +151,10 @@ class LLMS_Engagements {
 
 			$related_select = ', relation_meta.meta_value AS related_post_id';
 			$related_join   = "LEFT JOIN $wpdb->postmeta AS relation_meta ON triggers.ID = relation_meta.post_id";
-			$related_where  = $wpdb->prepare( "AND relation_meta.meta_key = '_llms_engagement_trigger_post' AND relation_meta.meta_value = %d", $related_post_id );
+			$related_where  = $wpdb->prepare(
+				"AND relation_meta.meta_key = '_llms_engagement_trigger_post' AND ( relation_meta.meta_value = %d OR relation_meta.meta_value = 'any' )",
+				$related_post_id
+			);
 
 		}
 


### PR DESCRIPTION
## Summary

- Engagements can now fire for **any** course, membership, lesson, quiz, section, access plan, or course track — not just a specific one
- Addresses the feature request where N engagements were needed for N courses when the same email/certificate/achievement should fire for all of them
- Works for all trigger types: enrollment, purchase, completion, quiz pass/fail, etc.
- Covers courses **and** memberships (and all other post types) in one change

## How It Works

**Admin UI:** The trigger post select fields (e.g., "Select a Course") can now be cleared. When cleared, the placeholder reads "Any Course" (or "Any Membership", etc.), and a help text says "Leave blank to apply to all."

**Storage:** An empty selection saves the literal string `'any'` in `_llms_engagement_trigger_post`. This is an explicit opt-in — we intentionally avoided treating empty/zero values as wildcards so that existing engagements with accidentally blank trigger posts don't suddenly fire on everything.

**Query:** The engagement matching SQL adds `OR relation_meta.meta_value = 'any'` alongside the specific post ID match, so both targeted and wildcard engagements are returned.

**List table:** The engagements admin list shows "Any" in italics for wildcard engagements.

## Design Decision: Explicit `'any'` vs Empty-Means-Any

We considered treating empty or `0` values as "any" but rejected it because:
- Existing engagements with accidentally empty trigger posts would silently start firing on everything
- An explicit sentinel value (`'any'`) makes the intent clear in the database
- It's safer for sites upgrading — no surprise behavior changes

## Files Changed

| File | Change |
|------|--------|
| `class.llms.engagements.php` | SQL WHERE clause matches both specific post IDs and `'any'` |
| `class.llms.meta.box.engagement.php` | Placeholder text, value loading, save logic (empty → `'any'`), description text |
| `class.llms.admin.post.table.engagements.php` | Shows "Any" label for wildcard engagements |

## Duplicate/Spam Safety

- **Achievements & certificates:** The existing `dupcheck()` uses the *actual* related post ID (the course the student enrolled in), not the engagement's trigger post config. So an "any course" achievement is awarded once per course — not re-awarded for the same course.
- **Emails:** No dupcheck (by design) — they fire on every matching event, which is correct for welcome/notification emails.

## Test Plan

- [ ] Create an engagement with trigger "Student enrolls in a course", leave course blank (shows "Any Course")
- [ ] Enroll a student in Course A → engagement fires
- [ ] Enroll same student in Course B → engagement fires again
- [ ] Create a second engagement for a *specific* Course A
- [ ] Enroll in Course A → both engagements fire
- [ ] Enroll in Course B → only the "any" engagement fires
- [ ] Verify "Any Membership" works the same way for membership triggers
- [ ] Verify the engagements list table shows "Any" for wildcard engagements
- [ ] Verify existing specific engagements are unaffected
- [ ] Verify achievements with "any" trigger only award once per course (dupcheck)
