### PR TITLE
fix(media-protection): invalidate authorization cache when media is protected

### DIFF
--- a/.changelogs/3167.yml
+++ b/.changelogs/3167.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed media protection URL rewrite failing when a persistent object cache (such as Object Cache Pro) is enabled. The cached authorization result is now invalidated when a media file is protected and cache writes are idempotent, so protected URLs are rewritten immediately.

--- a/includes/admin/class-llms-admin-media-protection-attachment-settings.php
+++ b/includes/admin/class-llms-admin-media-protection-attachment-settings.php
@@ -161,6 +161,9 @@ class LLMS_Admin_Media_Protection_Attachment_Settings {
 			}
 
 			$protector->add_authorization_meta_to_media_post( $attachment_id );
+			// Clear the current user's cached authorization so the URL is rewritten on the
+			// next render, even when a persistent object cache (e.g. Object Cache Pro) is in use.
+			$protector->invalidate_authorization_cache( $attachment_id );
 
 			return true;
 		}

--- a/includes/class-llms-media-protector.php
+++ b/includes/class-llms-media-protector.php
@@ -526,7 +526,7 @@ class LLMS_Media_Protector {
 	/**
 	 * Build the cache key used for the authorization result of a media/user pair.
 	 *
-	 * @since 10.0.6
+	 * @since [version]
 	 *
 	 * @param int $media_id The post ID of the media file.
 	 * @param int $user_id  The ID of the user wanting to view the media file.
@@ -542,7 +542,7 @@ class LLMS_Media_Protector {
 	 * When the protection state of a media item changes the cached authorization result must be
 	 * removed so the next request does not reuse a stale value from a persistent object cache.
 	 *
-	 * @since 10.0.6
+	 * @since [version]
 	 *
 	 * @param int      $media_id The post ID of the media file.
 	 * @param int|null $user_id  Optional. The ID of the user whose cached result should be removed.
@@ -1078,7 +1078,7 @@ class LLMS_Media_Protector {
 	 * stale values being retained by persistent object caches such as Object Cache Pro.
 	 *
 	 * @since 7.7.0
-	 * @since 10.0.6 Invalidates the cached authorization result for the current user.
+	 * @since [version] Invalidates the cached authorization result for the current user.
 	 *
 	 * @param $post_id
 	 * @param string $hook_name The name of the filter that will be applied by {@see LLMS_Media_Protector::is_authorized_to_view()}.

--- a/includes/class-llms-media-protector.php
+++ b/includes/class-llms-media-protector.php
@@ -432,7 +432,7 @@ class LLMS_Media_Protector {
 			return null;
 		}
 
-		$cache_key     = 'llms-media-authorization-' . $media_id . '-' . $user_id;
+		$cache_key     = $this->get_authorization_cache_key( $media_id, $user_id );
 		$authorization = wp_cache_get( $cache_key, 'llms_media_authorization', false, $found );
 		if ( $found ) {
 			return ( ( $authorization === 'null' ) ? null : $authorization );
@@ -441,7 +441,10 @@ class LLMS_Media_Protector {
 		$authorization_filter = get_post_meta( $media_id, self::AUTHORIZATION_FILTER_KEY, true );
 		if ( ! $authorization_filter ) {
 			// We need to use string of 'null' since on some hosting like wordpress.com the value of null comes back as bool false.
-			wp_cache_add( $cache_key, 'null', 'llms_media_authorization' );
+			// Use the same cache expiration as authorized results so unprotected->protected transitions
+			// clear consistently even when the protection meta is added without an explicit invalidation.
+			$cache_expiration = apply_filters( 'llms_media_protection_cache_expiration_time', MINUTE_IN_SECONDS * 1, $media_id, $user_id );
+			wp_cache_set( $cache_key, 'null', 'llms_media_authorization', $cache_expiration );
 
 			return null;
 		}
@@ -515,9 +518,50 @@ class LLMS_Media_Protector {
 		 */
 		$cache_expiration = apply_filters( 'llms_media_protection_cache_expiration_time', MINUTE_IN_SECONDS * 1, $media_id, $user_id );
 
-		wp_cache_add( $cache_key, $is_authorized, 'llms_media_authorization', $cache_expiration );
+		wp_cache_set( $cache_key, $is_authorized, 'llms_media_authorization', $cache_expiration );
 
 		return $is_authorized;
+	}
+
+	/**
+	 * Build the cache key used for the authorization result of a media/user pair.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @param int $media_id The post ID of the media file.
+	 * @param int $user_id  The ID of the user wanting to view the media file.
+	 * @return string
+	 */
+	protected function get_authorization_cache_key( $media_id, $user_id ) {
+		return 'llms-media-authorization-' . $media_id . '-' . $user_id;
+	}
+
+	/**
+	 * Clear the cached authorization result for a media file.
+	 *
+	 * When the protection state of a media item changes the cached authorization result must be
+	 * removed so the next request does not reuse a stale value from a persistent object cache.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @param int      $media_id The post ID of the media file.
+	 * @param int|null $user_id  Optional. The ID of the user whose cached result should be removed.
+	 *                           Defaults to the current user. When null is passed, only the current
+	 *                           user's cache is cleared; other users' entries expire naturally via
+	 *                           the `llms_media_protection_cache_expiration_time` filter.
+	 * @return void
+	 */
+	public function invalidate_authorization_cache( $media_id, $user_id = null ) {
+		if ( ! is_numeric( $media_id ) || ! intval( $media_id ) ) {
+			return;
+		}
+
+		$user_id = is_null( $user_id ) ? get_current_user_id() : intval( $user_id );
+		if ( ! $user_id ) {
+			return;
+		}
+
+		wp_cache_delete( $this->get_authorization_cache_key( $media_id, $user_id ), 'llms_media_authorization' );
 	}
 
 	/**
@@ -1029,6 +1073,13 @@ class LLMS_Media_Protector {
 	/**
 	 * Add authorization meta to the post.
 	 *
+	 * Clears any cached authorization result for the current user so a subsequent read
+	 * recomputes the authorization against the new protection state. This protects against
+	 * stale values being retained by persistent object caches such as Object Cache Pro.
+	 *
+	 * @since 7.7.0
+	 * @since 10.0.6 Invalidates the cached authorization result for the current user.
+	 *
 	 * @param $post_id
 	 * @param string $hook_name The name of the filter that will be applied by {@see LLMS_Media_Protector::is_authorized_to_view()}.
 	 *
@@ -1040,5 +1091,6 @@ class LLMS_Media_Protector {
 		}
 
 		update_post_meta( $post_id, self::AUTHORIZATION_FILTER_KEY, $hook_name );
+		$this->invalidate_authorization_cache( $post_id );
 	}
 }

--- a/includes/class-llms-rest-fields.php
+++ b/includes/class-llms-rest-fields.php
@@ -129,6 +129,7 @@ class LLMS_REST_Fields {
 
 					if ( $settings->move_attachment_to_protected_dir( $object->ID ) ) {
 						update_post_meta( $object->ID, '_llms_media_protection_product_id', absint( $value ) );
+						$protector->invalidate_authorization_cache( $object->ID );
 					}
 				},
 				'schema'          => array(

--- a/tests/phpunit/unit-tests/class-llms-test-media-protector.php
+++ b/tests/phpunit/unit-tests/class-llms-test-media-protector.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests for LLMS_Media_Protector
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group media_protection
+ *
+ * @since 10.0.6
+ */
+class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
+
+	/**
+	 * Cache group used by the media protector.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'llms_media_authorization';
+
+	/**
+	 * Set up before class.
+	 *
+	 * Loads the media protector class file.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once LLMS_PLUGIN_DIR . 'includes/class-llms-media-protector.php';
+	}
+
+	/**
+	 * Set up before each test.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+		wp_cache_flush_group( self::CACHE_GROUP );
+	}
+
+	/**
+	 * Build a cache key for a given media/user pair to match the key format used internally.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @param int $media_id Media post ID.
+	 * @param int $user_id  User ID.
+	 * @return string
+	 */
+	private function build_cache_key( $media_id, $user_id ) {
+		return 'llms-media-authorization-' . $media_id . '-' . $user_id;
+	}
+
+	/**
+	 * Test that invalidate_authorization_cache() deletes a pre-existing entry for the supplied user.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_invalidate_authorization_cache_deletes_for_supplied_user() {
+
+		$user_id   = $this->factory->user->create();
+		$media_id  = 1234;
+		$cache_key = $this->build_cache_key( $media_id, $user_id );
+
+		// Seed the cache with a previously cached unprotected sentinel.
+		wp_cache_set( $cache_key, 'null', self::CACHE_GROUP, MINUTE_IN_SECONDS );
+		$this->assertSame( 'null', wp_cache_get( $cache_key, self::CACHE_GROUP ) );
+
+		( new LLMS_Media_Protector() )->invalidate_authorization_cache( $media_id, $user_id );
+
+		$found = false;
+		$value = wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+		$this->assertFalse( $found );
+		$this->assertFalse( $value );
+	}
+
+	/**
+	 * Test that invalidate_authorization_cache() without a user argument targets the current user only.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_invalidate_authorization_cache_defaults_to_current_user() {
+
+		$current_user_id = $this->factory->user->create();
+		$other_user_id   = $this->factory->user->create();
+
+		wp_set_current_user( $current_user_id );
+		$this->assertSame( $current_user_id, get_current_user_id() );
+
+		$protector = new LLMS_Media_Protector();
+		$media_id  = 9999;
+
+		wp_cache_set( $this->build_cache_key( $media_id, $current_user_id ), 'null', self::CACHE_GROUP, MINUTE_IN_SECONDS );
+		wp_cache_set( $this->build_cache_key( $media_id, $other_user_id ), 'null', self::CACHE_GROUP, MINUTE_IN_SECONDS );
+
+		$protector->invalidate_authorization_cache( $media_id );
+
+		$current_found = false;
+		wp_cache_get( $this->build_cache_key( $media_id, $current_user_id ), self::CACHE_GROUP, false, $current_found );
+		$this->assertFalse( $current_found );
+
+		// Other user's entry must remain intact.
+		$this->assertSame( 'null', wp_cache_get( $this->build_cache_key( $media_id, $other_user_id ), self::CACHE_GROUP ) );
+	}
+
+	/**
+	 * Test that add_authorization_meta_to_media_post() invalidates the cached authorization for the current user.
+	 *
+	 * Reproduces the bug in issue #3167: with a persistent object cache the cached
+	 * authorization result survives the protection state change and the URL is not rewritten.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_add_authorization_meta_invalidates_cached_authorization() {
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$attachment_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'attachment',
+				'post_author' => $user_id,
+			)
+		);
+
+		$cache_key = $this->build_cache_key( $attachment_id, $user_id );
+
+		// Simulate a previously cached "unprotected" sentinel for this user.
+		wp_cache_set( $cache_key, 'null', self::CACHE_GROUP, MINUTE_IN_SECONDS );
+
+		( new LLMS_Media_Protector() )->add_authorization_meta_to_media_post( $attachment_id );
+
+		$found = false;
+		wp_cache_get( $cache_key, self::CACHE_GROUP, false, $found );
+
+		$this->assertFalse( $found, 'add_authorization_meta_to_media_post() must invalidate the cached authorization result.' );
+	}
+
+	/**
+	 * Test that is_authorized_to_view() overwrites a previously cached 'null' value once the media is protected.
+	 *
+	 * This verifies the fix to use wp_cache_set() in place of wp_cache_add() so a stale sentinel
+	 * cannot be retained by a persistent object cache.
+	 *
+	 * @since 10.0.6
+	 *
+	 * @return void
+	 */
+	public function test_is_authorized_to_view_overwrites_stale_null_cache() {
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$attachment_id = $this->factory->post->create(
+			array(
+				'post_type'   => 'attachment',
+				'post_author' => $user_id,
+			)
+		);
+
+		$cache_key = $this->build_cache_key( $attachment_id, $user_id );
+
+		// Simulate stale cache: media was viewed while unprotected, so 'null' was cached.
+		wp_cache_set( $cache_key, 'null', self::CACHE_GROUP, MINUTE_IN_SECONDS );
+
+		// Add the protection meta and trigger invalidation.
+		( new LLMS_Media_Protector() )->add_authorization_meta_to_media_post( $attachment_id );
+
+		$protector = new LLMS_Media_Protector();
+
+		// The current user is the author, so authorization must be true.
+		$is_authorized = $protector->is_authorized_to_view( $user_id, $attachment_id );
+
+		$this->assertTrue( $is_authorized );
+
+		$cached = wp_cache_get( $cache_key, self::CACHE_GROUP );
+		$this->assertNotSame( 'null', $cached, 'Cached value should be overwritten once protection is set.' );
+		$this->assertTrue( (bool) $cached );
+	}
+}

