### PR TITLE
Removing SQL_CALC_FOUND_ROWS

### DIFF
--- a/.changelogs/remove_sql-calc-found-rows.yml
+++ b/.changelogs/remove_sql-calc-found-rows.yml
@@ -1,0 +1,4 @@
+significance: major
+type: changed
+entry: Removing use of SQL_CALC_FOUND_ROWS due to depreciation in MySQL and
+  observed unreliability of count results.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "lifterlms/lifterlms-blocks": "2.7.2",
     "lifterlms/lifterlms-cli": "0.0.5",
     "lifterlms/lifterlms-helper": "3.5.8",
-    "lifterlms/lifterlms-rest": "1.0.3",
+    "lifterlms/lifterlms-rest": "1.0.5",
     "woocommerce/action-scheduler": "3.5.4",
     "gocodebox/banner-notifications": "1.1.1"
   },

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -299,6 +299,9 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	 * Overrides the parent to detect if a filter re-added SQL_CALC_FOUND_ROWS
 	 * to the query, and falls back to FOUND_ROWS() if so.
 	 *
+	 * Also warns when a subclass does not set $this->count_query, which means
+	 * get_found_results() and get_max_pages() will return 0.
+	 *
 	 * @since [version]
 	 *
 	 * @return void
@@ -307,11 +310,11 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 
 		parent::query();
 
-		if (
-			! $this->get( 'suppress_filters' ) &&
+		$has_sql_calc = ! $this->get( 'suppress_filters' ) &&
 			is_string( $this->query ) &&
-			str_contains( $this->query, 'SQL_CALC_FOUND_ROWS' )
-		) {
+			str_contains( $this->query, 'SQL_CALC_FOUND_ROWS' );
+
+		if ( $has_sql_calc ) {
 			_deprecated_argument(
 				"llms_{$this->id}_query_prepare_query",
 				'[version]',
@@ -321,6 +324,24 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 			global $wpdb;
 			$this->found_results = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ); // db call ok; no-cache ok.
 			$this->max_pages     = absint( ceil( $this->found_results / $this->get( 'per_page' ) ) );
+		}
+
+		if (
+			$this->number_results &&
+			! $this->get( 'no_found_rows' ) &&
+			! $this->get( 'count_only' ) &&
+			empty( $this->count_query ) &&
+			! $has_sql_calc
+		) {
+			_doing_it_wrong(
+				get_class( $this ) . '::prepare_query',
+				sprintf(
+					/* translators: %s: The query subclass name. */
+					'Subclasses of LLMS_Database_Query should set $this->count_query in prepare_query() when no_found_rows is not true. %s does not set count_query, so get_found_results() and get_max_pages() will return 0.',
+					get_class( $this )
+				),
+				'[version]'
+			);
 		}
 	}
 

