### PR TITLE
fix(admin): widen voucher "Uses" field for multi-digit values

### DIFF
--- a/.changelogs/voucher-uses-input-width.yml
+++ b/.changelogs/voucher-uses-input-width.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: "Increased the voucher admin \"Uses\" field width so redemption counts with more than two digits are readable."

--- a/assets/scss/admin/modules/_voucher.scss
+++ b/assets/scss/admin/modules/_voucher.scss
@@ -88,7 +88,7 @@ a.llms-voucher-delete {
   }
 
   .llms-voucher-uses {
-    width: 50px;
+    width: 80px;
   }
 
   .llms-voucher-add-codes {


### PR DESCRIPTION
## Summary

The "Uses" input on the admin voucher edit screen (`Orders > Vouchers > Edit`) was hardcoded to `50px`, which clips multi-digit redemption counts like `1000`. Widens the input to `80px` so the value is fully readable.

Fixes #3235

## Changes

### `assets/scss/admin/modules/_voucher.scss`

**Before:**
```scss
.llms-voucher-uses {
  width: 50px;
}
```

**After:**
```scss
.llms-voucher-uses {
  width: 80px;
}
```

**Why:** the `50px` width clips values above two digits. `80px` comfortably fits 4-5 digits. The change matches the codebase convention of using `px` units for admin input widths (see `_quiz-attempt-review.scss`).

PHP and JS templates for the field both use `class="llms-voucher-uses"` with no inline `size` attribute, so the SCSS change covers both initial render and dynamically injected rows from the "Add codes" button.

## Testing

1. Navigate to `Orders > Vouchers`.
2. Edit any voucher with at least one code row.
3. Click into the "Uses" input and type `1000`. All four digits render fully without clipping.
4. Click "Add N new code(s)" with N = 5, set uses to `100`, click Add. New rows inherit the wider width.

Result: works as expected.

## Screenshots

|Before|After|
|-----|-----|
|<img width="1420" height="337" alt="SCR-20260714-cevc" src="https://github.com/user-attachments/assets/3f70323d-8295-4404-a884-ccd8ace56afe" />|<img width="1442" height="360" alt="image" src="https://github.com/user-attachments/assets/28257ee6-4cfe-44da-bdf2-f2d815e8c0e3" />|