--- a/tests/phpunit/unit-tests/class-llms-test-media-protector.php
+++ b/tests/phpunit/unit-tests/class-llms-test-media-protector.php
@@ -6,14 +6,12 @@
  *
  * @group media_protection
  *
- * @since 10.0.6
+ * @since [version]
  */
 class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 
 	/**
 	 * Cache group used by the media protector.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @var string
 	 */
@@ -23,8 +21,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 	 * Set up before class.
 	 *
 	 * Loads the media protector class file.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */
@@ -36,8 +32,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 	/**
 	 * Set up before each test.
 	 *
-	 * @since 10.0.6
-	 *
 	 * @return void
 	 */
 	public function set_up() {
@@ -47,8 +41,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 
 	/**
 	 * Build a cache key for a given media/user pair to match the key format used internally.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @param int $media_id Media post ID.
 	 * @param int $user_id  User ID.
@@ -60,8 +52,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 
 	/**
 	 * Test that invalidate_authorization_cache() deletes a pre-existing entry for the supplied user.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */
@@ -85,8 +75,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 
 	/**
 	 * Test that invalidate_authorization_cache() without a user argument targets the current user only.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */
@@ -120,8 +108,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 	 * Reproduces the bug in issue #3167: with a persistent object cache the cached
 	 * authorization result survives the protection state change and the URL is not rewritten.
 	 *
-	 * @since 10.0.6
-	 *
 	 * @return void
 	 */
 	public function test_add_authorization_meta_invalidates_cached_authorization() {
@@ -154,8 +140,6 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 	 *
 	 * This verifies the fix to use wp_cache_set() in place of wp_cache_add() so a stale sentinel
 	 * cannot be retained by a persistent object cache.
-	 *
-	 * @since 10.0.6
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Summary

Media protection URL rewriting was broken when a persistent object cache (like Object Cache Pro) is active. The authorization result for an attachment is cached per `(media_id, user_id)` with `wp_cache_add()`, so once an unprotected attachment is viewed its `'null'` sentinel stays in cache and never gets overwritten when the file is later protected. This fix switches the writes to `wp_cache_set()` and explicitly invalidates the current user's cache whenever a media file is moved into the protected directory.

Fixes #3167

## Changes

### `includes/class-llms-media-protector.php`

**Before:**
```php
wp_cache_add( $cache_key, 'null', 'llms_media_authorization', $cache_expiration );
...
wp_cache_add( $cache_key, $authorization, 'llms_media_authorization', $cache_expiration );
```

**After:**
```php
wp_cache_set( $cache_key, 'null', 'llms_media_authorization', $cache_expiration );
...
wp_cache_set( $cache_key, $authorization, 'llms_media_authorization', $cache_expiration );
```

**Why:** `wp_cache_add()` only writes when the key is missing. With a persistent object cache the `'null'` sentinel from the first unprotected view survives across requests, so `is_authorized_to_view()` keeps returning the old value after the file is protected. `wp_cache_set()` overwrites the cache with the current state.

Also added `invalidate_authorization_cache()` and hooked it into `add_authorization_meta_to_media_post()` so the cache is cleared when the protection meta is added.

### `includes/admin/class-llms-admin-media-protection-attachment-settings.php`

**After:** after a successful move to the protected directory, call `$protector->invalidate_authorization_cache( $attachment_id )`.

**Why:** clears the current user's cached authorization immediately so the next `wp_get_attachment_url()` call returns the protected URL.

### `includes/class-llms-rest-fields.php`

**After:** in the REST `update_callback` for `_llms_media_protection_product_id`, after a successful move call `$protector->invalidate_authorization_cache( $object->ID )`.

**Why:** the block-editor protection modal uses the REST endpoint, so the classic-admin path alone did not cover it.

### `tests/phpunit/unit-tests/class-llms-test-media-protector.php`

New tests covering:
- `invalidate_authorization_cache()` deletes the cache for the supplied user and defaults to the current user.
- `add_authorization_meta_to_media_post()` clears the cached authorization.
- `is_authorized_to_view()` overwrites a stale `'null'` cache entry.

### `.changelogs/3167.yml`

Patch-level changelog entry for the fix.

## Testing

**Test 1: Protect an unprotected image with Object Cache Pro active**
1. Upload an image to the media library.
2. View the image URL. It should be the normal `/wp-content/uploads/...` URL.
3. Open the attachment, select a course/membership in "LifterLMS Media Protection", and save.
4. Refresh the attachment. URL is now `https://example.com/?llms_media_id={ID}`.

Result: Works as expected.

**Test 2: Re-protect an already protected media file**
1. With Object Cache Pro active, protect an attachment.
2. Re-open it and change the selected course/membership.
3. The new product is honored on the next load.

Result: Works as expected.

**Test 3: Without object cache**
1. Repeat Test 1 after dropping the `object-cache.php` drop-in.

Result: Same behavior, no regression.

**Automated tests**
```bash
composer tests-run -- --filter LLMS_Test_Media_Protector
```
Result: OK (4 tests, 10 assertions).