### PR TITLE
Styling fix for WP 7.0 "Add New Plan" metabox

### DIFF
--- a/.changelogs/fix-add-new-plan-meta-box-scrolling-7-0.yml
+++ b/.changelogs/fix-add-new-plan-meta-box-scrolling-7-0.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Fixed the \"Add New Plan\" access plan dialog not scrolling within the block editor meta boxes area in WordPress 7.0."

--- a/assets/scss/admin/metaboxes/_metabox-product.scss
+++ b/assets/scss/admin/metaboxes/_metabox-product.scss
@@ -109,7 +109,14 @@
 		position: relative;
 		background-color: white;
 		overflow: auto;
-		max-height: 90vh;
+		box-sizing: border-box;
+		// In WP < 7.0 the metabox rendered full-screen so `position: fixed` on the
+		// container resolved against the viewport and `90vh` was always the limit. In WP 7.0+
+		// the block editor wraps the meta-boxes area in an element that establishes the
+		// containing block for fixed positioning, so the container only fills that (often
+		// short) region. `min()` keeps the viewport cap while also clamping to the container
+		// height so the content scrolls instead of overflowing the meta-boxes area.
+		max-height: min(90vh, 100%);
 
 		.llms-dialog-close {
 			position: absolute;


### PR DESCRIPTION

## Description

Fixes #3222 

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="4242" height="1846" alt="CleanShot 2026-06-26 at 10 01 05@2x" src="https://github.com/user-attachments/assets/3cd6f5aa-9467-4dc1-9a2c-2aa15a875498" />


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

