### PR TITLE
Fix i18n NoHtmlWrappedStrings warning in parent-course template

### DIFF
--- a/.changelogs/i18n-template-cleanup.yml
+++ b/.changelogs/i18n-template-cleanup.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed HTML-wrapped translatable string in parent course template for WordPress i18n compliance.

--- a/templates/course/parent-course.php
+++ b/templates/course/parent-course.php
@@ -6,7 +6,8 @@
  *
  * @since  1.0.0
  * @since 5.7.0 Replaced the call to the deprecated `LLMS_Lesson::get_parent_course()` method with `LLMS_Lesson::get( 'parent_course' )`.
- * @version 5.7.0
+ * @since 10.0.6 Moved HTML outside of translatable string for i18n compliance.
+ * @version 10.0.6
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,4 +16,11 @@ global $post;
 
 $lesson = new LLMS_Lesson( $post );
 
-echo wp_kses_post( sprintf( __( '<p class="llms-parent-course-link">Back to: <a class="llms-lesson-link" href="%1$s">%2$s</a></p>', 'lifterlms' ), get_permalink( $lesson->get( 'parent_course' ) ), get_the_title( $lesson->get( 'parent_course' ) ) ) );
+echo wp_kses_post(
+	sprintf(
+		'<p class="llms-parent-course-link">%1$s <a class="llms-lesson-link" href="%2$s">%3$s</a></p>',
+		esc_html__( 'Back to:', 'lifterlms' ),
+		get_permalink( $lesson->get( 'parent_course' ) ),
+		get_the_title( $lesson->get( 'parent_course' ) )
+	)
+);


### PR DESCRIPTION
## Summary

Fixed `WordPress.WP.I18n.NoHtmlWrappedStrings` warning in parent-course template. The translatable string had HTML tags wrapped inside `__()`, which is against WordPress i18n best practices. Moved the HTML outside and only the text is translatable now.

## Changes

### templates/course/parent-course.php

**Before:**
```php
echo wp_kses_post( sprintf( __( '<p class="llms-parent-course-link">Back to: <a class="llms-lesson-link" href="%1$s">%2$s</a></p>', 'lifterlms' ), get_permalink( $lesson->get( 'parent_course' ) ), get_the_title( $lesson->get( 'parent_course' ) ) ) );
```

**After:**
```php
echo wp_kses_post(
    sprintf(
        '<p class="llms-parent-course-link">%1$s <a class="llms-lesson-link" href="%2$s">%3$s</a></p>',
        esc_html__( 'Back to:', 'lifterlms' ),
        get_permalink( $lesson->get( 'parent_course' ) ),
        get_the_title( $lesson->get( 'parent_course' ) )
    )
);
```

**Why:** HTML tags should not be inside translation strings. Translators only need to translate the visible text, not deal with markup.

### .changelogs/i18n-template-cleanup.yml

Added changelog entry for the fix.

## Testing

**Test 1: Parent course link on lesson page**
1. Open a lesson that belongs to a parent course
2. Check the "Back to:" link renders correctly
3. Verify the HTML structure (p tag, a tag with correct classes) is the same as before

Result: Works as expected, output HTML is identical

## PHPCS

`WordPress.WP.I18n` sniff passes clean on the fixed file.