### PR TITLE
Adding the Abilities API wrapper 

### DIFF
--- a/.changelogs/add-abilities-api.yml
+++ b/.changelogs/add-abilities-api.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added WordPress Abilities API (WP 6.9+) integration, registering the LifterLMS REST API endpoints for courses, sections, lessons, memberships, access plans, students, enrollments, and student progress as discoverable abilities for AI clients and automation tools.

--- a/libraries/lifterlms-rest/class-lifterlms-rest-api.php
+++ b/libraries/lifterlms-rest/class-lifterlms-rest-api.php
@@ -96,6 +96,13 @@ final class LifterLMS_REST_API {
 			include_once LLMS_REST_API_PLUGIN_DIR . 'includes/admin/class-llms-rest-admin-form-controller.php';
 		}
 
+		// Abilities API integration (WP 6.9+).
+		if ( function_exists( 'wp_register_ability' ) ) {
+			include_once LLMS_REST_API_PLUGIN_DIR . 'includes/abilities/class-llms-rest-ability-factory.php';
+			include_once LLMS_REST_API_PLUGIN_DIR . 'includes/abilities/class-llms-rest-abilities.php';
+			LLMS_REST_Abilities::init();
+		}
+
 		add_action( 'rest_api_init', array( $this, 'rest_api_includes' ), 5 );
 		add_action( 'rest_api_init', array( $this, 'rest_api_controllers_init' ), 10 );
 

