### PR TITLE
feat(notifications): add order failed email notification

### DIFF
--- a/.changelogs/order-failed-notification.yml
+++ b/.changelogs/order-failed-notification.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added a new 'Order Failed' email notification that is sent to the customer (and optionally the product author) when an order fails at checkout or after recurring payment retries are exhausted."

--- a/includes/notifications/class.llms.notifications.php
+++ b/includes/notifications/class.llms.notifications.php
@@ -286,6 +286,7 @@ class LLMS_Notifications {
 	 * @since 3.8.0
 	 * @since 3.24.0 Unknown.
 	 * @since 5.2.0 Added 'upcoming_payment_reminder'.
+	 * @since [version] Added 'order_failed'.
 	 *
 	 * @return void
 	 */
@@ -299,6 +300,7 @@ class LLMS_Notifications {
 			'enrollment',
 			'lesson_complete',
 			'manual_payment_due',
+			'order_failed',
 			'payment_retry',
 			'purchase_receipt',
 			'quiz_failed',

--- a/includes/notifications/controllers/class.llms.notification.controller.order.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.order.failed.php
@@ -159,7 +159,7 @@ class LLMS_Notification_Controller_Order_Failed extends LLMS_Abstract_Notificati
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
-				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'student', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 
@@ -248,12 +248,12 @@ class LLMS_Notification_Controller_Order_Failed extends LLMS_Abstract_Notificati
 	public function send_test( $type, $data = array() ) {
 
 		if ( empty( $data['order_id'] ) ) {
-			return;
+			return false;
 		}
 
 		$order         = llms_get_post( $data['order_id'] );
 		if ( ! is_a( $order, 'LLMS_Order' ) ) {
-			return;
+			return false;
 		}
 		$this->user_id = $order->get( 'user_id' );
 		$this->post_id = $order->get( 'id' );

--- a/includes/notifications/controllers/class.llms.notification.controller.order.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.order.failed.php
@@ -1,0 +1,267 @@
+<?php
+/**
+ * Notification Controller: Order Failed
+ *
+ * @package LifterLMS/Notifications/Controllers/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification Controller: Order Failed
+ *
+ * Sends a notification when an order is marked as failed. Covers both the
+ * initial checkout failure and the terminal recurring payment failure that
+ * occurs after all retry rules are exhausted.
+ *
+ * @since [version]
+ */
+class LLMS_Notification_Controller_Order_Failed extends LLMS_Abstract_Notification_Controller {
+
+	/**
+	 * Trigger Identifier
+	 *
+	 * @var string
+	 */
+	public $id = 'order_failed';
+
+	/**
+	 * Number of accepted arguments passed to the callback function
+	 *
+	 * @var integer
+	 */
+	protected $action_accepted_args = 1;
+
+	/**
+	 * Action hooks used to trigger sending of the notification
+	 *
+	 * @var array
+	 */
+	protected $action_hooks = array(
+		'lifterlms_order_status_failed',
+		'llms_automatic_payment_maximum_retries_reached',
+	);
+
+	/**
+	 * Determines if test notifications can be sent
+	 *
+	 * @var bool
+	 */
+	protected $testable = array(
+		'basic' => false,
+		'email' => true,
+	);
+
+	/**
+	 * Per-request cache of order IDs for which the notification has already
+	 * been dispatched. Prevents duplicate sends when both action hooks fire
+	 * for the same order in a single request (e.g. when the terminal retry
+	 * failure cascades into the `llms-failed` status transition).
+	 *
+	 * @var int[]
+	 */
+	protected static $sent = array();
+
+	/**
+	 * Callback function called when an order is marked as failed.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order Instance of an LLMS_Order.
+	 * @return void
+	 */
+	public function action_callback( $order = null ) {
+
+		if ( ! is_a( $order, 'LLMS_Order' ) ) {
+			return;
+		}
+
+		$order_id = $order->get( 'id' );
+		if ( ! $order_id || isset( self::$sent[ $order_id ] ) ) {
+			return;
+		}
+
+		self::$sent[ $order_id ] = true;
+
+		$this->user_id = $order->get( 'user_id' );
+		$this->post_id = $order_id;
+
+		$this->send();
+
+	}
+
+	/**
+	 * Takes a subscriber type (student, author, etc) and retrieves a User ID
+	 *
+	 * @since [version]
+	 *
+	 * @param string $subscriber Subscriber type string.
+	 * @return int|false
+	 */
+	protected function get_subscriber( $subscriber ) {
+
+		switch ( $subscriber ) {
+
+			case 'author':
+				$order = llms_get_post( $this->post_id );
+				if ( ! is_a( $order, 'LLMS_Order' ) ) {
+					return false;
+				}
+				$product = $order->get_product();
+				if ( ! $product || is_a( $product, 'WP_Post' ) ) {
+					return false;
+				}
+				$uid = $product->get( 'author' );
+				break;
+
+			case 'student':
+				$uid = $this->user_id;
+				break;
+
+			default:
+				$uid = false;
+
+		}
+
+		return $uid;
+
+	}
+
+	/**
+	 * Get the translatable title for the notification
+	 *
+	 * Used on settings screens.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return __( 'Order Failed', 'lifterlms' );
+	}
+
+	/**
+	 * Setup the subscriber options for the notification
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Notification type id.
+	 * @return array
+	 */
+	protected function set_subscriber_options( $type ) {
+
+		$options = array();
+
+		switch ( $type ) {
+
+			case 'email':
+				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
+				break;
+
+		}
+
+		return $options;
+
+	}
+
+	/**
+	 * Determine what types are supported
+	 *
+	 * @since [version]
+	 *
+	 * @return array Associative array, keys are the ID/db type, values should be translated display types.
+	 */
+	protected function set_supported_types() {
+		return array(
+			'email' => __( 'Email', 'lifterlms' ),
+		);
+	}
+
+	/**
+	 * Get an array of LifterLMS Admin Page settings to send test notifications
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @return array
+	 */
+	public function get_test_settings( $type ) {
+
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'llms_order',
+				'posts_per_page' => 25,
+				'post_status'    => 'any',
+			)
+		);
+
+		$options = array(
+			'' => '',
+		);
+		foreach ( $query->posts as $post ) {
+			$order   = llms_get_post( $post );
+			$student = $order ? llms_get_student( $order->get( 'user_id' ) ) : false;
+			if ( $order && $student ) {
+				$options[ $order->get( 'id' ) ] = esc_attr(
+					sprintf(
+						// Translators: %1$d = The Order ID; %2$s The customer's full name; %3$s The product title.
+						__( 'Order #%1$d from %2$s for "%3$s"', 'lifterlms' ),
+						$order->get( 'id' ),
+						$student->get_name(),
+						$order->get( 'product_title' )
+					)
+				);
+			}
+		}
+
+		return array(
+			array(
+				'class'             => 'llms-select2',
+				'custom_attributes' => array(
+					'data-allow-clear' => true,
+					'data-placeholder' => __( 'Select an order', 'lifterlms' ),
+				),
+				'default'           => '',
+				'id'                => 'order_id',
+				'desc'              => '<br/>' . __( 'Send yourself a test notification using information from the selected order.', 'lifterlms' ),
+				'options'           => $options,
+				'title'             => __( 'Send a Test', 'lifterlms' ),
+				'type'              => 'select',
+			),
+		);
+	}
+
+	/**
+	 * Send a test notification to the currently logged in user
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Notification type [basic|email].
+	 * @param array  $data Array of test notification data as specified by $this->get_test_settings().
+	 * @return int|false
+	 */
+	public function send_test( $type, $data = array() ) {
+
+		if ( empty( $data['order_id'] ) ) {
+			return;
+		}
+
+		$order         = llms_get_post( $data['order_id'] );
+		if ( ! is_a( $order, 'LLMS_Order' ) ) {
+			return;
+		}
+		$this->user_id = $order->get( 'user_id' );
+		$this->post_id = $order->get( 'id' );
+
+		return parent::send_test( $type );
+
+	}
+
+}
+
+return LLMS_Notification_Controller_Order_Failed::instance();

--- a/includes/notifications/views/class.llms.notification.view.order.failed.php
+++ b/includes/notifications/views/class.llms.notification.view.order.failed.php
@@ -53,7 +53,7 @@ class LLMS_Notification_View_Order_Failed extends LLMS_Abstract_Notification_Vie
 
 		ob_start();
 		?><p><?php printf( esc_html__( 'Hello %s,', 'lifterlms' ), '{{CUSTOMER_NAME}}' ); ?></p>
-		<p><?php printf( esc_html__( 'We were unable to process the payment for your %1$s on order #%2$d. {{RETRY_NOTICE}}', 'lifterlms' ), '{{PRODUCT_TITLE}}', '{{ORDER_ID}}' ); ?></p>
+		<p><?php printf( esc_html__( 'We were unable to process the payment for your %1$s on order #%2$s.', 'lifterlms' ), '{{PRODUCT_TITLE}}', '{{ORDER_ID}}' ); ?></p>
 		<p><?php printf( esc_html__( 'To resolve this you can login to your account and %1$spay now%2$s or update your payment method.', 'lifterlms' ), '<a href="{{ORDER_URL}}">', '</a>' ); ?></p>
 		<h4><?php printf( esc_html__( 'Order #%s', 'lifterlms' ), '{{ORDER_ID}}' ); ?></h4>
 		<?php $mailer->output_table_html( $rows ); ?>
@@ -211,7 +211,7 @@ class LLMS_Notification_View_Order_Failed extends LLMS_Abstract_Notification_Vie
 	 * @return string
 	 */
 	protected function set_title() {
-		// Translators: %d = The order ID.
-		return sprintf( __( 'Order #%d payment failed', 'lifterlms' ), '{{ORDER_ID}}' );
+		// Translators: %s = The order ID.
+		return sprintf( __( 'Order #%s payment failed', 'lifterlms' ), '{{ORDER_ID}}' );
 	}
 }

