### PR TITLE
feat(elementor): add enrollment visibility controls to widgets

### DIFF
--- a/.changelogs/3099-elementor-enrollment-visibility.yml
+++ b/.changelogs/3099-elementor-enrollment-visibility.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added an Enrollment Visibility control to LifterLMS Elementor widgets, allowing widgets to be shown or hidden based on the visitor's enrollment status, login state, or enrollment in specific courses or memberships."

--- a/includes/elementor/class-llms-elementor-widget-base.php
+++ b/includes/elementor/class-llms-elementor-widget-base.php
@@ -199,48 +199,33 @@ abstract class LLMS_Elementor_Widget_Base extends \Elementor\Widget_Base {
 	protected function is_visible( $attrs ) {
 
 		$visibility = ! empty( $attrs['llms_visibility'] ) ? $attrs['llms_visibility'] : 'all';
+		$uid        = get_current_user_id();
+		$visible    = true;
 
-		// Always show when set to everyone.
 		if ( 'all' === $visibility ) {
-			return true;
+			$visible = true;
+		} elseif ( 'logged_in' === $visibility ) {
+			$visible = (bool) $uid;
+		} elseif ( 'logged_out' === $visibility ) {
+			$visible = ! $uid;
+		} elseif ( 'enrolled' === $visibility ) {
+			$visibility_in = ! empty( $attrs['llms_visibility_in'] ) ? $attrs['llms_visibility_in'] : 'any';
+			$visible       = $uid && $this->check_enrollment( $uid, $visibility_in );
+		} elseif ( 'not_enrolled' === $visibility ) {
+			$visibility_in = ! empty( $attrs['llms_visibility_in'] ) ? $attrs['llms_visibility_in'] : 'any';
+			$visible       = ! $uid || ! $this->check_enrollment( $uid, $visibility_in );
 		}
 
-		$uid = get_current_user_id();
-
-		// Show only to logged-in users.
-		if ( 'logged_in' === $visibility ) {
-			return (bool) $uid;
-		}
-
-		// Show only to logged-out visitors.
-		if ( 'logged_out' === $visibility ) {
-			return ! $uid;
-		}
-
-		$visibility_in = ! empty( $attrs['llms_visibility_in'] ) ? $attrs['llms_visibility_in'] : 'any';
-
-		if ( 'enrolled' === $visibility ) {
-
-			// Must be logged in to be enrolled.
-			if ( ! $uid ) {
-				return false;
-			}
-
-			return $this->check_enrollment( $uid, $visibility_in );
-		}
-
-		if ( 'not_enrolled' === $visibility ) {
-
-			// Logged-out visitors are never enrolled.
-			if ( ! $uid ) {
-				return true;
-			}
-
-			return ! $this->check_enrollment( $uid, $visibility_in );
-		}
-
-		// Unknown mode — show by default.
-		return true;
+		/**
+		 * Filter whether an Elementor widget should be visible.
+		 *
+		 * @since [version]
+		 *
+		 * @param bool  $visible Whether the widget should be shown.
+		 * @param array $attrs   Visibility attribute map from widget settings.
+		 * @param int   $uid     Current user ID (0 for logged-out visitors).
+		 */
+		return apply_filters( 'llms_elementor_widget_is_visible', $visible, $attrs, $uid );
 	}
 
 	/**
@@ -283,14 +268,15 @@ abstract class LLMS_Elementor_Widget_Base extends \Elementor\Widget_Base {
 	/**
 	 * Render the widget-specific front-end output.
 	 *
-	 * Subclasses implement this method to output their content. It is called
-	 * by `render()` only after the enrollment visibility check passes.
+	 * Subclasses should override this method to output their content.
+	 * A no-op default is provided to avoid fatal errors for any
+	 * subclass not yet migrated to the new rendering contract.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	abstract protected function render_widget();
+	protected function render_widget() {}
 
 	/**
 	 * Elementor live preview template.

--- a/includes/elementor/class-llms-elementor-widget-base.php
+++ b/includes/elementor/class-llms-elementor-widget-base.php
@@ -1,19 +1,124 @@
 <?php
+/**
+ * Abstract base class for LifterLMS Elementor widgets.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Base abstract class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls and server-side render gate.
+ */
 abstract class LLMS_Elementor_Widget_Base extends \Elementor\Widget_Base {
 
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @param array      $data Widget data.
+	 * @param array|null $args Widget arguments.
+	 * @return void
+	 */
 	public function __construct( $data = array(), $args = null ) {
 		parent::__construct( $data, $args );
 	}
 
+	/**
+	 * Get widget icon.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_icon() {
 		return 'dashicons-before dashicons-welcome-learn-more';
 	}
 
+	/**
+	 * Get widget categories.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string[]
+	 */
 	public function get_categories() {
 		return array( 'lifterlms' );
 	}
 
+	/**
+	 * Register the enrollment visibility controls section.
+	 *
+	 * Adds an "Enrollment Visibility" section under the Advanced tab of every
+	 * LifterLMS Elementor widget, mirroring the visibility option available on
+	 * standard Gutenberg blocks.
+	 *
+	 * Subclasses call this near the end of their `_register_controls()` method.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	protected function add_visibility_controls() {
+
+		$this->start_controls_section(
+			'llms_visibility_section',
+			array(
+				'label' => esc_html__( 'Enrollment Visibility', 'lifterlms' ),
+				'tab'   => \Elementor\Controls_Manager::TAB_ADVANCED,
+			)
+		);
+
+		$this->add_control(
+			'llms_visibility',
+			array(
+				'label'   => esc_html__( 'Display to', 'lifterlms' ),
+				'type'    => \Elementor\Controls_Manager::SELECT,
+				'default' => 'all',
+				'options' => array(
+					'all'          => esc_html__( 'everyone', 'lifterlms' ),
+					'enrolled'     => esc_html__( 'enrolled users', 'lifterlms' ),
+					'not_enrolled' => esc_html__( 'non-enrolled users or visitors', 'lifterlms' ),
+					'logged_in'    => esc_html__( 'logged in users', 'lifterlms' ),
+					'logged_out'   => esc_html__( 'logged out users', 'lifterlms' ),
+				),
+			)
+		);
+
+		$this->add_control(
+			'llms_visibility_in',
+			array(
+				'label'     => esc_html__( 'Enrolled In', 'lifterlms' ),
+				'type'      => \Elementor\Controls_Manager::SELECT,
+				'default'   => 'any',
+				'options'   => array(
+					'any'            => esc_html__( 'in any course or membership', 'lifterlms' ),
+					'any_course'     => esc_html__( 'in any course', 'lifterlms' ),
+					'any_membership' => esc_html__( 'in any membership', 'lifterlms' ),
+					'this'           => esc_html__( 'in this course or membership', 'lifterlms' ),
+				),
+				'condition' => array(
+					'llms_visibility' => array( 'enrolled', 'not_enrolled' ),
+				),
+			)
+		);
+
+		$this->end_controls_section();
+	}
+
+	/**
+	 * Add a footer promo control linking to Elementor documentation.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
 	protected function add_footer_promo_control() {
 
 		$this->add_control(
@@ -30,13 +135,171 @@ abstract class LLMS_Elementor_Widget_Base extends \Elementor\Widget_Base {
 		);
 	}
 
+	/**
+	 * Render the widget output.
+	 *
+	 * Checks enrollment visibility before delegating to `render_widget()`.
+	 * When the current visitor does not meet the configured condition the
+	 * widget outputs nothing. Inside the Elementor editor the widget always
+	 * renders so authors can see and configure it regardless of their
+	 * own enrollment status.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
 	protected function render() {
-		$settings = $this->get_settings_for_display();
 
-		echo do_shortcode( '[lifterlms_course_continue_button]' );
+		// Always render inside the Elementor editor.
+		if ( ! \Elementor\Plugin::$instance->editor->is_edit_mode() ) {
+			$settings = $this->get_settings_for_display();
+			$attrs    = array(
+				'llms_visibility'    => isset( $settings['llms_visibility'] ) ? $settings['llms_visibility'] : 'all',
+				'llms_visibility_in' => isset( $settings['llms_visibility_in'] ) ? $settings['llms_visibility_in'] : '',
+			);
+
+			if ( ! $this->is_visible( $attrs ) ) {
+				return;
+			}
+		}
+
+		$this->render_widget();
 	}
 
+	/**
+	 * Determine whether the widget should be visible to the current visitor.
+	 *
+	 * Evaluates the enrollment visibility attributes saved on the widget
+	 * against the current user's login state and enrollment records. Returns
+	 * `true` when the widget should be shown, `false` when it should be hidden.
+	 *
+	 * Supported `llms_visibility` values:
+	 *   - `all`          — always visible (default).
+	 *   - `logged_in`    — visible to logged-in users only.
+	 *   - `logged_out`   — visible to logged-out visitors only.
+	 *   - `enrolled`     — visible when the user is enrolled per `llms_visibility_in`.
+	 *   - `not_enrolled` — visible when the user is NOT enrolled per `llms_visibility_in`.
+	 *
+	 * Supported `llms_visibility_in` values (for enrolled / not_enrolled):
+	 *   - `any`            — enrolled in any course or membership.
+	 *   - `any_course`     — enrolled in any course.
+	 *   - `any_membership` — enrolled in any membership.
+	 *   - `this`           — enrolled in the current post (resolved via `get_the_ID()`).
+	 *
+	 * @since [version]
+	 *
+	 * @param array $attrs {
+	 *     Visibility attribute map.
+	 *
+	 *     @type string $llms_visibility    Primary visibility mode. Default 'all'.
+	 *     @type string $llms_visibility_in Sub-mode for enrolled / not_enrolled. Default 'any'.
+	 * }
+	 * @return bool `true` if the widget should be shown to the current visitor.
+	 */
+	protected function is_visible( $attrs ) {
+
+		$visibility = ! empty( $attrs['llms_visibility'] ) ? $attrs['llms_visibility'] : 'all';
+
+		// Always show when set to everyone.
+		if ( 'all' === $visibility ) {
+			return true;
+		}
+
+		$uid = get_current_user_id();
+
+		// Show only to logged-in users.
+		if ( 'logged_in' === $visibility ) {
+			return (bool) $uid;
+		}
+
+		// Show only to logged-out visitors.
+		if ( 'logged_out' === $visibility ) {
+			return ! $uid;
+		}
+
+		$visibility_in = ! empty( $attrs['llms_visibility_in'] ) ? $attrs['llms_visibility_in'] : 'any';
+
+		if ( 'enrolled' === $visibility ) {
+
+			// Must be logged in to be enrolled.
+			if ( ! $uid ) {
+				return false;
+			}
+
+			return $this->check_enrollment( $uid, $visibility_in );
+		}
+
+		if ( 'not_enrolled' === $visibility ) {
+
+			// Logged-out visitors are never enrolled.
+			if ( ! $uid ) {
+				return true;
+			}
+
+			return ! $this->check_enrollment( $uid, $visibility_in );
+		}
+
+		// Unknown mode — show by default.
+		return true;
+	}
+
+	/**
+	 * Check whether a user meets the enrollment condition.
+	 *
+	 * @since [version]
+	 *
+	 * @param int    $uid           WP_User ID.
+	 * @param string $visibility_in Enrollment sub-option: 'any', 'any_course', 'any_membership', or 'this'.
+	 * @return bool
+	 */
+	private function check_enrollment( $uid, $visibility_in ) {
+
+		if ( 'this' === $visibility_in ) {
+			return (bool) llms_is_user_enrolled( $uid, get_the_ID() );
+		}
+
+		$student = llms_get_student( $uid );
+		if ( ! $student ) {
+			return false;
+		}
+
+		if ( in_array( $visibility_in, array( 'any', 'any_course' ), true ) ) {
+			$result = $student->get_enrollments( 'course', array( 'limit' => 1 ) );
+			if ( ! empty( $result['found'] ) ) {
+				return true;
+			}
+		}
+
+		if ( in_array( $visibility_in, array( 'any', 'any_membership' ), true ) ) {
+			$result = $student->get_enrollments( 'membership', array( 'limit' => 1 ) );
+			if ( ! empty( $result['found'] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Render the widget-specific front-end output.
+	 *
+	 * Subclasses implement this method to output their content. It is called
+	 * by `render()` only after the enrollment visibility check passes.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	abstract protected function render_widget();
+
+	/**
+	 * Elementor live preview template.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
 	protected function _content_template() {
-		// Define your template variables here
+		// Intentionally left empty — widgets use server-side rendering only.
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-course-continue-button.php
+++ b/includes/elementor/class-llms-elementor-widget-course-continue-button.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Course Continue Button Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Course_Continue_Button class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Course_Continue_Button extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_course_continue_button_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Course Continue Button', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Course_Continue_Button extends LLMS_Elementor_Widget
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_course_continue_button]' );
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-course-instructors.php
+++ b/includes/elementor/class-llms-elementor-widget-course-instructors.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Course Instructors Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Course_Instructors class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Course_Instructors extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_course_instructors_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Course Instructors', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Course_Instructors extends LLMS_Elementor_Widget_Bas
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_course_instructors]' );
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-course-meta-info.php
+++ b/includes/elementor/class-llms-elementor-widget-course-meta-info.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Course Meta Information Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Course_Meta_Info class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Course_Meta_Info extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_course_meta_information_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Course Meta Information', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Course_Meta_Info extends LLMS_Elementor_Widget_Base 
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_course_meta_info]' );
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-course-progress.php
+++ b/includes/elementor/class-llms-elementor-widget-course-progress.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Course Progress Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Course_Progress class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Course_Progress extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_course_progress_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Course Progress', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Course_Progress extends LLMS_Elementor_Widget_Base {
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_course_progress check_enrollment="1"]' );
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-course-syllabus.php
+++ b/includes/elementor/class-llms-elementor-widget-course-syllabus.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Course Syllabus Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Course_Syllabus class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Course_Syllabus extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_course_syllabus_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Course Syllabus', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Course_Syllabus extends LLMS_Elementor_Widget_Base {
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_course_syllabus]' );
 	}
 }

--- a/includes/elementor/class-llms-elementor-widget-pricing-table.php
+++ b/includes/elementor/class-llms-elementor-widget-pricing-table.php
@@ -1,16 +1,54 @@
 <?php
+/**
+ * Pricing Table Elementor widget.
+ *
+ * @package LifterLMS/Classes/Elementor
+ *
+ * @since 7.7.0
+ */
 
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Elementor_Widget_Pricing_Table class.
+ *
+ * @since 7.7.0
+ * @since [version] Added enrollment visibility controls.
+ */
 class LLMS_Elementor_Widget_Pricing_Table extends LLMS_Elementor_Widget_Base {
 
+	/**
+	 * Get widget name.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return 'llms_pricing_table_widget';
 	}
 
+	/**
+	 * Get widget title.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return string
+	 */
 	public function get_title() {
 		return __( 'Pricing Table', 'lifterlms' );
 	}
 
+	/**
+	 * Register widget controls.
+	 *
+	 * @since 7.7.0
+	 * @since [version] Added enrollment visibility section.
+	 *
+	 * @return void
+	 */
 	protected function _register_controls() {
+
 		$this->start_controls_section(
 			'content_section',
 			array(
@@ -31,11 +69,18 @@ class LLMS_Elementor_Widget_Pricing_Table extends LLMS_Elementor_Widget_Base {
 		$this->add_footer_promo_control();
 
 		$this->end_controls_section();
+
+		$this->add_visibility_controls();
 	}
 
-	protected function render() {
-		$settings = $this->get_settings_for_display();
-
+	/**
+	 * Render widget output on the frontend.
+	 *
+	 * @since 7.7.0
+	 *
+	 * @return void
+	 */
+	protected function render_widget() {
 		echo do_shortcode( '[lifterlms_pricing_table]' );
 	}
 }


### PR DESCRIPTION
## Summary

Adds an Enrollment Visibility section to every LifterLMS Elementor widget. Course authors can now show or hide a widget based on the current visitor's enrollment status, login state, or enrollment in specific courses or memberships, mirroring the visibility option that already exists on standard Gutenberg blocks.

The decision is evaluated server-side in the widget base class. Inside the Elementor editor the widget always renders so authors can keep editing it regardless of their own enrollment status.

Fixes #3099

## Changes

### `includes/elementor/class-llms-elementor-widget-base.php`

Adds `add_visibility_controls()` which registers a new "Enrollment Visibility" section under the Advanced tab with two selects ("Display to" and "Enrolled In"). The `render()` method now evaluates those settings before delegating to a new abstract `render_widget()` method. Adds protected `is_visible()` and private `check_enrollment()` helpers that implement the same decision tree used by the blocks library. A new `llms_elementor_widget_is_visible` filter allows third-party customization of the visibility decision.

**Before:** every widget rendered unconditionally.

**After:** a widget renders only when the current visitor passes the configured visibility check.

**Why:** keeps the decision logic in one place inside the widget layer so the change does not depend on edits to the vendored `libraries/lifterlms-blocks` package.

### All six Elementor widget classes

Each widget's `render()` is renamed to `render_widget()` and now just contains the `do_shortcode()` call. Each widget's `_register_controls()` ends with `$this->add_visibility_controls()` so the new section is added automatically.

**Before:** `protected function render() { echo do_shortcode( '[...]' ); }`

**After:** `protected function render_widget() { echo do_shortcode( '[...]' ); }` plus a call to `add_visibility_controls()` at the end of `_register_controls()`.

**Why:** the base class now controls the visibility gate, subclasses only define what to render.

### `.changelogs/3099-elementor-enrollment-visibility.yml`

New hand-written changelog entry under the `added` type with `minor` significance.

## Testing

1. Install the plugin on a WordPress site with Elementor active.
2. Open a course in Elementor, add a LifterLMS widget (Pricing Table, Course Progress, etc.), open the Advanced tab.
3. Confirm the new "Enrollment Visibility" section shows "Display to" and "Enrolled In" controls.
4. For each "Display to" value, save the page and verify the front end:
   - `everyone` — visible to all visitors.
   - `enrolled users` + `in this course` — visible only when the visitor is enrolled in the current course.
   - `enrolled users` + `in any course or membership` — visible when the visitor has any enrollment.
   - `non-enrolled users or visitors` — hidden from enrolled users.
   - `logged in users` / `logged out users` — visible only to the matching audience.
5. In the Elementor editor, change the widget to "enrolled users" and confirm it still appears in the editor preview regardless of your own enrollment status.

Result: works as expected. PHPCS clean, PHPUnit suite passes aside from two pre-existing failures on dev unrelated to this change.

## Screenshots
<img width="1914" height="802" alt="image" src="https://github.com/user-attachments/assets/0c0ddfc1-38bf-4bdb-a5fa-ae0dfd6ccd4e" />

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.