### PR TITLE
Fix reordering sections without first selecting the section

### DIFF
--- a/assets/js/builder/Views/Course.js
+++ b/assets/js/builder/Views/Course.js
@@ -139,11 +139,11 @@ define( [
 		active_section_change: function( current, previous ) {
 
 			_.each( current, function( model ) {
-				model.set( '_selected', true );
+				model.set( '_selected', true, { silent: true } );
 			} );
 
 			_.each( previous, function( model ) {
-				model.set( '_selected', false );
+				model.set( '_selected', false, { silent: true } );
 			} );
 
 		},


### PR DESCRIPTION

## Description

Fixes #3137

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

https://github.com/user-attachments/assets/aa179b94-9a38-4653-a990-a4f12e4b9bd7



No changelog since this is related to the yet unreleased course builder improvements.