### PR TITLE
fix(security): replace wp_redirect() with wp_safe_redirect()

### DIFF
--- a/.changelogs/security-redirect-handling.yml
+++ b/.changelogs/security-redirect-handling.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed redirect handling in content restriction and lesson completion, replacing unsafe `wp_redirect()` with `llms_redirect_and_exit()` for open redirect protection.

--- a/.changelogs/security-redirect-handling.yml
+++ b/.changelogs/security-redirect-handling.yml
@@ -1,3 +1,3 @@
 significance: patch
-type: fixed
-entry: Fixed redirect handling in content restriction and lesson completion, replacing unsafe `wp_redirect()` with `wp_safe_redirect()` for open redirect protection.
+type: security
+entry: Improved redirect handling in content restriction and lesson completion.

--- a/.changelogs/security-redirect-handling.yml
+++ b/.changelogs/security-redirect-handling.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: fixed
-entry: Fixed redirect handling in content restriction and lesson completion, replacing unsafe `wp_redirect()` with `llms_redirect_and_exit()` for open redirect protection.
+entry: Fixed redirect handling in content restriction and lesson completion, replacing unsafe `wp_redirect()` with `wp_safe_redirect()` for open redirect protection.

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -87,7 +87,6 @@ class LLMS_Template_Loader {
 	 *
 	 * @since 3.0.0
 	 * @since 7.4.0 Added `nocache_headers()` to prevent caching of redirects.
-	 * @since 10.1.0 Replaced `wp_redirect()` with `llms_redirect_and_exit()` for safe redirect.
 	 *
 	 * @param string $msg      Notice message to display.
 	 * @param string $redirect Optional. Url to redirect to after setting a notice. Default empty string.
@@ -101,7 +100,9 @@ class LLMS_Template_Loader {
 		}
 
 		if ( $redirect ) {
-			llms_redirect_and_exit( $redirect );
+			nocache_headers();
+			wp_safe_redirect( $redirect );
+			exit;
 		}
 	}
 

--- a/includes/class.llms.template.loader.php
+++ b/includes/class.llms.template.loader.php
@@ -87,6 +87,7 @@ class LLMS_Template_Loader {
 	 *
 	 * @since 3.0.0
 	 * @since 7.4.0 Added `nocache_headers()` to prevent caching of redirects.
+	 * @since 10.1.0 Replaced `wp_redirect()` with `llms_redirect_and_exit()` for safe redirect.
 	 *
 	 * @param string $msg      Notice message to display.
 	 * @param string $redirect Optional. Url to redirect to after setting a notice. Default empty string.
@@ -100,9 +101,7 @@ class LLMS_Template_Loader {
 		}
 
 		if ( $redirect ) {
-			nocache_headers();
-			wp_redirect( $redirect );
-			exit;
+			llms_redirect_and_exit( $redirect );
 		}
 	}
 

--- a/includes/controllers/class.llms.controller.lesson.progression.php
+++ b/includes/controllers/class.llms.controller.lesson.progression.php
@@ -124,6 +124,7 @@ class LLMS_Controller_Lesson_Progression {
 	 *
 	 * @since 3.17.1
 	 * @since 3.29.0 Unknown.
+	 * @since 10.1.0 Replaced `wp_redirect()` with `llms_redirect_and_exit()` for safe redirect.
 	 *
 	 * @return void
 	 */
@@ -152,8 +153,7 @@ class LLMS_Controller_Lesson_Progression {
 			$next_lesson_id = $lesson->get_next_lesson();
 			if ( $next_lesson_id ) {
 
-				wp_redirect( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
-				exit;
+				llms_redirect_and_exit( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
 
 			}
 		}

--- a/includes/controllers/class.llms.controller.lesson.progression.php
+++ b/includes/controllers/class.llms.controller.lesson.progression.php
@@ -124,7 +124,6 @@ class LLMS_Controller_Lesson_Progression {
 	 *
 	 * @since 3.17.1
 	 * @since 3.29.0 Unknown.
-	 * @since 10.1.0 Replaced `wp_redirect()` with `llms_redirect_and_exit()` for safe redirect.
 	 *
 	 * @return void
 	 */
@@ -153,7 +152,8 @@ class LLMS_Controller_Lesson_Progression {
 			$next_lesson_id = $lesson->get_next_lesson();
 			if ( $next_lesson_id ) {
 
-				llms_redirect_and_exit( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
+				wp_safe_redirect( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
+				exit;
 
 			}
 		}


### PR DESCRIPTION
## Description

Plugin Check flagged 2 instances of `wp_redirect()` that should use `wp_safe_redirect()` to prevent open redirect vulnerabilities. Replaced them with `wp_safe_redirect()` (with the existing `nocache_headers()` retained at the call site where it was already in place).

## Changes

### includes/class.llms.template.loader.php

**Before:**
```php
if ( $redirect ) {
    nocache_headers();
    wp_redirect( $redirect );
    exit;
}
```

**After:**
```php
if ( $redirect ) {
    nocache_headers();
    wp_safe_redirect( $redirect );
    exit;
}
```

**Why:** The `$redirect` parameter can receive an untrusted URL from callers via filters. `wp_safe_redirect()` blocks external hosts by default. `nocache_headers()` is preserved (already in trunk since 7.4.0) to prevent caching of the redirect response.

### includes/controllers/class.llms.controller.lesson.progression.php

**Before:**
```php
wp_redirect( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
exit;
```

**After:**
```php
wp_safe_redirect( apply_filters( 'llms_lesson_complete_redirect', get_permalink( $next_lesson_id ) ) );
exit;
```

**Why:** The URL passes through a filter so a third-party plugin could inject an arbitrary URL. Safe redirect prevents exploitation. This call site did not previously call `nocache_headers()`, so none is added (keeps the diff scoped to the security fix).

### Note on `llms_redirect_and_exit()`

The original version of this PR used the `llms_redirect_and_exit()` wrapper. Per maintainer feedback, the project is removing its simple wrapper methods in favor of core WordPress functions, so the wrapper is inlined to `wp_safe_redirect()` + `exit` (and `nocache_headers()` where it was already present).

## How has this been tested?

1. Trigger a content restriction redirect (e.g. access a course with unmet prerequisite) — verify redirect goes to expected page, no browser cache of the redirect response.
2. Complete a lesson with autoadvance enabled — verify redirect to next lesson works.
3. `composer run-script check-cs-errors` — passes.
4. `composer run-script tests-run` — existing PHPUnit suite passes; the inline `wp_safe_redirect()` + `exit` does not depend on the `llms_redirect_and_exit()` test mock, so no test changes were required at these two call sites.

## Screenshots <!-- if applicable -->

N/A — CLI/no UI change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] This PR requires and contains at least one changelog file (`npm run dev changelog add -- -i`).
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.