### PR TITLE
fix(builder): display quiz post ID in course builder quiz card header

### DIFF
--- a/.changelogs/3024.yml
+++ b/.changelogs/3024.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: added
+links:
+  - "#3024"
+description: Display the quiz post ID in the course builder quiz card header so quizzes with identical titles can be distinguished.

--- a/includes/admin/views/builder/quiz.php
+++ b/includes/admin/views/builder/quiz.php
@@ -3,7 +3,8 @@
  * Builder quiz model view
  *
  * @since   3.16.0
- * @version 3.17.6
+ * @since   [Next Version] Added quiz ID display in the header.
+ * @version [Next Version]
  */
 ?>
 <script type="text/html" id="tmpl-llms-quiz-template">
@@ -35,6 +36,10 @@
 			<h3 class="llms-headline llms-model-title">
 				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
 			</h3>
+
+			<# if ( ! data.has_temp_id() ) { #>
+				<span class="llms-item-id"><?php esc_html_e( 'ID:', 'lifterlms' ); ?> {{{ data.get( 'id' ) }}}</span>
+			<# } #>
 
 			<div class="llms-headline llms-quiz-points">
 				<?php esc_html_e( 'Total Points', 'lifterlms' ); ?>: <strong id="llms-quiz-total-points">{{{ data.get( '_points' ) }}}</strong>

--- a/includes/admin/views/builder/quiz.php
+++ b/includes/admin/views/builder/quiz.php
@@ -37,10 +37,6 @@
 				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
 			</h3>
 
-			<# if ( ! data.has_temp_id() ) { #>
-				<span class="llms-item-id"><?php esc_html_e( 'ID:', 'lifterlms' ); ?> {{{ data.get( 'id' ) }}}</span>
-			<# } #>
-
 			<div class="llms-headline llms-quiz-points">
 				<?php esc_html_e( 'Total Points', 'lifterlms' ); ?>: <strong id="llms-quiz-total-points">{{{ data.get( '_points' ) }}}</strong>
 			</div>
@@ -52,6 +48,10 @@
 			</label>
 
 			<div class="llms-action-icons">
+
+				<# if ( ! data.has_temp_id() ) { #>
+					<span class="llms-item-id"><?php esc_html_e( 'ID:', 'lifterlms' ); ?> {{{ data.get( 'id' ) }}}</span>
+				<# } #>
 
 				<# if ( ! data.has_temp_id() ) { #>
 					<a class="llms-action-icon danger tip--bottom-left" data-tip="<?php esc_attr_e( 'Detach Quiz', 'lifterlms' ); ?>" href="#llms-detach-model">


### PR DESCRIPTION
## Summary

When multiple quizzes share the same title, course instructors cannot tell them apart while configuring quiz-based engagements. This change adds the quiz post ID to the course builder quiz card header, mirroring the existing lesson ID display.

Fixes #3024

## Changes

### `includes/admin/views/builder/quiz.php`

**Before:**
```php
<h3 class="llms-headline llms-model-title">
    <?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
</h3>

<div class="llms-headline llms-quiz-points">
```

**After:**
```php
<h3 class="llms-headline llms-model-title">
    <?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
</h3>

<# if ( ! data.has_temp_id() ) { #>
    <span class="llms-item-id"><?php esc_html_e( 'ID:', 'lifterlms' ); ?> {{{ data.get( 'id' ) }}}</span>
<# } #>

<div class="llms-headline llms-quiz-points">
```

**Why:** The builder quiz model already exposes `id` and `has_temp_id()`, so the template change is the minimal fix. Hidden temp IDs for unsaved quizzes match the lesson card behavior.

## Testing

**Test 1: Saved quiz shows ID**
1. Open a course in the course builder.
2. Add a lesson and create a new quiz inside it.
3. Save the course so the quiz gets a real post ID.
4. Reopen the quiz card header.

Result: `ID: <post_id>` appears below the quiz title.

**Test 2: Unsaved quiz hides ID**
1. Add a new lesson and start a new quiz.
2. Do not save.

Result: The `ID:` label is not shown while the quiz still has a `temp_` ID.

**Test 3: Lesson ID display unchanged**
1. Open a saved lesson card.

Result: The existing `ID:` display for lessons is unchanged.

## Screenshot
<img width="958" height="716" alt="image" src="https://github.com/user-attachments/assets/944dec74-3cba-4b07-80f8-873dff95a8be" />
