### PR TITLE
Added lesson navigation shortcode

### DIFF
--- a/.changelogs/lesson-navigation-shortcode.yml
+++ b/.changelogs/lesson-navigation-shortcode.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added [lifterlms_lesson_navigation] shortcode.

--- a/includes/shortcodes/class.llms.shortcode.lesson.navigation.php
+++ b/includes/shortcodes/class.llms.shortcode.lesson.navigation.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * LifterLMS Lesson Navigation Shortcode
+ *
+ * [lifterlms_lesson_navigation]
+ *
+ * @package LifterLMS/Shortcodes/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Shortcode_Lesson_Navigation
+ *
+ * @since [version]
+ */
+class LLMS_Shortcode_Lesson_Navigation extends LLMS_Shortcode {
+
+	/**
+	 * Shortcode tag
+	 *
+	 * @var string
+	 */
+	public $tag = 'lifterlms_lesson_navigation';
+
+	/**
+	 * Retrieve the actual content of the shortcode
+	 *
+	 * $atts & $content are both filtered before being passed to get_output()
+	 * output is filtered so the return of get_output() doesn't need its own filter
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function get_output() {
+
+		ob_start();
+		lifterlms_template_lesson_navigation();
+		return ob_get_clean();
+	}
+}
+
+return LLMS_Shortcode_Lesson_Navigation::instance();

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -38,6 +38,7 @@ class LLMS_Shortcodes {
 	 * @since 6.0.0 Removed loading of class files that don't instantiate their class in favor of autoloading.
 	 * @since 6.4.0 Allowed `LLMS_Shortcode_User_Info` class to be filtered.
 	 * @since 7.5.0 Added `LLMS_Shortcode_Favorites` class in shortcodes array.
+	 * @since [version] Added `LLMS_Shortcode_Lesson_Navigation` class in shortcodes array.
 	 *
 	 * @return void
 	 */
@@ -66,6 +67,7 @@ class LLMS_Shortcodes {
 				'LLMS_Shortcode_Courses',
 				'LLMS_Shortcode_Hide_Content',
 				'LLMS_Shortcode_Lesson_Mark_Complete',
+				'LLMS_Shortcode_Lesson_Navigation',
 				'LLMS_Shortcode_Membership_Link',
 				'LLMS_Shortcode_Membership_Instructors',
 				'LLMS_Shortcode_My_Achievements',


### PR DESCRIPTION

## Description
Adds `[lifterlms_lesson_navigation]` shortcode

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2856" height="1596" alt="CleanShot 2026-04-27 at 05 14 55@2x" src="https://github.com/user-attachments/assets/8597eb31-5c6c-4c56-95a3-516e06ea3d2c" />
<img width="2178" height="1560" alt="CleanShot 2026-04-27 at 05 14 42@2x" src="https://github.com/user-attachments/assets/d59673a8-d662-4d97-925b-60f3694395d3" />


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

