### PR TITLE
Extra check when updating data via the course builder

### DIFF
--- a/.changelogs/fix_rest-api-and-course-builder-checks-1.yml
+++ b/.changelogs/fix_rest-api-and-course-builder-checks-1.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: security
+attributions:
+  - "@RegorSec"
+entry: Additional checks on permissions with the REST API.

--- a/.changelogs/fix_rest-api-and-course-builder-checks.yml
+++ b/.changelogs/fix_rest-api-and-course-builder-checks.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: Improved checks when saving Course Builder data.

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "lifterlms/lifterlms-blocks": "2.7.2",
     "lifterlms/lifterlms-cli": "0.0.5",
     "lifterlms/lifterlms-helper": "3.5.9",
-    "lifterlms/lifterlms-rest": "1.0.5",
+    "lifterlms/lifterlms-rest": "1.0.6",
     "woocommerce/action-scheduler": "3.5.4",
     "gocodebox/banner-notifications": "1.1.1"
   },

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -1142,14 +1142,6 @@ class LLMS_Admin_Builder {
 				// Don't create useless revision on "creating".
 				add_filter( 'wp_revisions_to_keep', '__return_zero', 999 );
 
-				/**
-				 * If the parent section was just created the lesson will have a temp id
-				 * replace it with the newly created section's real ID.
-				 */
-				if ( ! isset( $lesson_data['parent_section'] ) || self::is_temp_id( $lesson_data['parent_section'] ) ) {
-					$lesson_data['parent_section'] = $section->get( 'id' );
-				}
-
 				// Return the real ID (important when creating a new lesson).
 				$res['id'] = $lesson->get( 'id' );
 
@@ -1162,6 +1154,17 @@ class LLMS_Admin_Builder {
 				);
 
 				$skip_props = apply_filters( 'llms_builder_update_lesson_skip_props', array( 'quiz' ) );
+
+				/**
+				 * Never trust client-supplied parent relationships.
+				 *
+				 * A lesson saved through the builder must belong to the authorized course and
+				 * one of its sections. These props are skipped in the generic update loop and
+				 * set explicitly below to prevent injecting or moving a lesson into a course
+				 * the current user is not authorized to edit.
+				 */
+				$skip_props[] = 'parent_course';
+				$skip_props[] = 'parent_section';
 
 				// Don't overwrite content if the content editor doesn't display.
 				if ( ! $created && '' !== $lesson->get( 'content' ) && ! llms_parse_bool( $lesson->get( 'content_added_in_builder' ) ) ) {
@@ -1180,6 +1183,15 @@ class LLMS_Admin_Builder {
 						$lesson->set( $prop, $lesson_data[ $prop ] );
 					}
 				}
+
+				// Force the lesson into the authorized course and section.
+				$authorized_course_id = $course_id ? absint( $course_id ) : absint( $section->get( 'parent_course' ) );
+				$lesson->set( 'parent_section', $section->get( 'id' ) );
+				if ( $authorized_course_id ) {
+					$lesson->set( 'parent_course', $authorized_course_id );
+				}
+				$res['parent_section'] = $lesson->get( 'parent_section' );
+				$res['parent_course']  = $lesson->get( 'parent_course' );
 
 				// Update all custom fields.
 				self::update_custom_schemas( 'lesson', $lesson, $lesson_data );
@@ -1436,11 +1448,14 @@ class LLMS_Admin_Builder {
 			);
 
 			// Update all updatable properties.
+			// Never trust a client-supplied lesson_id; the quiz must belong to the authorized lesson.
 			foreach ( $properties as $prop ) {
-				if ( isset( $quiz_data[ $prop ] ) ) {
+				if ( isset( $quiz_data[ $prop ] ) && 'lesson_id' !== $prop ) {
 					$quiz->set( $prop, $quiz_data[ $prop ] );
 				}
 			}
+			$quiz->set( 'lesson_id', $lesson->get( 'id' ) );
+			$res['lesson_id'] = $lesson->get( 'id' );
 
 			// Include permalink and slug in the response so the builder can update the model.
 			$res['permalink'] = get_permalink( $quiz->get( 'id' ) );

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -1085,6 +1085,15 @@ class LLMS_Admin_Builder {
 
 		$ret = array();
 
+		/**
+		 * Resolve the course these lessons must belong to and confirm the current user can edit it.
+		 *
+		 * Authorizing the target relationship here keeps the method self-contained rather than
+		 * relying solely on a permission check performed earlier in the heartbeat request.
+		 */
+		$authorized_course_id = $course_id ? absint( $course_id ) : absint( $section->get( 'parent_course' ) );
+		$can_edit_course      = ! $authorized_course_id || current_user_can( 'edit_course', $authorized_course_id );
+
 		foreach ( $lessons as $lesson_data ) {
 
 			if ( ! isset( $lesson_data['id'] ) ) {
@@ -1097,6 +1106,13 @@ class LLMS_Admin_Builder {
 					'orig_id' => $lesson_data['id'],
 				)
 			);
+
+			if ( ! $can_edit_course ) {
+				// Translators: %s = Lesson post id.
+				$res['error'] = sprintf( esc_html__( 'Unable to update lesson "%s". You are not allowed to edit the parent course.', 'lifterlms' ), $lesson_data['id'] );
+				array_push( $ret, $res );
+				continue;
+			}
 
 			// Create a new lesson.
 			if ( self::is_temp_id( $lesson_data['id'] ) ) {
@@ -1185,7 +1201,6 @@ class LLMS_Admin_Builder {
 				}
 
 				// Force the lesson into the authorized course and section.
-				$authorized_course_id = $course_id ? absint( $course_id ) : absint( $section->get( 'parent_course' ) );
 				$lesson->set( 'parent_section', $section->get( 'id' ) );
 				if ( $authorized_course_id ) {
 					$lesson->set( 'parent_course', $authorized_course_id );
@@ -1385,6 +1400,14 @@ class LLMS_Admin_Builder {
 			)
 		);
 
+		// Confirm the current user can edit the course this quiz belongs to, independent of earlier checks.
+		$authorized_course_id = $course_id ? absint( $course_id ) : absint( $lesson->get( 'parent_course' ) );
+		if ( $authorized_course_id && ! current_user_can( 'edit_course', $authorized_course_id ) ) {
+			// Translators: %s = Quiz post id.
+			$res['error'] = sprintf( esc_html__( 'Unable to update quiz "%s". You are not allowed to edit the parent course.', 'lifterlms' ), $quiz_data['id'] );
+			return $res;
+		}
+
 		// Create a quiz.
 		if ( self::is_temp_id( $quiz_data['id'] ) ) {
 
@@ -1491,6 +1514,13 @@ class LLMS_Admin_Builder {
 				'orig_id' => $section_data['id'],
 			)
 		);
+
+		// Confirm the current user can edit the course this section belongs to, independent of earlier checks.
+		if ( $course_id && ! current_user_can( 'edit_course', absint( $course_id ) ) ) {
+			// Translators: %s = Section post id.
+			$res['error'] = sprintf( esc_html__( 'Unable to update section "%s". You are not allowed to edit the parent course.', 'lifterlms' ), $section_data['id'] );
+			return $res;
+		}
 
 		// Create a new section.
 		if ( self::is_temp_id( $section_data['id'] ) ) {

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -546,6 +546,8 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	 */
 	public function test_move_lesson_in_a_brand_new_section() {
 
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
 		// Create a Course with a Lesson.
 		$course = $this->factory->course->create_and_get( array(
 			'sections' => 1,
@@ -593,7 +595,9 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	 */
 	public function test_update_lessons_cannot_move_to_another_course() {
 
-		// Authorized course (A) the builder is editing, with a section + lesson.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Course the builder is editing, with a section + lesson.
 		$course_a  = $this->factory->course->create_and_get( array(
 			'sections' => 1,
 			'lessons'  => 1,
@@ -602,7 +606,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 		$section_a = $course_a->get_sections()[0];
 		$lesson_a  = $course_a->get_lessons()[0];
 
-		// Course (B) with its own section.
+		// A different course with its own section.
 		$course_b  = $this->factory->course->create_and_get( array(
 			'sections' => 1,
 			'lessons'  => 0,
@@ -610,7 +614,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 		) );
 		$section_b = $course_b->get_sections()[0];
 
-		// Craft builder data attempting to move lesson A into course B / section B.
+		// Craft builder data attempting to move the lesson into course B / section B.
 		$lessons_data = array(
 			array(
 				'id'             => $lesson_a->get( 'id' ),
@@ -640,7 +644,9 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	 */
 	public function test_update_lessons_new_lesson_cannot_inject_into_another_course() {
 
-		// Authorized course (A) with a section.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Course being edited, with a section.
 		$course_a  = $this->factory->course->create_and_get( array(
 			'sections' => 1,
 			'lessons'  => 0,
@@ -648,7 +654,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 		) );
 		$section_a = $course_a->get_sections()[0];
 
-		// Victim course (B) with its own section.
+		// A different course with its own section.
 		$course_b  = $this->factory->course->create_and_get( array(
 			'sections' => 1,
 			'lessons'  => 0,
@@ -659,7 +665,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 		$lessons_data = array(
 			array(
 				'id'             => 'temp_1',
-				'title'          => 'Injected lesson',
+				'title'          => 'New lesson',
 				'parent_course'  => $course_b->get( 'id' ),
 				'parent_section' => $section_b->get( 'id' ),
 			),
@@ -673,7 +679,7 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 
 		$new_lesson = llms_get_post( $res[0]['id'] );
 
-		// The new lesson must belong to the authorized course/section, not the victim course.
+		// The new lesson must belong to the authorized course/section, not course B.
 		$this->assertEquals( $course_a->get( 'id' ), $new_lesson->get( 'parent_course' ) );
 		$this->assertEquals( $section_a->get( 'id' ), $new_lesson->get_parent_section() );
 		$this->assertEmpty( $course_b->get_lessons() );
@@ -688,6 +694,8 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	 */
 	public function test_update_quiz_forces_lesson_id_to_authorized_lesson() {
 
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
 		$course = $this->factory->course->create_and_get( array(
 			'sections' => 1,
 			'lessons'  => 1,
@@ -695,13 +703,13 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 		) );
 		$lesson = $course->get_lessons()[0];
 
-		// A victim lesson the attacker should not be able to point the quiz at.
-		$victim_lesson_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
+		// A lesson outside the builder context that the quiz must not be pointed at.
+		$other_lesson_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
 
 		$quiz_data = array(
 			'id'        => 'temp_1',
 			'title'     => 'Quiz',
-			'lesson_id' => $victim_lesson_id,
+			'lesson_id' => $other_lesson_id,
 		);
 
 		$res = LLMS_Unit_Test_Util::call_method(
@@ -712,6 +720,146 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 
 		$quiz = llms_get_post( $res['id'] );
 		$this->assertEquals( $lesson->get( 'id' ), $quiz->get( 'lesson_id' ) );
+	}
+
+	/**
+	 * Test that a user who can only edit one course cannot use a builder heartbeat to move or
+	 * inject lessons into a different course they are not allowed to edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_heartbeat_cannot_move_or_inject_lessons_into_unauthorized_course() {
+
+		$user_with_access    = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		$user_without_access = $this->factory->user->create( array( 'role' => 'instructor' ) );
+
+		// Course B is owned by a different user.
+		wp_set_current_user( $user_without_access );
+		$course_b  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+		$section_b = $course_b->get_sections()[0];
+
+		// Course A is owned by the user performing the save.
+		wp_set_current_user( $user_with_access );
+		$course_a  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 1,
+			'quizzes'  => 0,
+		) );
+		$section_a = $course_a->get_sections()[0];
+		$lesson_a  = $course_a->get_lessons()[0];
+
+		// The privilege boundary this test depends on.
+		$this->assertTrue( current_user_can( 'edit_course', $course_a->get( 'id' ) ) );
+		$this->assertFalse( current_user_can( 'edit_course', $course_b->get( 'id' ) ) );
+
+		// Heartbeat for course A that attempts to move the existing lesson and inject a new one into course B.
+		$builder_data = array(
+			'id'      => $course_a->get( 'id' ),
+			'updates' => array(
+				'id'       => $course_a->get( 'id' ),
+				'sections' => array(
+					array(
+						'id'      => $section_a->get( 'id' ),
+						'lessons' => array(
+							array(
+								'id'             => $lesson_a->get( 'id' ),
+								'parent_course'  => $course_b->get( 'id' ),
+								'parent_section' => $section_b->get( 'id' ),
+							),
+							array(
+								'id'             => 'temp_1',
+								'title'          => 'New lesson',
+								'parent_course'  => $course_b->get( 'id' ),
+								'parent_section' => $section_b->get( 'id' ),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'heartbeat_received',
+			array( array(), array( 'llms_builder' => wp_json_encode( $builder_data ) ) )
+		);
+
+		$this->assertEquals( 'success', $res['llms_builder']['status'] );
+
+		// The existing lesson stays in course A.
+		$lesson_a = llms_get_post( $lesson_a->get( 'id' ) );
+		$this->assertEquals( $course_a->get( 'id' ), $lesson_a->get( 'parent_course' ) );
+		$this->assertEquals( $section_a->get( 'id' ), $lesson_a->get_parent_section() );
+
+		// Course B gains no lessons from the crafted request.
+		$this->assertEmpty( $course_b->get_lessons() );
+	}
+
+	/**
+	 * Test that update_section refuses to write into a course the current user cannot edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_section_requires_edit_course_capability() {
+
+		$owner = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $owner );
+		$course = $this->factory->course->create_and_get( array(
+			'sections' => 0,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+
+		// A different user without access to the course attempts the save.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'instructor' ) ) );
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_section',
+			array( array( 'id' => 'temp_1', 'title' => 'New section' ), $course->get( 'id' ) )
+		);
+
+		$this->assertArrayHasKey( 'error', $res );
+		$this->assertEmpty( $course->get_sections() );
+	}
+
+	/**
+	 * Test that update_quiz refuses to write into a course the current user cannot edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_quiz_requires_edit_course_capability() {
+
+		$owner = $this->factory->user->create( array( 'role' => 'instructor' ) );
+		wp_set_current_user( $owner );
+		$course = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 1,
+			'quizzes'  => 0,
+		) );
+		$lesson = $course->get_lessons()[0];
+
+		// A different user without access to the course attempts the save.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'instructor' ) ) );
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_quiz',
+			array( array( 'id' => 'temp_1', 'title' => 'New quiz' ), $lesson, $course->get( 'id' ) )
+		);
+
+		$this->assertArrayHasKey( 'error', $res );
+		$this->assertFalse( $lesson->is_quiz_enabled() );
 	}
 
 	/**

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -585,6 +585,136 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that a lesson cannot be moved into a course the builder is not authorized to edit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_lessons_cannot_move_to_another_course() {
+
+		// Authorized course (A) the builder is editing, with a section + lesson.
+		$course_a  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 1,
+			'quizzes'  => 0,
+		) );
+		$section_a = $course_a->get_sections()[0];
+		$lesson_a  = $course_a->get_lessons()[0];
+
+		// Course (B) with its own section.
+		$course_b  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+		$section_b = $course_b->get_sections()[0];
+
+		// Craft builder data attempting to move lesson A into course B / section B.
+		$lessons_data = array(
+			array(
+				'id'             => $lesson_a->get( 'id' ),
+				'parent_course'  => $course_b->get( 'id' ),
+				'parent_section' => $section_b->get( 'id' ),
+			),
+		);
+
+		LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_lessons',
+			array( $lessons_data, $section_a, $course_a->get( 'id' ) )
+		);
+
+		// The lesson must remain in the authorized course/section.
+		$lesson_a = llms_get_post( $lesson_a->get( 'id' ) );
+		$this->assertEquals( $course_a->get( 'id' ), $lesson_a->get( 'parent_course' ) );
+		$this->assertEquals( $section_a->get( 'id' ), $lesson_a->get_parent_section() );
+	}
+
+	/**
+	 * Test that a newly created lesson cannot be injected into another course via the builder.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_lessons_new_lesson_cannot_inject_into_another_course() {
+
+		// Authorized course (A) with a section.
+		$course_a  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+		$section_a = $course_a->get_sections()[0];
+
+		// Victim course (B) with its own section.
+		$course_b  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+		$section_b = $course_b->get_sections()[0];
+
+		$lessons_data = array(
+			array(
+				'id'             => 'temp_1',
+				'title'          => 'Injected lesson',
+				'parent_course'  => $course_b->get( 'id' ),
+				'parent_section' => $section_b->get( 'id' ),
+			),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_lessons',
+			array( $lessons_data, $section_a, $course_a->get( 'id' ) )
+		);
+
+		$new_lesson = llms_get_post( $res[0]['id'] );
+
+		// The new lesson must belong to the authorized course/section, not the victim course.
+		$this->assertEquals( $course_a->get( 'id' ), $new_lesson->get( 'parent_course' ) );
+		$this->assertEquals( $section_a->get( 'id' ), $new_lesson->get_parent_section() );
+		$this->assertEmpty( $course_b->get_lessons() );
+	}
+
+	/**
+	 * Test that a quiz's lesson_id is forced to the authorized lesson and cannot be pointed elsewhere.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_quiz_forces_lesson_id_to_authorized_lesson() {
+
+		$course = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 1,
+			'quizzes'  => 0,
+		) );
+		$lesson = $course->get_lessons()[0];
+
+		// A victim lesson the attacker should not be able to point the quiz at.
+		$victim_lesson_id = $this->factory->post->create( array( 'post_type' => 'lesson' ) );
+
+		$quiz_data = array(
+			'id'        => 'temp_1',
+			'title'     => 'Quiz',
+			'lesson_id' => $victim_lesson_id,
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_quiz',
+			array( $quiz_data, $lesson, $course->get( 'id' ) )
+		);
+
+		$quiz = llms_get_post( $res['id'] );
+		$this->assertEquals( $lesson->get( 'id' ), $quiz->get( 'lesson_id' ) );
+	}
+
+	/**
 	 * Catch wp_die() called by ajax methods & store the output buffer contents for use later.
 	 *
 	 * The same method is used in LLMS_Test_AJAX_Handler.


### PR DESCRIPTION

## Description
Avoid the ability to move content from one course to another course.

Updating REST API version to latest.

## How has this been tested?
Manually and PHPUnit tests

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

