### PR TITLE
fix: Plugin Review compliance - archive packaging

### DIFF
--- a/.changelogs/plugin-review-compliance.yml
+++ b/.changelogs/plugin-review-compliance.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: dev
+entry: "Fixed WordPress.org Plugin Check compliance items: excluded AI agent markdown files from production archive and restored composer.json in distribution package."

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,9 @@
 
       "artifacts",
 
+      "AGENTS.md",
       "CHANGELOG.md",
-      "composer.json",
+      "CLAUDE.md",
       "lerna.json",
       "package.json",
       "package-lock.json",


### PR DESCRIPTION
## Summary

WordPress.org Plugin Check flagged packaging issues in the production ZIP. Fixed composer.json archive.exclude to keep composer.json in the ZIP alongside vendor/ and exclude AI agent markdown files (AGENTS.md, CLAUDE.md) from the distribution.

## Changes

### composer.json archive.exclude

**Before:**
```json
"CHANGELOG.md",
"composer.json",
"lerna.json",
```

**After:**
```json
"AGENTS.md",
"CHANGELOG.md",
"CLAUDE.md",
"lerna.json",
```

**Why:** PCP requires composer.json present when vendor/ exists. AGENTS.md and CLAUDE.md are dev workflow files not needed in production.

### .changelogs/plugin-review-compliance.yml

New changelog entry documenting the compliance fixes.

## Testing

**Test 1: Verify archive.exclude changes**
1. Run `composer validate` - passes
2. Check composer.json line 54 - "composer.json" removed from exclude list
3. Check lines 53, 55 - AGENTS.md and CLAUDE.md added to exclude list

Result: composer.json will be included in production ZIP, markdown files excluded.