### PR TITLE
fix(template): add wp-element-button to access plan button

### DIFF
--- a/.changelogs/3234-wp-element-button.yml
+++ b/.changelogs/3234-wp-element-button.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: "Added the `wp-element-button` class to the access plan button and free enrollment form so they inherit theme button styling from `theme.json`."

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -212,7 +212,7 @@ class LLMS_Shortcodes {
 	 *
 	 * @since 3.2.5
 	 * @since 3.4.1 Unknown.
-	 * @since 10.0.11 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
+	 * @since 10.0.10 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
 	 *
 	 * @param array  $atts    Associative array of shortcode attributes.
 	 * @param string $content Optional. Shortcode content, enables custom text/html in the button. Default empty string.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -212,6 +212,7 @@ class LLMS_Shortcodes {
 	 *
 	 * @since 3.2.5
 	 * @since 3.4.1 Unknown.
+	 * @since 10.0.11 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
 	 *
 	 * @param array  $atts    Associative array of shortcode attributes.
 	 * @param string $content Optional. Shortcode content, enables custom text/html in the button. Default empty string.
@@ -235,7 +236,7 @@ class LLMS_Shortcodes {
 		if ( ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
 			$plan = new LLMS_Access_Plan( $atts['id'] );
 
-			$classes  = 'llms-button-' . $atts['type'];
+			$classes  = 'llms-button-' . $atts['type'] . ' wp-element-button';
 			$classes .= ! empty( $atts['size'] ) ? ' ' . $atts['size'] : '';
 			$classes .= ! empty( $atts['classes'] ) ? ' ' . $atts['classes'] : '';
 

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -212,7 +212,6 @@ class LLMS_Shortcodes {
 	 *
 	 * @since 3.2.5
 	 * @since 3.4.1 Unknown.
-	 * @since 10.0.10 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
 	 *
 	 * @param array  $atts    Associative array of shortcode attributes.
 	 * @param string $content Optional. Shortcode content, enables custom text/html in the button. Default empty string.

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -8,8 +8,8 @@
  *
  * @since 3.23.0
  * @since 4.2.0 Added `llms_display_free_enroll_form` filter hook.
- * @since 10.0.11 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
- * @version 10.0.11
+ * @since 10.0.10 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
+ * @version 10.0.10
  */
 defined( 'ABSPATH' ) || exit;
 ?>

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -8,8 +8,8 @@
  *
  * @since 3.23.0
  * @since 4.2.0 Added `llms_display_free_enroll_form` filter hook.
- * @since 10.0.10 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
- * @version 10.0.10
+ * @since [version] Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -8,7 +8,8 @@
  *
  * @since 3.23.0
  * @since 4.2.0 Added `llms_display_free_enroll_form` filter hook.
- * @version 4.2.0
+ * @since 10.0.11 Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
+ * @version 10.0.11
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -25,5 +26,5 @@ if ( apply_filters( 'llms_display_free_enroll_form', get_current_user_id() && $p
 	?>
 	<?php llms_get_template( 'product/free-enroll-form.php', compact( 'plan' ) ); ?>
 <?php else : ?>
-	<a class="llms-button-action button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
+	<a class="llms-button-action button wp-element-button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
 <?php endif; ?>

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -9,7 +9,8 @@
  * @since 3.4.0
  * @since 3.30.0 Added redirect field.
  * @since 5.0.0 Use `LLMS_Forms::get_free_enroll_form_html()` in favor of deprecated `LLMS_Person_Handler::get_available_fields()`.
- * @version 5.0.0
+ * @since 10.0.11 Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
+ * @version 10.0.11
  *
  * @property LLMS_Access_Plan $plan Instance of the plan object.
  */
@@ -37,6 +38,6 @@ if ( ! $uid || empty( $plan ) || ! $plan->has_free_checkout() ) {
 
 	<?php do_action( 'lifterlms_after_free_enroll_fields' ); ?>
 
-	<button class="llms-button-action button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
+	<button class="llms-button-action button wp-element-button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
 
 </form>

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -9,8 +9,8 @@
  * @since 3.4.0
  * @since 3.30.0 Added redirect field.
  * @since 5.0.0 Use `LLMS_Forms::get_free_enroll_form_html()` in favor of deprecated `LLMS_Person_Handler::get_available_fields()`.
- * @since 10.0.11 Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
- * @version 10.0.11
+ * @since 10.0.10 Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
+ * @version 10.0.10
  *
  * @property LLMS_Access_Plan $plan Instance of the plan object.
  */

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -9,8 +9,8 @@
  * @since 3.4.0
  * @since 3.30.0 Added redirect field.
  * @since 5.0.0 Use `LLMS_Forms::get_free_enroll_form_html()` in favor of deprecated `LLMS_Person_Handler::get_available_fields()`.
- * @since 10.0.10 Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
- * @version 10.0.10
+ * @since [version] Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
+ * @version [version]
  *
  * @property LLMS_Access_Plan $plan Instance of the plan object.
  */

--- a/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
+++ b/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
@@ -93,7 +93,7 @@ class LLMS_Test_Functions_Templates_Pricing_Tables extends LLMS_UnitTestCase {
 		$ob = $this->get_ob( 'llms_template_access_plan_button', array( 0 ) );
 
 		// purchase button link
-		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button"' ) );
+		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button wp-element-button"' ) );
 		$this->assertTrue( false !== strpos( $ob['html'], sprintf( 'href="%s"', esc_url( $ob['plan']->get_checkout_url() ) ) ) );
 
 		// check free enroll form


### PR DESCRIPTION
## Description

Fixes #3234

Appends the `wp-element-button` CSS class to the access plan button so it inherits theme button styling from `theme.json` when the active theme declares `styles.elements.button`. The class is appended to the existing class list, so themes that have not declared `elements.button` see no visual change and the existing `llms-button-action button` styling is preserved.

The access plan button is rendered in three places. All three are covered:

- Pricing-table footer (`templates/product/access-plan-button.php`)
- Free-enroll form submit (`templates/product/free-enroll-form.php`)
- Shortcode and block `[lifterlms_access_plan_button]` (`LLMS_Shortcodes::access_plan_button()`)

`wp-element-button` is a WordPress Global Styles element-class contract introduced in WP 5.9. It has no effect on themes that do not opt in via `theme.json`, so there is no visual regression for classic themes.

## How has this been tested?

- `composer run-script check-cs` and `composer run-script check-cs-errors`: clean across the full repo, no new warnings or errors on the four edited files.
- Three parallel verification passes on the diff: scope match against #3234, sibling call-site check, deprecated-pattern check. All passed.
- PHPUnit suite not executed here (no MySQL test DB in the headless environment). `composer run-script tests` should be run in a local dev environment.
- Manual end-to-end steps are in `TESTING_INSTRUCTIONS.md` (Test 1: block-theme pricing-table button picks up theme styling; Test 2: free-enroll form submit; Test 3: shortcode and block; Test 4: classic-theme BC; Test 5: existing theme-support overrides).

Out of scope for this PR (intentional):

- Other checkout buttons ("Buy Now", "Confirm Payment").
- Admin-area buttons.
- Lesson/quiz completion buttons.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. (PHPUnit not run in this environment; see `TESTING_INSTRUCTIONS.md`)
- [x] My code follows the LifterLMS Coding & Documentation Standards.