### PR TITLE
Avoid media protecting error if there are multiple registered sizes with the same filename, or thumbnail size file doesn't exist

### DIFF
--- a/.changelogs/check-thumbnail-sizes-protected-image.yml
+++ b/.changelogs/check-thumbnail-sizes-protected-image.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#3129"
+entry: Avoid error protecting media image when multiple thumbnail of same size exist.

--- a/.changelogs/check-thumbnail-sizes-protected-image.yml
+++ b/.changelogs/check-thumbnail-sizes-protected-image.yml
@@ -2,4 +2,5 @@ significance: patch
 type: fixed
 links:
   - "#3129"
-entry: Avoid error protecting media image when multiple thumbnail of same size exist.
+entry: Avoid error protecting media image when multiple thumbnail of same size
+  exist, or registered thumbnail size is missing.

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -116,6 +116,9 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 
 					$old_thumb = $base_dir . '/' . $size_info['file'];
 					$new_thumb = $new_base_dir . '/' . $size_info['file'];
+					if ( ! $wp_filesystem->exists( $old_thumb ) ) {
+						continue;
+					}
 					if ( ! $wp_filesystem->move( $old_thumb, $new_thumb ) ) {
 						error_log( 'Unable to move protected file. Thumbnail moving failed: ' . $new_thumb );
 

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -120,7 +120,7 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 						continue;
 					}
 					if ( ! $wp_filesystem->move( $old_thumb, $new_thumb ) ) {
-						error_log( 'Unable to move protected file. Thumbnail moving failed: ' . $new_thumb );
+						error_log( 'Unable to move protected file. Thumbnail moving failed: ' . $old_thumb . ' to ' . $new_thumb );
 
 						// Move the file back along with any thumbnails we already moved.
 						$wp_filesystem->move( $new_file, $file );

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -106,7 +106,14 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 				$base_dir     = dirname( $file );
 				$new_base_dir = dirname( $new_file );
 
+				// Multiple registered sizes can share the same physical file.
+				$moved_files = array();
+
 				foreach ( $metadata['sizes'] as $size => $size_info ) {
+					if ( in_array( $size_info['file'], $moved_files, true ) ) {
+						continue;
+					}
+
 					$old_thumb = $base_dir . '/' . $size_info['file'];
 					$new_thumb = $new_base_dir . '/' . $size_info['file'];
 					if ( ! $wp_filesystem->move( $old_thumb, $new_thumb ) ) {
@@ -114,14 +121,9 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 
 						// Move the file back along with any thumbnails we already moved.
 						$wp_filesystem->move( $new_file, $file );
-						foreach ( $metadata['sizes'] as $s => $size_info ) {
-							if ( $s === $size ) {
-								// We've reached the spot where we failed, so we can stop.
-								return false;
-							}
-
-							$old_thumb = $base_dir . '/' . $size_info['file'];
-							$new_thumb = $new_base_dir . '/' . $size_info['file'];
+						foreach ( $moved_files as $moved_file ) {
+							$old_thumb = $base_dir . '/' . $moved_file;
+							$new_thumb = $new_base_dir . '/' . $moved_file;
 							if ( $wp_filesystem->exists( $new_thumb ) ) {
 								$wp_filesystem->move( $new_thumb, $old_thumb );
 							}
@@ -129,6 +131,8 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 
 						return false;
 					}
+
+					$moved_files[] = $size_info['file'];
 				}
 			}
 

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -128,6 +128,7 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 					$old_thumb = $base_dir . '/' . $size_info['file'];
 					$new_thumb = $new_base_dir . '/' . $size_info['file'];
 					if ( ! $wp_filesystem->exists( $old_thumb ) ) {
+						error_log( 'Registered metadata thumbnail file does not exist. Skipping. ' . $old_thumb );
 						continue;
 					}
 					if ( ! $wp_filesystem->move( $old_thumb, $new_thumb ) ) {


### PR DESCRIPTION

## Description

Fixes #3129

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

