### PR TITLE
fix: replace date() with WordPress Date/Time API in 14 files

### DIFF
--- a/.changelogs/datetime-date.yml
+++ b/.changelogs/datetime-date.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Replaced PHP `date()` calls flagged by `WordPress.DateTime.RestrictedFunctions.date_date` with timezone-aware alternatives (`gmdate()`, `wp_date()`, `current_time()`). Project PHPCS ruleset no longer excludes the `date_date` sniff.

--- a/includes/abstracts/llms-abstract-generator-posts.php
+++ b/includes/abstracts/llms-abstract-generator-posts.php
@@ -351,7 +351,7 @@ abstract class LLMS_Abstract_Generator_Posts {
 			return llms_current_time( 'mysql' );
 		}
 
-		return date( 'Y-m-d H:i:s', strtotime( $raw_date ) );
+		return gmdate( 'Y-m-d H:i:s', strtotime( $raw_date ) );
 	}
 
 	/**

--- a/includes/abstracts/llms.abstract.post.data.php
+++ b/includes/abstracts/llms.abstract.post.data.php
@@ -85,7 +85,7 @@ abstract class LLMS_Abstract_Post_Data {
 	 */
 	protected function strtotime( $date ) {
 		if ( ! is_numeric( $date ) ) {
-			$date = date( 'U', strtotime( $date ) );
+			$date = strtotime( $date );
 		}
 		return $date;
 	}
