### PR TITLE
Removing deprecated Sass functions

### DIFF
--- a/.changelogs/fix_update-saas-methods.yml
+++ b/.changelogs/fix_update-saas-methods.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: dev
+entry: Removing deprecated methods in the scss files.

--- a/assets/scss/_includes/_buttons.scss
+++ b/assets/scss/_includes/_buttons.scss
@@ -86,12 +86,12 @@ a.llms-button-primary {
 	color: $color-cinder;
 	&:hover {
 		color: #414141;
-		background: darken( #e1e1e1, 8 );
+		background: #cdcdcd;
 	}
 	&:focus,
 	&:active {
 		color: #414141;
-		background: lighten( #e1e1e1, 4 );
+		background: #ebebeb;
 	}
 }
 /* Fix for cases where link color overrides the button color */
@@ -114,11 +114,11 @@ a.llms-button-secondary {
 .llms-button-danger {
 	background: $color-danger;
 	&:hover {
-		background: darken( $color-danger, 8 );
+		background: #981c17;
 	}
 	&:focus,
 	&:active {
-		background: lighten( $color-danger, 4 );
+		background: #cd261f;
 	}
 }
 

--- a/assets/scss/_includes/_llms-form-field.scss
+++ b/assets/scss/_includes/_llms-form-field.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .llms-form-fields {
 	@extend %clearfix;
 	box-sizing: border-box;
@@ -95,7 +97,7 @@
 
 		&.valid {
 			input[type="date"], input[type="time"], input[type="datetime-local"], input[type="week"], input[type="month"], input[type="text"], input[type="email"], input[type="url"], input[type="password"], input[type="search"], input[type="tel"], input[type="number"], textarea, select {
-				background: rgba( #83c373, .3 );
+				background: color.change( #83c373, $alpha: 0.3 );
 				border-color: #83c373;
 			}
 		}
@@ -103,7 +105,7 @@
 		&.error,
 		&.invalid {
 			input[type="date"], input[type="time"], input[type="datetime-local"], input[type="week"], input[type="month"], input[type="text"], input[type="email"], input[type="url"], input[type="password"], input[type="search"], input[type="tel"], input[type="number"], textarea, select {
-				background: rgba( $color-red, .3 );
+				background: color.change( $color-red, $alpha: 0.3 );
 				border-color: $color-red;
 			}
 		}
@@ -263,7 +265,7 @@
 		&.very-weak {
 			border-color: #e35b5b;
 			&:before {
-				background: rgba( #e35b5b, 0.25 );
+				background: color.change( #e35b5b, $alpha: 0.25 );
 				width: 25%;
 			}
 		}
@@ -275,7 +277,7 @@
 		&.weak {
 			border-color: #f78b53;
 			&:before {
-				background: rgba( #f78b53, 0.25 );
+				background: color.change( #f78b53, $alpha: 0.25 );
 				width: 50%;
 			}
 		}
@@ -283,7 +285,7 @@
 		&.medium {
 			border-color: #ffc733;
 			&:before {
-				background: rgba( #ffc733, 0.25 );
+				background: color.change( #ffc733, $alpha: 0.25 );
 				width: 75%;
 			}
 		}
@@ -291,7 +293,7 @@
 		&.strong {
 			border-color: #83c373;
 			&:before {
-				background: rgba( #83c373, 0.25 );
+				background: color.change( #83c373, $alpha: 0.25 );
 				width: 100%;
 			}
 		}

--- a/assets/scss/_includes/_mixins.scss
+++ b/assets/scss/_includes/_mixins.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 
 @mixin clearfix() {
 	&:before,
@@ -93,7 +94,7 @@
 		&.llms-pass, // quiz
 		&.llms-txn-succeeded {
 			color: $color-green;
-			background-color: rgba( $color-green, .15 );
+			background-color: color.change( $color-green, $alpha: 0.15 );
 		}
 
 		&.llms-fail, // quiz
@@ -102,7 +103,7 @@
 		&.llms-cancelled,
 		&.llms-txn-failed {
 			color: $color-red;
-			background-color: rgba( $color-red, .15 );
+			background-color: color.change( $color-red, $alpha: 0.15 );
 		}
 
 		&.llms-incomplete, // assignment
@@ -113,7 +114,7 @@
 		&.llms-txn-pending,
 		&.llms-txn-refunded {
 			color: $color-orange;
-			background-color: rgba( $color-orange, .15 );
+			background-color: color.change( $color-orange, $alpha: 0.15 );
 		}
 
 	}

--- a/assets/scss/_includes/_quiz-result-question-list.scss
+++ b/assets/scss/_includes/_quiz-result-question-list.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .llms-quiz-attempt-results {
 	margin: 0;
 	padding: 0;
@@ -20,20 +22,20 @@
 
 		&.status--waiting.correct,
 		&.status--waiting.incorrect {
-			background: rgba( $color-orange, 0.2 );
+			background: color.change( $color-orange, $alpha: 0.2 );
 			.llms-status-icon {
 				background-color: $color-orange;
 			}
 		}
 
 		&.status--graded.correct {
-			background: rgba( $color-green, 0.15 );
+			background: color.change( $color-green, $alpha: 0.15 );
 			.llms-status-icon {
 				background-color: $color-green;
 			}
 		}
 		&.status--graded.incorrect {
-			background: rgba( $color-red, 0.15 );
+			background: color.change( $color-red, $alpha: 0.15 );
 			.llms-status-icon {
 				background-color: $color-red;
 			}
@@ -96,7 +98,7 @@
 			}
 
 			.llms-quiz-attempt-answer-section {
-				border-top: 2px solid rgba( #fff, 0.5 );
+				border-top: 2px solid color.change( #fff, $alpha: 0.5 );
 				margin-top: 20px;
 				padding-top: 20px;
 				&:first-child {

--- a/assets/scss/_includes/_vars-brand-colors.scss
+++ b/assets/scss/_includes/_vars-brand-colors.scss
@@ -4,13 +4,13 @@
 //
 
 $color-brand-blue: #466dd8;
-$color-brand-blue-dark: darken( $color-brand-blue, 8 );
-$color-brand-dark-blue: darken( $color-brand-blue, 24 );
-$color-brand-blue-light: lighten( $color-brand-blue, 8 );
+$color-brand-blue-dark: #2b55cb;
+$color-brand-dark-blue: #1c3987;
+$color-brand-blue-light: #6888df;
 
 $color-brand-orange: #f8954f;
 $color-brand-orange-dark: #f67d28;
-$color-brand-orange-light: lighten( $color-brand-orange, 8 );
+$color-brand-orange-light: #faad76;
 
 $color-brand-aqua: #17bebb;
 

--- a/assets/scss/_includes/_vars.scss
+++ b/assets/scss/_includes/_vars.scss
@@ -2,12 +2,12 @@
 $color-brand-dark-blue: #243c56;
 
 $color-brand-blue: #466dd8;
-$color-brand-blue-dark: darken( $color-brand-blue, 12 ); // #0077e4
-$color-brand-blue-light: lighten( $color-brand-blue, 8 );
+$color-brand-blue-dark: #274eba;
+$color-brand-blue-light: #6888df;
 
 $color-brand-orange: #f8954f;
 $color-brand-orange-dark: #f67d28;
-$color-brand-orange-light: lighten( $color-brand-orange, 8 );
+$color-brand-orange-light: #faad76;
 
 $color-brand-aqua: #17bebb;
 
@@ -25,7 +25,7 @@ $color-aqua: #35bbaa;
 $color-purple: #845ef7;
 $color-orange: #c05621;
 
-$color-red-hover: darken($color-red,5);
+$color-red-hover: #a51f19;
 
 
 // ----- state / action names ----- \\

--- a/assets/scss/_includes/_vars.scss
+++ b/assets/scss/_includes/_vars.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 // ----- LifterLMS Brand Colors ----- \\
 $color-brand-dark-blue: #243c56;
 
@@ -59,7 +60,7 @@ $color-darkblue:		#0185a3;
 
 $color-border: #dedede;
 
-$el-box-shadow: 0 1px 2px 0 rgba($color-black,0.4);
+$el-box-shadow: 0 1px 2px 0 color.change($color-black, $alpha: 0.4);
 $el-background: #f1f1f1;
 $el-background-hover: #eaeaea;
 

--- a/assets/scss/admin-wizard.scss
+++ b/assets/scss/admin-wizard.scss
@@ -1,3 +1,4 @@
+@use 'sass:color';
 @import "_includes/vars";
 
 $input_padding: 0.3em 0.6em;
@@ -56,7 +57,7 @@ $input_padding: 0.3em 0.6em;
 
 	p.error {
 		color: $color-red;
-		background: rgba($color-red,0.1);
+		background: color.change($color-red, $alpha: 0.1);
 		border: 1px solid currentColor;
 		padding: 1em;
 		border-radius: 4px;

--- a/assets/scss/admin/_course-builder.scss
+++ b/assets/scss/admin/_course-builder.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 body.admin_page_llms-course-builder {
 	background: #fff;
 
@@ -359,7 +361,7 @@ body.admin_page_llms-course-builder {
 
 			&.llms-sortable-placeholder {
 				border: 3px dashed $color-brand-blue;
-				background: rgba( $color-brand-blue, 0.3 );
+				background: color.change( $color-brand-blue, $alpha: 0.3 );
 				margin: 0 10px;
 				padding: 5px;
 				&:before { display: none; }
@@ -1578,7 +1580,7 @@ body.admin_page_llms-course-builder {
 
 				li.llms-question-choice.llms-sortable-placeholder {
 					border: 3px dashed $color-brand-blue !important;
-					background: rgba( $color-brand-blue, 0.3 );
+					background: color.change( $color-brand-blue, $alpha: 0.3 );
 				}
 
 				li.llms-question-choice.ui-sortable-helper {
@@ -1599,7 +1601,7 @@ body.admin_page_llms-course-builder {
 
 		li.llms-question.llms-sortable-placeholder {
 			border: 3px dashed $color-brand-blue !important;
-			background: rgba( $color-brand-blue, 0.3 );
+			background: color.change( $color-brand-blue, $alpha: 0.3 );
 		}
 
 	}

--- a/assets/scss/admin/_tabs.scss
+++ b/assets/scss/admin/_tabs.scss
@@ -10,7 +10,7 @@
 
 			.llms-nav-link:hover,
 			&.llms-active .llms-nav-link {
-				background: darken( #e1e1e1, 8 );
+				background: #cdcdcd;
 			}
 
 		}

--- a/assets/scss/admin/metaboxes/_metabox-orders.scss
+++ b/assets/scss/admin/metaboxes/_metabox-orders.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .post-type-llms_order #post-body-content { display: none; }
 #lifterlms-order-details {
 	.handlediv,
@@ -12,8 +14,8 @@
 
 // failed transaction color
 .llms-table tbody tr.llms-txn-failed td {
-	background-color: rgba( $color-red, 0.5 );
-	border-bottom-color: rgba( $color-red, 0.5 );
+	background-color: color.change( $color-red, $alpha: 0.5 );
+	border-bottom-color: color.change( $color-red, $alpha: 0.5 );
 }
 
 // refunded transaction color

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -1,3 +1,5 @@
+@use 'sass:color';
+
 .single-llms_quiz {
 	#llms-quiz-wrapper {
 		@import "../_includes/quiz-result-question-list";
@@ -129,7 +131,7 @@
 
 	.llms-error {
 		@include clearfix();
-		background: rgba( $color-red, .15 );
+		background: color.change( $color-red, $alpha: 0.15 );
 		border: 1px solid $color-red;
 		border-radius: $radius-small;
 		margin: 20px 0;

--- a/assets/scss/frontend/_notices.scss
+++ b/assets/scss/frontend/_notices.scss
@@ -1,5 +1,7 @@
+@use 'sass:color';
+
 .llms-notice {
-	background: rgba( $color-brand-blue, .3 );
+	background: color.change( $color-brand-blue, $alpha: 0.3 );
 	border-color: $color-brand-blue;
 	border-style: solid;
 	border-width: 1px;
@@ -20,17 +22,17 @@
 	}
 
 	&.llms-debug {
-		background: rgba( #cacaca, .3 );
+		background: color.change( #cacaca, $alpha: 0.3 );
 		border-color: #cacaca;
 	}
 
 	&.llms-error {
-		background: rgba( $color-red, .15 );
+		background: color.change( $color-red, $alpha: 0.15 );
 		border-color: $color-red;
 	}
 
 	&.llms-success {
-		background: rgba( $color-green, .15 );
+		background: color.change( $color-green, $alpha: 0.15 );
 		border-color: $color-green;
 	}
 


### PR DESCRIPTION


## Description
The use of the other methods caused floating point weirdness in the compiled css files.

Does not change the use of `@import` yet

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