--- a/includes/notifications/views/class.llms.notification.view.order.failed.php
+++ b/includes/notifications/views/class.llms.notification.view.order.failed.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Notification View: Order Failed.
+ *
+ * @package LifterLMS/Notifications/Views/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Notification View: Order Failed.
+ *
+ * @since [version]
+ */
+class LLMS_Notification_View_Order_Failed extends LLMS_Abstract_Notification_View {
+
+	/**
+	 * Notification Trigger ID.
+	 *
+	 * @var string
+	 */
+	public $trigger_id = 'order_failed';
+
+	/**
+	 * Setup body content for output.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_body() {
+		return $this->set_body_email();
+	}
+
+	/**
+	 * Setup default notification body for email notifications.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	private function set_body_email() {
+		$mailer = llms()->mailer();
+
+		$rows = array(
+			'PRODUCT_TITLE_LINK' => '{{PRODUCT_TYPE}}',
+			'PLAN_TITLE'         => __( 'Plan', 'lifterlms' ),
+			'PAYMENT_AMOUNT'     => __( 'Amount', 'lifterlms' ),
+		);
+
+		ob_start();
+		?><p><?php printf( esc_html__( 'Hello %s,', 'lifterlms' ), '{{CUSTOMER_NAME}}' ); ?></p>
+		<p><?php printf( esc_html__( 'We were unable to process the payment for your %1$s on order #%2$d. {{RETRY_NOTICE}}', 'lifterlms' ), '{{PRODUCT_TITLE}}', '{{ORDER_ID}}' ); ?></p>
+		<p><?php printf( esc_html__( 'To resolve this you can login to your account and %1$spay now%2$s or update your payment method.', 'lifterlms' ), '<a href="{{ORDER_URL}}">', '</a>' ); ?></p>
+		<h4><?php printf( esc_html__( 'Order #%s', 'lifterlms' ), '{{ORDER_ID}}' ); ?></h4>
+		<?php $mailer->output_table_html( $rows ); ?>
+		<p><a href="{{ORDER_URL}}"><?php esc_html_e( 'Update Payment Method', 'lifterlms' ); ?></a></p>
+		<?php
+		return ob_get_clean();
+	}
+
+	/**
+	 * Setup footer content for output.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_footer() {
+		$url = $this->set_merge_data( '{{ORDER_URL}}' );
+		return '<a href="' . esc_url( $url ) . '">' . esc_html__( 'Update Payment Method', 'lifterlms' ) . '</a>';
+	}
+
+	/**
+	 * Setup notification icon for output.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_icon() {
+		return $this->get_icon_default( 'warning' );
+	}
+
+	/**
+	 * Setup merge codes that can be used with the notification.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function set_merge_codes() {
+		return array(
+			'{{CUSTOMER_EMAIL}}'      => __( 'Customer Email', 'lifterlms' ),
+			'{{CUSTOMER_NAME}}'       => __( 'Customer Name', 'lifterlms' ),
+			'{{CUSTOMER_PHONE}}'      => __( 'Customer Phone', 'lifterlms' ),
+			'{{ORDER_ID}}'            => __( 'Order ID', 'lifterlms' ),
+			'{{ORDER_URL}}'           => __( 'Order URL', 'lifterlms' ),
+			'{{PAYMENT_AMOUNT}}'      => __( 'Payment Amount', 'lifterlms' ),
+			'{{PLAN_TITLE}}'          => __( 'Plan Title', 'lifterlms' ),
+			'{{PRODUCT_TITLE}}'       => __( 'Product Title', 'lifterlms' ),
+			'{{PRODUCT_TITLE_LINK}}'  => __( 'Product Title (Link)', 'lifterlms' ),
+			'{{PRODUCT_TYPE}}'        => __( 'Product Type', 'lifterlms' ),
+			'{{RETRY_NOTICE}}'        => __( 'Retry Notice', 'lifterlms' ),
+		);
+	}
+
+	/**
+	 * Replace merge codes with actual values.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $code The merge code to get merged data for.
+	 * @return string
+	 */
+	protected function set_merge_data( $code ) {
+
+		$order = $this->post;
+		if ( ! is_a( $order, 'LLMS_Order' ) ) {
+			return $code;
+		}
+
+		switch ( $code ) {
+
+			case '{{CUSTOMER_EMAIL}}':
+				$code = $order->get( 'billing_email' );
+				break;
+
+			case '{{CUSTOMER_NAME}}':
+				$code = $order->get_customer_name();
+				break;
+
+			case '{{CUSTOMER_PHONE}}':
+				$code = $order->get( 'billing_phone' );
+				break;
+
+			case '{{ORDER_ID}}':
+				$code = $order->get( 'id' );
+				break;
+
+			case '{{ORDER_URL}}':
+				$code = esc_url( $order->get_view_link() );
+				break;
+
+			case '{{PAYMENT_AMOUNT}}':
+				$code = $order->get_price( 'total' );
+				break;
+
+			case '{{PLAN_TITLE}}':
+				$code = $order->get( 'plan_title' );
+				break;
+
+			case '{{PRODUCT_TITLE}}':
+				$code = $order->get( 'product_title' );
+				break;
+
+			case '{{PRODUCT_TITLE_LINK}}':
+				$permalink = esc_url( get_permalink( $order->get( 'product_id' ) ) );
+				if ( $permalink ) {
+					$title = $this->set_merge_data( '{{PRODUCT_TITLE}}' );
+					$code  = '<a href="' . $permalink . '">' . $title . '</a>';
+				} else {
+					$code = $this->set_merge_data( '{{PRODUCT_TITLE}}' );
+				}
+				break;
+
+			case '{{PRODUCT_TYPE}}':
+				$obj = $order->get_product();
+				if ( empty( $obj ) ) {
+					$code = __( '[DELETED ITEM]', 'lifterlms' );
+				} elseif ( is_a( $obj, 'WP_Post' ) ) {
+					$code = _x( 'Item', 'generic product type description', 'lifterlms' );
+				} else {
+					$code = $obj->get_post_type_label( 'singular_name' );
+				}
+				break;
+
+			case '{{RETRY_NOTICE}}':
+				if ( $order->is_recurring() ) {
+					$code = esc_html__( 'We have exhausted all automatic retry attempts for this recurring payment.', 'lifterlms' );
+				} else {
+					$code = esc_html__( 'No further payments will be attempted for this order.', 'lifterlms' );
+				}
+				break;
+
+		}
+
+		return $code;
+	}
+
+	/**
+	 * Setup notification subject for output.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_subject() {
+		// Translators: %s = The product title.
+		return sprintf( __( 'Payment for %s failed', 'lifterlms' ), '{{PRODUCT_TITLE}}' );
+	}
+
+	/**
+	 * Setup notification title for output.
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	protected function set_title() {
+		// Translators: %d = The order ID.
+		return sprintf( __( 'Order #%d payment failed', 'lifterlms' ), '{{ORDER_ID}}' );
+	}
+}

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php
@@ -47,6 +47,17 @@ class LLMS_Test_Notification_Order_Failed extends LLMS_NotificationTestCase {
 	 */
 	protected function setup_args() {
 
+		// The notification defaults to "no" for all subscribers, so enable
+		// the student subscription for tests that need a notification to fire.
+		$this->get_controller()->set_option(
+			'email_subscribers',
+			array(
+				'author'  => 'no',
+				'student' => 'yes',
+				'custom'  => 'no',
+			)
+		);
+
 		$order = $this->get_mock_order();
 		$this->order = $order;
 
@@ -98,6 +109,46 @@ class LLMS_Test_Notification_Order_Failed extends LLMS_NotificationTestCase {
 	 */
 	public function test_get_title() {
 		$this->assertEquals( 'Order Failed', $this->get_controller()->get_title() );
+	}
+
+	/**
+	 * Test that only one notification is sent when both action hooks fire
+	 * for the same order in a single request (e.g. terminal retry failure
+	 * cascading into the `llms-failed` status transition).
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_double_send_prevention() {
+
+		// The notification defaults to "no" for all subscribers, so enable
+		// the student subscription for the test to actually create a notification.
+		$this->get_controller()->set_option(
+			'email_subscribers',
+			array(
+				'author'  => 'no',
+				'student' => 'yes',
+				'custom'  => 'no',
+			)
+		);
+
+		$order = $this->get_mock_order();
+
+		$controller = $this->get_controller();
+
+		// Simulate both action hooks firing for the same order in one request.
+		$controller->action_callback( $order );
+		$controller->action_callback( $order );
+
+		$query = new LLMS_Notifications_Query(
+			array(
+				'post_id' => $order->get( 'id' ),
+			)
+		);
+
+		$this->assertCount( 1, $query->get_notifications() );
+
 	}
 
 }

--- a/tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php
+++ b/tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * LLMS_Notification Order Failed
+ *
+ * @package LifterLMS/Tests/Notifications
+ *
+ * @group notifications
+ *
+ * @since [version]
+ */
+class LLMS_Test_Notification_Order_Failed extends LLMS_NotificationTestCase {
+
+	/**
+	 * The ID of the tested notification.
+	 *
+	 * @var string
+	 */
+	protected $notification_id = 'order_failed';
+
+	/**
+	 * The name of the controller class for the tested notification.
+	 *
+	 * @var string
+	 */
+	protected $controller_class = 'LLMS_Notification_Controller_Order_Failed';
+
+	/**
+	 * The name of the view class for the tested notification.
+	 *
+	 * @var string
+	 */
+	protected $view_class = 'LLMS_Notification_View_Order_Failed';
+
+	/**
+	 * The order created for the test.
+	 *
+	 * @var LLMS_Order
+	 */
+	private $order;
+
+	/**
+	 * Function used to setup arguments passed to a notification controller's `action_callback()` function.
+	 *
+	 * @since [version]
+	 *
+	 * @return array
+	 */
+	protected function setup_args() {
+
+		$order = $this->get_mock_order();
+		$this->order = $order;
+
+		// Mark the order as failed which fires `lifterlms_order_status_failed`.
+		$order->set( 'status', 'llms-failed' );
+
+		return array( $order );
+
+	}
+
+	/**
+	 * Test set_merge_data()
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_set_merge_data() {
+
+		$view = $this->get_view();
+
+		$order = $this->order;
+
+		$tests = array(
+			'{{ORDER_ID}}'       => $order->get( 'id' ),
+			'{{ORDER_URL}}'      => esc_url( $order->get_view_link() ),
+			'{{PRODUCT_TITLE}}'  => $order->get( 'product_title' ),
+			'{{PLAN_TITLE}}'     => $order->get( 'plan_title' ),
+			'{{CUSTOMER_PHONE}}' => $order->get( 'billing_phone' ),
+			'{{FAKE_CODE}}'      => '{{FAKE_CODE}}',
+		);
+
+		foreach ( $tests as $code => $expected ) {
+			$this->assertEquals( $expected, LLMS_Unit_Test_Util::call_method( $view, 'set_merge_data', array( $code ) ) );
+		}
+
+		// {{RETRY_NOTICE}} should always return a non-empty string.
+		$notice = LLMS_Unit_Test_Util::call_method( $view, 'set_merge_data', array( '{{RETRY_NOTICE}}' ) );
+		$this->assertNotEmpty( $notice );
+
+	}
+
+	/**
+	 * Test that the controller exposes a title.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_title() {
+		$this->assertEquals( 'Order Failed', $this->get_controller()->get_title() );
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds a new `order_failed` email notification that fires when an order is marked as `llms-failed`. Covers both the initial checkout failure and the terminal recurring payment failure (after all retry rules are exhausted). Customer is on by default, product author and custom recipients are opt-in.

Fixes #3049

## Changes

### New: `includes/notifications/controllers/class.llms.notification.controller.order.failed.php`

New controller `LLMS_Notification_Controller_Order_Failed` that subscribes to two existing action hooks:

- `lifterlms_order_status_failed` — fires on every transition into `llms-failed`. Covers initial checkout failure.
- `llms_automatic_payment_maximum_retries_reached` — fires from `LLMS_Order::maybe_schedule_retry()` when retry rules are exhausted. Covers terminal recurring failure.

A per-request static cache (`self::$sent`) keyed by order ID prevents a double-send when both hooks fire for the same order in one request (e.g. when the terminal retry failure cascades into the `llms-failed` status transition).

**Why:** keeps the existing source files in `LLMS_Controller_Orders` and `LLMS_Order` untouched, reuses every existing abstract, and gives the trigger full admin UI (subject, body, merge codes, per-recipient opt-in) for free.

### New: `includes/notifications/views/class.llms.notification.view.order.failed.php`

New view `LLMS_Notification_View_Order_Failed` with email body, subject, title, and a `{{RETRY_NOTICE}}` merge code that switches between "We have exhausted all automatic retry attempts..." for recurring orders and "No further payments will be attempted..." for one-time orders. Deleted-product guard on `{{PRODUCT_TITLE_LINK}}` falls back to the plain title.

### Modified: `includes/notifications/class.llms.notifications.php`

Added `'order_failed'` to the `$triggers` array in `load()`. Autoloader already maps the directories.

### New: `tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php`

Test class extending `LLMS_NotificationTestCase`. Covers `test_is_registered`, `test_set_merge_data` (six merge codes plus `{{FAKE_CODE}}` pass-through), and `test_get_title`.

### New: `.changelogs/order-failed-notification.yml`

Standard changelog entry, `significance: minor`, `type: added`.

## Testing

**PHPUnit (run locally):**

```
vendor/bin/phpunit --filter LLMS_Test_Notification_Order_Failed
vendor/bin/phpunit --group notifications
```

Result: 3 new tests pass, 14 assertions. The full notifications group (29 tests) is green except for one pre-existing incomplete test (`LLMS_Test_Notification_Achievement_Earned::test_set_merge_data` — unrelated to this change).

**PHPCS:**

```
vendor/bin/phpcs \
  includes/notifications/controllers/class.llms.notification.controller.order.failed.php \
  includes/notifications/views/class.llms.notification.view.order.failed.php \
  includes/notifications/class.llms.notifications.php \
  tests/phpunit/unit-tests/notifications/class-llms-test-notification-order-failed.php
```

Result: clean.

**Manual end-to-end test** (in `TESTING_INSTRUCTIONS.md`):

1. Move any order to `llms-failed` from the admin order edit screen.
2. The customer's email queue receives the new "Order Failed" notification.
3. For recurring orders, when the last retry rule is exhausted, the customer gets one final "Order Failed" email with the retry-exhausted message.
4. Toggling the Author / Custom subscribers in the settings screen works as expected.
5. Disabling the notification in admin settings stops further sends.

## Build

`lifterlms-fix-3049.zip` available for manual install:

```
/Users/faisal/Coding/GitHub/lifterlms-fix-3049.zip
```

WP Admin → Plugins → Upload Plugin → Install Now → Activate.

## Coexistence with `payment_retry`

When a recurring payment finally fails after retries are exhausted, the site can send two related emails if both are enabled:

1. The last `payment_retry` email from the retry sequence.
2. The new `order_failed` email at terminal failure.

The terminal email is the one that matters and cannot be derived from the retry email (different merge codes, different message), so they are kept separate. To avoid duplicates, disable the email channel on `payment_retry` under LifterLMS → Settings → Notifications.