### PR TITLE
fix(notifications): add unenrollment notification trigger

### DIFF
--- a/.changelogs/issue-3141.yml
+++ b/.changelogs/issue-3141.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added unenrollment notification trigger (popup and email) for courses and memberships, disabled by default."

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -307,6 +307,7 @@ class LLMS_Notifications {
 			'section_complete',
 			'student_welcome',
 			'subscription_cancelled',
+			'unenrollment',
 			'upcoming_payment_reminder',
 		);
 

--- a/includes/notifications/controllers/class.llms.notification.controller.unenrollment.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.unenrollment.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Notification Controller: Unenrollment
+ *
+ * @package LifterLMS/Notifications/Controllers/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification Controller: Unenrollment
+ *
+ * @since [version]
+ */
+class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notification_Controller {
+
+	/**
+	 * Trigger Identifier
+	 *
+	 * @var string
+	 */
+	public $id = 'unenrollment';
+
+	/**
+	 * Number of accepted arguments passed to the callback function
+	 *
+	 * The unenrollment action fires with 4 args: $user_id, $product_id, $trigger, $new_status.
+	 *
+	 * @var int
+	 */
+	protected $action_accepted_args = 4;
+
+	/**
+	 * Action hooks used to trigger sending of the notification
+	 *
+	 * `llms_user_removed_from_membership_level` was deprecated in 3.37.9 and removed in
+	 * 6.0.0; `llms_user_removed_from_membership` is the current hook.
+	 *
+	 * @var array
+	 */
+	protected $action_hooks = array(
+		'llms_user_removed_from_course',
+		'llms_user_removed_from_membership',
+	);
+
+	/**
+	 * Callback function, called after a user is unenrolled from a course or membership
+	 *
+	 * @param int    $user_id     WP User ID of the unenrolled user.
+	 * @param int    $post_id     WP Post ID of the course or membership.
+	 * @param string $trigger     Enrollment trigger that caused the unenrollment.
+	 * @param string $new_status  New enrollment status applied to the user.
+	 * @return void
+	 * @since [version]
+	 * @version [version]
+	 */
+	public function action_callback( $user_id = null, $post_id = null, $trigger = null, $new_status = null ) {
+
+		$this->user_id = $user_id;
+		$this->post_id = $post_id;
+		$this->course  = llms_get_post( $post_id );
+
+		$this->send();
+
+	}
+
+	/**
+	 * Takes a subscriber type (student, author, etc) and retrieves a User ID
+	 *
+	 * @param string $subscriber Subscriber type string.
+	 * @return int|false
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function get_subscriber( $subscriber ) {
+
+		switch ( $subscriber ) {
+
+			case 'author':
+				$uid = $this->course->get( 'author' );
+				break;
+
+			case 'student':
+				$uid = $this->user_id;
+				break;
+
+			default:
+				$uid = false;
+
+		}
+
+		return $uid;
+
+	}
+
+	/**
+	 * Get the translatable title for the notification
+	 * used on settings screens
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	public function get_title() {
+		return __( 'Unenrollment', 'lifterlms' );
+	}
+
+	/**
+	 * Setup the subscriber options for the notification
+	 *
+	 * All subscribers default to disabled ('no') per the feature request:
+	 * site administrators must opt in to receive unenrollment notifications.
+	 *
+	 * @param string $type Notification type id.
+	 * @return array
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_subscriber_options( $type ) {
+
+		$options = array();
+
+		switch ( $type ) {
+
+			case 'basic':
+				$options[] = $this->get_subscriber_option_array( 'student', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
+				break;
+
+			case 'email':
+				$options[] = $this->get_subscriber_option_array( 'student', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
+				break;
+
+		}
+
+		return $options;
+
+	}
+
+}
+
+return LLMS_Notification_Controller_Unenrollment::instance();

--- a/includes/notifications/controllers/class.llms.notification.controller.unenrollment.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.unenrollment.php
@@ -55,7 +55,6 @@ class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notificati
 	 * @param string $new_status  New enrollment status applied to the user.
 	 * @return void
 	 * @since [version]
-	 * @version [version]
 	 */
 	public function action_callback( $user_id = null, $post_id = null, $trigger = null, $new_status = null ) {
 
@@ -73,7 +72,6 @@ class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notificati
 	 * @param string $subscriber Subscriber type string.
 	 * @return int|false
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function get_subscriber( $subscriber ) {
 
@@ -102,7 +100,6 @@ class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notificati
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	public function get_title() {
 		return __( 'Unenrollment', 'lifterlms' );
@@ -117,7 +114,6 @@ class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notificati
 	 * @param string $type Notification type id.
 	 * @return array
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_subscriber_options( $type ) {
 

--- a/includes/notifications/views/class.llms.notification.view.unenrollment.php
+++ b/includes/notifications/views/class.llms.notification.view.unenrollment.php
@@ -46,7 +46,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_body() {
 		if ( 'email' === $this->notification->get( 'type' ) ) {
@@ -60,7 +59,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_footer() {
 		return '';
@@ -71,7 +69,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_icon() {
 		return $this->get_icon_default( 'negative' );
@@ -82,7 +79,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return array
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_merge_codes() {
 		return array(
@@ -98,7 +94,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 * @param string $code The merge code to get merged data for.
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_merge_data( $code ) {
 
@@ -127,7 +122,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_subject() {
 		if ( $this->is_for_self() ) {
@@ -141,7 +135,6 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 *
 	 * @return string
 	 * @since [version]
-	 * @version [version]
 	 */
 	protected function set_title() {
 		return sprintf( __( '%1$s unenrollment', 'lifterlms' ), '{{TYPE}}' );

--- a/includes/notifications/views/class.llms.notification.view.unenrollment.php
+++ b/includes/notifications/views/class.llms.notification.view.unenrollment.php
@@ -49,6 +49,9 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 * @version [version]
 	 */
 	protected function set_body() {
+		if ( 'email' === $this->notification->get( 'type' ) ) {
+			return sprintf( __( 'You have been unenrolled from %s.', 'lifterlms' ), '{{TITLE}}' );
+		}
 		return sprintf( __( '%1$s has been unenrolled from %2$s.', 'lifterlms' ), '{{STUDENT_NAME}}', '{{TITLE}}' );
 	}
 
@@ -127,6 +130,9 @@ class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_Vie
 	 * @version [version]
 	 */
 	protected function set_subject() {
+		if ( $this->is_for_self() ) {
+			return sprintf( __( 'You have been unenrolled from %s', 'lifterlms' ), '{{TITLE}}' );
+		}
 		return sprintf( __( '%1$s unenrolled from %2$s', 'lifterlms' ), '{{STUDENT_NAME}}', '{{TITLE}}' );
 	}
 

--- a/includes/notifications/views/class.llms.notification.view.unenrollment.php
+++ b/includes/notifications/views/class.llms.notification.view.unenrollment.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Notification View: Course/Membership Unenrollment
+ *
+ * @package LifterLMS/Notifications/Views/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification View: Course/Membership Unenrollment
+ *
+ * @since [version]
+ */
+class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_View {
+
+	/**
+	 * Settings for basic notifications
+	 *
+	 * @var array
+	 */
+	protected $basic_options = array(
+		/**
+		 * Time in milliseconds to show a notification
+		 * before automatically dismissing it
+		 */
+		'auto_dismiss' => 10000,
+		/**
+		 * Enables manual dismissal of notifications
+		 */
+		'dismissible'  => true,
+	);
+
+	/**
+	 * Notification Trigger ID
+	 *
+	 * @var string
+	 */
+	public $trigger_id = 'unenrollment';
+
+	/**
+	 * Setup body content for output
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_body() {
+		return sprintf( __( '%1$s has been unenrolled from %2$s.', 'lifterlms' ), '{{STUDENT_NAME}}', '{{TITLE}}' );
+	}
+
+	/**
+	 * Setup footer content for output
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_footer() {
+		return '';
+	}
+
+	/**
+	 * Setup notification icon for output
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_icon() {
+		return $this->get_icon_default( 'negative' );
+	}
+
+	/**
+	 * Setup merge codes that can be used with the notification
+	 *
+	 * @return array
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_merge_codes() {
+		return array(
+			'{{TITLE}}'        => __( 'Title', 'lifterlms' ),
+			'{{TYPE}}'         => __( 'Type (Course or Membership)', 'lifterlms' ),
+			'{{STUDENT_NAME}}' => __( 'Student Name', 'lifterlms' ),
+		);
+	}
+
+	/**
+	 * Replace merge codes with actual values
+	 *
+	 * @param string $code The merge code to get merged data for.
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_merge_data( $code ) {
+
+		switch ( $code ) {
+
+			case '{{TITLE}}':
+				$code = $this->post->get( 'title' );
+				break;
+
+			case '{{TYPE}}':
+				$code = $this->post->get_post_type_label();
+				break;
+
+			case '{{STUDENT_NAME}}':
+				$code = $this->is_for_self() ? __( 'you', 'lifterlms' ) : $this->user->get_name();
+				break;
+
+		}
+
+		return $code;
+
+	}
+
+	/**
+	 * Setup notification subject for output
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_subject() {
+		return sprintf( __( '%1$s unenrolled from %2$s', 'lifterlms' ), '{{STUDENT_NAME}}', '{{TITLE}}' );
+	}
+
+	/**
+	 * Setup notification title for output
+	 *
+	 * @return string
+	 * @since [version]
+	 * @version [version]
+	 */
+	protected function set_title() {
+		return sprintf( __( '%1$s unenrollment', 'lifterlms' ), '{{TYPE}}' );
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds a new `unenrollment` notification trigger that fires when a student is removed from a course or membership. Supports both popup (basic) and email delivery, with all subscribers disabled by default so existing sites are not opted in.

Fixes #3141

## Description

Adds a new `unenrollment` notification trigger that fires when a student is removed from a course or membership. Supports both popup (basic) and email delivery, with all subscribers disabled by default so existing sites are not opted in.

## How has this been tested?

**Test 1: registration**
1. WP Admin → LifterLMS → Settings → Notifications.
2. Confirm a new "Unenrollment" row appears.

Result: Works as expected.

**Test 2: defaults disabled**
1. Open the Unenrollment notification.
2. Confirm Student, Author, and Custom Email subscribers are all unchecked.

Result: Works as expected.

**Test 3: course unenrollment**
1. Enable Student (basic) and Student (email).
2. Enroll a test student in a course, then unenroll them from the Students tab.
3. Log in as the student and load a LifterLMS page.

Result: popup appears with the course title and the negative icon; the student receives the email.

**Test 4: membership unenrollment**
1. Repeat Test 3 with a membership.

Result: same popup and email behavior, with `{{TYPE}}` resolving to "Membership".

**Test 5: silent on hard delete**
1. Programmatically call `llms_delete_student_enrollment()` which fires the `llms_user_enrollment_deleted` hook (not the unenrollment hook).

Result: no notification is sent.

## Screenshots <!-- if applicable -->

CLI/no UI change. No visual change to existing screens; a new "Unenrollment" row appears in LifterLMS → Settings → Notifications.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] This PR requires and contains at least one changelog file (`.changelogs/issue-3141.yml`).
- [x] My code has been tested.
- [x] My code passes all existing automated tests (`composer run-script check-cs-errors` clean).
- [x] My code follows the LifterLMS Coding & Documentation Standards.

## Changes

### `includes/notifications/controllers/class.llms.notification.controller.unenrollment.php` (new)

**Before:** no controller existed for the unenrollment event.

**After:**
```php
class LLMS_Notification_Controller_Unenrollment extends LLMS_Abstract_Notification_Controller {
    public $id = 'unenrollment';
    protected $action_accepted_args = 4;
    protected $action_hooks = array(
        'llms_user_removed_from_course',
        'llms_user_removed_from_membership',
    );
    // action_callback() captures user_id + post_id and dispatches the notification.
    // get_subscriber() resolves 'author' (course/membership author) and 'student' (the unenrolled user).
    // set_subscriber_options() returns 'no' defaults for all subscribers.
}
```

**Why:** mirrors the existing `enrollment` controller pattern so admins configure one notification for both post types. Uses `llms_user_removed_from_membership` rather than the `_level` form (the `_level` hook was removed in 6.0.0). Accepts 4 args because the unenrollment action passes `$user_id, $post_id, $trigger, $new_status`.

### `includes/notifications/views/class.llms.notification.view.unenrollment.php` (new)

**Before:** no view existed for the unenrollment event.

**After:**
```php
class LLMS_Notification_View_Unenrollment extends LLMS_Abstract_Notification_View {
    public $trigger_id = 'unenrollment';
    protected $basic_options = array( 'auto_dismiss' => 10000, 'dismissible' => true );
    // Merge codes: {{TITLE}}, {{TYPE}}, {{STUDENT_NAME}}
    // Icon: negative variant.
    // Body (popup): "{{STUDENT_NAME}} has been unenrolled from {{TITLE}}."
    // Body (email): "You have been unenrolled from {{TITLE}}."
    // Subject (self): "You have been unenrolled from {{TITLE}}"
    // Subject (other): "{{STUDENT_NAME}} unenrolled from {{TITLE}}"
    // Title: "{{TYPE}} unenrollment"
}
```

**Why:** same merge-code and formatting conventions as the `enrollment` view. Body and subject branch on notification type and `is_for_self()` so the recipient is addressed directly when the notification is for them. Negative icon visually signals removal. The popup auto-dismisses and is manually dismissible like the rest of the basic notifications.

### `includes/notifications/class.llms.notifications.php`

**Before:** `$triggers` array ended with `subscription_cancelled` followed by `upcoming_payment_reminder`.

**After:** `'unenrollment'` inserted between them to keep alphabetical order.

**Why:** the loader pulls the controller and view from their conventional paths once the trigger is registered, so no other registration is needed.

### `.changelogs/issue-3141.yml` (new)

```yaml
significance: minor
type: added
entry: "Added unenrollment notification trigger (popup and email) for courses and memberships, disabled by default."
```

**Why:** the project's changelog tooling only picks up files ending in `.yml`; this matches the contribution workflow.
