### PR TITLE
Additional check before sending notification emails

### DIFF
--- a/.changelogs/additional-check-notification-emails.yml
+++ b/.changelogs/additional-check-notification-emails.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Avoid sending an email notification if the status is not new, if the
+  background processor does not finish correctly.

--- a/includes/notifications/processors/class.llms.notification.processor.email.php
+++ b/includes/notifications/processors/class.llms.notification.processor.email.php
@@ -40,9 +40,15 @@ class LLMS_Notification_Processor_Email extends LLMS_Abstract_Notification_Proce
 	protected function task( $notification_id ) {
 
 		$this->log( sprintf( 'sending email notification ID #%d', $notification_id ) );
-		try {
 
-			$notification = new LLMS_Notification( $notification_id );
+		$notification = new LLMS_Notification( $notification_id );
+
+		if ( 'new' !== $notification->get( 'status', true ) ) {
+			$this->log( sprintf( 'Skipping email notification ID #%d - status is "%s", not "new"', $notification_id, $notification->get( 'status' ) ) );
+			return false;
+		}
+
+		try {
 
 			$view = $notification->get_view();
 

--- a/includes/notifications/processors/class.llms.notification.processor.email.php
+++ b/includes/notifications/processors/class.llms.notification.processor.email.php
@@ -43,8 +43,9 @@ class LLMS_Notification_Processor_Email extends LLMS_Abstract_Notification_Proce
 
 		$notification = new LLMS_Notification( $notification_id );
 
-		if ( 'new' !== $notification->get( 'status', true ) ) {
-			$this->log( sprintf( 'Skipping email notification ID #%d - status is "%s", not "new"', $notification_id, $notification->get( 'status' ) ) );
+		$status = $notification->get( 'status', true );
+		if ( 'new' !== $status ) {
+			$this->log( sprintf( 'Skipping email notification ID #%d - status is "%s", not "new"', $notification_id, $status ) );
 			return false;
 		}
 

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
@@ -426,7 +426,7 @@ class LLMS_Test_Notifications extends LLMS_UnitTestCase {
 		);
 
 		$this->assertEquals( false, $res );
-		$this->assertEquals( 'error', $n1->get('status') );
+		$this->assertEquals( 'error', $n1->get( 'status', true ) );
 
 		$this->assertStringContainsString(
 			'Error caught Call to a member function get_order() on null',

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
@@ -275,6 +275,76 @@ class LLMS_Test_Notifications extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test email processor task() skips notifications that are not in "new" status.
+	 *
+	 * Prevents duplicate emails when the background queue is replayed after a
+	 * process interruption that left the batch in wp_options uncleaned.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_email_processor_task_skips_non_new_notifications() {
+
+		$order = $this->get_mock_order();
+		$txn   = $order->record_transaction(
+			array(
+				'amount'             => $order->get_initial_price( array(), 'float' ),
+				'source_description' => 'Mock Payment',
+				'transaction_id'     => uniqid( 'mock-' ),
+				'status'             => 'llms-txn-succeeded',
+				'payment_gateway'    => 'manual',
+			)
+		);
+
+		$email_processor = $this->main->get_processor( 'email' );
+
+		$statuses_to_skip = array( 'sent', 'error', 'read' );
+
+		foreach ( $statuses_to_skip as $status ) {
+
+			$this->logs->clear( 'notifications' );
+
+			$n   = new LLMS_Notification();
+			$nid = $n->create(
+				array(
+					'post_id'    => $txn->get( 'id' ),
+					'subscriber' => $this->factory->user->create(),
+					'type'       => 'email',
+					'trigger_id' => 'purchase_receipt',
+					'user_id'    => get_current_user_id(),
+				)
+			);
+
+			$n->set( 'status', $status );
+
+			$res = LLMS_Unit_Test_Util::call_method( $email_processor, 'task', array( $nid ) );
+
+			$this->assertFalse( $res, "task() should return false for status '{$status}'" );
+
+			// Status should remain unchanged.
+			$this->assertEquals( $status, $n->get( 'status', true ), "Status should stay '{$status}' after being skipped" );
+
+			// A skip log message should be written.
+			$log = implode( $this->logs->get( 'notifications' ) );
+			$this->assertStringContainsString(
+				"Skipping email notification ID #{$nid}",
+				$log,
+				"Expected skip log for status '{$status}'"
+			);
+			$this->assertStringContainsString(
+				$status,
+				$log,
+				"Skip log should include the current status '{$status}'"
+			);
+
+		}
+
+		$this->logs->clear( 'notifications' );
+
+	}
+
+	/**
 	 * Test email processor task's method on errored notification.
 	 *
 	 * @since 7.1.0

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notifications.php
@@ -418,6 +418,7 @@ class LLMS_Test_Notifications extends LLMS_UnitTestCase {
 
 		// Delete the first transaction so that a fatal will be triggered.
 		wp_delete_post( $txn->get( 'id' ) );
+		$n1->set( 'status', 'new' );
 		$res = LLMS_Unit_Test_Util::call_method(
 			$email_processor,
 			'task',


### PR DESCRIPTION

## Description
If the background processor does not complete successfully, a notification email could be re-sent. Check that the notification status is "new" before sending and skip otherwise.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

