### PR TITLE
fix(plugin-check): add phpcs ignore annotations for Plugin Check compliance

### DIFF
--- a/.changelogs/3200.yml
+++ b/.changelogs/3200.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Fixed WordPress.org Plugin Check compliance issues: added phpcs:ignore annotations for PluginCheck.CodeAnalysis.EnqueuedResourceOffloading (Cloudflare Turnstile external CAPTCHA API), PluginCheck.Security.DirectDB.UnescapedDBParameter (two $wpdb->prepare() queries with safely-assembled SQL fragments), and Generic.PHP.ForbiddenFunctions.Found (_cleanup_header_comment() WP core function used in plugin file header parsing)."

--- a/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
+++ b/includes/admin/reporting/tables/llms.table.quiz.non.attempts.php
@@ -283,6 +283,7 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			$course->get( 'id' ),
 		);
 
+		// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $from_joins_where is a static SQL fragment; dynamic parts ($status_sql, $search_sql) are built via $wpdb->prepare() or hardcoded literals, and all variable values are passed through $prepare_args below.
 		$total_results = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT(DISTINCT u.ID) {$from_joins_where}",
@@ -290,6 +291,7 @@ class LLMS_Table_Quiz_Non_Attempts extends LLMS_Admin_Table {
 			)
 		); // db call ok; no-cache ok.
 
+		// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $from_joins_where is a static SQL fragment; dynamic parts ($status_sql, $search_sql) are built via $wpdb->prepare() or hardcoded literals, and all variable values are passed through $prepare_args below.
 		$results = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT DISTINCT

--- a/includes/class.llms.course.data.php
+++ b/includes/class.llms.course.data.php
@@ -234,6 +234,7 @@ class LLMS_Course_Data extends LLMS_Abstract_Post_Data {
 			$order_ids = implode( ',', array_map( 'absint', $order_ids ) );
 
 			global $wpdb;
+			// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $order_ids is built via array_map( 'absint', $order_ids ) above, so it is a comma-separated list of integer values only.
 			$revenue = $wpdb->get_var(
 				$wpdb->prepare(
 					"SELECT SUM( m2.meta_value )

--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -189,6 +189,7 @@ class LLMS_Data {
 		$version   = '';
 
 		if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi', $file_data, $match ) && $match[1] ) {
+			// phpcs:ignore Generic.PHP.ForbiddenFunctions.Found -- _cleanup_header_comment() is a WordPress core function (wp-includes/functions.php) used to parse plugin file headers; safe within the WP runtime.
 			$version = _cleanup_header_comment( $match[1] );
 		}
 

--- a/includes/spam/class-llms-turnstile.php
+++ b/includes/spam/class-llms-turnstile.php
@@ -42,6 +42,7 @@ class LLMS_Turnstile extends LLMS_Captcha {
 			return;
 		}
 
+		// phpcs:ignore PluginCheck.CodeAnalysis.EnqueuedResourceOffloading.OffloadedContent -- Cloudflare Turnstile is a third-party CAPTCHA widget API loaded from the official Cloudflare CDN, not plugin code offloaded to a remote server.
 		wp_enqueue_script( 'cloudflare-turnstile', 'https://challenges.cloudflare.com/turnstile/v0/api.js' );
 	}
 


### PR DESCRIPTION
## Summary

Added phpcs ignore comments for 4 Plugin Check findings that are false positives or safe patterns. Each annotation includes a rationale comment so reviewers can see why the code is acceptable.

## Changes

### Turnstile script enqueue

**Before:**
```php
wp_enqueue_script( 'cloudflare-turnstile', 'https://challenges.cloudflare.com/turnstile/v0/api.js' );
```

**After:**
```php
// phpcs:ignore PluginCheck.CodeAnalysis.EnqueuedResourceOffloading.OffloadedContent -- Cloudflare Turnstile is a third-party CAPTCHA widget API loaded from the official Cloudflare CDN, not plugin code offloaded to a remote server.
wp_enqueue_script( 'cloudflare-turnstile', 'https://challenges.cloudflare.com/turnstile/v0/api.js' );
```

**Why:** Cloudflare Turnstile is a third-party CAPTCHA service. The script comes from Cloudflare's official CDN, not from our own servers. This is the standard way to load their widget.

### Course revenue query

**Before:**
```php
$order_ids = implode( ',', array_map( 'absint', $order_ids ) );

global $wpdb;
$revenue = $wpdb->get_var(
    $wpdb->prepare(
        "SELECT SUM( m2.meta_value ) ... AND m1.meta_value IN ({$order_ids}) ...",
        ...
    )
);
```

**After:**
```php
$order_ids = implode( ',', array_map( 'absint', $order_ids ) );

global $wpdb;
// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $order_ids is built via array_map( 'absint', $order_ids ) above, so it is a comma-separated list of integer values only.
$revenue = $wpdb->get_var(
    $wpdb->prepare(
        "SELECT SUM( m2.meta_value ) ... AND m1.meta_value IN ({$order_ids}) ...",
        ...
    )
);
```

**Why:** The $order_ids variable is built with array_map('absint') which ensures every value is a positive integer. The query is already wrapped in $wpdb->prepare().

### Quiz non-attempts table queries (2 locations)

**Before:**
```php
$total_results = $wpdb->get_var(
    $wpdb->prepare(
        "SELECT COUNT(DISTINCT u.ID) {$from_joins_where}",
        $prepare_args
    )
);
```

**After:**
```php
// phpcs:ignore PluginCheck.Security.DirectDB.UnescapedDBParameter -- $from_joins_where is a static SQL fragment; dynamic parts ($status_sql, $search_sql) are built via $wpdb->prepare() or hardcoded literals, and all variable values are passed through $prepare_args below.
$total_results = $wpdb->get_var(
    $wpdb->prepare(
        "SELECT COUNT(DISTINCT u.ID) {$from_joins_where}",
        $prepare_args
    )
);
```

**Why:** The $from_joins_where fragment is built from static SQL plus sub-fragments ($status_sql, $search_sql) that are already prepared with $wpdb->prepare(). All variable values go through $prepare_args.

### Plugin file version parser

**Before:**
```php
if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi', $file_data, $match ) && $match[1] ) {
    $version = _cleanup_header_comment( $match[1] );
}
```

**After:**
```php
if ( preg_match( '/^[ \t\/*#@]*' . preg_quote( '@version', '/' ) . '(.*)$/mi', $file_data, $match ) && $match[1] ) {
    // phpcs:ignore Generic.PHP.ForbiddenFunctions.Found -- _cleanup_header_comment() is a WordPress core function (wp-includes/functions.php) used to parse plugin file headers; safe within the WP runtime.
    $version = _cleanup_header_comment( $match[1] );
}
```

**Why:** _cleanup_header_comment() is a WordPress core function in wp-includes/functions.php. It is safe to use inside the WordPress runtime for parsing plugin file headers.

## Testing

**Test 1: Plugin Check scan**
1. Install Plugin Check plugin
2. Run scan on LifterLMS
3. Check that these 4 findings no longer appear in the report

Result: All 4 findings resolved

**Test 2: PHPCS validation**
1. Run `composer check-cs` on the 4 modified files
2. Verify no new errors or warnings

Result: Exit code 0, no issues