### PR TITLE
Fix notices button colours with WP 7.0

### DIFF
--- a/.changelogs/fix-custom-fields-notice.yml
+++ b/.changelogs/fix-custom-fields-notice.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#3161"
+entry: Fixed the appearance of the custom fields notice on the forms screen under WordPress 7.0.

--- a/assets/js/llms-admin-forms.js
+++ b/assets/js/llms-admin-forms.js
@@ -58,6 +58,7 @@
 			'font-size: 23px;',
 			'height: 30px;',
 			'line-height: 1;',
+			'min-height: 30px;',
 			'margin-left: 5px;',
 			'padding: 0;',
 			'position: relative;',
@@ -66,7 +67,7 @@
 			'width: 30px;',
 		].join( ';' );
 
-		btn.innerHTML = '<span class="screen-reader-text>' + txt + '</span>';
+		btn.innerHTML = '<span class="screen-reader-text">' + txt + '</span>';
 		btn.title     = __( 'Help', 'lifterlms' );
 
 		btn.addEventListener( 'click', toggleHelpNode );

--- a/assets/scss/admin/_main.scss
+++ b/assets/scss/admin/_main.scss
@@ -252,6 +252,31 @@ div[id^="lifterlms-"] .inside {
 		display: inline-block;
 	}
 
+	// WP 7.0's `div.notice a` rule underlines links and recolors them, overriding the button styles.
+	a.llms-button-action,
+	a.llms-button-danger,
+	a.llms-button-primary {
+		color: $color-white;
+		text-decoration: none;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: $color-white;
+		}
+	}
+
+	a.llms-button-secondary {
+		color: $color-cinder;
+		text-decoration: none;
+
+		&:hover,
+		&:focus,
+		&:active {
+			color: $color-cinder;
+		}
+	}
+
 	p {
 		font-size: 14px;
 		line-height: 22px;


### PR DESCRIPTION

## Description
Also fixes screen reader text of the help bubble.
Fixes #3161

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->

<img width="4486" height="1834" alt="CleanShot 2026-07-21 at 07 15 20@2x" src="https://github.com/user-attachments/assets/9011dcc8-ed2b-451c-9fe4-9dc4ede5c283" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

