### PR TITLE
Fix: wrap add_query_arg() with esc_url() on admin notice href

### DIFF
--- a/includes/admin/class.llms.admin.notices.core.php
+++ b/includes/admin/class.llms.admin.notices.core.php
@@ -103,13 +103,13 @@ class LLMS_Admin_Notices_Core {
 			$html  = __( 'No LifterLMS Payment Gateways are currently enabled. Students will only be able to enroll in courses or memberships with free access plans.', 'lifterlms' ) . '<br><br>';
 			$html .= sprintf(
 				__( 'For starters you can configure manual payments on the %1$sCheckout Settings tab%2$s. Be sure to check out all the available %3$sLifterLMS Payment Gateways%4$s and install one later so that you can start selling your courses and memberships.', 'lifterlms' ),
-				'<a href="' . add_query_arg(
+				'<a href="' . esc_url( add_query_arg(
 					array(
 						'page' => 'llms-settings',
 						'tab'  => 'checkout',
 					),
 					admin_url( 'admin.php' )
-				) . '">',
+				) ) . '">',
 				'</a>',
 				'<a href="https://lifterlms.com/product-category/plugins/payment-gateways/" target="_blank">',
 				'</a>'


### PR DESCRIPTION
Hey folks,

The checkout settings link in the no-payment-gateways admin notice builds its URL with add_query_arg() but concatenates the result directly into '<a href="' . add_query_arg(...) . '">' without esc_url(). URLs placed in HTML attribute context must go through esc_url() — it validates the scheme and encodes unsafe characters.

One-line fix in class.llms.admin.notices.core.php.

(full disclosure, I used AI help with the testing and tweaks - Christopher)