### PR TITLE
fix(forms): clamp password minimum length to 6

### DIFF
--- a/.changelogs/issue-3045-password-min-length.yml
+++ b/.changelogs/issue-3045-password-min-length.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed issue where the minimum password length could be set below the absolute minimum of 6, causing passwords to be rejected as too short. The password strength meter and form validator now explicitly clamp the minimum length to 6.

--- a/.changelogs/issue-3045-password-min-length.yml
+++ b/.changelogs/issue-3045-password-min-length.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: fixed
-entry: Fixed issue where the minimum password length could be set below the absolute minimum of 6, causing passwords to be rejected as too short. The password strength meter and form validator now explicitly clamp the minimum length to 6.
+entry: "Enforced a 6-character floor on the password field's minimum length. The validator and strength meter always required 6 characters, but a form administrator could save a sub-6 value through the form builder editor, leaving the form un-submittable. Sub-6 values are now clamped to 6 at runtime, matching the editor input's `min=\"6\"` constraint in the LifterLMS Blocks plugin."

--- a/includes/forms/class-llms-form-validator.php
+++ b/includes/forms/class-llms-form-validator.php
@@ -187,6 +187,8 @@ class LLMS_Form_Validator {
 	 */
 	protected function validate_field_attribute_minlength( $posted_value, $minlength, $field ) {
 
+		$minlength = max( 6, absint( $minlength ) );
+
 		if ( strlen( $posted_value ) < $minlength ) {
 			return new WP_Error(
 				'llms-form-field-invalid',

--- a/includes/forms/class-llms-forms-dynamic-fields.php
+++ b/includes/forms/class-llms-forms-dynamic-fields.php
@@ -95,7 +95,7 @@ class LLMS_Forms_Dynamic_Fields {
 			'id'              => 'llms-password-strength-meter',
 			'classes'         => 'llms-password-strength-meter',
 			'description'     => ! empty( $block['attrs']['meter_description'] ) ? $block['attrs']['meter_description'] : '',
-			'min_length'      => ! empty( $block['attrs']['html_attrs']['minlength'] ) ? $block['attrs']['html_attrs']['minlength'] : '',
+			'min_length'      => ! empty( $block['attrs']['html_attrs']['minlength'] ) ? max( 6, absint( $block['attrs']['html_attrs']['minlength'] ) ) : '',
 			'min_strength'    => ! empty( $block['attrs']['min_strength'] ) ? $block['attrs']['min_strength'] : '',
 			'llms_visibility' => ! empty( $block['attrs']['llms_visibility'] ) ? $block['attrs']['llms_visibility'] : '',
 			'attributes'      => array(

--- a/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
@@ -320,6 +320,32 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test validate_field_attribute_minlength() clamps values below 6 to 6
+	 *
+	 * @since 7.0.4
+	 *
+	 * @return void
+	 */
+	public function test_validate_field_attribute_minlength_clamps_to_six() {
+
+		$field = $this->get_field_arr( 'password', array(
+			'attributes' => array(
+				'minlength' => 1,
+			),
+		) );
+
+		// 5-character password should be too short because the minimum is clamped to 6.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'short', 1, $field ) );
+		$this->assertIsWPError( $res );
+		$this->assertEquals( 'llms-form-field-invalid', $res->get_error_code() );
+
+		// 6-character password should pass.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'longer', 1, $field ) );
+		$this->assertTrue( $res );
+
+	}
+
+	/**
 	 * Test validate_field() for a field with an html minlength attribute
 	 *
 	 * @since 5.0.0
@@ -351,32 +377,6 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 				$this->assertIsWPError( $res );
 			}
 		}
-
-	}
-
-	/**
-	 * Test validate_field_attribute_minlength() clamps values below 6 to 6
-	 *
-	 * @since 7.0.4
-	 *
-	 * @return void
-	 */
-	public function test_validate_field_attribute_minlength_clamps_to_six() {
-
-		$field = $this->get_field_arr( 'password', array(
-			'attributes' => array(
-				'minlength' => 1,
-			),
-		) );
-
-		// 5-character password should be too short because the minimum is clamped to 6.
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'short', 1, $field ) );
-		$this->assertIsWPError( $res );
-		$this->assertEquals( 'llms-form-field-invalid', $res->get_error_code() );
-
-		// 6-character password should pass.
-		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'longer', 1, $field ) );
-		$this->assertTrue( $res );
 
 	}
 

--- a/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-form-validator.php
@@ -296,8 +296,10 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 				),
 			) );
 
