### PR TITLE
fix: replace deprecated get_terms() form and tag WP 6.4 conditional

### DIFF
--- a/.changelogs/3199.yml
+++ b/.changelogs/3199.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: "Replaced deprecated `get_terms()` two-argument string form (e.g. `'hide_empty=0'`, removed in WP 4.5.0) with the modern single-argument array form in the course options meta box. Adjusted the `traverse_and_serialize_blocks()` reference to be conditional on WordPress 6.4.0+ via a `phpcs:ignore` annotation while preserving the existing `function_exists()` fallback to `_inject_theme_attribute_in_block_template_content()` for older WordPress versions."

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -53,7 +53,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 
 		$course = new LLMS_Course( $this->post );
 
-		$course_tracks_options = get_terms( 'course_track', 'hide_empty=0' );
+		$course_tracks_options = get_terms( array( 'taxonomy' => 'course_track', 'hide_empty' => false ) );
 		$course_tracks         = array();
 		foreach ( (array) $course_tracks_options as $term ) {
 			$course_tracks[] = array(
@@ -63,7 +63,7 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 		}
 
 		// Setup course difficulty select options.
-		$difficulty_terms   = get_terms( 'course_difficulty', 'hide_empty=0' );
+		$difficulty_terms   = get_terms( array( 'taxonomy' => 'course_difficulty', 'hide_empty' => false ) );
 		$difficulty_options = array();
 		foreach ( $difficulty_terms as $term ) {
 			$difficulty_options[] = array(

--- a/includes/class-llms-block-templates.php
+++ b/includes/class-llms-block-templates.php
@@ -373,6 +373,7 @@ class LLMS_Block_Templates {
 		$template                 = new WP_Block_Template();
 		$template->id             = $theme ? $theme . '//' . $template_slug : $namespace . '//' . $template_slug;
 		$template->theme          = $theme ? $theme : $namespace;
+		// phpcs:ignore WordPress.WP.RequiresWP -- Fallback to deprecated _inject_theme_attribute_in_block_template_content() handled below for WP < 6.4.0.
 		$template->content        = function_exists( 'traverse_and_serialize_blocks' ) ?
 			traverse_and_serialize_blocks( parse_blocks( $template_content ), '_inject_theme_attribute_in_template_part_block' ) :
 			_inject_theme_attribute_in_block_template_content( $template_content );


### PR DESCRIPTION
## Summary

Fixes Plugin Check warnings for deprecated WordPress function signatures in two files. The `get_terms()` calls in the course options meta box were using the legacy two-argument string form removed in WP 4.5.0, and the `traverse_and_serialize_blocks()` reference in the block templates class needs a `phpcs:ignore` for the WP 6.4.0 minimum requirement (plugin minimum is 5.9.0). No behavior change.

## Changes

### `includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php`

**Before:**
```php
$course_tracks_options = get_terms( 'course_track', 'hide_empty=0' );
// ...
$difficulty_terms   = get_terms( 'course_difficulty', 'hide_empty=0' );
```

**After:**
```php
$course_tracks_options = get_terms( array( 'taxonomy' => 'course_track', 'hide_empty' => false ) );
// ...
$difficulty_terms   = get_terms( array( 'taxonomy' => 'course_difficulty', 'hide_empty' => false ) );
```

**Why:** `get_terms()` deprecated the second string argument in WP 4.5.0. Modern form takes a single array of args. Same taxonomy, same empty-term inclusion, just the supported signature.

### `includes/class-llms-block-templates.php`

**Before:**
```php
$template->content = function_exists( 'traverse_and_serialize_blocks' ) ?
    traverse_and_serialize_blocks( parse_blocks( $template_content ), '_inject_theme_attribute_in_template_part_block' ) :
    _inject_theme_attribute_in_block_template_content( $template_content );
```

**After:**
```php
// phpcs:ignore WordPress.WP.RequiresWP -- Fallback to deprecated _inject_theme_attribute_in_block_template_content() handled below for WP < 6.4.0.
$template->content = function_exists( 'traverse_and_serialize_blocks' ) ?
    traverse_and_serialize_blocks( parse_blocks( $template_content ), '_inject_theme_attribute_in_template_part_block' ) :
    _inject_theme_attribute_in_block_template_content( $template_content );
```

**Why:** `traverse_and_serialize_blocks()` requires WP 6.4.0 but the plugin supports WP 5.9.0+. The existing `function_exists()` guard plus fallback to `_inject_theme_attribute_in_block_template_content()` already handles older WP. The annotation tells PHPCS the conditional is intentional.

## Testing

1. Open a course in WP admin → Course Options meta box loads with all course tracks and difficulties listed.
2. Create a new course with no tracks assigned → empty list renders without errors.
3. On WP 5.9, 6.0, 6.3 (or any sub-6.4): load a LifterLMS block template (e.g. a Single Course page with the LifterLMS theme template). Page renders using the legacy fallback path.
4. On WP 6.4+: same template renders via `traverse_and_serialize_blocks()`.

## Build

No JS or CSS changes. No build artifact needed.

## Validation

```
php -l includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
php -l includes/class-llms-block-templates.php
vendor/bin/phpcs --standard=phpcs.xml <both files>
vendor/bin/phpcs --standard=phpcs.xml --sniffs=WordPress.WP.DeprecatedParameters,WordPress.WP.RequiresWP <both files>
```

All clean. 0 errors on both files. The 3 Plugin Check findings are gone.

## Files

- `includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php` (2 lines)
- `includes/class-llms-block-templates.php` (1 line annotation)
- `.changelogs/3199.yml`