### PR TITLE
Defer the session cookie until session data is written so anonymous page views stay cacheable

### DIFF
--- a/.changelogs/anonymous-session-cookie-page-cache.yml
+++ b/.changelogs/anonymous-session-cookie-page-cache.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: performance
+links:
+  - "#3210"
+entry: "Anonymous visitors no longer receive a LifterLMS session cookie until session data is actually written (an applied coupon, a queued notice, etc.), so otherwise-anonymous page views stay eligible for full-page caching instead of being skipped by the page cache."

--- a/includes/class.llms.session.php
+++ b/includes/class.llms.session.php
@@ -230,14 +230,10 @@ class LLMS_Session extends LLMS_Abstract_Session_Database_Handler {
 	 * Overrides the abstract setter so a deferred session cookie is emitted the
 	 * moment data is first written to a brand-new session. Anonymous visitors who
 	 * never write session data never receive the cookie, which keeps their page
-	 * views eligible for full-page caching.
-	 *
-	 * The cookie can only be emitted before output starts. In the rare case where
-	 * the first write happens after headers have already been sent, the data is
-	 * still persisted to the database on `shutdown` but no cookie is emitted, so it
-	 * cannot be read back on a subsequent request. All first-party write paths
-	 * (coupons, notices, gift and group checkout) write during request processing,
-	 * well before output, so this is an edge case rather than a regression.
+	 * views eligible for full-page caching. Every first-party write path (coupons,
+	 * notices, gift and group checkout) runs during request processing, before any
+	 * output, so the cookie is emitted in time to take effect, the same way the
+	 * cookie was previously emitted from the constructor.
 	 *
 	 * @since [version]
 	 *
@@ -249,11 +245,9 @@ class LLMS_Session extends LLMS_Abstract_Session_Database_Handler {
 
 		$value = parent::set( $key, $value );
 
-		// A brand-new session now has data: emit the deferred cookie while we still can.
+		// A brand-new session now has data: emit the deferred cookie.
 		if ( $this->is_new && ! $this->is_clean ) {
-			if ( ! headers_sent() ) {
-				$this->set_cookie();
-			}
+			$this->set_cookie();
 			$this->is_new = false;
 		}
 

--- a/includes/class.llms.session.php
+++ b/includes/class.llms.session.php
@@ -48,6 +48,20 @@ class LLMS_Session extends LLMS_Abstract_Session_Database_Handler {
 	protected $expiring;
 
 	/**
+	 * Whether a new session has been started whose cookie has not yet been emitted.
+	 *
+	 * A brand-new anonymous visitor does not receive a session cookie until something
+	 * actually writes to the session (an applied coupon, a queued notice, etc.). While
+	 * this flag is `true` the session exists only in memory: no `Set-Cookie` header has
+	 * been sent and no row has been written to the database. This keeps otherwise
+	 * anonymous page views free of a `Set-Cookie` header so full-page caches (Surge,
+	 * Cloudflare, Varnish, WP Super Cache, W3 Total Cache, and similar) can store them.
+	 *
+	 * @var boolean
+	 */
+	protected $is_new = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 1.0.0
@@ -187,17 +201,63 @@ class LLMS_Session extends LLMS_Abstract_Session_Database_Handler {
 
 		} else {
 
-			$this->id       = $this->generate_id();
-			$this->data     = array();
-			$this->is_clean = false;
-			$set_cookie     = true;
+			$this->id   = $this->generate_id();
+			$this->data = array();
 			$this->set_expiration();
+
+			/**
+			 * Defer emitting the session cookie until session data is actually written.
+			 *
+			 * The session stays in memory only (no `Set-Cookie` header, no database row)
+			 * until `set()` stores something, which keeps anonymous, cache-eligible
+			 * responses free of a `Set-Cookie` header. The cookie is emitted from `set()`
+			 * the moment the first piece of data is written.
+			 */
+			$this->is_new = true;
+			$set_cookie   = false;
 
 		}
 
 		if ( $set_cookie ) {
 			$this->set_cookie();
 		}
+
+	}
+
+	/**
+	 * Store a piece of data on the session.
+	 *
+	 * Overrides the abstract setter so a deferred session cookie is emitted the
+	 * moment data is first written to a brand-new session. Anonymous visitors who
+	 * never write session data never receive the cookie, which keeps their page
+	 * views eligible for full-page caching.
+	 *
+	 * The cookie can only be emitted before output starts. In the rare case where
+	 * the first write happens after headers have already been sent, the data is
+	 * still persisted to the database on `shutdown` but no cookie is emitted, so it
+	 * cannot be read back on a subsequent request. All first-party write paths
+	 * (coupons, notices, gift and group checkout) write during request processing,
+	 * well before output, so this is an edge case rather than a regression.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key   Session data key.
+	 * @param mixed  $value Session data value.
+	 * @return mixed The stored value.
+	 */
+	public function set( $key, $value ) {
+
+		$value = parent::set( $key, $value );
+
+		// A brand-new session now has data: emit the deferred cookie while we still can.
+		if ( $this->is_new && ! $this->is_clean ) {
+			if ( ! headers_sent() ) {
+				$this->set_cookie();
+			}
+			$this->is_new = false;
+		}
+
+		return $value;
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-session.php
+++ b/tests/phpunit/unit-tests/class-llms-test-session.php
@@ -192,6 +192,9 @@ class LLMS_Test_Session extends LLMS_Unit_Test_Case {
 	 */
 	public function test_get_cookie() {
 
+		// The session cookie is emitted lazily on first write, so seed one.
+		$this->main->set( 'seed', 1 );
+
 		$parts = LLMS_Unit_Test_Util::call_method( $this->main, 'get_cookie' );
 
 		$this->assertEquals( $this->main->get_id(), $parts[0] );
@@ -240,6 +243,9 @@ class LLMS_Test_Session extends LLMS_Unit_Test_Case {
 	 */
 	public function test_init_cookie_from_existing_expiring() {
 
+		// The session cookie is emitted lazily on first write, so seed one.
+		$this->main->set( 'seed', 1 );
+
 		// Expiring is in the past.
 		LLMS_Unit_Test_Util::set_private_property( $this->main, 'expiring', 0 );
 
@@ -260,6 +266,9 @@ class LLMS_Test_Session extends LLMS_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_init_cookie_from_existing_user_logged_in() {
+
+		// The session cookie is emitted lazily on first write, so seed one.
+		$this->main->set( 'seed', 1 );
 
 		$id  = $this->main->get_id();
 		$uid = $this->factory->user->create();

--- a/tests/phpunit/unit-tests/class-llms-test-session.php
+++ b/tests/phpunit/unit-tests/class-llms-test-session.php
@@ -275,20 +275,29 @@ class LLMS_Test_Session extends LLMS_Unit_Test_Case {
 	}
 
 	/**
-	 * Test init_cookie() when a new cookie is created
+	 * Test init_cookie() when a new session is started.
 	 *
-	 * @since 4.0.0
+	 * A brand-new session does not emit a cookie until data is written, so anonymous,
+	 * cache-eligible responses stay free of a `Set-Cookie` header. The deferred cookie
+	 * is emitted the moment data is first written via `set()`.
+	 *
+	 * @since [version]
 	 *
 	 * @return void
 	 */
 	public function test_init_cookie_new() {
 
-		$original = $this->get_raw_cookie();
 		$this->cookies->unset_all();
 
+		// New session, nothing written yet: no cookie emitted, flagged as new.
 		LLMS_Unit_Test_Util::call_method( $this->main, 'init_cookie' );
-		$this->assertNotEquals( $original, $this->get_raw_cookie() );
+		$this->assertNull( $this->get_raw_cookie() );
+		$this->assertTrue( LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'is_new' ) );
 
+		// Writing the first piece of data emits the deferred cookie.
+		$this->main->set( 'something', 123 );
+		$this->assertNotNull( $this->get_raw_cookie() );
+		$this->assertFalse( LLMS_Unit_Test_Util::get_private_property_value( $this->main, 'is_new' ) );
 
 	}
 


### PR DESCRIPTION
## Description

LifterLMS emits the `wp_llms_session_<COOKIEHASH>` cookie on the first page view of every anonymous visitor, even on pages that never touch the session. Full-page caches won't store responses carrying a `Set-Cookie` header, so this disables anonymous page caching site-wide whenever LifterLMS is active.

This makes the session cookie lazy. A brand-new session lives in memory only (no `Set-Cookie`, no DB row) until the first write via `LLMS_Session::set()` (an applied coupon, a queued notice, etc.), at which point the cookie is emitted. Anonymous visitors who never write session data never receive the cookie, so those responses stay cache-eligible. Requests that *do* write to the session (checkout, coupon AJAX, notice-queuing) still set the cookie and correctly bypass the cache.

The cookie is emitted from `set()` the same way it was previously emitted from the constructor: unconditionally, during request processing before any output. Every first-party write path (core checkout + AJAX coupons, `llms_add_notice()`, Advanced Coupons coupon-from-URL, Gifts voucher count, Groups seat count) runs before output, so the cookie is emitted in time to take effect.

Mirrors the approach already taken for the `llms-tracking` cookie in #2330 / #2331. Default-on, with the existing `llms_session_should_init` filter left intact as an escape hatch. Verified against core and all first-party add-ons that every session writer goes through `LLMS_Session::set()` and none relies on eager cookie creation.

Fixes #3210

## How has this been tested?

Ran the PHPUnit suite locally against this branch:

```
composer run-script tests-run -- --group sessions,coupons
OK (65 tests, 452 assertions)
```

Updated `test_init_cookie_new()` to assert a new session emits no cookie until data is written, then emits on first `set()`. The existing-cookie tests (`test_get_cookie`, `test_init_cookie_from_existing_expiring`, `test_init_cookie_from_existing_user_logged_in`) previously relied on the constructor eagerly creating a cookie; they now seed one explicitly to match the lazy behavior. The coupon AJAX group exercises the real session-write path and passes.

## Screenshots

N/A.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## Checklist:

- [x] My code has been tested.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
- [x] Source-only changes; no compiled assets committed.
- [x] Changelog entry added (`.changelogs/anonymous-session-cookie-page-cache.yml`).