--- a/includes/abstracts/abstract.llms.database.query.php
+++ b/includes/abstracts/abstract.llms.database.query.php
@@ -27,6 +27,18 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	protected $id = 'database';
 
 	/**
+	 * SQL query used to count total found results.
+	 *
+	 * Set by subclasses in prepare_query() from the same clause
+	 * variables (FROM, JOIN, WHERE) used for the main query.
+	 *
+	 * @since [version]
+	 *
+	 * @var string
+	 */
+	protected $count_query = '';
+
+	/**
 	 * Retrieve query argument default values.
 	 *
 	 * @since 6.0.0
@@ -152,31 +164,37 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	}
 
 	/**
-	 * Perform a SQL to retrieve the total number of found results for the given query.
+	 * Retrieve the total number of found results for the given query.
+	 *
+	 * Uses a separate COUNT(*) query built from the same SQL clauses as the
+	 * main query, set by subclasses in prepare_query().
 	 *
 	 * @since 6.0.0
+	 * @since [version] Replaced FOUND_ROWS() with $this->count_query.
 	 *
 	 * @return int
 	 */
 	protected function found_results() {
 
 		global $wpdb;
-		return (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ); // db call ok; no-cache ok.
+
+		if ( empty( $this->count_query ) ) {
+			return 0;
+		}
+
+		return (int) $wpdb->get_var( $this->count_query ); // db call ok; no-cache ok.
 	}
 
 	/**
 	 * Retrieve the prepared SQL for the SELECT clause.
 	 *
 	 * @since 4.5.1
+	 * @since [version] Removed SQL_CALC_FOUND_ROWS; found results are now counted via a separate query.
 	 *
 	 * @param string $select_columns Optional. Columns to select. Default '*'.
 	 * @return string
 	 */
 	protected function sql_select_columns( $select_columns = '*' ) {
-
-		if ( ! $this->get( 'count_only' ) && ! $this->get( 'no_found_rows' ) ) {
-			$select_columns = 'SQL_CALC_FOUND_ROWS ' . $select_columns;
-		}
 
 		if ( $this->get( 'suppress_filters' ) ) {
 			return $select_columns;
@@ -200,10 +218,15 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 	 *
 	 * @since 3.16.0
 	 * @since 4.5.1 Drop use of `$this->get_filter('limit')` in favor of `"llms_{$this->id}_query_limit"`.
+	 * @since [version] Returns empty string for count_only queries.
 	 *
 	 * @return string
 	 */
 	protected function sql_limit() {
+
+		if ( $this->get( 'count_only' ) ) {
+			return '';
+		}
 
 		global $wpdb;
 
@@ -268,6 +291,37 @@ abstract class LLMS_Database_Query extends LLMS_Abstract_Query {
 		 * @param LLMS_Database_Query $db_query The LLMS_Database_Query instance.
 		 */
 		return apply_filters( "llms_{$this->id}_query_orderby", $sql, $this );
+	}
+
+	/**
+	 * Execute a query.
+	 *
+	 * Overrides the parent to detect if a filter re-added SQL_CALC_FOUND_ROWS
+	 * to the query, and falls back to FOUND_ROWS() if so.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function query() {
+
+		parent::query();
+
+		if (
+			! $this->get( 'suppress_filters' ) &&
+			is_string( $this->query ) &&
+			str_contains( $this->query, 'SQL_CALC_FOUND_ROWS' )
+		) {
+			_deprecated_argument(
+				"llms_{$this->id}_query_prepare_query",
+				'[version]',
+				'SQL_CALC_FOUND_ROWS should no longer be added via filters. Results are now counted with a separate COUNT query.'
+			);
+
+			global $wpdb;
+			$this->found_results = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' ); // db call ok; no-cache ok.
+			$this->max_pages     = absint( ceil( $this->found_results / $this->get( 'per_page' ) ) );
+		}
 	}
 
 	/**

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -248,7 +248,8 @@ abstract class LLMS_Abstract_Post_Data {
 			)
 		);
 
-		$query_args['post_id'] = $this->post_id;
+		$query_args['post_id']        = $this->post_id;
+		$query_args['no_found_rows'] = true;
 
 		$query = new LLMS_Query_User_Postmeta( $query_args );
 

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -252,18 +252,8 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 
 		$offset = ( $this->current_page - 1 ) * $per;
 
-		$results = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS DISTINCT
-					u.ID as user_id,
-					u.user_email,
-					u.display_name,
-					u.user_registered,
-					m_first.meta_value as first_name,
-					m_last.meta_value as last_name,
-					upm.meta_value as enrollment_status,
-					upm.updated_date as enrollment_date
-				FROM {$wpdb->users} u
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$from_joins_where = "FROM {$wpdb->users} u
 				INNER JOIN {$wpdb->prefix}lifterlms_user_postmeta upm
 					ON u.ID = upm.user_id
 					AND upm.post_id = %d
@@ -286,18 +276,39 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 					AND upm2.meta_key = '_status'
 				)
 				AND qa.id IS NULL
-				{$search_sql}
-				{$order_sql}
-				LIMIT %d, %d",
-				$course->get( 'id' ),    // Course ID for enrollment check
-				$this->quiz_id,          // Quiz ID for attempt check
-				$course->get( 'id' ),    // Course ID for latest enrollment status
-				$offset,
-				$per
-			)
+				{$search_sql}";
+
+		$prepare_args = array(
+			$course->get( 'id' ),
+			$this->quiz_id,
+			$course->get( 'id' ),
 		);
 
-		$total_results = $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+		$total_results = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT u.ID) {$from_joins_where}",
+				$prepare_args
+			)
+		); // db call ok; no-cache ok.
+
+		$results = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT
+					u.ID as user_id,
+					u.user_email,
+					u.display_name,
+					u.user_registered,
+					m_first.meta_value as first_name,
+					m_last.meta_value as last_name,
+					upm.meta_value as enrollment_status,
+					upm.updated_date as enrollment_date
+				{$from_joins_where}
+				{$order_sql}
+				LIMIT %d, %d",
+				array_merge( $prepare_args, array( $offset, $per ) )
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$this->max_pages    = ceil( $total_results / $per );
 		$this->is_last_page = ( $this->current_page >= $this->max_pages );

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -252,7 +252,6 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 
 		$offset = ( $this->current_page - 1 ) * $per;
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$from_joins_where = "FROM {$wpdb->users} u
 				INNER JOIN {$wpdb->prefix}lifterlms_user_postmeta upm
 					ON u.ID = upm.user_id
@@ -308,7 +307,6 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 				array_merge( $prepare_args, array( $offset, $per ) )
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		$this->max_pages    = ceil( $total_results / $per );
 		$this->is_last_page = ( $this->current_page >= $this->max_pages );

--- a/includes/admin/reporting/tables/llms.table.quizzes.php
+++ b/includes/admin/reporting/tables/llms.table.quizzes.php
@@ -163,8 +163,8 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 			case 'attempts':
 				$query = new LLMS_Query_Quiz_Attempt(
 					array(
-						'quiz_id'  => $quiz->get( 'id' ),
-						'per_page' => 1,
+						'quiz_id'    => $quiz->get( 'id' ),
+						'count_only' => true,
 					)
 				);
 
@@ -175,7 +175,7 @@ class LLMS_Table_Quizzes extends LLMS_Admin_Table {
 						'quiz_id' => $quiz->get( 'id' ),
 					)
 				);
-				$value = '<a href="' . $url . '">' . $query->get_found_results() . '</a>';
+				$value = '<a href="' . $url . '">' . $query->get_count_only_result() . '</a>';
 
 				break;
 

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -140,6 +140,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	 *
 	 * @since 4.6.0
 	 * @since 4.7.0 Added `SQL_CALC_FOUND_ROWS` and improved query to exclude results with a completed payment plan.
+	 * @since [version] Replaced SQL_CALC_FOUND_ROWS with a separate COUNT(*) query.
 	 *
 	 * @return object[]
 	 */
@@ -147,9 +148,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 
 		global $wpdb;
 
-		$orders = $wpdb->get_results(
-			"SELECT SQL_CALC_FOUND_ROWS p.ID
-			   FROM {$wpdb->posts} AS p
+		$from_joins_where = "FROM {$wpdb->posts} AS p
 		  LEFT JOIN {$wpdb->postmeta} AS m
 			     ON p.ID = m.post_ID
 			    AND m.meta_key = '_llms_plan_ended'
@@ -161,13 +160,18 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 			    AND p.post_type   = 'llms_order'
 			    AND p.post_status = 'llms-active'
 			    AND a.action_id IS NULL
-			    AND m.meta_value IS NULL
+			    AND m.meta_value IS NULL";
+
+		$total = $wpdb->get_var( "SELECT COUNT(*) {$from_joins_where}" ); // no-cache ok.
+		wp_cache_set( sprintf( '%s-total-results', $this->id ), $total, 'llms_tool_data' );
+
+		$orders = $wpdb->get_results(
+			"SELECT p.ID
+			   {$from_joins_where}
 		   ORDER BY p.ID ASC
 			  LIMIT 50
 			;"
 		); // no-cache ok -- Caching implemented in `get_orders()`.
-
-		wp_cache_set( sprintf( '%s-total-results', $this->id ), $wpdb->get_var( 'SELECT FOUND_ROWS()' ), 'llms_tool_data' );
 
 		return $orders;
 

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -137,6 +137,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 	 * @since 3.36.0
 	 * @since 4.7.0 Use `$this->sql_select_columns({columns})` to determine the columns to select.
 	 * @since 6.0.0 Renamed from `preprare_query()`.
+	 * @since [version] Build count_query from shared clauses instead of using SQL_CALC_FOUND_ROWS.
 	 *
 	 * @return string
 	 */
@@ -144,9 +145,16 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
+		$from  = "FROM {$wpdb->prefix}lifterlms_events";
+		$where = $this->sql_where();
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$where}";
+		}
+
 		return "SELECT {$this->sql_select_columns( 'id' )}
-				FROM {$wpdb->prefix}lifterlms_events
-				{$this->sql_where()}
+				{$from}
+				{$where}
 				{$this->sql_orderby()}
 				{$this->sql_limit()};";
 

--- a/includes/class-llms-sessions.php
+++ b/includes/class-llms-sessions.php
@@ -348,6 +348,7 @@ class LLMS_Sessions {
 			$args['exclude'][]   = $end->get( 'id' );
 		}
 
+		$args['no_found_rows'] = true;
 		$query = new LLMS_Events_Query( $args );
 		return $query->get_events();
 

--- a/includes/class.llms.query.quiz.attempt.php
+++ b/includes/class.llms.query.quiz.attempt.php
@@ -137,6 +137,7 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 	 *
 	 * @since 3.16.0
 	 * @since 6.0.0 Renamed from `preprare_query()`.
+	 * @since [version] Build count_query from shared clauses instead of using SQL_CALC_FOUND_ROWS.
 	 *
 	 * @return string
 	 */
@@ -144,11 +145,19 @@ class LLMS_Query_Quiz_Attempt extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		$select = 'SELECT SQL_CALC_FOUND_ROWS qa.id';
-		$from   = "FROM {$wpdb->prefix}lifterlms_quiz_attempts qa";
-		$joins  = $this->sql_joins();
+		$from  = "FROM {$wpdb->prefix}lifterlms_quiz_attempts qa";
+		$joins = $this->sql_joins();
+		$where = $this->sql_where();
 
-		return "{$select} {$from} {$joins} {$this->sql_where()} {$this->sql_orderby()} {$this->sql_limit()};";
+		if ( $this->get( 'count_only' ) ) {
+			return "SELECT COUNT(*) AS total {$from} {$joins} {$where};";
+		}
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$joins} {$where}";
+		}
+
+		return "SELECT qa.id {$from} {$joins} {$where} {$this->sql_orderby()} {$this->sql_limit()};";
 	}
 
 	/**

--- a/includes/class.llms.query.user.postmeta.php
+++ b/includes/class.llms.query.user.postmeta.php
@@ -203,6 +203,7 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 	 *
 	 * @since 3.15.0
 	 * @since 6.0.0 Renamed from `preprare_query()`.
+	 * @since [version] Build count_query from shared clauses instead of using SQL_CALC_FOUND_ROWS.
 	 *
 	 * @return string
 	 */