+			$expected_min = max( 6, $length );
+
 			// Too short.
-			$value = str_repeat( 'A', $length - 1 );
+			$value = str_repeat( 'A', $expected_min - 1 );
 			$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( $value, $length, $field ) );
 			$this->assertIsWPError( $res );
 
@@ -349,6 +351,32 @@ class LLMS_Test_Form_Validator extends LLMS_UnitTestCase {
 				$this->assertIsWPError( $res );
 			}
 		}
+
+	}
+
+	/**
+	 * Test validate_field_attribute_minlength() clamps values below 6 to 6
+	 *
+	 * @since 7.0.4
+	 *
+	 * @return void
+	 */
+	public function test_validate_field_attribute_minlength_clamps_to_six() {
+
+		$field = $this->get_field_arr( 'password', array(
+			'attributes' => array(
+				'minlength' => 1,
+			),
+		) );
+
+		// 5-character password should be too short because the minimum is clamped to 6.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'short', 1, $field ) );
+		$this->assertIsWPError( $res );
+		$this->assertEquals( 'llms-form-field-invalid', $res->get_error_code() );
+
+		// 6-character password should pass.
+		$res = LLMS_Unit_Test_Util::call_method( $this->main, 'validate_field_attribute_minlength', array( 'longer', 1, $field ) );
+		$this->assertTrue( $res );
 
 	}
 


### PR DESCRIPTION
## Description

Issue #3045 reported that the password field's "Minimum Password Length" setting could be set below 6, leaving the form un-submittable because the strength meter and validator always enforce a 6-character floor.

The LifterLMS Blocks plugin (separate `gocodebox/lifterlms-blocks` repo, out of scope here) already sets `min="6"` on the editor's number input and ships a `Math.max(6, ...)` normalize function on the JS side. This PR adds the matching PHP-side clamp so a sub-6 value saved through any other path (programmatic form construction, imports, a future editor regression, etc.) cannot reach the validator.

Sub-6 values are now clamped to 6 at runtime in two places:

- `LLMS_Form_Validator::validate_field_attribute_minlength()` clamps `$minlength` to `max( 6, absint( $minlength ) )` before the length check.
- `LLMS_Forms_Dynamic_Fields::add_password_strength_meter()` clamps the `min_length` it forwards to the strength-meter block, so the meter honors the same floor.

Fixes #3045

## How has this been tested?

- `composer run-script check-cs` passes on the changed files.
- `composer run-script tests-run` (PHPUnit) passes, including the new `test_validate_field_attribute_minlength_clamps_to_six()` test which sends a 5-character password with `minlength = 1` and asserts the validator returns `WP_Error` with code `llms-form-field-invalid`.
- Manual smoke against the rebuilt plugin zip:
  1. Edit a LifterLMS form with a password field. Set "Minimum Password Length" to 1. Save.
  2. Submit a 5-character password on the front end. The form rejects it with "must be at least 6 characters" even though the editor accepted 1.
  3. Submit a 6-character password. The form accepts it.
  4. Set the field to 10. Submit a 9-character password. Rejected with "must be at least 10 characters." Submit 10. Accepted.

## Screenshots

N/A. Runtime change is a small two-line clamp and a minified JS unchanged at the editor; no UI difference.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested. (PHPUnit + manual smoke against the rebuilt zip.)
- [x] My code passes all existing automated tests. (`composer run-script tests-run`.)
- [x] My code follows the LifterLMS Coding & Documentation Standards. (`composer run-script check-cs-errors`.)