### PR TITLE
Check quiz lesson access

### DIFF
--- a/.changelogs/fix-lesson-check.yml
+++ b/.changelogs/fix-lesson-check.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: "Additional checks when starting a quiz."

--- a/includes/class.llms.ajax.handler.php
+++ b/includes/class.llms.ajax.handler.php
@@ -473,11 +473,9 @@ class LLMS_AJAX_Handler {
 				$access_lesson_id = absint( $existing_attempt->get( 'lesson_id' ) );
 			}
 		}
-		if ( $access_lesson_id ) {
-			$access_check = self::verify_quiz_access( $student, $access_lesson_id, $access_quiz_id );
-			if ( is_wp_error( $access_check ) ) {
-				return $access_check;
-			}
+		$access_check = self::verify_quiz_access( $student, $access_lesson_id, $access_quiz_id );
+		if ( is_wp_error( $access_check ) ) {
+			return $access_check;
 		}
 
 		// Limit reached?

--- a/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
+++ b/tests/phpunit/unit-tests/ajax/class-llms-test-ajax-handler-quizzes.php
@@ -109,7 +109,8 @@ class LLMS_Test_AJAX_Handler_Quizzes extends LLMS_UnitTestCase {
 
 		$res = LLMS_AJAX_Handler::quiz_start(
 			array(
-				'quiz_id' => $this->quiz->get( 'id' ),
+				'quiz_id'   => $this->quiz->get( 'id' ),
+				'lesson_id' => $this->lesson->get( 'id' ),
 			)
 		);
 


### PR DESCRIPTION

## Description
Always check access on lesson on quiz start.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

