### PR TITLE
Add order note when access expiration changed

### DIFF
--- a/.changelogs/add-order-note-when-access-expiration-changed.yml
+++ b/.changelogs/add-order-note-when-access-expiration-changed.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Adding order note when changing the access expiration date.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.submit.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.submit.php
@@ -98,6 +98,7 @@ class LLMS_Meta_Box_Order_Submit extends LLMS_Admin_Metabox {
 	 * @since 3.36.0 Date fields require array when sanitized.
 	 * @since 5.9.0 Stop using deprecated `FILTER_SANITIZE_STRING`.
 	 * @since 7.0.0 Do not save recurring payments related dates if order's gateway do not support recurring payments modification.
+	 * @since [version] Add order note when access expiration date is changed.
 	 *
 	 * @param int $post_id  WP Post ID of the Order
 	 * @return null
@@ -155,7 +156,19 @@ class LLMS_Meta_Box_Order_Submit extends LLMS_Admin_Metabox {
 
 				// If the dates are not equal, update the date.
 				if ( $new_date !== $saved_date ) {
-					$order->set_date( str_replace( '_llms_date_', '', $key ), $new_date . ':00' );
+					$date_key = str_replace( '_llms_date_', '', $key );
+					$order->set_date( $date_key, $new_date . ':00' );
+
+					if ( 'access_expires' === $date_key ) {
+						$old_date_display = $saved_date
+							? date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $saved_date ) )
+							: __( 'none', 'lifterlms' );
+						$new_date_display = date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), strtotime( $new_date ) );
+
+						// Translators: %1$s = old access expiration date; %2$s = new access expiration date.
+						$note = sprintf( __( 'Access expiration date changed from %1$s to %2$s', 'lifterlms' ), $old_date_display, $new_date_display );
+						$order->add_note( $note, true );
+					}
 				}
 			}
 		}


### PR DESCRIPTION

## Description
When access expiration changed at the order level, add a note.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="1240" height="1196" alt="CleanShot 2026-04-24 at 07 46 08@2x" src="https://github.com/user-attachments/assets/7672f3a4-5885-46b1-83e3-84405f21e987" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

