### PR TITLE
fix: wrap add_query_arg() with esc_url() in no-gateways admin notice

### DIFF
--- a/includes/admin/class.llms.admin.notices.core.php
+++ b/includes/admin/class.llms.admin.notices.core.php
@@ -103,13 +103,13 @@ class LLMS_Admin_Notices_Core {
 			$html  = __( 'No LifterLMS Payment Gateways are currently enabled. Students will only be able to enroll in courses or memberships with free access plans.', 'lifterlms' ) . '<br><br>';
 			$html .= sprintf(
 				__( 'For starters you can configure manual payments on the %1$sCheckout Settings tab%2$s. Be sure to check out all the available %3$sLifterLMS Payment Gateways%4$s and install one later so that you can start selling your courses and memberships.', 'lifterlms' ),
-				'<a href="' . add_query_arg(
+				'<a href="' . esc_url( add_query_arg(
 					array(
 						'page' => 'llms-settings',
 						'tab'  => 'checkout',
 					),
 					admin_url( 'admin.php' )
-				) . '">',
+				) ) . '">',
 				'</a>',
 				'<a href="https://lifterlms.com/product-category/plugins/payment-gateways/" target="_blank">',
 				'</a>'


### PR DESCRIPTION
## What

In `LLMS_Admin_Notices_Core::gateways()`, a URL built with `add_query_arg()` was placed directly in an `<a href>` attribute without passing through `esc_url()` first.

**Before:**
```php
'<a href="' . add_query_arg( array( 'page' => 'llms-settings', 'tab' => 'checkout' ), admin_url( 'admin.php' ) ) . '">'
```

**After:**
```php
'<a href="' . esc_url( add_query_arg( array( 'page' => 'llms-settings', 'tab' => 'checkout' ), admin_url( 'admin.php' ) ) ) . '">'
```

## Why

WordPress Coding Standards require every URL placed in an HTML attribute context to go through `esc_url()`. `add_query_arg()` returns a raw URL string — while the inputs here are controlled constants, skipping `esc_url()` is a coding standard violation and sets a pattern that becomes risky in contexts where inputs are less controlled.

`esc_url()` validates the URL scheme and encodes unsafe characters before they enter an HTML attribute, preventing markup injection through URL values.

This is called out explicitly in the [WordPress VIP Go Coding Standards](https://docs.wpvip.com/technical-references/code-review/insecure-functions/) as a common source of XSS vulnerabilities.

---
*Development and testing assisted by AI. All code reviewed and verified manually.*