@@ -101,7 +101,7 @@ abstract class LLMS_Abstract_Post_Data {
 	 */
 	protected function get_date( $period, $date ) {
 
-		return date( 'Y-m-d H:i:s', $this->dates[ $period ][ $date ] );
+		return gmdate( 'Y-m-d H:i:s', $this->dates[ $period ][ $date ] );
 
 	}
 

--- a/includes/achievements/class.llms.achievement.user.php
+++ b/includes/achievements/class.llms.achievement.user.php
@@ -253,7 +253,7 @@ class LLMS_Achievement_User extends LLMS_Achievement {
 			$this->user_firstname,
 			$this->user_lastname,
 			$this->user_email,
-			date( 'M d, Y', strtotime( current_time( 'mysql' ) ) ),
+			wp_date( 'M d, Y', strtotime( current_time( 'mysql' ) ) ),
 		);
 
 		$content = $this->format_string( $this->content );

--- a/includes/admin/class.llms.admin.dashboard-widget.php
+++ b/includes/admin/class.llms.admin.dashboard-widget.php
@@ -129,7 +129,7 @@ class LLMS_Admin_Dashboard_Widget {
 						'current_courses'     => array(),
 						'current_memberships' => array(),
 						'dates'               => array(
-							'start' => date( 'Y-m-d', strtotime( '-1 week' ) ),
+							'start' => gmdate( 'Y-m-d', strtotime( '-1 week' ) ),
 							'end'   => current_time( 'Y-m-d' ),
 						),
 					)

--- a/includes/admin/reporting/class.llms.admin.reporting.php
+++ b/includes/admin/reporting/class.llms.admin.reporting.php
@@ -170,26 +170,26 @@ class LLMS_Admin_Reporting {
 
 		$dates = array(
 			'start' => '',
-			'end'   => date( 'Y-m-d', $now ),
+			'end'   => wp_date( 'Y-m-d', $now ),
 		);
 
 		switch ( $range ) {
 
 			case 'this-year':
-				$dates['start'] = date( 'Y', $now ) . '-01-01';
+				$dates['start'] = wp_date( 'Y', $now ) . '-01-01';
 				break;
 
 			case 'last-month':
-				$dates['start'] = date( 'Y-m-d', strtotime( 'first day of last month', $now ) );
-				$dates['end']   = date( 'Y-m-d', strtotime( 'last day of last month', $now ) );
+				$dates['start'] = wp_date( 'Y-m-d', strtotime( 'first day of last month', $now ) );
+				$dates['end']   = wp_date( 'Y-m-d', strtotime( 'last day of last month', $now ) );
 				break;
 
 			case 'this-month':
-				$dates['start'] = date( 'Y-m', $now ) . '-01';
+				$dates['start'] = wp_date( 'Y-m', $now ) . '-01';
 				break;
 
 			case 'last-7-days':
-				$dates['start'] = date( 'Y-m-d', strtotime( '-7 days', $now ) );
+				$dates['start'] = wp_date( 'Y-m-d', strtotime( '-7 days', $now ) );
 				break;
 
 			case 'custom':

--- a/includes/admin/views/dashboard.php
+++ b/includes/admin/views/dashboard.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 		<hr class="wp-header-end">
 
 		<div class="llms-dashboard-activity">
-			<h2><?php printf( esc_html__( 'Recent Activity: %1$1s to %2$2s', 'lifterlms' ), esc_html( date( get_option( 'date_format' ), current_time( 'timestamp' ) - WEEK_IN_SECONDS ) ), esc_html( date( get_option( 'date_format' ), current_time( 'timestamp' ) ) ) ); ?></h2>
+			<h2><?php printf( esc_html__( 'Recent Activity: %1$1s to %2$2s', 'lifterlms' ), esc_html( wp_date( get_option( 'date_format' ), current_time( 'timestamp' ) - WEEK_IN_SECONDS ) ), esc_html( wp_date( get_option( 'date_format' ), current_time( 'timestamp' ) ) ) ); ?></h2>
 			<?php echo '<style type="text/css">#llms-charts-wrapper{display:none;}</style>'; ?>
 			<?php
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in template.
@@ -40,7 +40,7 @@ defined( 'ABSPATH' ) || exit;
 								'current_courses'     => array(),
 								'current_memberships' => array(),
 								'dates'               => array(
-									'start' => date( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS ),
+									'start' => gmdate( 'Y-m-d', current_time( 'timestamp' ) - WEEK_IN_SECONDS ),
 									'end'   => current_time( 'Y-m-d' ),
 								),
 							)

--- a/includes/class-llms-events-query.php
+++ b/includes/class-llms-events-query.php
@@ -125,7 +125,7 @@ class LLMS_Events_Query extends LLMS_Database_Query {
 				if ( ! is_numeric( $date ) ) {
 					$date = strtotime( $date );
 				}
-				$this->arguments[ $key ] = date( 'Y-m-d H:i:s', $date );
+				$this->arguments[ $key ] = gmdate( 'Y-m-d H:i:s', $date );
 			}
 		}
 

--- a/includes/class-llms-events.php
+++ b/includes/class-llms-events.php
@@ -130,7 +130,7 @@ class LLMS_Events {
 
 		// Convert timestamps to MYSQL date.
 		if ( isset( $raw_event['time'] ) && is_numeric( $raw_event['time'] ) ) {
-			$prepared['date'] = date( 'Y-m-d H:i:s', $raw_event['time'] );
+			$prepared['date'] = gmdate( 'Y-m-d H:i:s', $raw_event['time'] );
 		}
 
 		if ( isset( $raw_event['url'] ) ) {

--- a/includes/class-llms-media-protector.php
+++ b/includes/class-llms-media-protector.php
@@ -1019,7 +1019,7 @@ class LLMS_Media_Protector {
 	 * @return array
 	 */
 	public function upload_dir( $uploads ) {
-		$uploads['subdir'] = trailingslashit( $this->get_upload_basedir() ) . date( 'Y/m' );
+		$uploads['subdir'] = trailingslashit( $this->get_upload_basedir() ) . current_time( 'Y/m' );
 		$uploads['path']   = $uploads['basedir'] . $uploads['subdir'];
 		$uploads['url']    = $uploads['baseurl'] . $uploads['subdir'];
 

--- a/includes/class.llms.date.php
+++ b/includes/class.llms.date.php
@@ -31,9 +31,9 @@ class LLMS_Date {
 	public static function pretty_date( $date, $type = '' ) {
 
 		if ( 'au' === $type ) {
-			return date( 'd/m/Y', strtotime( $date ) );
+			return wp_date( 'd/m/Y', strtotime( $date ) );
 		} else {
-			return date( 'm/d/Y', strtotime( $date ) );
+			return wp_date( 'm/d/Y', strtotime( $date ) );
 		}
 
 	}
@@ -70,7 +70,7 @@ class LLMS_Date {
 			list($d, $m, $y) = preg_split( '/\//', $date );
 			$date            = sprintf( '%4d-%02d-%02d', $y, $m, $d );
 		} else {
-			$date = date( 'Y-m-d', strtotime( $date ) );
+			$date = gmdate( 'Y-m-d', strtotime( $date ) );
 		}
 
 		return $date;
@@ -87,8 +87,8 @@ class LLMS_Date {
 	public static function get_date_range_by_filter( $filter ) {
 
 		$today         = current_time( 'Y-m-d' );
-		$current_month = date( 'm', strtotime( $today ) );
-		$current_year  = date( 'Y', strtotime( $today ) );
+		$current_month = wp_date( 'm', strtotime( $today ) );
+		$current_year  = wp_date( 'Y', strtotime( $today ) );
 
 		if ( 'week' === $filter ) {
 
@@ -97,8 +97,8 @@ class LLMS_Date {
 
 		} elseif ( 'month' === $filter ) {
 
-			$start_date = date( 'Y-m-01', strtotime( $today ) );
-			$end_date   = date( 'Y-m-t', strtotime( $today ) );
+			$start_date = wp_date( 'Y-m-01', strtotime( $today ) );
+			$end_date   = wp_date( 'Y-m-t', strtotime( $today ) );
 
 		} elseif ( 'quarter' === $filter ) {
 
@@ -141,7 +141,7 @@ class LLMS_Date {
 	public function last_seven_days( $where = '' ) {
 		global $wpdb;
 
-		$where .= $wpdb->prepare( ' AND post_date > %s', date( 'Y-m-d', strtotime( '-7 days' ) ) );
+		$where .= $wpdb->prepare( ' AND post_date > %s', gmdate( 'Y-m-d', strtotime( '-7 days' ) ) );
 
 		return $where;
 	}
@@ -151,7 +151,7 @@ class LLMS_Date {
 		$date = get_user_meta( $user_id, 'llms_last_login', true );
 
 		if ( $date ) {
-			return date( 'd.m.Y H:i:s', get_user_meta( $user_id, 'llms_last_login', true ) );
+			return wp_date( 'd.m.Y H:i:s', get_user_meta( $user_id, 'llms_last_login', true ) );
 		} else {
 			return false;
 		}

--- a/includes/class.llms.voucher.php
+++ b/includes/class.llms.voucher.php
@@ -216,8 +216,8 @@ class LLMS_Voucher {
 		global $wpdb;
 
 		$data['voucher_id'] = $this->id;
-		$data['created_at'] = date( 'Y-m-d H:i:s' );
-		$data['updated_at'] = date( 'Y-m-d H:i:s' );
+		$data['created_at'] = current_time( 'mysql' );
+		$data['updated_at'] = current_time( 'mysql' );
 
 		return $wpdb->insert( $this->get_codes_table_name(), $data );
 	}
@@ -234,7 +234,7 @@ class LLMS_Voucher {
 
 		global $wpdb;
 
-		$data['updated_at'] = date( 'Y-m-d H:i:s' );
+		$data['updated_at'] = current_time( 'mysql' );
 
 		$where = array(
 			'id' => $data['id'],
@@ -255,7 +255,7 @@ class LLMS_Voucher {
 
 		global $wpdb;
 
-		$data['updated_at'] = date( 'Y-m-d H:i:s' );
+		$data['updated_at'] = current_time( 'mysql' );
 		$data['is_deleted'] = 1;
 
 		$where = array(
@@ -428,7 +428,7 @@ class LLMS_Voucher {
 
 		global $wpdb;
 
-		$data['redemption_date'] = date( 'Y-m-d H:i:s' );
+		$data['redemption_date'] = current_time( 'mysql' );
 
 		return $wpdb->insert( $this->get_redemptions_table_name(), $data );
 	}

--- a/includes/functions/llms-functions-deprecated.php
+++ b/includes/functions/llms-functions-deprecated.php
@@ -125,11 +125,11 @@ function llms_expire_membership() {
 			);
 
 			// add expiration terms to start date
-			$exp_date = date( 'Y-m-d', strtotime( date( 'Y-m-d', strtotime( $start_date[0]->updated_date ) ) . ' +' . $interval . ' ' . $period ) );
+			$exp_date = gmdate( 'Y-m-d', strtotime( gmdate( 'Y-m-d', strtotime( $start_date[0]->updated_date ) ) . ' +' . $interval . ' ' . $period ) );
 
 			// get current datetime
 			$today = current_time( 'mysql' );
-			$today = date( 'Y-m-d', strtotime( $today ) );
+			$today = gmdate( 'Y-m-d', strtotime( $today ) );
 
 			// if a date parse causes exp date to be unmodified then return.
 			if ( $exp_date == $start_date[0]->updated_date ) {

--- a/includes/functions/updates/llms-functions-updates-300.php
+++ b/includes/functions/updates/llms-functions-updates-300.php
@@ -144,8 +144,8 @@ function llms_update_300_create_access_plans() {
 
 				if ( 'yes' === $plan['on_sale'] ) {
 
-					$plan['sale_end']   = ! empty( $meta['_sale_price_dates_to'][0] ) ? date( 'm/d/Y', strtotime( $meta['_sale_price_dates_to'][0] ) ) : '';
-					$plan['sale_start'] = ! empty( $meta['_sale_price_dates_from'][0] ) ? date( 'm/d/Y', strtotime( $meta['_sale_price_dates_from'][0] ) ) : '';
+					$plan['sale_end']   = ! empty( $meta['_sale_price_dates_to'][0] ) ? gmdate( 'm/d/Y', strtotime( $meta['_sale_price_dates_to'][0] ) ) : '';
+					$plan['sale_start'] = ! empty( $meta['_sale_price_dates_from'][0] ) ? gmdate( 'm/d/Y', strtotime( $meta['_sale_price_dates_from'][0] ) ) : '';
 					$plan['sale_price'] = $meta['_sale_price'][0];
 
 				}
@@ -424,7 +424,7 @@ function llms_update_300_migrate_course_postmeta() {
 		$wpdb->update(
 			$wpdb->postmeta,
 			array(
-				'meta_value' => date( 'm/d/Y', strtotime( $r->meta_value ) ),
+				'meta_value' => gmdate( 'm/d/Y', strtotime( $r->meta_value ) ),
 			),
 			array(
 				'meta_id' => $r->meta_id,

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -340,7 +340,7 @@ class LLMS_Order extends LLMS_Post_Model {
 		 * @param string     $format The requested date format.
 		 * @param LLMS_Order $order  The order object.
 		 */
-		return apply_filters( 'llms_order_calculate_next_payment_date', date( $format, $next_payment_time ), $format, $this );
+		return apply_filters( 'llms_order_calculate_next_payment_date', gmdate( $format, $next_payment_time ), $format, $this );
 	}
 
 	/**
@@ -1754,7 +1754,7 @@ class LLMS_Order extends LLMS_Post_Model {
 			sprintf(
 				// Translators: %s = next attempt date.
 				esc_html__( 'Automatic retry attempt scheduled for %s', 'lifterlms' ),
-				date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp )
+				wp_date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp )
 			)
 		);
 
@@ -1850,7 +1850,7 @@ class LLMS_Order extends LLMS_Post_Model {
 			$date_val = strtotime( $date_val );
 		}
 
-		$this->set( 'date_' . $date_key, date( 'Y-m-d H:i:s', $date_val ) );
+		$this->set( 'date_' . $date_key, gmdate( 'Y-m-d H:i:s', $date_val ) );
 
 		switch ( $date_key ) {
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -75,7 +75,7 @@
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName" />
 
 		<!-- @todo: This needs to be adjusted since WP 5.3 -->
-		<exclude name="WordPress.DateTime.RestrictedFunctions.date_date" />
+
 
 		<!-- These templates follow WP Template style so they're okay -->
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase">


### PR DESCRIPTION
## Summary

Replace date() calls with WordPress-compliant alternatives (gmdate, wp_date, current_time) across 14 files. Remove PHPCS exclusion for WordPress.DateTime.RestrictedFunctions.date_date sniff so future violations are caught by check-cs.

Fixes 40 PCP date_date violations.

## Changes

### Core date class (includes/class.llms.date.php)

**Before:**
```php
return date( 'd/m/Y', strtotime( $date ) );
$today = current_time( 'Y-m-d' );
$current_month = date( 'm', strtotime( $today ) );
return date( 'd.m.Y H:i:s', get_user_meta( $user_id, 'llms_last_login', true ) );
```

**After:**
```php
return wp_date( 'd/m/Y', strtotime( $date ) );
$today = current_time( 'Y-m-d' );
$current_month = wp_date( 'm', strtotime( $today ) );
return wp_date( 'd.m.Y H:i:s', get_user_meta( $user_id, 'llms_last_login', true ) );
```

**Why:** wp_date() respects site timezone for display. gmdate() for DB storage. current_time('Y/m') for upload paths.

### Voucher timestamps (includes/class.llms.voucher.php)

All date('Y-m-d H:i:s') for created_at/updated_at/redemption_date replaced with current_time('mysql').

### Administative views (includes/admin/views/dashboard.php)

date(get_option('date_format'), …) changed to wp_date() for locale-aware display. Date boundaries use gmdate().

### Config (phpcs.xml)

Removed the `WordPress.DateTime.RestrictedFunctions.date_date` exclusion that skipped this sniff project-wide. The @todo note about WP 5.3 is no longer relevant as the minimum WP version is 5.9.

## Testing

1. composer check-cs -- verify project PHPCS passes with date_date sniff active
2. vendor/bin/phpcs --standard=WordPress --sniffs=WordPress.DateTime.RestrictedFunctions on modified files -- zero violations
3. php -l on all 14 modified files -- no syntax errors