### PR TITLE
fix(assets): only enqueue context-specific assets on LifterLMS pages

### DIFF
--- a/.changelogs/fix-146-conditional-frontend-assets.yml
+++ b/.changelogs/fix-146-conditional-frontend-assets.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: performance
+entry: "Only enqueues context-specific LifterLMS scripts and styles on LifterLMS-related pages, reducing asset loading on non-LifterLMS pages. Added the `llms_load_frontend_assets` filter to control frontend asset loading."

--- a/includes/class.llms.frontend.assets.php
+++ b/includes/class.llms.frontend.assets.php
@@ -25,6 +25,7 @@ defined( 'ABSPATH' ) || exit;
  *              - `LLMS_Frontend_Assets::enqueue_inline_pw_script()` method
  *              - `LLMS_Frontend_Assets::enqueue_inline_script()` method
  *              - `LLMS_Frontend_Assets::is_inline_script_enqueued()` method
+ * @since [version] Added `is_llms_context()` method for conditional asset loading and `llms_load_frontend_assets` filter.
  */
 class LLMS_Frontend_Assets {
 
@@ -44,6 +45,28 @@ class LLMS_Frontend_Assets {
 		'header' => array(),
 		'footer' => array(),
 	);
+
+	/**
+	 * Determine if the current frontend page is a LifterLMS context that needs assets.
+	 *
+	 * @since [version]
+	 *
+	 * @return boolean
+	 */
+	private static function is_llms_context() {
+
+		$load = is_lifterlms() || is_llms_account_page() || is_llms_checkout();
+
+		/**
+		 * Filters whether frontend assets should load on the current page.
+		 *
+		 * @since [version]
+		 *
+		 * @param boolean $load Whether assets should load. Auto-detected from the current page type by default.
+		 */
+		return (bool) apply_filters( 'llms_load_frontend_assets', $load );
+
+	}
 
 	/**
 	 * Initializer
@@ -142,7 +165,10 @@ class LLMS_Frontend_Assets {
 
 		llms()->assets->register_style( 'llms-iziModal' );
 
-		llms()->assets->enqueue_style( 'webui-popover' );
+		if ( self::is_llms_context() ) {
+			llms()->assets->enqueue_style( 'webui-popover' );
+		}
+
 		llms()->assets->enqueue_style( 'lifterlms-styles' );
 
 		if ( in_array( $post_type, array( 'llms_my_certificate', 'llms_certificate' ), true ) ) {
@@ -177,12 +203,16 @@ class LLMS_Frontend_Assets {
 	 */
 	public static function enqueue_scripts() {
 
-		// I don't think we need these next 3 scripts.
-		wp_enqueue_script( 'jquery-ui-tooltip' );
-		wp_enqueue_script( 'jquery-ui-datepicker' );
-		wp_enqueue_script( 'jquery-ui-slider' );
+		// jquery-ui libs and the standalone llms-ajax script are only used on LifterLMS pages.
+		if ( self::is_llms_context() ) {
+			wp_enqueue_script( 'jquery-ui-tooltip' );
+			wp_enqueue_script( 'jquery-ui-datepicker' );
+			wp_enqueue_script( 'jquery-ui-slider' );
 
-		llms()->assets->enqueue_script( 'webui-popover' );
+			llms()->assets->enqueue_script( 'webui-popover' );
+
+			wp_enqueue_script( 'llms-ajax', LLMS_PLUGIN_URL . 'assets/js/llms-ajax' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
+		}
 
 		llms()->assets->register_script( 'llms-jquery-matchheight' );
 		if ( is_llms_account_page() || is_course() || is_membership() || is_lesson() || is_memberships() || is_courses() || is_tax( array( 'course_cat', 'course_tag', 'course_difficulty', 'course_track', 'membership_tag', 'membership_cat' ) ) ) {
@@ -196,11 +226,9 @@ class LLMS_Frontend_Assets {
 			llms()->assets->enqueue_script( 'llms-notifications' );
 		}
 
-		// Doesn't seem like there's any reason to enqueue this script on the frontend.
-		wp_enqueue_script( 'llms-ajax', LLMS_PLUGIN_URL . 'assets/js/llms-ajax' . LLMS_ASSETS_SUFFIX . '.js', array( 'jquery' ), llms()->version, true );
-
-		// I think we only need this on account and checkout pages.
-		llms()->assets->enqueue_script( 'llms-form-checkout' );
+		if ( is_llms_account_page() || is_llms_checkout() ) {
+			llms()->assets->enqueue_script( 'llms-form-checkout' );
+		}
 
 		if ( is_singular( 'llms_quiz' ) ) {
 			llms()->assets->enqueue_script( 'llms-quiz' );

--- a/includes/shortcodes/class.llms.shortcode.checkout.php
+++ b/includes/shortcodes/class.llms.shortcode.checkout.php
@@ -201,6 +201,10 @@ class LLMS_Shortcode_Checkout {
 
 		global $wp;
 
+		// Ensure checkout assets load even when the shortcode is used off the configured checkout page.
+		llms()->assets->enqueue_script( 'llms-form-checkout' );
+		llms()->assets->enqueue_style( 'lifterlms-styles' );
+
 		$atts = $atts ? $atts : array();
 
 		$atts['cols'] = isset( $atts['cols'] ) ? $atts['cols'] : 2;

--- a/includes/shortcodes/class.llms.shortcode.courses.php
+++ b/includes/shortcodes/class.llms.shortcode.courses.php
@@ -189,6 +189,7 @@ class LLMS_Shortcode_Courses extends LLMS_Shortcode {
 	protected function get_output() {
 
 		$this->enqueue_script( 'llms-jquery-matchheight' );
+		llms()->assets->enqueue_style( 'lifterlms-styles' );
 
 		ob_start();
 

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -316,6 +316,7 @@ class LLMS_Shortcodes {
 
 		// Enqueue match height so the loop isn't all messed up visually.
 		self::enqueue_script( 'llms-jquery-matchheight' );
+		llms()->assets->enqueue_style( 'lifterlms-styles' );
 
 		if ( isset( $atts['category'] ) ) {
 			$tax = array(
@@ -608,6 +609,10 @@ class LLMS_Shortcodes {
 
 			// enqueue match height for height alignments.
 			self::enqueue_script( 'llms-jquery-matchheight' );
+			llms()->assets->enqueue_style( 'lifterlms-styles' );
+			// Pricing table locked-plan popovers need webui-popover.
+			llms()->assets->enqueue_script( 'webui-popover' );
+			llms()->assets->enqueue_style( 'webui-popover' );
 
 			ob_start();
 			lifterlms_template_pricing_table( $atts['product'] );

--- a/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
+++ b/tests/phpunit/unit-tests/class-llms-test-frontend-assets.php
@@ -25,7 +25,26 @@ class LLMS_Test_Frontend_Assets extends LLMS_UnitTestCase {
 
 		parent::set_up();
 		$this->clear_inline_scripts();
+		$this->dequeue_test_assets();
 
+	}
+
+	/**
+	 * Dequeue assets that tests may add to the WP scripts/styles queue so each test starts clean.
+	 *
+	 * @return void
+	 */
+	private function dequeue_test_assets() {
+
+		$scripts = array( 'llms', 'llms-ajax', 'llms-form-checkout', 'llms-notifications', 'llms-quiz', 'llms-favorites', 'llms-iziModal', 'llms-select2', 'llms-jquery-matchheight', 'webui-popover', 'jquery-ui-tooltip', 'jquery-ui-datepicker', 'jquery-ui-slider' );
+		$styles  = array( 'lifterlms-styles', 'webui-popover', 'llms-select2-styles', 'llms-iziModal', 'certificates' );
+
+		foreach ( $scripts as $handle ) {
+			wp_dequeue_script( $handle );
+		}
+		foreach ( $styles as $handle ) {
+			wp_dequeue_style( $handle );
+		}
 	}
 
 	/**
@@ -142,10 +161,160 @@ class LLMS_Test_Frontend_Assets extends LLMS_UnitTestCase {
 
 		// Dashboard.
 		$this->go_to( llms_get_endpoint_url( 'orders', 123, llms_get_page_url( 'myaccount' ) ) );
-		$this->assertEquals( 
-			array( 'switchPaymentSource' ), 
+		$this->assertEquals(
+			array( 'switchPaymentSource' ),
 			array_keys( LLMS_Unit_Test_Util::call_method( 'LLMS_Frontend_Assets', 'get_checkout_urls' ) )
 		);
 	}
 
+	/**
+	 * Data provider for context-specific asset handles.
+	 *
+	 * @return array[]
+	 */
+	public function data_provider_llms_context_handles() {
+
+		return array(
+			array( 'script', 'llms-ajax' ),
+			array( 'script', 'jquery-ui-tooltip' ),
+			array( 'script', 'jquery-ui-datepicker' ),
+			array( 'script', 'jquery-ui-slider' ),
+			array( 'script', 'webui-popover' ),
+			array( 'style', 'webui-popover' ),
+		);
+	}
+
+	/**
+	 * Test that context-specific assets are NOT enqueued on a plain (non-LifterLMS) page.
+	 *
+	 * @dataProvider data_provider_llms_context_handles
+	 *
+	 * @param string $type   Asset type ('script' or 'style').
+	 * @param string $handle Asset handle.
+	 * @return void
+	 */
+	public function test_context_assets_not_enqueued_on_plain_page( $type, $handle ) {
+
+		$this->go_to( home_url( '/?p=1' ) );
+
+		LLMS_Frontend_Assets::enqueue_styles();
+		LLMS_Frontend_Assets::enqueue_scripts();
+
+		$this->assertAssetNotEnqueued( $type, $handle );
+	}
+
+	/**
+	 * Test that context-specific assets ARE enqueued on a LifterLMS course page.
+	 *
+	 * @dataProvider data_provider_llms_context_handles
+	 *
+	 * @param string $type   Asset type ('script' or 'style').
+	 * @param string $handle Asset handle.
+	 * @return void
+	 */
+	public function test_context_assets_enqueued_on_course_page( $type, $handle ) {
+
+		$course_id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$this->go_to( get_permalink( $course_id ) );
+
+		LLMS_Frontend_Assets::enqueue_styles();
+		LLMS_Frontend_Assets::enqueue_scripts();
+
+		$this->assertAssetIsEnqueued( $type, $handle );
+	}
+
+	/**
+	 * Test that the llms-form-checkout script loads on account and checkout pages.
+	 *
+	 * @return void
+	 */
+	public function test_form_checkout_enqueued_on_account_and_checkout() {
+
+		LLMS_Install::create_pages();
+
+		// Checkout page.
+		$this->go_to( llms_get_page_url( 'checkout' ) );
+		LLMS_Frontend_Assets::enqueue_scripts();
+		$this->assertAssetIsEnqueued( 'script', 'llms-form-checkout' );
+
+		wp_dequeue_script( 'llms-form-checkout' );
+
+		// Account page.
+		$this->go_to( llms_get_page_url( 'myaccount' ) );
+		LLMS_Frontend_Assets::enqueue_scripts();
+		$this->assertAssetIsEnqueued( 'script', 'llms-form-checkout' );
+	}
+
+	/**
+	 * Test the llms_load_frontend_assets filter can force-load assets on a plain page.
+	 *
+	 * @return void
+	 */
+	public function test_load_frontend_assets_filter_force_on() {
+
+		$callback = function () {
+			return true;
+		};
+		add_filter( 'llms_load_frontend_assets', $callback );
+
+		$this->go_to( home_url( '/?p=1' ) );
+
+		LLMS_Frontend_Assets::enqueue_styles();
+		LLMS_Frontend_Assets::enqueue_scripts();
+
+		$this->assertAssetIsEnqueued( 'script', 'llms-ajax' );
+		$this->assertAssetIsEnqueued( 'script', 'webui-popover' );
+		$this->assertAssetIsEnqueued( 'style', 'webui-popover' );
+
+		remove_filter( 'llms_load_frontend_assets', $callback );
+	}
+
+	/**
+	 * Test that lifterlms-styles and the llms script still load by default on a plain page.
+	 *
+	 * These stay always-on for backward compatibility; the filter exists to suppress them.
+	 *
+	 * @return void
+	 */
+	public function test_core_styles_scripts_always_on_by_default() {
+
+		$this->go_to( home_url( '/?p=1' ) );
+
+		LLMS_Frontend_Assets::enqueue_styles();
+		LLMS_Frontend_Assets::enqueue_scripts();
+
+		$this->assertAssetIsEnqueued( 'style', 'lifterlms-styles' );
+		$this->assertAssetIsEnqueued( 'script', 'llms' );
+	}
+
+	/**
+	 * Test the llms_load_frontend_assets filter can suppress the gated context assets.
+	 *
+	 * On an LLMS page with the filter forced off, the gated assets stay suppressed
+	 * while the always-on core assets (lifterlms-styles, llms) still load.
+	 *
+	 * @return void
+	 */
+	public function test_load_frontend_assets_filter_force_off() {
+
+		$callback = function () {
+			return false;
+		};
+		add_filter( 'llms_load_frontend_assets', $callback );
+
+		$course_id = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$this->go_to( get_permalink( $course_id ) );
+
+		LLMS_Frontend_Assets::enqueue_styles();
+		LLMS_Frontend_Assets::enqueue_scripts();
+
+		// Gated assets stay suppressed even on an LLMS page.
+		$this->assertAssetNotEnqueued( 'script', 'llms-ajax' );
+		$this->assertAssetNotEnqueued( 'script', 'webui-popover' );
+		$this->assertAssetNotEnqueued( 'style', 'webui-popover' );
+
+		remove_filter( 'llms_load_frontend_assets', $callback );
+	}
+
 }
+


### PR DESCRIPTION
## Description

LifterLMS currently enqueues a set of frontend scripts and styles on every page where the plugin is active, even plain posts and pages that contain no LifterLMS content. This change conditionally enqueues the context-specific assets so they only load on LifterLMS-related pages (course, lesson, membership, account, checkout).

Affected assets (now gated):
- `jquery-ui-tooltip`, `jquery-ui-datepicker`, `jquery-ui-slider`
- `webui-popover` (script and style)
- `llms-ajax`
- `llms-form-checkout` (narrowed to account and checkout only)

The `lifterlms-styles` stylesheet and the `llms` script remain enqueued by default for backward compatibility, but both can be suppressed through the new `llms_load_frontend_assets` filter.

Adds the `llms_load_frontend_assets` filter for sites that want to force assets on or off:
- `add_filter( 'llms_load_frontend_assets', '__return_true' );` forces a load on pages the auto-detection misses (e.g. a custom template embedding LifterLMS shortcodes).
- `add_filter( 'llms_load_frontend_assets', '__return_false' );` fully suppresses frontend assets for non-LifterLMS templates.

Shortcodes that render LifterLMS UI off the auto-detected page types (`[lifterlms_courses]`, `[lifterlms_memberships]`, `[lifterlms_pricing_table]`, `[lifterlms_checkout]`) now self-enqueue `lifterlms-styles` so they remain styled when the filter is forced off. The pricing table shortcode also self-enqueues `webui-popover` so locked-plan popovers continue to work.

Fixes #146

## How has this been tested?

Unit tests cover all gating paths in `tests/phpunit/unit-tests/class-llms-test-frontend-assets.php`:
- Context assets not enqueued on a plain (non-LifterLMS) page.
- Context assets enqueued on a single course page.
- `llms-form-checkout` enqueued on account and checkout pages.
- `llms_load_frontend_assets` filter forces load on a plain page.
- `llms_load_frontend_assets` filter suppresses gated assets on an LLMS page.
- Core assets (`lifterlms-styles`, `llms`) stay always-on by default.

Test run: `composer tests -- --filter LLMS_Test_Frontend_Assets` (19/19 pass).
Coding standards: `composer check-cs` (clean).

Manual testing covered:
- Plain page, course page, account page, checkout page source-viewed to confirm expected assets are present or absent.
- `[lifterlms_pricing_table]` on a plain page with a locked access plan: popover displays on click.
- `[lifterlms_courses]` on a plain page: course loop is styled.
- `[lifterlms_checkout]` shortcode on a page other than the configured checkout: form-checkout script loads.

Environment: WordPress 6.x, PHP 7.4/8.x.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality) - the `llms_load_frontend_assets` filter.

## Checklist:

- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