@@ -210,16 +211,27 @@ class LLMS_Query_User_Postmeta extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		$vars = array();
+		$from  = "FROM {$wpdb->prefix}lifterlms_user_postmeta";
+		$where = $this->sql_where();
 
-		$vars[] = $this->get_skip();
-		$vars[] = $this->get( 'per_page' );
+		if ( $this->get( 'count_only' ) ) {
+			return "SELECT COUNT(*) AS total {$from} {$where};";
+		}
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$where}";
+		}
+
+		$vars = array(
+			$this->get_skip(),
+			$this->get( 'per_page' ),
+		);
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$sql = $wpdb->prepare(
-			"SELECT SQL_CALC_FOUND_ROWS meta_id
-			 FROM {$wpdb->prefix}lifterlms_user_postmeta
-			 {$this->sql_where()}
+			"SELECT meta_id
+			 {$from}
+			 {$where}
 			 {$this->sql_orderby()}
 			 LIMIT %d, %d;",
 			$vars

--- a/includes/class.llms.student.query.php
+++ b/includes/class.llms.student.query.php
@@ -153,6 +153,7 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 	 * @since 3.13.0 Unknown.
 	 * @since 4.10.2 Demands to `$this->sql_select()` to determine whether or not `SQL_CALC_FOUND_ROWS` statement is needed.
 	 * @since 6.0.0 Renamed from `preprare_query()`.
+	 * @since [version] Build count_query from shared clauses instead of using SQL_CALC_FOUND_ROWS.
 	 *
 	 * @return string
 	 */
@@ -160,40 +161,50 @@ class LLMS_Student_Query extends LLMS_Database_Query {
 
 		global $wpdb;
 
-		$vars = array();
+		$search_vars = array();
 
 		if ( $this->get( 'search' ) ) {
 			$search = '%' . $wpdb->esc_like( $this->get( 'search' ) ) . '%';
-			$vars[] = $search;
-			$vars[] = $search;
-			$vars[] = $search;
+			$search_vars[] = $search;
+			$search_vars[] = $search;
+			$search_vars[] = $search;
 		}
 
-		$limit_clause = '';
-		if ( ! $this->get( 'count_only' ) ) {
-			$vars[]       = $this->get_skip();
-			$vars[]       = $this->get( 'per_page' );
-			$limit_clause = 'LIMIT %d, %d';
-		}
-
-		$count_wrapper_start = $count_wrapper_end = '';
-		if ( $this->get( 'count_only' ) ) {
-			$count_wrapper_start = 'SELECT COUNT(*) AS total FROM (';
-			$count_wrapper_end   = ') as t';
-		}
-
-		$sql_query = "{$count_wrapper_start}SELECT {$this->sql_select()}
+		$base_query = "SELECT {$this->sql_select()}
 			FROM {$wpdb->users} AS u
 			{$this->sql_joins()}
 			{$this->sql_search()}
-			{$this->sql_having()}
-			{$this->sql_orderby()}
-			{$limit_clause}{$count_wrapper_end};";
+			{$this->sql_having()}";
 
-		if ( empty( $vars ) ) {
-			// If we don't have placeholders, we can't use prepare().
-			return $sql_query;
+		if ( $this->get( 'count_only' ) ) {
+			$sql_query = "SELECT COUNT(*) AS total FROM ({$base_query}) as t;";
+
+			if ( empty( $search_vars ) ) {
+				return $sql_query;
+			}
+
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			return $wpdb->prepare( $sql_query, $search_vars );
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$count_sql = "SELECT COUNT(*) FROM ({$base_query}) as t";
+			if ( ! empty( $search_vars ) ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+				$this->count_query = $wpdb->prepare( $count_sql, $search_vars );
+			} else {
+				$this->count_query = $count_sql;
+			}
+		}
+
+		$vars = $search_vars;
+		$vars[] = $this->get_skip();
+		$vars[] = $this->get( 'per_page' );
+
+		$sql_query = "{$base_query}
+			{$this->sql_orderby()}
+			LIMIT %d, %d;";
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		// phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber -- $vars is an array with the correct number of items.

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -257,13 +257,14 @@ class LLMS_Membership extends LLMS_Post_Model implements LLMS_Interface_Post_Ins
 
 		$query = new LLMS_Student_Query(
 			array(
-				'post_id'  => $this->get( 'id' ),
-				'statuses' => array( 'enrolled' ),
-				'per_page' => 1,
+				'post_id'    => $this->get( 'id' ),
+				'statuses'   => array( 'enrolled' ),
+				'count_only' => true,
+				'sort'       => array( 'id' => 'ASC' ),
 			)
 		);
 
-		return $query->get_found_results();
+		return $query->get_count_only_result();
 	}
 
 	/**

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -462,32 +462,41 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			$status = '';
 		}
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$query = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT SQL_CALC_FOUND_ROWS DISTINCT upm.post_id AS id
-			 FROM {$wpdb->prefix}lifterlms_user_postmeta AS upm
+		$from_where = "FROM {$wpdb->prefix}lifterlms_user_postmeta AS upm
 			 JOIN {$wpdb->posts} AS p ON p.ID = upm.post_id
 			 WHERE p.post_type = %s
 			   AND p.post_status = 'publish'
 			   AND upm.meta_key = '_status'
 			   AND upm.user_id = %d
-			   {$status}
+			   {$status}";
+
+		$prepare_args = array( $post_type, $this->get_id() );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$found = absint(
+			$wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT COUNT(DISTINCT upm.post_id) {$from_where}",
+					$prepare_args
+				)
+			)
+		); // db call ok; no-cache ok.
+
+		$query = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT DISTINCT upm.post_id AS id
+			 {$from_where}
 			 ORDER BY {$args['orderby']} {$args['order']}
 			 LIMIT %d, %d;
 			",
-				array(
-					$post_type,
-					$this->get_id(),
-					$args['skip'],
-					$args['limit'],
+				array_merge(
+					$prepare_args,
+					array( $args['skip'], $args['limit'] )
 				)
 			),
 			'OBJECT_K'
 		); // db call ok; no-cache ok.
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-		$found = absint( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) ); // db call ok; no-cache ok.
 
 		return array(
 			'found'   => $found,
@@ -676,9 +685,10 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 			wp_parse_args(
 				$args,
 				array(
-					'types'    => 'all',
-					'per_page' => 10,
-					'user_id'  => $this->get_id(),
+					'types'         => 'all',
+					'per_page'      => 10,
+					'user_id'       => $this->get_id(),
+					'no_found_rows' => true,
 				)
 			)
 		);
@@ -1160,6 +1170,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 					'user_id'               => $this->get_id(),
 					'post_id'               => $object_id,
 					'per_page'              => 1,
+					'no_found_rows'         => true,
 				)
 			);
 
@@ -1921,6 +1932,7 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 				'user_id'               => $this->get_id(),
 				'post_id'               => $object_id,
 				'per_page'              => 1,
+				'no_found_rows'         => true,
 			)
 		);
 

--- a/includes/models/model.llms.student.quizzes.php
+++ b/includes/models/model.llms.student.quizzes.php
@@ -34,11 +34,11 @@ class LLMS_Student_Quizzes extends LLMS_Abstract_User_Data {
 			array(
 				'student_id' => $this->get_id(),
 				'quiz_id'    => $quiz_id,
-				'per_page'   => 1,
+				'count_only' => true,
 			)
 		);
 
-		return $query->get_found_results();
+		return $query->get_count_only_result();
 
 	}
 

--- a/includes/notifications/class.llms.notifications.query.php
+++ b/includes/notifications/class.llms.notifications.query.php
@@ -222,12 +222,21 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 	 * @since 3.9.4 Unknown.
 	 * @since 6.0.0 Renamed from `preprare_query()`.
 	 * @since 7.1.0 Use `$this->sql_select_columns({columns})` to determine the columns to select.
+	 * @since [version] Build count_query from shared clauses instead of using SQL_CALC_FOUND_ROWS.
 	 *
 	 * @return string
 	 */
 	protected function prepare_query() {
 
 		global $wpdb;
+
+		$from  = "FROM {$wpdb->prefix}lifterlms_notifications AS n";
+		$join  = "LEFT JOIN {$wpdb->posts} AS p on p.ID = n.post_id";
+		$where = $this->sql_where();
+
+		if ( ! $this->get( 'no_found_rows' ) ) {
+			$this->count_query = "SELECT COUNT(*) {$from} {$join} {$where}";
+		}
 
 		$vars = array(
 			$this->get_skip(),
@@ -237,9 +246,9 @@ class LLMS_Notifications_Query extends LLMS_Database_Query {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- SQL is prepared in other functions.
 		$sql = $wpdb->prepare(
 			"SELECT {$this->sql_select_columns()}
-			FROM {$wpdb->prefix}lifterlms_notifications AS n
-			LEFT JOIN {$wpdb->posts} AS p on p.ID = n.post_id
-			{$this->sql_where()}
+			{$from}
+			{$join}
+			{$where}
 			{$this->sql_orderby()}
 			LIMIT %d, %d
 			;",

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
@@ -409,6 +409,29 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * A subclass that does not set count_query triggers _doing_it_wrong.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_missing_count_query_triggers_doing_it_wrong() {
+
+		$this->factory->post->create_many( 3 );
+
+		$stub = new class() extends LLMS_Database_Query {
+			protected $id = 'test_no_count';
+			protected function parse_args() {}
+			protected function prepare_query() {
+				global $wpdb;
+				return "SELECT ID FROM {$wpdb->posts} LIMIT 10";
+			}
+		};
+
+		$this->setExpectedIncorrectUsage( get_class( $stub ) . '::prepare_query' );
+	}
+
+	/**
 	 * Filters that reintroduce SQL_CALC_FOUND_ROWS trigger a deprecation and FOUND_ROWS() fallback.
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
@@ -290,15 +290,18 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 	/**
 	 * Test sql_select_columns() method
 	 *
+	 * SQL_CALC_FOUND_ROWS is no longer prepended.
+	 *
 	 * @since 4.5.1
+	 * @since [version] Updated: SQL_CALC_FOUND_ROWS is no longer added.
 	 *
 	 * @return void
 	 */
 	public function test_sql_select_columns() {
 
 		$query = $this->query();
-		$this->assertEquals( 'SQL_CALC_FOUND_ROWS *', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns' ) );
-		$this->assertEquals( 'SQL_CALC_FOUND_ROWS column', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns', array( 'column' ) ) );
+		$this->assertEquals( '*', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns' ) );
+		$this->assertEquals( 'column', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns', array( 'column' ) ) );
 
 		// Query but avoiding calculating found rows.
 		$query = $this->query(
@@ -342,6 +345,7 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 	 * Prepare query to build a testable SQL
 	 *
 	 * @since 4.5.1
+	 * @since [version] Set count_query for found_results() support.
 	 *
 	 * @return string
 	 */
@@ -350,6 +354,10 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 		$select  = LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns' );
 		$orderby = LLMS_Unit_Test_Util::call_method( $query, 'sql_orderby' );
 		$limit   = LLMS_Unit_Test_Util::call_method( $query, 'sql_limit' );
+
+		if ( ! $query->get( 'no_found_rows' ) ) {
+			LLMS_Unit_Test_Util::set_private_property( $query, 'count_query', "SELECT COUNT(*) FROM {$wpdb->posts}" );
+		}
 
 		return "
 			SELECT {$select}

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-database-query.php
@@ -41,7 +41,7 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 		return new class() extends LLMS_Database_Query {
 			protected function parse_args() {}
 			protected function prepare_query() {
-				return $this->_prepare_query();
+				return '';
 			}
 		};
 
@@ -311,6 +311,140 @@ class LLMS_Test_Database_Query extends LLMS_UnitTestCase {
 		);
 		$this->assertEquals( '*', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns' ) );
 		$this->assertEquals( 'column', LLMS_Unit_Test_Util::call_method( $query, 'sql_select_columns', array( 'column' ) ) );
+	}
+
+	/**
+	 * Pagination: found_results, max_pages, and per-page counts.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_pagination_found_results_and_max_pages() {
+		$this->factory->post->create_many( 30 );
+
+		$query = $this->query(
+			array(
+				'per_page' => 10,
+			)
+		);
+
+		$this->assertSame( 30, $query->get_found_results() );
+		$this->assertSame( 3, $query->get_max_pages() );
+		$this->assertSame( 10, $query->get_number_results() );
+
+		$query_page_3 = $this->query(
+			array(
+				'per_page' => 10,
+				'page'     => 3,
+			)
+		);
+
+		$this->assertSame( 10, $query_page_3->get_number_results() );
+	}
+
+	/**
+	 * When `no_found_rows` is true, the count query is skipped.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_found_rows_skips_count() {
+		$this->factory->post->create_many( 5 );
+
+		$query = $this->query(
+			array(
+				'no_found_rows' => true,
+			)
+		);
+
+		$this->assertTrue( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
+	 * With no matching posts, found_results and max_pages are zero.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_empty_results_found_results_zero() {
+		$query = $this->query();
+
+		$this->assertFalse( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
+	 * The main query string must not use SQL_CALC_FOUND_ROWS.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_sql_calc_found_rows_not_in_query_output() {
+		$this->factory->post->create_many( 3 );
+
+		$query = $this->query();
+
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $query->get_query() );
+	}
+
+	/**
+	 * sql_limit() returns an empty string when `count_only` is true.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_sql_limit_returns_empty_for_count_only() {
+		$stub = $this->get_stub();
+		$stub->set( 'count_only', true );
+
+		$this->assertSame( '', LLMS_Unit_Test_Util::call_method( $stub, 'sql_limit' ) );
+	}
+
+	/**
+	 * Filters that reintroduce SQL_CALC_FOUND_ROWS trigger a deprecation and FOUND_ROWS() fallback.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_filter_reintroducing_sql_calc_found_rows() {
+		$this->expected_deprecated = array_merge(
+			$this->expected_deprecated,
+			array( 'llms_database_query_prepare_query' )
+		);
+
+		add_filter( 'llms_database_query_prepare_query', array( $this, '_filter_prepend_sql_calc_found_rows' ), 20, 2 );
+
+		try {
+			$this->factory->post->create_many( 4 );
+
+			$query = $this->query();
+
+			$this->assertGreaterThan( 0, $query->get_found_results() );
+		} finally {
+			remove_filter( 'llms_database_query_prepare_query', array( $this, '_filter_prepend_sql_calc_found_rows' ), 20 );
+		}
+	}
+
+	/**
+	 * Filter callback: prepend SQL_CALC_FOUND_ROWS to the SELECT for {@see test_filter_reintroducing_sql_calc_found_rows()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param string              $sql   Query SQL.
+	 * @param LLMS_Database_Query $query Query instance.
+	 * @return string
+	 */
+	public function _filter_prepend_sql_calc_found_rows( $sql, $query ) {
+		return preg_replace( '/SELECT /', 'SELECT SQL_CALC_FOUND_ROWS ', $sql, 1 );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/class-llms-test-events-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-events-query.php
@@ -39,35 +39,44 @@ class LLMS_Test_Events_Query extends LLMS_Unit_Test_Case {
 
 
 	/**
-	 * Test that the events query, using default args, calculates found rows
+	 * Test that the events query, using default args, sets up a count_query
+	 * and does not use SQL_CALC_FOUND_ROWS.
 	 *
 	 * @since 4.7.0
 	 * @since 6.0.0 Don't call deprecated `preprare_query()`.
+	 * @since [version] Updated: SQL_CALC_FOUND_ROWS replaced with count_query.
 	 *
 	 * @return void
 	 */
-	public function test_query_with_default_args_calculates_found_rows() {
+	public function test_query_with_default_args_sets_count_query() {
 		$query = new LLMS_Events_Query();
 		$sql = LLMS_Unit_Test_Util::call_method( $query, 'prepare_query' );
-		$this->assertSame( 0, strpos( $sql, 'SELECT SQL_CALC_FOUND_ROWS' ) );
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $sql );
+
+		$count_query = LLMS_Unit_Test_Util::get_private_property_value( $query, 'count_query' );
+		$this->assertStringStartsWith( 'SELECT COUNT(*)', $count_query );
 	}
 
 	/**
-	 * Test that the events query, passing no_found_rows as true doesn't calculate found rows
+	 * Test that the events query, passing no_found_rows as true, does not set count_query.
 	 *
 	 * @since 4.7.0
 	 * @since 6.0.0 Don't call deprecated `preprare_query()`.
+	 * @since [version] Updated: SQL_CALC_FOUND_ROWS replaced with count_query.
 	 *
 	 * @return void
 	 */
-	public function test_query_correctly_doesnt_calculate_found_rows() {
+	public function test_query_correctly_doesnt_set_count_query() {
 		$query = new LLMS_Events_Query(
 			array(
 				'no_found_rows' => true,
 			)
 		);
 		$sql = LLMS_Unit_Test_Util::call_method( $query, 'prepare_query' );
-		$this->assertSame( false, strpos( $sql, 'SQL_CALC_FOUND_ROWS' ) );
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $sql );
+
+		$count_query = LLMS_Unit_Test_Util::get_private_property_value( $query, 'count_query' );
+		$this->assertEmpty( $count_query );
 	}
 
 }

--- a/tests/phpunit/unit-tests/class-llms-test-events-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-events-query.php
@@ -58,6 +58,78 @@ class LLMS_Test_Events_Query extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test found_results and max_pages with real events data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_found_results_with_pagination() {
+
+		$user_id = $this->factory->user->create();
+
+		for ( $i = 0; $i < 7; $i++ ) {
+			$event = new LLMS_Event();
+			$event->setUp(
+				array(
+					'actor_id'     => $user_id,
+					'object_type'  => 'post',
+					'object_id'    => 1,
+					'event_type'   => 'page',
+					'event_action' => 'load',
+				)
+			);
+			$event->save();
+		}
+
+		$query = new LLMS_Events_Query(
+			array(
+				'actor'    => $user_id,
+				'per_page' => 3,
+			)
+		);
+
+		$this->assertSame( 7, $query->get_found_results() );
+		$this->assertSame( 3, $query->get_max_pages() );
+		$this->assertSame( 3, $query->get_number_results() );
+	}
+
+	/**
+	 * Test that no_found_rows skips counting with real data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_found_rows_skips_count() {
+
+		$user_id = $this->factory->user->create();
+
+		$event = new LLMS_Event();
+		$event->setUp(
+			array(
+				'actor_id'     => $user_id,
+				'object_type'  => 'post',
+				'object_id'    => 1,
+				'event_type'   => 'page',
+				'event_action' => 'load',
+			)
+		);
+		$event->save();
+
+		$query = new LLMS_Events_Query(
+			array(
+				'actor'         => $user_id,
+				'no_found_rows' => true,
+			)
+		);
+
+		$this->assertTrue( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
 	 * Test that the events query, passing no_found_rows as true, does not set count_query.
 	 *
 	 * @since 4.7.0

--- a/tests/phpunit/unit-tests/class-llms-test-quiz-attempt-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-quiz-attempt-query.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Tests for LLMS_Query_Quiz_Attempt found_results / count_only behavior.
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group quizzes
+ * @group query
+ * @group dbquery
+ *
+ * @since [version]
+ */
+class LLMS_Test_Quiz_Attempt_Query extends LLMS_UnitTestCase {
+
+	/**
+	 * Teardown.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		global $wpdb;
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}lifterlms_quiz_attempts" );
+	}
+
+	/**
+	 * Create mock quiz attempts for a student.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $count Number of attempts.
+	 * @return array { quiz_id, lesson_id, student_id }
+	 */
+	private function create_attempts( $count = 1 ) {
+
+		$uid     = $this->factory->user->create();
+		$courses = $this->generate_mock_courses( 1, 1, 1, 1, 1 );
+		$course  = llms_get_post( $courses[0] );
+		$lesson  = $course->get_lessons()[0];
+		$lid     = $lesson->get( 'id' );
+		$qid     = $lesson->get( 'quiz' );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$attempt = LLMS_Quiz_Attempt::init( $qid, $lid, $uid );
+			$attempt->save();
+		}
+
+		return array(
+			'quiz_id'    => $qid,
+			'lesson_id'  => $lid,
+			'student_id' => $uid,
+		);
+	}
+
+	/**
+	 * Test found_results and max_pages with pagination.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_found_results_with_pagination() {
+
+		$data = $this->create_attempts( 7 );
+
+		$query = new LLMS_Query_Quiz_Attempt(
+			array(
+				'student_id' => $data['student_id'],
+				'quiz_id'    => $data['quiz_id'],
+				'per_page'   => 3,
+			)
+		);
+
+		$this->assertSame( 7, $query->get_found_results() );
+		$this->assertSame( 3, $query->get_max_pages() );
+		$this->assertSame( 3, $query->get_number_results() );
+	}
+
+	/**
+	 * Test no_found_rows skips counting.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_found_rows_skips_count() {
+
+		$data = $this->create_attempts( 3 );
+
+		$query = new LLMS_Query_Quiz_Attempt(
+			array(
+				'student_id'    => $data['student_id'],
+				'quiz_id'       => $data['quiz_id'],
+				'no_found_rows' => true,
+			)
+		);
+
+		$this->assertTrue( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
+	 * Test count_only returns accurate count.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_count_only() {
+
+		$data = $this->create_attempts( 5 );
+
+		$query = new LLMS_Query_Quiz_Attempt(
+			array(
+				'student_id' => $data['student_id'],
+				'quiz_id'    => $data['quiz_id'],
+				'count_only' => true,
+			)
+		);
+
+		$this->assertSame( 5, $query->get_count_only_result() );
+	}
+}

--- a/tests/phpunit/unit-tests/class-llms-test-user-postmeta-query.php
+++ b/tests/phpunit/unit-tests/class-llms-test-user-postmeta-query.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for LLMS_Query_User_Postmeta found_results / count_only behavior.
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group query
+ * @group dbquery
+ *
+ * @since [version]
+ */
+class LLMS_Test_User_Postmeta_Query extends LLMS_UnitTestCase {
+
+	/**
+	 * Teardown.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		global $wpdb;
+		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}lifterlms_user_postmeta" );
+	}
+
+	/**
+	 * Insert mock user postmeta rows.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $count   Number of rows.
+	 * @param int $user_id User ID.
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	private function insert_rows( $count, $user_id, $post_id ) {
+
+		global $wpdb;
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$wpdb->insert(
+				"{$wpdb->prefix}lifterlms_user_postmeta",
+				array(
+					'user_id'      => $user_id,
+					'post_id'      => $post_id,
+					'meta_key'     => '_status',
+					'meta_value'   => 'enrolled',
+					'updated_date' => current_time( 'mysql' ),
+				),
+				array( '%d', '%d', '%s', '%s', '%s' )
+			);
+		}
+	}
+
+	/**
+	 * Test found_results and max_pages with pagination.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_found_results_with_pagination() {
+
+		$uid = $this->factory->user->create();
+		$pid = $this->factory->post->create();
+		$this->insert_rows( 9, $uid, $pid );
+
+		$query = new LLMS_Query_User_Postmeta(
+			array(
+				'user_id'  => $uid,
+				'post_id'  => $pid,
+				'per_page' => 4,
+			)
+		);
+
+		$this->assertSame( 9, $query->get_found_results() );
+		$this->assertSame( 3, $query->get_max_pages() );
+		$this->assertSame( 4, $query->get_number_results() );
+	}
+
+	/**
+	 * Test no_found_rows skips counting.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_found_rows_skips_count() {
+
+		$uid = $this->factory->user->create();
+		$pid = $this->factory->post->create();
+		$this->insert_rows( 3, $uid, $pid );
+
+		$query = new LLMS_Query_User_Postmeta(
+			array(
+				'user_id'       => $uid,
+				'post_id'       => $pid,
+				'no_found_rows' => true,
+			)
+		);
+
+		$this->assertTrue( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
+	 * Test count_only returns accurate count.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_count_only() {
+
+		$uid = $this->factory->user->create();
+		$pid = $this->factory->post->create();
+		$this->insert_rows( 6, $uid, $pid );
+
+		$query = new LLMS_Query_User_Postmeta(
+			array(
+				'user_id'    => $uid,
+				'post_id'    => $pid,
+				'count_only' => true,
+			)
+		);
+
+		$this->assertSame( 6, $query->get_count_only_result() );
+	}
+}

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-student.php
@@ -208,4 +208,32 @@ class LLMS_Test_LLMS_Student extends LLMS_UnitTestCase {
 		$this->assertEquals( $actions + 3, did_action( 'llms_user_enrollment_deleted' ) );
 	}
 
+	/**
+	 * Test get_enrollments() returns accurate found count without SQL_CALC_FOUND_ROWS.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_enrollments_found_count() {
+
+		$courses = $this->generate_mock_courses( 5, 1, 1, 0 );
+
+		foreach ( $courses as $cid ) {
+			$this->student->enroll( $cid );
+		}
+
+		$result = $this->student->get_enrollments( 'course', array( 'limit' => 2 ) );
+
+		$this->assertSame( 5, $result['found'] );
+		$this->assertSame( 2, $result['limit'] );
+		$this->assertCount( 2, $result['results'] );
+		$this->assertTrue( $result['more'] );
+
+		$result_all = $this->student->get_enrollments( 'course', array( 'limit' => 10 ) );
+		$this->assertSame( 5, $result_all['found'] );
+		$this->assertCount( 5, $result_all['results'] );
+		$this->assertFalse( $result_all['more'] );
+	}
+
 }

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications-query.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications-query.php
@@ -66,6 +66,78 @@ class LLMS_Test_Notifications_Query extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test found_results and max_pages with real notifications data.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_found_results_with_pagination() {
+
+		$post_id = $this->factory->post->create();
+
+		for ( $i = 0; $i < 8; $i++ ) {
+			$n = new LLMS_Notification();
+			$n->create(
+				array(
+					'post_id'    => $post_id,
+					'subscriber' => 1,
+					'type'       => 'basic',
+					'trigger_id' => 1,
+					'user_id'    => 1,
+				)
+			);
+		}
+
+		$query = new LLMS_Notifications_Query(
+			array(
+				'subscriber' => 1,
+				'post_id'    => $post_id,
+				'per_page'   => 3,
+			)
+		);
+
+		$this->assertSame( 8, $query->get_found_results() );
+		$this->assertSame( 3, $query->get_max_pages() );
+		$this->assertSame( 3, $query->get_number_results() );
+	}
+
+	/**
+	 * Test that no_found_rows skips counting.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_no_found_rows_skips_count() {
+
+		$post_id = $this->factory->post->create();
+
+		$n = new LLMS_Notification();
+		$n->create(
+			array(
+				'post_id'    => $post_id,
+				'subscriber' => 1,
+				'type'       => 'basic',
+				'trigger_id' => 1,
+				'user_id'    => 1,
+			)
+		);
+
+		$query = new LLMS_Notifications_Query(
+			array(
+				'subscriber'    => 1,
+				'post_id'       => $post_id,
+				'no_found_rows' => true,
+			)
+		);
+
+		$this->assertTrue( $query->has_results() );
+		$this->assertSame( 0, $query->get_found_results() );
+		$this->assertSame( 0, $query->get_max_pages() );
+	}
+
+	/**
 	 * Test getting notifications, escluding the errored ones (default).
 	 *
 	 * @since 7.1.0

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications-query.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications-query.php
@@ -13,33 +13,42 @@
 class LLMS_Test_Notifications_Query extends LLMS_Unit_Test_Case {
 
 	/**
-	 * Test that the notifications query, using default args, calculates found rows.
+	 * Test that the notifications query, using default args, sets up a count_query
+	 * and does not use SQL_CALC_FOUND_ROWS.
 	 *
 	 * @since 7.1.0
+	 * @since [version] Updated: SQL_CALC_FOUND_ROWS replaced with count_query.
 	 *
 	 * @return void
 	 */
-	public function test_query_with_default_args_calculates_found_rows() {
+	public function test_query_with_default_args_sets_count_query() {
 		$query = new LLMS_Notifications_Query();
 		$sql = LLMS_Unit_Test_Util::call_method( $query, 'prepare_query' );
-		$this->assertSame( 0, strpos( $sql, 'SELECT SQL_CALC_FOUND_ROWS' ) );
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $sql );
+
+		$count_query = LLMS_Unit_Test_Util::get_private_property_value( $query, 'count_query' );
+		$this->assertStringStartsWith( 'SELECT COUNT(*)', $count_query );
 	}
 
 	/**
-	 * Test that the notifications query, passing no_found_rows as true doesn't calculate found rows.
+	 * Test that the notifications query, passing no_found_rows as true, does not set count_query.
 	 *
 	 * @since 7.1.0
+	 * @since [version] Updated: SQL_CALC_FOUND_ROWS replaced with count_query.
 	 *
 	 * @return void
 	 */
-	public function test_query_correctly_doesnt_calculate_found_rows() {
+	public function test_query_correctly_doesnt_set_count_query() {
 		$query = new LLMS_Notifications_Query(
 			array(
 				'no_found_rows' => true,
 			)
 		);
 		$sql = LLMS_Unit_Test_Util::call_method( $query, 'prepare_query' );
-		$this->assertSame( false, strpos( $sql, 'SQL_CALC_FOUND_ROWS' ) );
+		$this->assertStringNotContainsString( 'SQL_CALC_FOUND_ROWS', $sql );
+
+		$count_query = LLMS_Unit_Test_Util::get_private_property_value( $query, 'count_query' );
+		$this->assertEmpty( $count_query );
 	}
 
 	/**


### PR DESCRIPTION

## Description

- Removing SQL_CALC_FOUND_ROWS by building a separate count query off the same table, joins, where.
- Check that SQL_CALC_FOUND_ROWS wasn't added to the query via a filter

Inspired by the approach in https://github.com/WordPress/wordpress-develop/pull/3863 (unmerged due to the risks of the core filters that can modify the query in any way)

Fixes #3079

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

