### PR TITLE
Fix php warning calling exit() with null

### DIFF
--- a/.changelogs/fix_php-warning-exit-with-null.yml
+++ b/.changelogs/fix_php-warning-exit-with-null.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Avoids PHP warning for passing null to exit() when using llms_exit().

--- a/includes/functions/llms-functions-wrappers.php
+++ b/includes/functions/llms-functions-wrappers.php
@@ -57,6 +57,10 @@ if ( ! function_exists( 'llms_exit' ) ) {
 	 * @return void
 	 */
 	function llms_exit( $status = null ) {
+		if ( is_null( $status ) ) {
+			exit();
+		}
+
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		exit( $status );
 	}


### PR DESCRIPTION

## Description
Avoids warning when llms_exit() is called with no params. For example:

`[28-Apr-2026 14:06:02 UTC] PHP Deprecated:  exit(): Passing null to parameter #1 ($status) of type string|int is deprecated in /var/www/html/site/public_html/wp-content/plugins/lifterlms/includes/functions/llms-functions-wrappers.php on line 61`

## How has this been tested?
Manually


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

