### PR TITLE
fix(admin): add filter to disable Access Plans metabox

### DIFF
--- a/.changelogs/267-disable-commerce-hooks.yml
+++ b/.changelogs/267-disable-commerce-hooks.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added a new `llms_metabox_product_screens` filter that allows developers to customize or disable the Access Plans metabox on courses and memberships."

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php
@@ -35,6 +35,18 @@ class LLMS_Meta_Box_Product extends LLMS_Admin_Metabox {
 			'course',
 			'llms_membership',
 		);
+
+		/**
+		 * Filters the post types on which the Access Plans metabox is registered.
+		 *
+		 * Return an empty array to disable the metabox entirely.
+		 *
+		 * @since [version]
+		 *
+		 * @param string[] $screens Post type slugs.
+		 */
+		$this->screens = apply_filters( 'llms_metabox_product_screens', $this->screens );
+
 		$this->priority = 'high';
 
 		// Output PHP variables for JS access.

--- a/tests/phpunit/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-product.php
+++ b/tests/phpunit/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-product.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Tests for LifterLMS Access Plans (Product) Metabox.
+ *
+ * @package LifterLMS/Tests
+ *
+ * @group metabox_product
+ * @group admin
+ * @group metaboxes
+ * @group metaboxes_post_type
+ *
+ * @since [version]
+ * @version [version]
+ */
+class LLMS_Test_Meta_Box_Product extends LLMS_PostTypeMetaboxTestCase {
+
+	/**
+	 * Setup test.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+		$this->metabox = new LLMS_Meta_Box_Product();
+
+	}
+
+	/**
+	 * Test the default screens returned by the metabox.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_screens_default() {
+
+		$this->assertEquals(
+			array( 'course', 'llms_membership' ),
+			LLMS_Unit_Test_Util::call_method( $this->metabox, 'get_screens' )
+		);
+
+	}
+
+	/**
+	 * Test that the `llms_metabox_product_screens` filter can disable the metabox.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_screens_filter_disables_metabox() {
+
+		add_filter( 'llms_metabox_product_screens', '__return_empty_array' );
+
+		try {
+			$metabox = new LLMS_Meta_Box_Product();
+			$this->assertEquals(
+				array(),
+				LLMS_Unit_Test_Util::call_method( $metabox, 'get_screens' )
+			);
+		} finally {
+			remove_filter( 'llms_metabox_product_screens', '__return_empty_array' );
+		}
+
+	}
+
+	/**
+	 * Test that the `llms_metabox_product_screens` filter can add a custom screen.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_screens_filter_adds_custom_screen() {
+
+		$callback = function() {
+			return array( 'course', 'llms_membership', 'custom_cpt' );
+		};
+
+		add_filter( 'llms_metabox_product_screens', $callback );
+
+		try {
+			$metabox = new LLMS_Meta_Box_Product();
+			$this->assertEquals(
+				array( 'course', 'llms_membership', 'custom_cpt' ),
+				LLMS_Unit_Test_Util::call_method( $metabox, 'get_screens' )
+			);
+		} finally {
+			remove_filter( 'llms_metabox_product_screens', $callback );
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds a new `llms_metabox_product_screens` filter that lets developers customize or disable the Access Plans metabox on courses and memberships. Combined with the existing filters in the table below, this gives developers a complete recipe for hiding every commerce surface in the plugin so it can run as a pure LMS.

Fixes #267

## Changes

### includes/admin/post-types/meta-boxes/class.llms.meta.box.product.php

**Before:**
```php
->screens  = array(
    'course',
    'llms_membership',
);
```

**After:**
```php
->screens  = array(
    'course',
    'llms_membership',
);

/**
 * Filters the post types on which the Access Plans metabox is registered.
 *
 * Return an empty array to disable the metabox entirely.
 *
 * @since [version]
 *
 * @param string[] $screens Post type slugs.
 */
$this->screens = apply_filters( 'llms_metabox_product_screens', $this->screens );
```

**Why:** The parent class `LLMS_Admin_Metabox` already iterates `$this->screens` for `add_meta_box` and save actions, so an empty array cleanly unregisters the metabox with no extra gating.

### .changelogs/267-disable-commerce-hooks.yml

New changelog entry (minor/added).

### tests/phpunit/unit-tests/admin/post-types/meta-boxes/class-llms-test-meta-box-product.php

3 tests: default screens, empty-array disable, custom-screen extension.

## Other filters the developer composes (no change needed)

| To remove | Hook | Location |
|---|---|---|
| Checkout settings page | `lifterlms_get_settings_pages` | includes/admin/class.llms.admin.settings.php:77 |
| Orders admin menu | `lifterlms_register_post_type_order` (set show_in_menu=false) | includes/class.llms.post-types.php:432 |
| Order History dashboard tab | `llms_get_student_dashboard_tabs` | includes/class.llms.student.dashboard.php:240 |
| Pricing table (course) | `remove_action( 'lifterlms_single_course_after_summary', 'lifterlms_template_pricing_table', 60 )` | includes/llms.template.hooks.php:40 |
| Pricing table (membership) | `remove_action( 'lifterlms_single_membership_after_summary', 'lifterlms_template_pricing_table', 10 )` | includes/llms.template.hooks.php:203 |
| Purchase receipt email | `llms_send_purchase_receipt_notification` (return false) | includes/notifications/controllers/class.llms.notification.controller.purchase.receipt.php:72 |
| No payment gateways notice | `llms_admin_notice_no_payment_gateways` (return false) | includes/admin/class.llms.admin.notices.core.php:102 |

## Testing

**Test 1: Default behavior unchanged**
1. Edit a course or membership.
2. Confirm Access Plans metabox is present.
Result: works as expected.

**Test 2: Disable via filter**
1. Add `add_filter( 'llms_metabox_product_screens', '__return_empty_array' );` to a mu-plugin.
2. Reload the course/membership edit screen.
Result: Access Plans metabox is gone.

**Test 3: PHPUnit**
1. `vendor/bin/phpunit --filter LLMS_Test_Meta_Box_Product`
Result: 3 tests, 3 assertions pass.

## Screenshots

No visible UI change by default. The metabox disappears only when a developer adds the filter.