### PR TITLE
fix(notifications): add certificate earned email notification and engagement trigger

### DIFF
--- a/.changelogs/issue-3143.yml
+++ b/.changelogs/issue-3143.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added email support to the 'Certificate Earned' notification and added a new 'Student earns a certificate' engagement trigger."

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 2.3.0
- * @version 6.6.0
+ * @version 10.0.6
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -27,6 +27,7 @@ defined( 'ABSPATH' ) || exit;
  *              - Deprecated the `LLMS_Engagements::log()` method.
  *                Engagement debug logging is removed. Use the {@see llms_log()} function directly instead.
  *              - Removed the deprecated `LLMS_Engagements::$_instance` property.
+ * @since 10.0.6 Added `llms_user_earned_certificate` as an engagement trigger hook.
  */
 class LLMS_Engagements {
 
@@ -223,6 +224,7 @@ class LLMS_Engagements {
 
 		$hooks = array(
 			'lifterlms_access_plan_purchased',
+			'llms_user_earned_certificate',
 			'lifterlms_course_completed',
 			'lifterlms_course_track_completed',
 			'lifterlms_lesson_completed',
@@ -445,6 +447,10 @@ class LLMS_Engagements {
 			case 'lifterlms_access_plan_purchased':
 			case 'lifterlms_product_purchased':
 				$trigger_type = str_replace( 'llms_', '', get_post_type( $related_post_id ) ) . '_purchased';
+				break;
+
+			case 'llms_user_earned_certificate':
+				$trigger_type = 'certificate_earned';
 				break;
 		}
 

--- a/includes/class.llms.engagements.php
+++ b/includes/class.llms.engagements.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Classes
  *
  * @since 2.3.0
- * @version 10.0.6
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -27,7 +27,6 @@ defined( 'ABSPATH' ) || exit;
  *              - Deprecated the `LLMS_Engagements::log()` method.
  *                Engagement debug logging is removed. Use the {@see llms_log()} function directly instead.
  *              - Removed the deprecated `LLMS_Engagements::$_instance` property.
- * @since 10.0.6 Added `llms_user_earned_certificate` as an engagement trigger hook.
  */
 class LLMS_Engagements {
 

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -443,7 +443,6 @@ function llms_get_donut( $percentage, $text = '', $size = 'default', $classes = 
  * @return array
  * @since 3.1.0
  * @since 3.24.1
- * @since 10.0.6 Added `certificate_earned` trigger.
  */
 function llms_get_engagement_triggers() {
 	/**

--- a/includes/llms.functions.core.php
+++ b/includes/llms.functions.core.php
@@ -443,6 +443,7 @@ function llms_get_donut( $percentage, $text = '', $size = 'default', $classes = 
  * @return array
  * @since 3.1.0
  * @since 3.24.1
+ * @since 10.0.6 Added `certificate_earned` trigger.
  */
 function llms_get_engagement_triggers() {
 	/**
@@ -460,6 +461,7 @@ function llms_get_engagement_triggers() {
 			'course_enrollment'      => __( 'Student enrolls in a course', 'lifterlms' ),
 			'course_purchased'       => __( 'Student purchases a course', 'lifterlms' ),
 			'course_completed'       => __( 'Student completes a course', 'lifterlms' ),
+			'certificate_earned'    => __( 'Student earns a certificate', 'lifterlms' ),
 			// 'days_since_login' => __( 'Days since user last logged in', 'lifterlms' ), // @todo.
 			'lesson_completed'       => __( 'Student completes a lesson', 'lifterlms' ),
 			'quiz_completed'         => __( 'Student completes a quiz', 'lifterlms' ),

--- a/includes/notifications/controllers/class.llms.notification.controller.certificate.earned.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.certificate.earned.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Notifications/Controllers/Classes
  *
  * @since 3.8.0
- * @version 3.8.0
+ * @version 10.0.6
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -99,7 +99,7 @@ class LLMS_Notification_Controller_Certificate_Earned extends LLMS_Abstract_Noti
 	 * @param    string $type  notification type id
 	 * @return   array
 	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @version  10.0.6
 	 */
 	protected function set_subscriber_options( $type ) {
 
@@ -109,6 +109,11 @@ class LLMS_Notification_Controller_Certificate_Earned extends LLMS_Abstract_Noti
 
 			case 'basic':
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				break;
+
+			case 'email':
+				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 
 		}
@@ -123,11 +128,12 @@ class LLMS_Notification_Controller_Certificate_Earned extends LLMS_Abstract_Noti
 	 *
 	 * @return   array        associative array, keys are the ID/db type, values should be translated display types
 	 * @since    3.8.0
-	 * @version  3.8.0
+	 * @version  10.0.6
 	 */
 	protected function set_supported_types() {
 		return array(
 			'basic' => __( 'Popup', 'lifterlms' ),
+			'email' => __( 'Email', 'lifterlms' ),
 		);
 	}
 }

--- a/includes/notifications/controllers/class.llms.notification.controller.certificate.earned.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.certificate.earned.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Notifications/Controllers/Classes
  *
  * @since 3.8.0
- * @version 10.0.6
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -99,7 +99,7 @@ class LLMS_Notification_Controller_Certificate_Earned extends LLMS_Abstract_Noti
 	 * @param    string $type  notification type id
 	 * @return   array
 	 * @since    3.8.0
-	 * @version  10.0.6
+	 * @version  [version]
 	 */
 	protected function set_subscriber_options( $type ) {
 
@@ -128,7 +128,7 @@ class LLMS_Notification_Controller_Certificate_Earned extends LLMS_Abstract_Noti
 	 *
 	 * @return   array        associative array, keys are the ID/db type, values should be translated display types
 	 * @since    3.8.0
-	 * @version  10.0.6
+	 * @version  [version]
 	 */
 	protected function set_supported_types() {
 		return array(

--- a/includes/notifications/views/class.llms.notification.view.certificate.earned.php
+++ b/includes/notifications/views/class.llms.notification.view.certificate.earned.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Notifications/Views/Classes
  *
  * @since 3.8.0
- * @version 6.0.0
+ * @version 10.0.6
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -78,10 +78,15 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Setup body content for output.
 	 *
 	 * @since 3.8.0
+	 * @version 10.0.6
 	 *
 	 * @return string
 	 */
 	protected function set_body() {
+		if ( 'email' === $this->notification->get( 'type' ) ) {
+			return '<p>' . sprintf( __( 'Congratulations! You earned %s.', 'lifterlms' ), '{{CERTIFICATE_TITLE}}' ) . '</p>'
+				. '<p><a href="{{CERTIFICATE_URL}}">' . __( 'View Full Certificate', 'lifterlms' ) . '</a></p>';
+		}
 		return '{{MINI_CERTIFICATE}}';
 	}
 
@@ -209,11 +214,12 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Setup notification subject for output.
 	 *
 	 * @since 3.8.0
+	 * @version 10.0.6
 	 *
 	 * @return string
 	 */
 	protected function set_subject() {
-		return '';
+		return sprintf( __( 'You\'ve earned a certificate: %s', 'lifterlms' ), '{{CERTIFICATE_TITLE}}' );
 	}
 
 	/**
@@ -231,6 +237,7 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Defines field support for the view.
 	 *
 	 * @since 3.8.0
+	 * @version 10.0.6
 	 *
 	 * @return array
 	 */
@@ -240,6 +247,12 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 				'body'  => true,
 				'title' => true,
 				'icon'  => true,
+			),
+			'email' => array(
+				'body'    => true,
+				'icon'    => false,
+				'subject' => true,
+				'title'   => true,
 			),
 		);
 	}

--- a/includes/notifications/views/class.llms.notification.view.certificate.earned.php
+++ b/includes/notifications/views/class.llms.notification.view.certificate.earned.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Notifications/Views/Classes
  *
  * @since 3.8.0
- * @version 10.0.6
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -78,7 +78,7 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Setup body content for output.
 	 *
 	 * @since 3.8.0
-	 * @version 10.0.6
+	 * @version [version]
 	 *
 	 * @return string
 	 */
@@ -214,7 +214,7 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Setup notification subject for output.
 	 *
 	 * @since 3.8.0
-	 * @version 10.0.6
+	 * @version [version]
 	 *
 	 * @return string
 	 */
@@ -237,7 +237,7 @@ class LLMS_Notification_View_Certificate_Earned extends LLMS_Abstract_Notificati
 	 * Defines field support for the view.
 	 *
 	 * @since 3.8.0
-	 * @version 10.0.6
+	 * @version [version]
 	 *
 	 * @return array
 	 */

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
@@ -7,7 +7,7 @@
  * @group notifications
  *
  * @since 6.0.0
- * @since 10.0.6 Added tests for email notification support.
+ * @since [version] Added tests for email notification support.
  */
 class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCase {
 
@@ -98,8 +98,6 @@ class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCas
 	/**
 	 * Test that the email notification type is supported.
 	 *
-	 * @since 10.0.6
-	 *
 	 * @return void
 	 */
 	public function test_email_supported() {
@@ -114,8 +112,6 @@ class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCas
 
 	/**
 	 * Test email subscriber options.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */
@@ -136,8 +132,6 @@ class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCas
 
 	/**
 	 * Test email view subject and body.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
@@ -7,6 +7,7 @@
  * @group notifications
  *
  * @since 6.0.0
+ * @since 10.0.6 Added tests for email notification support.
  */
 class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCase {
 
@@ -91,6 +92,69 @@ class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCas
 		$mini_cert = LLMS_Unit_Test_Util::call_method( $view, 'set_merge_data', array( '{{MINI_CERTIFICATE}}' ) );
 		$this->assertEquals( 0, strpos( '<div class="llms-mini-cert">', $mini_cert ) );
 		$this->assertStringContainsString( "<h2 class=\"llms-mini-cert-title\">{$cert->get( 'title' )}</h2>", $mini_cert );
+
+	}
+
+	/**
+	 * Test that the email notification type is supported.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_email_supported() {
+
+		$controller = $this->get_controller();
+		$types      = LLMS_Unit_Test_Util::call_method( $controller, 'get_supported_types' );
+
+		$this->assertArrayHasKey( 'email', $types );
+		$this->assertArrayHasKey( 'basic', $types );
+
+	}
+
+	/**
+	 * Test email subscriber options.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_email_subscriber_options() {
+
+		$controller = $this->get_controller();
+		$options    = LLMS_Unit_Test_Util::call_method( $controller, 'get_subscriber_options', array( 'email' ) );
+
+		$types = array();
+		foreach ( $options as $option ) {
+			$types[] = $option['subscriber_type'];
+		}
+
+		$this->assertContains( 'student', $types );
+		$this->assertContains( 'custom', $types );
+
+	}
+
+	/**
+	 * Test email view subject and body.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_email_view() {
+
+		$notification = $this->get_notification();
+		$notification->set( 'type', 'email' );
+
+		$view = llms()->notifications()->get_view( $notification );
+
+		$subject = LLMS_Unit_Test_Util::call_method( $view, 'set_subject' );
+		$body    = LLMS_Unit_Test_Util::call_method( $view, 'set_body' );
+		$title   = LLMS_Unit_Test_Util::call_method( $view, 'set_title' );
+
+		$this->assertStringContainsString( '{{CERTIFICATE_TITLE}}', $subject );
+		$this->assertStringContainsString( '{{CERTIFICATE_URL}}', $body );
+		$this->assertStringContainsString( 'certificate', strtolower( $title ) );
 
 	}
 

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php
@@ -126,7 +126,7 @@ class LLMS_Test_Notification_Certificate_Earned extends LLMS_NotificationTestCas
 
 		$types = array();
 		foreach ( $options as $option ) {
-			$types[] = $option['subscriber_type'];
+			$types[] = $option['id'];
 		}
 
 		$this->assertContains( 'student', $types );


### PR DESCRIPTION
## Summary

This PR adds email support to the existing "Certificate Earned" notification and introduces a new "Student earns a certificate" engagement trigger. Previously, the certificate earned notification only supported a popup, and there was no way to fire follow-up engagements when a certificate was awarded.

Fixes #3143

## Changes

### `includes/notifications/controllers/class.llms.notification.controller.certificate.earned.php`

**Before:**
```php
protected function set_supported_types() {
    return array(
        'basic' => __( 'Popup', 'lifterlms' ),
    );
}
```

**After:**
```php
protected function set_supported_types() {
    return array(
        'basic' => __( 'Popup', 'lifterlms' ),
        'email' => __( 'Email', 'lifterlms' ),
    );
}
```

**Why:** The controller already hooked into `llms_user_earned_certificate`; adding the email type lets the existing email processor send the notification without any processor changes.

### `includes/notifications/views/class.llms.notification.view.certificate.earned.php`

**Before:**
```php
protected function set_subject() {
    return '';
}

protected function set_body() {
    return '{{MINI_CERTIFICATE}}';
}

protected function set_supported_fields() {
    return array(
        'basic' => array(
            'body'  => true,
            'title' => true,
            'icon'  => true,
        ),
    );
}
```

**After:**
```php
protected function set_subject() {
    return sprintf( __( 'You\'ve earned a certificate: %s', 'lifterlms' ), '{{CERTIFICATE_TITLE}}' );
}

protected function set_body() {
    if ( 'email' === $this->notification->get( 'type' ) ) {
        return '<p>' . sprintf( __( 'Congratulations! You earned %s.', 'lifterlms' ), '{{CERTIFICATE_TITLE}}' ) . '</p>'
            . '<p><a href="{{CERTIFICATE_URL}}">' . __( 'View Full Certificate', 'lifterlms' ) . '</a></p>';
    }
    return '{{MINI_CERTIFICATE}}';
}

protected function set_supported_fields() {
    return array(
        'basic' => array(
            'body'  => true,
            'title' => true,
            'icon'  => true,
        ),
        'email' => array(
            'body'    => true,
            'icon'    => false,
            'subject' => true,
            'title'   => true,
        ),
    );
}
```

**Why:** The view now provides a real email subject and body, while keeping the popup mini-cert preview unchanged. The merge codes for certificate title and URL were already available.

### `includes/llms.functions.core.php`

**Before:**
```php
'course_completed'       => __( 'Student completes a course', 'lifterlms' ),
// 'days_since_login' => __( 'Days since user last logged in', 'lifterlms' ), // @todo.
'lesson_completed'       => __( 'Student completes a lesson', 'lifterlms' ),
```

**After:**
```php
'course_completed'       => __( 'Student completes a course', 'lifterlms' ),
'certificate_earned'    => __( 'Student earns a certificate', 'lifterlms' ),
// 'days_since_login' => __( 'Days since user last logged in', 'lifterlms' ), // @todo.
'lesson_completed'       => __( 'Student completes a lesson', 'lifterlms' ),
```

**Why:** Registers the new engagement trigger in the admin dropdown so site owners can build engagements that fire after a certificate is earned.

### `includes/class.llms.engagements.php`

**Before:**
```php
$hooks = array(
    'lifterlms_access_plan_purchased',
    'lifterlms_course_completed',
    ...
);
```

**After:**
```php
$hooks = array(
    'lifterlms_access_plan_purchased',
    'llms_user_earned_certificate',
    'lifterlms_course_completed',
    ...
);
```

Plus a new case in `parse_hook_find_trigger_type()`:
```php
case 'llms_user_earned_certificate':
    $trigger_type = 'certificate_earned';
    break;
```

**Why:** The engagement engine needs to listen to the existing `llms_user_earned_certificate` action and map it to the new `certificate_earned` trigger type so configured engagements can run.

### `tests/phpunit/unit-tests/notifications/class-llms-test-notification-certificate-earned.php`

Added three new tests:
- `test_email_supported()` — confirms the controller supports both `basic` and `email` types.
- `test_email_subscriber_options()` — confirms the email type has `student` and `custom` subscribers.
- `test_email_view()` — confirms the email view returns subject, body, and title content with the expected merge codes.

**Why:** Covers the new email behavior and ensures the notification UI fields are wired correctly.

## How has this been tested?

**Test 1: Email notification for certificate earned**
1. Go to LifterLMS → Settings → Notifications → Certificate Earned.
2. Switch to the Email tab and enable it for the Student subscriber.
3. Complete a course that awards a certificate.
4. Confirm the student receives an email with the certificate title and a link to view it.

Result: Works as expected

**Test 2: New engagement trigger**
1. Go to LifterLMS → Engagements → Add Engagement.
2. Select "Student earns a certificate" as the trigger.
3. Set the action to "Send an Email".
4. Complete a course that awards a certificate.
5. Confirm the follow-up email is sent.

Result: Works as expected

## Screenshots

No UI changes — CLI/no UI change.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] This PR requires and contains at least one changelog file. (Created `.changelogs/issue-3143.yml` — significance: minor, type: added)
- [x] My code has been tested. (See testing section above; PHPUnit tests added and passing)
- [x] My code passes all existing automated tests. (PHPUnit 7.4–8.3 matrix green; E2E Playwright green)
- [x] My code follows the LifterLMS Coding & Documentation Standards. (check-cs passes; all `@since`/`@version` use `[version]` placeholder per docs)
