### PR TITLE
Additional checks on access plan availability during checkout

### DIFF
--- a/.changelogs/fix-access-plan-checkout-check.yml
+++ b/.changelogs/fix-access-plan-checkout-check.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: "Additional checks during checkout order creation."

--- a/includes/class-llms-order-generator.php
+++ b/includes/class-llms-order-generator.php
@@ -685,6 +685,12 @@ class LLMS_Order_Generator {
 		}
 
 		$this->plan = $plan;
+
+		$purchasable = llms_check_access_plan_purchasable( $plan );
+		if ( is_wp_error( $purchasable ) ) {
+			return $this->error( $purchasable->get_error_code(), $purchasable->get_error_message() );
+		}
+
 		return true;
 
 	}

--- a/includes/functions/llms.functions.order.php
+++ b/includes/functions/llms.functions.order.php
@@ -277,6 +277,49 @@ function llms_locate_order_for_user_and_plan( $user_id, $plan_id ) {
 }
 
 /**
+ * Determines whether an access plan can be purchased by a user during checkout.
+ *
+ * Mirrors the front-end purchasability gating so that restricted access plans and products cannot be purchased
+ * by submitting a crafted access plan ID directly to the checkout handlers. Enforces member-only plan availability
+ * and course restrictions (enrollment window and student capacity).
+ *
+ * Intentionally does not call `LLMS_Product::is_purchasable()` because that additionally requires an enabled
+ * payment gateway, which would incorrectly block free checkout on sites with no gateways enabled.
+ *
+ * @since [version]
+ *
+ * @param LLMS_Access_Plan $plan    The access plan being purchased.
+ * @param int|null         $user_id Optional. WP_User ID of the purchasing user. Defaults to the current user.
+ * @return true|WP_Error Returns `true` when the plan can be purchased or a `WP_Error` describing why it cannot.
+ */
+function llms_check_access_plan_purchasable( $plan, $user_id = null ) {
+
+	$can_purchase = true;
+
+	if ( ! $plan || ! is_a( $plan, 'LLMS_Access_Plan' ) ) {
+		$can_purchase = new WP_Error( 'invalid-plan-id', __( 'Invalid Access Plan ID.', 'lifterlms' ) );
+	} elseif ( ! $plan->is_available_to_user( $user_id ) ) {
+		$can_purchase = new WP_Error( 'plan-not-available', __( 'This access plan is not available.', 'lifterlms' ) );
+	} else {
+		$product = $plan->get_product();
+		if ( ! $product || $product->has_restrictions() ) {
+			$can_purchase = new WP_Error( 'product-not-purchasable', __( 'This product is not available for purchase.', 'lifterlms' ) );
+		}
+	}
+
+	/**
+	 * Filters whether an access plan can be purchased during checkout.
+	 *
+	 * @since [version]
+	 *
+	 * @param true|WP_Error         $can_purchase Whether the plan can be purchased. `true` if it can, a `WP_Error` otherwise.
+	 * @param LLMS_Access_Plan|null $plan         The access plan being purchased.
+	 * @param int|null              $user_id      WP_User ID of the purchasing user, or `null` for the current user.
+	 */
+	return apply_filters( 'llms_check_access_plan_purchasable', $can_purchase, $plan, $user_id );
+}
+
+/**
  * Setup a pending order which can be passed to an LLMS_Payment_Gateway for processing.
  *
  * @since 3.29.0
@@ -339,6 +382,11 @@ function llms_setup_pending_order( $data = array() ) {
 	if ( ! $plan || 'llms_access_plan' !== $plan->get( 'type' ) ) {
 		$err->add( 'invalid-plan-id', __( 'Invalid Access Plan ID.', 'lifterlms' ) );
 		return $err;
+	}
+
+	$purchasable = llms_check_access_plan_purchasable( $plan );
+	if ( is_wp_error( $purchasable ) ) {
+		return $purchasable;
 	}
 
 	// Used later.

--- a/tests/phpunit/unit-tests/class-llms-test-order-generator.php
+++ b/tests/phpunit/unit-tests/class-llms-test-order-generator.php
@@ -867,6 +867,87 @@ class LLMS_Test_Order_Generator extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test validate_plan() rejects a member-only plan when the user isn't a member.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_validate_plan_member_only_not_available() {
+
+		wp_set_current_user( 0 );
+
+		$membership_id = $this->factory->post->create( array( 'post_type' => 'llms_membership' ) );
+
+		$plan = $this->get_mock_plan( 0 );
+		$plan->set( 'availability', 'members' );
+		$plan->set( 'availability_restrictions', array( $membership_id ) );
+
+		$gen = new LLMS_Order_Generator( array(
+			'llms_plan_id' => $plan->get( 'id' ),
+		) );
+
+		$res = LLMS_Unit_Test_Util::call_method( $gen, 'validate_plan' );
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'plan-not-available', $res );
+
+	}
+
+	/**
+	 * Test validate_plan() allows a member-only plan for an enrolled member.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_validate_plan_member_only_available() {
+
+		$membership_id = $this->factory->post->create( array( 'post_type' => 'llms_membership' ) );
+
+		$student = $this->factory->student->create_and_get();
+		$student->enroll( $membership_id );
+		wp_set_current_user( $student->get( 'id' ) );
+
+		$plan = $this->get_mock_plan( 0 );
+		$plan->set( 'availability', 'members' );
+		$plan->set( 'availability_restrictions', array( $membership_id ) );
+
+		$gen = new LLMS_Order_Generator( array(
+			'llms_plan_id' => $plan->get( 'id' ),
+		) );
+
+		$this->assertTrue( LLMS_Unit_Test_Util::call_method( $gen, 'validate_plan' ) );
+
+	}
+
+	/**
+	 * Test validate_plan() rejects a plan whose product has purchase restrictions (e.g. capacity reached).
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_validate_plan_product_restricted() {
+
+		$plan    = $this->get_mock_plan( 0 );
+		$course  = new LLMS_Course( $plan->get( 'product_id' ) );
+
+		// Restrict enrollment by closing the enrollment period in the past.
+		$course->set( 'enrollment_period', 'yes' );
+		$course->set( 'enrollment_start_date', '01/01/2000' );
+		$course->set( 'enrollment_end_date', '01/02/2000' );
+
+		$gen = new LLMS_Order_Generator( array(
+			'llms_plan_id' => $plan->get( 'id' ),
+		) );
+
+		$res = LLMS_Unit_Test_Util::call_method( $gen, 'validate_plan' );
+		$this->assertIsWPError( $res );
+		$this->assertWPErrorCodeEquals( 'product-not-purchasable', $res );
+
+	}
+
+	/**
 	 * Test validate_terms() when terms aren't required.
 	 *
 	 * @since 7.0.0


### PR DESCRIPTION

## Description
Additional verification of purchasability of an access plan during checkout.

## How has this been tested?
Manually + unit tests

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

