### PR TITLE
fix: add ABSPATH direct access protection to 15 PHP files

### DIFF
--- a/.changelogs/3198.yml
+++ b/.changelogs/3198.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Added ABSPATH direct file access protection guards to 15 PHP files flagged by Plugin Check's missing_direct_file_access_protection check. Fix applies to builder template views, access plan dialog, and order view function file."

--- a/.changelogs/3198.yml
+++ b/.changelogs/3198.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: fixed
-entry: "Added ABSPATH direct file access protection guards to 15 PHP files flagged by Plugin Check's missing_direct_file_access_protection check. Fix applies to builder template views, access plan dialog, and order view function file."
+entry: "Added ABSPATH direct file access protection guards."

--- a/includes/admin/views/access-plans/access-plan-dialog.php
+++ b/includes/admin/views/access-plans/access-plan-dialog.php
@@ -1,3 +1,4 @@
+<?php defined( 'ABSPATH' ) || exit; ?>
 <div
 	id="llms-access-plan-dialog"
 	class="llms-dialog-container"

--- a/includes/admin/views/builder/assignment.php
+++ b/includes/admin/views/builder/assignment.php
@@ -5,6 +5,7 @@
  * @since   3.17.0
  * @version 3.17.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-assignment-template">
 

--- a/includes/admin/views/builder/course.php
+++ b/includes/admin/views/builder/course.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.17.8
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-course-template">
 

--- a/includes/admin/views/builder/editor.php
+++ b/includes/admin/views/builder/editor.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.17.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-editor-template">
 

--- a/includes/admin/views/builder/elements.php
+++ b/includes/admin/views/builder/elements.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.16.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-elements-template">
 

--- a/includes/admin/views/builder/lesson-settings.php
+++ b/includes/admin/views/builder/lesson-settings.php
@@ -5,6 +5,7 @@
  * @since   3.17.0
  * @version 3.17.2
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-lesson-settings-template">
 

--- a/includes/admin/views/builder/lesson.php
+++ b/includes/admin/views/builder/lesson.php
@@ -7,6 +7,7 @@
  * @since 7.2.0 Added lesson id.
  * @version 7.2.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-lesson-template">
 

--- a/includes/admin/views/builder/question-choice.php
+++ b/includes/admin/views/builder/question-choice.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.17.8
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-question-choice-template">
 

--- a/includes/admin/views/builder/question-type.php
+++ b/includes/admin/views/builder/question-type.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.27.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-question-type-template">
 

--- a/includes/admin/views/builder/question.php
+++ b/includes/admin/views/builder/question.php
@@ -7,6 +7,7 @@
  * @since 7.4.0 Escaped strings in labels.
  * @version 7.4.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-question-template">
 

--- a/includes/admin/views/builder/quiz.php
+++ b/includes/admin/views/builder/quiz.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.17.6
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-quiz-template">
 

--- a/includes/admin/views/builder/section.php
+++ b/includes/admin/views/builder/section.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.17.2
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-section-template">
 

--- a/includes/admin/views/builder/sidebar.php
+++ b/includes/admin/views/builder/sidebar.php
@@ -6,6 +6,7 @@
  * @since 7.2.0 Added video explainer wrapper element.
  * @version 7.2.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <script type="text/html" id="tmpl-llms-sidebar-template">

--- a/includes/admin/views/builder/utilities.php
+++ b/includes/admin/views/builder/utilities.php
@@ -5,6 +5,7 @@
  * @since   3.16.0
  * @version 3.16.0
  */
+defined( 'ABSPATH' ) || exit;
 ?>
 <script type="text/html" id="tmpl-llms-utilities-template">
 

--- a/includes/functions/llms-functions-template-view-order.php
+++ b/includes/functions/llms-functions-template-view-order.php
@@ -8,6 +8,8 @@
  * @version 6.0.0
  */
 
+defined( 'ABSPATH' ) || exit;
+
 if ( ! function_exists( 'llms_template_view_order' ) ) {
 
 	/**


### PR DESCRIPTION
## Summary

Plugin Check flagged 15 PHP files missing the standard `defined( 'ABSPATH' ) || exit;` direct access protection. Adds the guard to builder view templates, the access plan dialog, and the order view function file. No business logic changed.

## Changes

### Builder view templates (13 files)

Inserts the ABSPATH guard after the file docblock, before the closing `?>`:

**Before:**
```php
<?php
/**
 * Builder lesson model view
 *
 * @since 3.16.0
 * @version 7.2.0
 */
?>
<script type="text/html" id="tmpl-llms-lesson-template">
```

**After:**
```php
<?php
/**
 * Builder lesson model view
 *
 * @since 3.16.0
 * @version 7.2.0
 */
defined( 'ABSPATH' ) || exit;
?>
<script type="text/html" id="tmpl-llms-lesson-template">
```

Files: lesson.php, elements.php, question.php, question-type.php, editor.php, section.php, course.php, utilities.php, question-choice.php, assignment.php, sidebar.php, lesson-settings.php, quiz.php.

### Access plan dialog template

The file contains no `<?php` opener, so the guard wraps the existing markup at the top of the file:

**Before:**
```php
<div
	id="llms-access-plan-dialog"
```

**After:**
```php
<?php defined( 'ABSPATH' ) || exit; ?>
<div
	id="llms-access-plan-dialog"
```

### Order view function file

The guard sits between the file docblock and the function definition wrapper:

**Before:**
```php
 * @since 6.0.0
 * @version 6.0.0
 */

if ( ! function_exists( 'llms_template_view_order' ) ) {
```

**After:**
```php
 * @since 6.0.0
 * @version 6.0.0
 */

defined( 'ABSPATH' ) || exit;

if ( ! function_exists( 'llms_template_view_order' ) ) {
```

**Why:** Plugin Check rejects any PHP file under `includes/`, `libraries/`, or the plugin root that can be reached via a direct HTTP request without first going through the WordPress bootstrap. The one-liner is the standard pattern already used across the rest of the codebase (see `includes/admin/views/access-plans/access-plan.php`, `includes/admin/views/dashboard.php`, `includes/functions/llms-functions-*.php`).

## Skipped

Two flagged files already have an equivalent guard and were not modified:
- `libraries/lifterlms-cli/src/commands.php` (uses `defined( 'ABSPATH' ) || exit;`)
- `libraries/lifterlms-rest/uninstall.php` (uses `defined( 'ABSPATH' ) || exit;`)

## Testing

1. Run `php -l` on all 15 modified files: no syntax errors.
2. Run `./vendor/bin/phpcs --standard=phpcs.xml` on all 15 files: exit 0, no warnings or errors.
3. Spot-check one builder template (`includes/admin/views/builder/lesson.php`) in the WP admin Course Builder screen: lesson list renders normally.
4. Spot-check the access plan dialog (`includes/admin/views/access-plans/access-plan-dialog.php`) in a course's access plan metabox: dialog opens and closes as before.

## Build

No new build artifacts. Source-only change.