--- a/libraries/lifterlms-rest/includes/abilities/class-llms-rest-abilities.php
+++ b/libraries/lifterlms-rest/includes/abilities/class-llms-rest-abilities.php
@@ -1,0 +1,383 @@
+<?php
+/**
+ * LLMS_REST_Abilities class file
+ *
+ * @package LifterLMS_REST/Abilities
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers LifterLMS abilities with the WordPress Abilities API (WP 6.9+).
+ *
+ * Exposes the `llms/v1` REST API surface (courses, sections, lessons, memberships,
+ * access plans, students, enrollments, and student progress) as first-class WordPress
+ * abilities so abilities-aware AI clients can discover and execute LifterLMS
+ * functionality natively.
+ *
+ * @since [version]
+ */
+class LLMS_REST_Abilities {
+
+	/**
+	 * Register Abilities API hooks.
+	 *
+	 * A no-op on WordPress versions without the Abilities API.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function init() {
+
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		add_action( 'wp_abilities_api_categories_init', array( __CLASS__, 'register_category' ) );
+		add_action( 'wp_abilities_api_init', array( __CLASS__, 'register_abilities' ) );
+	}
+
+	/**
+	 * Register the LifterLMS ability category.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function register_category() {
+
+		wp_register_ability_category(
+			'lifterlms',
+			array(
+				'label'       => __( 'LifterLMS', 'lifterlms' ),
+				'description' => __( 'Abilities for managing LifterLMS courses, memberships, students, enrollments, and student progress.', 'lifterlms' ),
+			)
+		);
+	}
+
+	/**
+	 * Register all LifterLMS abilities.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function register_abilities() {
+
+		// Controller classes are normally loaded on `rest_api_init`, which may not have fired yet.
+		LLMS_REST_API()->rest_api_includes();
+
+		foreach ( self::get_ability_configs() as $config ) {
+			LLMS_REST_Ability_Factory::register( $config );
+		}
+	}
+
+	/**
+	 * Retrieve the configuration for every ability to be registered.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[] List of ability configuration arrays. See {@see LLMS_REST_Ability_Factory::register()}.
+	 */
+	private static function get_ability_configs() {
+
+		$configs = array();
+
+		foreach ( self::get_crud_resources() as $resource ) {
+			$configs = array_merge( $configs, self::get_crud_configs( $resource ) );
+		}
+
+		$configs = array_merge( $configs, self::get_custom_configs() );
+
+		/**
+		 * Filters the list of LifterLMS ability configurations.
+		 *
+		 * Add-ons providing their own `llms/v1` REST controllers can append configurations
+		 * here to have their endpoints registered as WordPress abilities.
+		 *
+		 * @since [version]
+		 *
+		 * @param array[] $configs List of ability configuration arrays. See {@see LLMS_REST_Ability_Factory::register()}.
+		 */
+		return apply_filters( 'llms_rest_ability_configs', $configs );
+	}
+
+	/**
+	 * Retrieve definitions for resources exposing standard CRUD abilities.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	private static function get_crud_resources() {
+
+		return array(
+			array(
+				'controller' => 'LLMS_REST_Courses_Controller',
+				'route'      => '/llms/v1/courses',
+				'slugs'      => array( 'course', 'courses' ),
+				'labels'     => array( __( 'Course', 'lifterlms' ), __( 'Courses', 'lifterlms' ) ),
+				'nouns'      => array( __( 'course', 'lifterlms' ), __( 'courses', 'lifterlms' ) ),
+			),
+			array(
+				'controller' => 'LLMS_REST_Sections_Controller',
+				'route'      => '/llms/v1/sections',
+				'slugs'      => array( 'section', 'sections' ),
+				'labels'     => array( __( 'Section', 'lifterlms' ), __( 'Sections', 'lifterlms' ) ),
+				'nouns'      => array( __( 'course section', 'lifterlms' ), __( 'course sections', 'lifterlms' ) ),
+			),
+			array(
+				'controller' => 'LLMS_REST_Lessons_Controller',
+				'route'      => '/llms/v1/lessons',
+				'slugs'      => array( 'lesson', 'lessons' ),
+				'labels'     => array( __( 'Lesson', 'lifterlms' ), __( 'Lessons', 'lifterlms' ) ),
+				'nouns'      => array( __( 'lesson', 'lifterlms' ), __( 'lessons', 'lifterlms' ) ),
+			),
+			array(
+				'controller' => 'LLMS_REST_Memberships_Controller',
+				'route'      => '/llms/v1/memberships',
+				'slugs'      => array( 'membership', 'memberships' ),
+				'labels'     => array( __( 'Membership', 'lifterlms' ), __( 'Memberships', 'lifterlms' ) ),
+				'nouns'      => array( __( 'membership', 'lifterlms' ), __( 'memberships', 'lifterlms' ) ),
+			),
+			array(
+				'controller' => 'LLMS_REST_Access_Plans_Controller',
+				'route'      => '/llms/v1/access-plans',
+				'slugs'      => array( 'access-plan', 'access-plans' ),
+				'labels'     => array( __( 'Access Plan', 'lifterlms' ), __( 'Access Plans', 'lifterlms' ) ),
+				'nouns'      => array( __( 'access plan (pricing plan for a course or membership)', 'lifterlms' ), __( 'access plans (pricing plans for courses and memberships)', 'lifterlms' ) ),
+			),
+			array(
+				'controller' => 'LLMS_REST_Students_Controller',
+				'route'      => '/llms/v1/students',
+				'slugs'      => array( 'student', 'students' ),
+				'labels'     => array( __( 'Student', 'lifterlms' ), __( 'Students', 'lifterlms' ) ),
+				'nouns'      => array( __( 'student', 'lifterlms' ), __( 'students', 'lifterlms' ) ),
+			),
+		);
+	}
+
+	/**
+	 * Build the five standard CRUD ability configurations for a resource.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $resource Resource definition. See {@see LLMS_REST_Abilities::get_crud_resources()}.
+	 * @return array[]
+	 */
+	private static function get_crud_configs( $resource ) {
+
+		list( $slug_singular, $slug_plural ) = $resource['slugs'];
+		list( $label_singular, $label_plural ) = $resource['labels'];
+		list( $noun_singular, $noun_plural ) = $resource['nouns'];
+
+		$base = array(
+			'controller' => $resource['controller'],
+		);
+
+		return array(
+			$base + array(
+				'name'        => "list-{$slug_plural}",
+				// Translators: %s = plural resource label (e.g. "Courses").
+				'label'       => sprintf( __( 'List %s', 'lifterlms' ), $label_plural ),
+				// Translators: %s = plural resource noun (e.g. "courses").
+				'description' => sprintf( __( 'Retrieves a paginated list of %s from this LifterLMS site. Supports filtering, ordering, and pagination parameters.', 'lifterlms' ), $noun_plural ),
+				'operation'   => 'list',
+				'method'      => 'GET',
+				'route'       => $resource['route'],
+			),
+			$base + array(
+				'name'        => "get-{$slug_singular}",
+				// Translators: %s = singular resource label (e.g. "Course").
+				'label'       => sprintf( __( 'Get %s', 'lifterlms' ), $label_singular ),
+				// Translators: %s = singular resource noun (e.g. "course").
+				'description' => sprintf( __( 'Retrieves the details of a single %s by its ID.', 'lifterlms' ), $noun_singular ),
+				'operation'   => 'get',
+				'method'      => 'GET',
+				'route'       => $resource['route'] . '/{id}',
+			),
+			$base + array(
+				'name'        => "create-{$slug_singular}",
+				// Translators: %s = singular resource label (e.g. "Course").
+				'label'       => sprintf( __( 'Create %s', 'lifterlms' ), $label_singular ),
+				// Translators: %s = singular resource noun (e.g. "course").
+				'description' => sprintf( __( 'Creates a new %s on this LifterLMS site.', 'lifterlms' ), $noun_singular ),
+				'operation'   => 'create',
+				'method'      => 'POST',
+				'route'       => $resource['route'],
+			),
+			$base + array(
+				'name'        => "update-{$slug_singular}",
+				// Translators: %s = singular resource label (e.g. "Course").
+				'label'       => sprintf( __( 'Update %s', 'lifterlms' ), $label_singular ),
+				// Translators: %s = singular resource noun (e.g. "course").
+				'description' => sprintf( __( 'Updates an existing %s by its ID.', 'lifterlms' ), $noun_singular ),
+				'operation'   => 'update',
+				'method'      => 'POST',
+				'route'       => $resource['route'] . '/{id}',
+			),
+			$base + array(
+				'name'        => "delete-{$slug_singular}",
+				// Translators: %s = singular resource label (e.g. "Course").
+				'label'       => sprintf( __( 'Delete %s', 'lifterlms' ), $label_singular ),
+				// Translators: %s = singular resource noun (e.g. "course").
+				'description' => sprintf( __( 'Deletes a %s by its ID.', 'lifterlms' ), $noun_singular ),
+				'operation'   => 'delete',
+				'method'      => 'DELETE',
+				'route'       => $resource['route'] . '/{id}',
+			),
+		);
+	}
+
+	/**
+	 * Retrieve ability configurations for non-CRUD routes.
+	 *
+	 * Covers course content and course enrollments sub-resources, student enrollments,
+	 * and student progress.
+	 *
+	 * @since [version]
+	 *
+	 * @return array[]
+	 */
+	private static function get_custom_configs() {
+
+		$student_id_desc = __( 'Unique student identifier. The WordPress user ID.', 'lifterlms' );
+		$course_id_desc  = __( 'Unique course identifier. The WordPress post ID.', 'lifterlms' );
+		$post_id_desc    = __( 'Unique course or membership identifier. The WordPress post ID.', 'lifterlms' );
+
+		return array(
+
+			// Courses: sub-resources.
+			array(
+				'name'                  => 'get-course-content',
+				'label'                 => __( 'Get Course Content', 'lifterlms' ),
+				'description'           => __( 'Retrieves the sections that make up the content of a course, ordered as they appear in the course.', 'lifterlms' ),
+				'controller'            => 'LLMS_REST_Courses_Controller',
+				'schema_controller'     => 'LLMS_REST_Sections_Controller',
+				'permission_controller' => 'LLMS_REST_Sections_Controller',
+				'operation'             => 'list',
+				'method'                => 'GET',
+				'route'                 => '/llms/v1/courses/{id}/content',
+				'path_params'           => array(
+					'id' => $course_id_desc,
+				),
+			),
+			array(
+				'name'                  => 'get-course-enrollments',
+				'label'                 => __( 'Get Course Enrollments', 'lifterlms' ),
+				'description'           => __( 'Retrieves the enrollments for a course, listing the enrolled students and their enrollment status.', 'lifterlms' ),
+				'controller'            => 'LLMS_REST_Courses_Controller',
+				'schema_controller'     => 'LLMS_REST_Enrollments_Controller',
+				'permission_controller' => 'LLMS_REST_Enrollments_Controller',
+				'operation'             => 'list',
+				'method'                => 'GET',
+				'route'                 => '/llms/v1/courses/{id}/enrollments',
+				'path_params'           => array(
+					'id' => $course_id_desc,
+				),
+			),
+
+			// Enrollments.
+			array(
+				'name'        => 'list-enrollments',
+				'label'       => __( 'List Enrollments', 'lifterlms' ),
+				'description' => __( 'Retrieves the list of course and membership enrollments for a student.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Enrollments_Controller',
+				'operation'   => 'list',
+				'method'      => 'GET',
+				'route'       => '/llms/v1/students/{id}/enrollments',
+				'path_params' => array(
+					'id' => $student_id_desc,
+				),
+			),
+			array(
+				'name'        => 'enroll-student',
+				'label'       => __( 'Enroll Student', 'lifterlms' ),
+				'description' => __( 'Enrolls a student in a course or membership.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Enrollments_Controller',
+				'operation'   => 'create',
+				'method'      => 'POST',
+				'args_method' => 'POST',
+				'route'       => '/llms/v1/students/{id}/enrollments/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => $post_id_desc,
+				),
+			),
+			array(
+				'name'        => 'update-enrollment',
+				'label'       => __( 'Update Enrollment', 'lifterlms' ),
+				'description' => __( 'Updates the status of an existing enrollment of a student in a course or membership.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Enrollments_Controller',
+				'operation'   => 'update',
+				'method'      => 'PATCH',
+				'args_method' => 'PATCH',
+				'route'       => '/llms/v1/students/{id}/enrollments/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => $post_id_desc,
+				),
+			),
+			array(
+				'name'        => 'unenroll-student',
+				'label'       => __( 'Unenroll Student', 'lifterlms' ),
+				'description' => __( 'Removes the enrollment of a student in a course or membership.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Enrollments_Controller',
+				'operation'   => 'delete',
+				'method'      => 'DELETE',
+				'args_method' => 'DELETE',
+				'route'       => '/llms/v1/students/{id}/enrollments/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => $post_id_desc,
+				),
+			),
+
+			// Student progress.
+			array(
+				'name'        => 'get-progress',
+				'label'       => __( 'Get Student Progress', 'lifterlms' ),
+				'description' => __( 'Retrieves the progress of a student in a course, section, or lesson.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Students_Progress_Controller',
+				'operation'   => 'get',
+				'method'      => 'GET',
+				'route'       => '/llms/v1/students/{id}/progress/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => __( 'Unique course, section, or lesson identifier. The WordPress post ID.', 'lifterlms' ),
+				),
+			),
+			array(
+				'name'        => 'update-progress',
+				'label'       => __( 'Update Student Progress', 'lifterlms' ),
+				'description' => __( 'Updates the progress of a student in a course, section, or lesson, marking it complete or incomplete.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Students_Progress_Controller',
+				'operation'   => 'update',
+				'method'      => 'POST',
+				'args_method' => 'POST',
+				'route'       => '/llms/v1/students/{id}/progress/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => __( 'Unique course, section, or lesson identifier. The WordPress post ID.', 'lifterlms' ),
+				),
+			),
+			array(
+				'name'        => 'delete-progress',
+				'label'       => __( 'Delete Student Progress', 'lifterlms' ),
+				'description' => __( 'Deletes (resets) the progress of a student in a course, section, or lesson.', 'lifterlms' ),
+				'controller'  => 'LLMS_REST_Students_Progress_Controller',
+				'operation'   => 'delete',
+				'method'      => 'DELETE',
+				'route'       => '/llms/v1/students/{id}/progress/{post_id}',
+				'path_params' => array(
+					'id'      => $student_id_desc,
+					'post_id' => __( 'Unique course, section, or lesson identifier. The WordPress post ID.', 'lifterlms' ),
+				),
+			),
+		);
+	}
+}

--- a/libraries/lifterlms-rest/includes/abilities/class-llms-rest-abilities.php
+++ b/libraries/lifterlms-rest/includes/abilities/class-llms-rest-abilities.php
@@ -217,7 +217,7 @@ class LLMS_REST_Abilities {
 				// Translators: %s = singular resource noun (e.g. "course").
 				'description' => sprintf( __( 'Updates an existing %s by its ID.', 'lifterlms' ), $noun_singular ),
 				'operation'   => 'update',
-				'method'      => 'POST',
+				'method'      => 'PATCH',
 				'route'       => $resource['route'] . '/{id}',
 			),
 			$base + array(

--- a/libraries/lifterlms-rest/includes/abilities/class-llms-rest-ability-factory.php
+++ b/libraries/lifterlms-rest/includes/abilities/class-llms-rest-ability-factory.php
@@ -1,0 +1,607 @@
+<?php
+/**
+ * LLMS_REST_Ability_Factory class file
+ *
+ * @package LifterLMS_REST/Abilities
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts LifterLMS REST API controllers into WordPress Abilities.
+ *
+ * Given an ability configuration describing a REST controller, an operation, and a route,
+ * this factory derives the ability's input and output JSON Schemas from the controller's
+ * own schema definitions and registers the ability with the WordPress Abilities API (WP 6.9+).
+ *
+ * Execution dispatches an internal `WP_REST_Request` through `rest_do_request()`, so all
+ * existing route permission callbacks, validation, sanitization, and hooks apply unchanged.
+ *
+ * @since [version]
+ */
+class LLMS_REST_Ability_Factory {
+
+	/**
+	 * Ability name namespace prefix.
+	 *
+	 * @var string
+	 */
+	const ABILITY_NAMESPACE = 'lifterlms';
+
+	/**
+	 * Map of operation to controller permission check method.
+	 *
+	 * @var array
+	 */
+	const PERMISSION_METHODS = array(
+		'list'   => 'get_items_permissions_check',
+		'get'    => 'get_item_permissions_check',
+		'create' => 'create_item_permissions_check',
+		'update' => 'update_item_permissions_check',
+		'delete' => 'delete_item_permissions_check',
+	);
+
+	/**
+	 * Valid JSON Schema types.
+	 *
+	 * @var string[]
+	 */
+	private static $valid_types = array( 'string', 'number', 'integer', 'boolean', 'object', 'array', 'null' );
+
+	/**
+	 * Scalar JSON Schema types eligible for output-schema widening.
+	 *
+	 * @var string[]
+	 */
+	private static $scalar_types = array( 'string', 'integer', 'number', 'boolean' );
+
+	/**
+	 * Cached controller instances keyed by class name.
+	 *
+	 * @var array
+	 */
+	private static $controllers = array();
+
+	/**
+	 * Register a single ability from a configuration array.
+	 *
+	 * Expected configuration keys:
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config {
+	 *     Ability configuration.
+	 *
+	 *     @type string $name                  Required. Un-namespaced ability name, e.g. `list-courses`.
+	 *     @type string $label                 Required. Human readable label.
+	 *     @type string $description           Required. Detailed description of what the ability does.
+	 *     @type string $controller            Required. REST controller class name the ability executes against.
+	 *     @type string $operation             Required. One of `list`, `get`, `create`, `update`, `delete`.
+	 *     @type string $method                Required. HTTP method used when dispatching the internal request.
+	 *     @type string $route                 Required. Full REST route with optional `{param}` placeholders,
+	 *                                         e.g. `/llms/v1/students/{id}/enrollments`.
+	 *     @type string $schema_controller     Optional. Controller class used to derive input/output schemas.
+	 *                                         Defaults to `controller`.
+	 *     @type string $permission_controller Optional. Controller class used for the permission callback.
+	 *                                         Defaults to `controller`.
+	 *     @type string $args_method           Optional. HTTP method passed to `get_endpoint_args_for_item_schema()`
+	 *                                         when deriving input args. Defaults based on `operation`.
+	 *     @type array  $path_params           Optional. Map of route placeholder names to descriptions.
+	 * }
+	 * @return WP_Ability|null The registered ability on success, `null` on failure.
+	 */
+	public static function register( $config ) {
+
+		if ( ! function_exists( 'wp_register_ability' ) || ! class_exists( $config['controller'] ) ) {
+			return null;
+		}
+
+		$args = array(
+			'label'               => $config['label'],
+			'description'         => $config['description'],
+			'category'            => self::ABILITY_NAMESPACE,
+			'input_schema'        => self::get_input_schema( $config ),
+			'output_schema'       => self::get_output_schema( $config ),
+			'execute_callback'    => function ( $input = null ) use ( $config ) {
+				return self::execute( $config, $input );
+			},
+			'permission_callback' => function ( $input = null ) use ( $config ) {
+				return self::check_permission( $config, $input );
+			},
+			'meta'                => array(
+				'show_in_rest' => true,
+			),
+		);
+
+		if ( in_array( $config['operation'], array( 'list', 'get' ), true ) ) {
+			$args['meta']['annotations'] = array(
+				'readonly' => true,
+			);
+		} elseif ( 'delete' === $config['operation'] ) {
+			$args['meta']['annotations'] = array(
+				'destructive' => true,
+			);
+		}
+
+		return wp_register_ability( self::ABILITY_NAMESPACE . '/' . $config['name'], $args );
+	}
+
+	/**
+	 * Retrieve a (cached) controller instance.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $class_name Controller class name.
+	 * @return object|null
+	 */
+	private static function get_controller( $class_name ) {
+
+		if ( ! class_exists( $class_name ) ) {
+			return null;
+		}
+
+		if ( ! isset( self::$controllers[ $class_name ] ) ) {
+			self::$controllers[ $class_name ] = new $class_name();
+		}
+
+		return self::$controllers[ $class_name ];
+	}
+
+	/**
+	 * Derive the ability input schema from the controller for the configured operation.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config Ability configuration.
+	 * @return array JSON Schema object.
+	 */
+	private static function get_input_schema( $config ) {
+
+		$controller = self::get_controller( ! empty( $config['schema_controller'] ) ? $config['schema_controller'] : $config['controller'] );
+		$args       = array();
+
+		if ( $controller ) {
+
+			switch ( $config['operation'] ) {
+
+				case 'list':
+					if ( method_exists( $controller, 'get_collection_params' ) ) {
+						$args = $controller->get_collection_params();
+					}
+					break;
+
+				case 'get':
+					if ( method_exists( $controller, 'get_get_item_params' ) ) {
+						$args = $controller->get_get_item_params();
+					}
+					break;
+
+				case 'create':
+				case 'update':
+					$args_method = ! empty( $config['args_method'] ) ? $config['args_method'] : ( 'create' === $config['operation'] ? WP_REST_Server::CREATABLE : WP_REST_Server::EDITABLE );
+					if ( method_exists( $controller, 'get_endpoint_args_for_item_schema' ) ) {
+						$args = $controller->get_endpoint_args_for_item_schema( $args_method );
+					}
+					break;
+
+				case 'delete':
+					if ( ! empty( $config['args_method'] ) && method_exists( $controller, 'get_endpoint_args_for_item_schema' ) ) {
+						$args = $controller->get_endpoint_args_for_item_schema( $config['args_method'] );
+					} elseif ( method_exists( $controller, 'get_delete_item_args' ) ) {
+						$args = $controller->get_delete_item_args();
+					}
+					break;
+
+			}
+		}
+
+		$schema = self::sanitize_args_to_schema( is_array( $args ) ? $args : array() );
+
+		foreach ( self::get_path_params( $config ) as $param => $description ) {
+
+			$schema['properties'][ $param ] = array(
+				'type'        => 'integer',
+				'description' => $description,
+			);
+
+			$schema['required']   = isset( $schema['required'] ) ? $schema['required'] : array();
+			$schema['required'][] = $param;
+		}
+
+		if ( isset( $schema['required'] ) ) {
+			$schema['required'] = array_values( array_unique( $schema['required'] ) );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Derive the ability output schema from the controller item schema.
+	 *
+	 * The derived schema is relaxed (scalar types widened, formats stripped) because the
+	 * Abilities API strictly validates execution output against the output schema, and
+	 * REST item schemas don't always match the exact shapes controllers return.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config Ability configuration.
+	 * @return array JSON Schema object.
+	 */
+	private static function get_output_schema( $config ) {
+
+		if ( 'delete' === $config['operation'] ) {
+			return array(
+				'type'       => 'object',
+				'properties' => array(
+					'deleted' => array(
+						'type'        => 'boolean',
+						'description' => __( 'Whether the resource was deleted.', 'lifterlms' ),
+					),
+				),
+			);
+		}
+
+		$controller  = self::get_controller( ! empty( $config['schema_controller'] ) ? $config['schema_controller'] : $config['controller'] );
+		$item_schema = array( 'type' => 'object' );
+
+		if ( $controller && method_exists( $controller, 'get_item_schema' ) ) {
+			$item_schema = self::relax_output_schema( self::sanitize_schema( $controller->get_item_schema() ) );
+		}
+
+		if ( 'list' === $config['operation'] ) {
+			return array(
+				'type'  => 'array',
+				'items' => $item_schema,
+			);
+		}
+
+		return $item_schema;
+	}
+
+	/**
+	 * Execute the ability by dispatching an internal REST request.
+	 *
+	 * @since [version]
+	 *
+	 * @param array      $config Ability configuration.
+	 * @param array|null $input  Validated ability input.
+	 * @return mixed|WP_Error Response data on success, `WP_Error` on failure.
+	 */
+	private static function execute( $config, $input = null ) {
+
+		$request  = self::build_request( $config, $input );
+		$response = rest_do_request( $request );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( $response->is_error() ) {
+			return $response->as_error();
+		}
+
+		if ( 'delete' === $config['operation'] ) {
+			return array(
+				'deleted' => true,
+			);
+		}
+
+		return $response->get_data();
+	}
+
+	/**
+	 * Check permissions by delegating to the controller's permission check for the operation.
+	 *
+	 * The controller's `WP_Error` results are normalized to `false`: `WP_Ability::execute()`
+	 * treats a `WP_Error` permission result as incorrect usage, and execution dispatches
+	 * through `rest_do_request()` anyway, which enforces the route's own permission callback
+	 * and surfaces its detailed error.
+	 *
+	 * @since [version]
+	 *
+	 * @param array      $config Ability configuration.
+	 * @param array|null $input  Ability input.
+	 * @return boolean
+	 */
+	private static function check_permission( $config, $input = null ) {
+
+		$controller = self::get_controller( ! empty( $config['permission_controller'] ) ? $config['permission_controller'] : $config['controller'] );
+		$method     = isset( self::PERMISSION_METHODS[ $config['operation'] ] ) ? self::PERMISSION_METHODS[ $config['operation'] ] : '';
+
+		if ( ! $controller || ! $method || ! method_exists( $controller, $method ) ) {
+			return false;
+		}
+
+		return true === $controller->{$method}( self::build_request( $config, $input ) );
+	}
+
+	/**
+	 * Build an internal REST request from ability input.
+	 *
+	 * Route placeholders (e.g. `{id}`) are substituted with the corresponding input values
+	 * and removed from the request parameters; all remaining input is passed as query or
+	 * body parameters depending on the HTTP method.
+	 *
+	 * @since [version]
+	 *
+	 * @param array      $config Ability configuration.
+	 * @param array|null $input  Ability input.
+	 * @return WP_REST_Request
+	 */
+	private static function build_request( $config, $input = null ) {
+
+		$input  = is_array( $input ) ? $input : array();
+		$route  = $config['route'];
+		$params = $input;
+
+		foreach ( array_keys( self::get_path_params( $config ) ) as $param ) {
+			if ( isset( $params[ $param ] ) ) {
+				$route = str_replace( '{' . $param . '}', (string) absint( $params[ $param ] ), $route );
+			}
+		}
+
+		$request = new WP_REST_Request( $config['method'], $route );
+
+		if ( in_array( $config['method'], array( 'GET', 'DELETE' ), true ) ) {
+			$request->set_query_params( $params );
+		} else {
+			$request->set_body_params( $params );
+		}
+
+		return $request;
+	}
+
+	/**
+	 * Retrieve the route path params and their descriptions.
+	 *
+	 * Placeholders are parsed from the configured route. Descriptions can be customized
+	 * via the `path_params` configuration key.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config Ability configuration.
+	 * @return array Map of param name to description.
+	 */
+	private static function get_path_params( $config ) {
+
+		$params = array();
+
+		if ( ! preg_match_all( '/\{([a-z_]+)\}/', $config['route'], $matches ) ) {
+			return $params;
+		}
+
+		foreach ( $matches[1] as $param ) {
+			if ( ! empty( $config['path_params'][ $param ] ) ) {
+				$params[ $param ] = $config['path_params'][ $param ];
+			} else {
+				$params[ $param ] = __( 'Unique identifier for the resource.', 'lifterlms' );
+			}
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Convert a WordPress REST args array into a valid JSON Schema object.
+	 *
+	 * Strips PHP callbacks and other non-schema keys, converts per-field boolean `required`
+	 * flags into a JSON Schema `required` array, and recursively sanitizes nested schemas.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $args WordPress REST API arguments array.
+	 * @return array JSON Schema object.
+	 */
+	private static function sanitize_args_to_schema( $args ) {
+
+		$properties = array();
+		$required   = array();
+
+		foreach ( $args as $key => $arg ) {
+
+			if ( ! is_array( $arg ) ) {
+				continue;
+			}
+
+			$properties[ $key ] = self::sanitize_schema( $arg );
+
+			/**
+			 * Some fields (e.g. post `title` and `content`) explicitly disable REST validation
+			 * and accept multiple shapes (a plain string or a `{raw}` object). Widen the declared
+			 * type so ability input validation matches the REST API's actual behavior.
+			 */
+			if ( array_key_exists( 'validate_callback', $arg ) && null === $arg['validate_callback'] && isset( $properties[ $key ]['type'] ) ) {
+				$properties[ $key ]['type'] = self::$valid_types;
+			}
+
+			if ( isset( $arg['required'] ) && true === $arg['required'] ) {
+				$required[] = $key;
+			}
+		}
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => $properties,
+		);
+
+		if ( ! empty( $required ) ) {
+			$schema['required'] = array_values( array_unique( $required ) );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Recursively sanitize a JSON Schema node.
+	 *
+	 * Copies only valid JSON Schema keywords, normalizes types, and recurses into
+	 * `properties`, `items`, and `additionalProperties`.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $schema A JSON Schema node (or a WP REST arg definition).
+	 * @return array Sanitized schema node.
+	 */
+	private static function sanitize_schema( $schema ) {
+
+		$sanitized = array();
+
+		if ( isset( $schema['type'] ) ) {
+			$sanitized = self::normalize_type( $sanitized, $schema['type'] );
+		}
+
+		foreach ( array( 'description', 'default', 'format', 'minimum', 'maximum', 'minLength', 'maxLength', 'minItems', 'maxItems', 'title' ) as $keyword ) {
+			if ( isset( $schema[ $keyword ] ) ) {
+				$sanitized[ $keyword ] = $schema[ $keyword ];
+			}
+		}
+
+		if ( isset( $schema['enum'] ) && is_array( $schema['enum'] ) ) {
+			$sanitized['enum'] = array_values( array_unique( $schema['enum'], SORT_REGULAR ) );
+		}
+
+		if ( isset( $schema['readonly'] ) && $schema['readonly'] ) {
+			$sanitized['readOnly'] = true;
+		}
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$sanitized['items'] = self::sanitize_schema( $schema['items'] );
+		}
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+
+			$sanitized['properties'] = array();
+			$required                = array();
+
+			foreach ( $schema['properties'] as $key => $property ) {
+
+				if ( ! is_array( $property ) ) {
+					continue;
+				}
+
+				$sanitized['properties'][ $key ] = self::sanitize_schema( $property );
+
+				if ( isset( $property['required'] ) && true === $property['required'] ) {
+					$required[] = $key;
+				}
+			}
+
+			if ( isset( $schema['required'] ) && is_array( $schema['required'] ) ) {
+				$required = array_merge( $schema['required'], $required );
+			}
+
+			if ( ! empty( $required ) ) {
+				$sanitized['required'] = array_values( array_unique( $required ) );
+			}
+		}
+
+		if ( isset( $schema['additionalProperties'] ) && is_array( $schema['additionalProperties'] ) ) {
+			$sanitized['additionalProperties'] = self::sanitize_schema( $schema['additionalProperties'] );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Normalize a schema `type` value to valid JSON Schema types.
+	 *
+	 * @since [version]
+	 *
+	 * @param array        $schema The schema node being built.
+	 * @param string|array $type   The type value to normalize.
+	 * @return array Schema with a normalized type (or no type when invalid).
+	 */
+	private static function normalize_type( $schema, $type ) {
+
+		if ( is_string( $type ) ) {
+			if ( in_array( $type, self::$valid_types, true ) ) {
+				$schema['type'] = $type;
+			}
+			return $schema;
+		}
+
+		if ( is_array( $type ) ) {
+
+			$normalized = array_values( array_unique( array_intersect( $type, self::$valid_types ) ) );
+
+			if ( 1 === count( $normalized ) ) {
+				$schema['type'] = $normalized[0];
+			} elseif ( $normalized ) {
+				$schema['type'] = $normalized;
+			}
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Relax an output schema so it accepts the shapes controllers actually return.
+	 *
+	 * The Abilities API strictly validates execution output against the output schema.
+	 * REST item schemas occasionally disagree with real response shapes (nullable fields,
+	 * date strings without timezone suffixes, etc.), so on output we widen scalar types
+	 * to a permissive union and strip `format` constraints. Input schemas keep their
+	 * tighter constraints.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $schema A sanitized JSON Schema node.
+	 * @return array Relaxed schema node.
+	 */
+	private static function relax_output_schema( $schema ) {
+
+		unset( $schema['format'] );
+
+		if ( isset( $schema['type'] ) && self::should_widen_type( $schema['type'] ) ) {
+			$schema['type'] = self::$valid_types;
+			unset( $schema['enum'] );
+		}
+
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $key => $property ) {
+				$schema['properties'][ $key ] = self::relax_output_schema( $property );
+			}
+		}
+
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) ) {
+			$schema['items'] = self::relax_output_schema( $schema['items'] );
+		}
+
+		if ( isset( $schema['additionalProperties'] ) && is_array( $schema['additionalProperties'] ) ) {
+			$schema['additionalProperties'] = self::relax_output_schema( $schema['additionalProperties'] );
+		}
+
+		unset( $schema['required'] );
+
+		return $schema;
+	}
+
+	/**
+	 * Determine whether an output-schema type should be widened to the permissive union.
+	 *
+	 * Single scalar types and unions composed solely of scalars and/or `null` are widened.
+	 * Types declaring compound members (`object`, `array`) are left alone.
+	 *
+	 * @since [version]
+	 *
+	 * @param string|array $type Schema `type` value.
+	 * @return boolean
+	 */
+	private static function should_widen_type( $type ) {
+
+		if ( is_string( $type ) ) {
+			return in_array( $type, self::$scalar_types, true );
+		}
+
+		if ( ! is_array( $type ) || ! $type ) {
+			return false;
+		}
+
+		$widenable = array_merge( self::$scalar_types, array( 'null' ) );
+
+		return ! array_diff( $type, $widenable );
+	}
+}

--- a/libraries/lifterlms-rest/includes/abilities/class-llms-rest-ability-factory.php
+++ b/libraries/lifterlms-rest/includes/abilities/class-llms-rest-ability-factory.php
@@ -99,6 +99,9 @@ class LLMS_REST_Ability_Factory {
 			return null;
 		}
 
+		// Captured by the callbacks below so requests built outside REST dispatch carry the same defaults.
+		$config['default_params'] = self::get_default_params( $config );
+
 		$args = array(
 			'label'               => $config['label'],
 			'description'         => $config['description'],
@@ -160,6 +163,36 @@ class LLMS_REST_Ability_Factory {
 	 */
 	private static function get_input_schema( $config ) {
 
+		$schema = self::sanitize_args_to_schema( self::get_endpoint_args( $config ) );
+
+		foreach ( self::get_path_params( $config ) as $param => $description ) {
+
+			$schema['properties'][ $param ] = array(
+				'type'        => 'integer',
+				'description' => $description,
+			);
+
+			$schema['required']   = isset( $schema['required'] ) ? $schema['required'] : array();
+			$schema['required'][] = $param;
+		}
+
+		if ( isset( $schema['required'] ) ) {
+			$schema['required'] = array_values( array_unique( $schema['required'] ) );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Retrieve the raw endpoint args (WP REST format) for the configured operation.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config Ability configuration.
+	 * @return array
+	 */
+	private static function get_endpoint_args( $config ) {
+
 		$controller = self::get_controller( ! empty( $config['schema_controller'] ) ? $config['schema_controller'] : $config['controller'] );
 		$args       = array();
 
@@ -198,24 +231,33 @@ class LLMS_REST_Ability_Factory {
 			}
 		}
 
-		$schema = self::sanitize_args_to_schema( is_array( $args ) ? $args : array() );
+		return is_array( $args ) ? $args : array();
+	}
 
-		foreach ( self::get_path_params( $config ) as $param => $description ) {
+	/**
+	 * Retrieve the default values of the endpoint args for the configured operation.
+	 *
+	 * During REST dispatch the server applies these defaults from the route registration.
+	 * Requests built manually for the ability callbacks skip route matching, so the same
+	 * defaults are set on the request explicitly (e.g. the enrollments `trigger` param,
+	 * which permission checks read before dispatch occurs).
+	 *
+	 * @since [version]
+	 *
+	 * @param array $config Ability configuration.
+	 * @return array Map of param name to default value.
+	 */
+	private static function get_default_params( $config ) {
 
-			$schema['properties'][ $param ] = array(
-				'type'        => 'integer',
-				'description' => $description,
-			);
+		$defaults = array();
 
-			$schema['required']   = isset( $schema['required'] ) ? $schema['required'] : array();
-			$schema['required'][] = $param;
+		foreach ( self::get_endpoint_args( $config ) as $key => $arg ) {
+			if ( is_array( $arg ) && array_key_exists( 'default', $arg ) ) {
+				$defaults[ $key ] = $arg['default'];
+			}
 		}
 
-		if ( isset( $schema['required'] ) ) {
-			$schema['required'] = array_values( array_unique( $schema['required'] ) );
-		}
-
-		return $schema;
+		return $defaults;
 	}
 
 	/**
@@ -322,8 +364,11 @@ class LLMS_REST_Ability_Factory {
 	 * Build an internal REST request from ability input.
 	 *
 	 * Route placeholders (e.g. `{id}`) are substituted with the corresponding input values
-	 * and removed from the request parameters; all remaining input is passed as query or
-	 * body parameters depending on the HTTP method.
+	 * and moved from the query/body parameters into the request's URL parameters. Setting
+	 * them as URL params keeps them readable (e.g. `$request['id']`) by controller
+	 * permission checks invoked directly via {@see LLMS_REST_Ability_Factory::check_permission()},
+	 * where no route matching occurs to populate them, while keeping the request body free
+	 * of path parameters the controllers don't expect there.
 	 *
 	 * @since [version]
 	 *
@@ -333,22 +378,30 @@ class LLMS_REST_Ability_Factory {
 	 */
 	private static function build_request( $config, $input = null ) {
 
-		$input  = is_array( $input ) ? $input : array();
-		$route  = $config['route'];
-		$params = $input;
+		$input      = is_array( $input ) ? $input : array();
+		$route      = $config['route'];
+		$params     = $input;
+		$url_params = array();
 
 		foreach ( array_keys( self::get_path_params( $config ) ) as $param ) {
 			if ( isset( $params[ $param ] ) ) {
-				$route = str_replace( '{' . $param . '}', (string) absint( $params[ $param ] ), $route );
+				$url_params[ $param ] = absint( $params[ $param ] );
+				$route                = str_replace( '{' . $param . '}', (string) $url_params[ $param ], $route );
+				unset( $params[ $param ] );
 			}
 		}
 
 		$request = new WP_REST_Request( $config['method'], $route );
+		$request->set_url_params( $url_params );
 
 		if ( in_array( $config['method'], array( 'GET', 'DELETE' ), true ) ) {
 			$request->set_query_params( $params );
 		} else {
 			$request->set_body_params( $params );
+		}
+
+		if ( ! empty( $config['default_params'] ) ) {
+			$request->set_default_params( $config['default_params'] );
 		}
 
 		return $request;

--- a/libraries/lifterlms-rest/includes/abilities/index.php
+++ b/libraries/lifterlms-rest/includes/abilities/index.php
@@ -1,0 +1,2 @@
+<?php
+// quiet you.

--- a/tests/phpunit/unit-tests/libraries/lifterlms-rest/class-llms-rest-test-abilities.php
+++ b/tests/phpunit/unit-tests/libraries/lifterlms-rest/class-llms-rest-test-abilities.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * Test the WordPress Abilities API integration.
+ *
+ * @package LifterLMS_REST/Tests
+ *
+ * @group abilities
+ * @group rest_abilities
+ *
+ * @since [version]
+ */
+class LLMS_REST_Test_Abilities extends LLMS_REST_Unit_Test_Case_Base {
+
+	/**
+	 * Setup the test case.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		parent::set_up();
+
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'The Abilities API is not available in this WordPress version.' );
+		}
+	}
+
+	/**
+	 * Retrieve a registered LifterLMS ability, initializing the abilities registry.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $name Un-namespaced ability name.
+	 * @return WP_Ability|null
+	 */
+	private function get_ability( $name ) {
+		return wp_get_ability( "lifterlms/{$name}" );
+	}
+
+	/**
+	 * Test all expected abilities are registered.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_abilities_registered() {
+
+		$expected = array();
+
+		foreach ( array( 'course', 'section', 'lesson', 'membership', 'access-plan', 'student' ) as $resource ) {
+			$plural     = 'access-plan' === $resource ? 'access-plans' : "{$resource}s";
+			$expected[] = "list-{$plural}";
+			$expected[] = "get-{$resource}";
+			$expected[] = "create-{$resource}";
+			$expected[] = "update-{$resource}";
+			$expected[] = "delete-{$resource}";
+		}
+
+		$expected = array_merge(
+			$expected,
+			array(
+				'get-course-content',
+				'get-course-enrollments',
+				'list-enrollments',
+				'enroll-student',
+				'update-enrollment',
+				'unenroll-student',
+				'get-progress',
+				'update-progress',
+				'delete-progress',
+			)
+		);
+
+		foreach ( $expected as $name ) {
+			$this->assertNotNull( $this->get_ability( $name ), "Ability lifterlms/{$name} is not registered." );
+		}
+
+		$registered = array_filter(
+			array_keys( wp_get_abilities() ),
+			function ( $name ) {
+				return 0 === strpos( $name, 'lifterlms/' );
+			}
+		);
+
+		$this->assertEquals( count( $expected ), count( $registered ) );
+	}
+
+	/**
+	 * Test the LifterLMS ability category is registered.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_category_registered() {
+
+		// Initialize the abilities registry (which registers categories, too).
+		wp_get_abilities();
+
+		$category = wp_get_ability_category( 'lifterlms' );
+
+		$this->assertNotNull( $category );
+		$this->assertEquals( 'LifterLMS', $category->get_label() );
+	}
+
+	/**
+	 * Test derived input schemas.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_input_schemas() {
+
+		// List: collection params.
+		$schema = $this->get_ability( 'list-courses' )->get_input_schema();
+		$this->assertEquals( 'object', $schema['type'] );
+		foreach ( array( 'page', 'per_page', 'order', 'orderby', 'include', 'exclude' ) as $param ) {
+			$this->assertArrayHasKey( $param, $schema['properties'], $param );
+		}
+
+		// No PHP callbacks may leak into the schema.
+		$this->assertArrayNotHasKey( 'validate_callback', $schema['properties']['order'] );
+		$this->assertArrayNotHasKey( 'sanitize_callback', $schema['properties']['order'] );
+
+		// Get: ID path param is required.
+		$schema = $this->get_ability( 'get-course' )->get_input_schema();
+		$this->assertArrayHasKey( 'id', $schema['properties'] );
+		$this->assertContains( 'id', $schema['required'] );
+
+		// Create: item schema args with required fields.
+		$schema = $this->get_ability( 'create-course' )->get_input_schema();
+		$this->assertArrayHasKey( 'title', $schema['properties'] );
+		$this->assertContains( 'title', $schema['required'] );
+		$this->assertContains( 'content', $schema['required'] );
+
+		// Nested routes: both path params required.
+		$schema = $this->get_ability( 'enroll-student' )->get_input_schema();
+		$this->assertContains( 'id', $schema['required'] );
+		$this->assertContains( 'post_id', $schema['required'] );
+	}
+
+	/**
+	 * Test derived output schemas and annotations.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_output_schemas_and_annotations() {
+
+		$list = $this->get_ability( 'list-courses' );
+		$this->assertEquals( 'array', $list->get_output_schema()['type'] );
+		$this->assertTrue( $list->get_meta_item( 'annotations' )['readonly'] );
+		$this->assertTrue( $list->get_meta_item( 'show_in_rest' ) );
+
+		$get = $this->get_ability( 'get-course' );
+		$this->assertEquals( 'object', $get->get_output_schema()['type'] );
+		$this->assertTrue( $get->get_meta_item( 'annotations' )['readonly'] );
+
+		$delete = $this->get_ability( 'delete-course' );
+		$this->assertArrayHasKey( 'deleted', $delete->get_output_schema()['properties'] );
+		$this->assertTrue( $delete->get_meta_item( 'annotations' )['destructive'] );
+	}
+
+	/**
+	 * Test course create/get/list/delete round trip through ability execution.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_execute_course_crud() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		// Create.
+		$created = $this->get_ability( 'create-course' )->execute(
+			array(
+				'title'   => 'Abilities API Test Course',
+				'content' => 'Course content.',
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $created ), is_wp_error( $created ) ? $created->get_error_message() : '' );
+		$this->assertEquals( 'Abilities API Test Course', $created['title']['rendered'] );
+
+		$course_id = $created['id'];
+
+		// Get.
+		$course = $this->get_ability( 'get-course' )->execute( array( 'id' => $course_id ) );
+		$this->assertFalse( is_wp_error( $course ) );
+		$this->assertEquals( $course_id, $course['id'] );
+
+		// List.
+		$list = $this->get_ability( 'list-courses' )->execute( array() );
+		$this->assertFalse( is_wp_error( $list ) );
+		$this->assertContains( $course_id, wp_list_pluck( $list, 'id' ) );
+
+		// Delete.
+		$deleted = $this->get_ability( 'delete-course' )->execute( array( 'id' => $course_id ) );
+		$this->assertEquals( array( 'deleted' => true ), $deleted );
+	}
+
+	/**
+	 * Test enrollment abilities round trip.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_execute_enrollments() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$course_id  = $this->factory->post->create( array( 'post_type' => 'course' ) );
+		$student_id = $this->factory->user->create( array( 'role' => 'student' ) );
+
+		$enrollment = $this->get_ability( 'enroll-student' )->execute(
+			array(
+				'id'      => $student_id,
+				'post_id' => $course_id,
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $enrollment ), is_wp_error( $enrollment ) ? $enrollment->get_error_message() : '' );
+		$this->assertEquals( 'enrolled', $enrollment['status'] );
+
+		$list = $this->get_ability( 'list-enrollments' )->execute( array( 'id' => $student_id ) );
+		$this->assertFalse( is_wp_error( $list ) );
+		$this->assertContains( $course_id, wp_list_pluck( $list, 'post_id' ) );
+
+		$deleted = $this->get_ability( 'unenroll-student' )->execute(
+			array(
+				'id'      => $student_id,
+				'post_id' => $course_id,
+			)
+		);
+		$this->assertEquals( array( 'deleted' => true ), $deleted );
+
+		$this->assertFalse( llms_is_user_enrolled( $student_id, $course_id ) );
+	}
+
+	/**
+	 * Test permission callbacks deny unauthorized users and allow authorized ones.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_permissions() {
+
+		$input = array(
+			'title'   => 'Denied Course',
+			'content' => 'Content.',
+		);
+
+		$ability = $this->get_ability( 'create-course' );
+
+		// Logged out.
+		wp_set_current_user( 0 );
+		$result = $ability->check_permissions( $input );
+		$this->assertTrue( is_wp_error( $result ) || false === $result );
+
+		// Subscriber.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
+		$result = $ability->check_permissions( $input );
+		$this->assertTrue( is_wp_error( $result ) || false === $result );
+
+		// Admin.
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		$this->assertTrue( $ability->check_permissions( $input ) );
+	}
+
+	/**
+	 * Test REST error responses are returned as WP_Error from execution.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_execute_error_passthrough() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$result = $this->get_ability( 'get-course' )->execute( array( 'id' => 99999999 ) );
+
+		$this->assertTrue( is_wp_error( $result ) );
+	}
+}

--- a/tests/phpunit/unit-tests/libraries/lifterlms-rest/class-llms-rest-test-abilities.php
+++ b/tests/phpunit/unit-tests/libraries/lifterlms-rest/class-llms-rest-test-abilities.php
@@ -195,6 +195,16 @@ class LLMS_REST_Test_Abilities extends LLMS_REST_Unit_Test_Case_Base {
 		$this->assertFalse( is_wp_error( $course ) );
 		$this->assertEquals( $course_id, $course['id'] );
 
+		// Update.
+		$updated = $this->get_ability( 'update-course' )->execute(
+			array(
+				'id'    => $course_id,
+				'title' => 'Abilities API Test Course (Updated)',
+			)
+		);
+		$this->assertFalse( is_wp_error( $updated ), is_wp_error( $updated ) ? $updated->get_error_message() : '' );
+		$this->assertEquals( 'Abilities API Test Course (Updated)', $updated['title']['rendered'] );
+
 		// List.
 		$list = $this->get_ability( 'list-courses' )->execute( array() );
 		$this->assertFalse( is_wp_error( $list ) );
@@ -232,6 +242,19 @@ class LLMS_REST_Test_Abilities extends LLMS_REST_Unit_Test_Case_Base {
 		$list = $this->get_ability( 'list-enrollments' )->execute( array( 'id' => $student_id ) );
 		$this->assertFalse( is_wp_error( $list ) );
 		$this->assertContains( $course_id, wp_list_pluck( $list, 'post_id' ) );
+
+		// Enrollment status rows are ordered by timestamp: wait so the updated status is subsequent to the one set on creation.
+		sleep( 1 );
+
+		$updated = $this->get_ability( 'update-enrollment' )->execute(
+			array(
+				'id'      => $student_id,
+				'post_id' => $course_id,
+				'status'  => 'expired',
+			)
+		);
+		$this->assertFalse( is_wp_error( $updated ), is_wp_error( $updated ) ? $updated->get_error_message() : '' );
+		$this->assertEquals( 'expired', $updated['status'] );
 
 		$deleted = $this->get_ability( 'unenroll-student' )->execute(
 			array(


### PR DESCRIPTION

## Description

Allow easier consumption of REST API endpoints and management of a LifterLMS site via the Abilities API.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

