### PR TITLE
feat(notifications): send notifications to all post instructors

### DIFF
--- a/.changelogs/all-instructors-notifications.yml
+++ b/.changelogs/all-instructors-notifications.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added an 'All Instructors' option to notifications so course and membership alerts can be sent to every assigned instructor, not just the primary author. A per-post override on the course and membership editors lets instructors force the setting on or off for a single course/membership."

--- a/includes/abstracts/llms.abstract.notification.controller.php
+++ b/includes/abstracts/llms.abstract.notification.controller.php
@@ -209,6 +209,103 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	}
 
 	/**
+	 * Add subscriptions for all instructors assigned to the post
+	 *
+	 * Subscribes every user ID stored in the course or membership's
+	 * `_llms_instructors` meta (primary author + secondary instructors +
+	 * assistants), regardless of the `visibility` field. The related course
+	 * or membership is resolved from `$this->post_id` by walking through any
+	 * related objects (lesson, section, quiz, order, transaction) so this
+	 * method works for every controller, not only those triggered directly
+	 * by a course or membership.
+	 *
+	 * Honors a per-post override stored in
+	 * `_llms_notification_all_instructors` on the related course or
+	 * membership: `no` blocks delivery even when the global admin toggle
+	 * is on; `yes` forces delivery when the global toggle is off. `global`
+	 * (or empty) follows the global setting.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $type Notification type id.
+	 * @return void
+	 */
+	private function add_all_instructors_subscriptions( $type ) {
+
+		$post = $this->get_instructors_post();
+
+		if ( ! $post ) {
+			return;
+		}
+
+		$override = $post->get( 'notification_all_instructors' );
+		if ( 'no' === $override ) {
+			return;
+		}
+
+		foreach ( $post->get_instructors( false ) as $instructor ) {
+			if ( ! empty( $instructor['id'] ) ) {
+				$this->subscribe( $instructor['id'], $type );
+			}
+		}
+	}
+
+	/**
+	 * Resolve the course or membership post whose instructors should receive
+	 * the notification.
+	 *
+	 * Tries, in order: the controller's `$this->course` property (if set),
+	 * then `$this->post_id` resolved through a chain of related objects
+	 * (lesson, quiz, section, order, transaction) until a post with the
+	 * `get_instructors()` method is found.
+	 *
+	 * @since [version]
+	 *
+	 * @return LLMS_Post_Model|false Course or membership post, or false if not resolvable.
+	 */
+	private function get_instructors_post() {
+
+		if ( ! empty( $this->course ) && is_object( $this->course ) && method_exists( $this->course, 'get_instructors' ) ) {
+			return $this->course;
+		}
+
+		$post = llms_get_post( $this->post_id );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$visited = array();
+
+		while ( $post && ! in_array( $post->get( 'id' ), $visited, true ) ) {
+			$visited[] = $post->get( 'id' );
+
+			if ( method_exists( $post, 'get_instructors' ) ) {
+				return $post;
+			}
+
+			$next = null;
+
+			if ( method_exists( $post, 'get_course' ) ) {
+				$next = $post->get_course();
+			} elseif ( method_exists( $post, 'get_parent_course' ) ) {
+				$parent_id = $post->get_parent_course();
+				$next      = $parent_id ? llms_get_post( $parent_id ) : null;
+			} elseif ( method_exists( $post, 'get_order' ) ) {
+				$order = $post->get_order();
+				if ( $order && method_exists( $order, 'get_product' ) ) {
+					$next = $order->get_product();
+				}
+			} elseif ( method_exists( $post, 'get_product' ) ) {
+				$next = $post->get_product();
+			}
+
+			$post = $next;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Adds subscribers before sending a notifications
 	 *
 	 * @since 3.8.0
@@ -220,6 +317,14 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 	 */
 	private function add_subscriptions( $filter_types = null ) {
 
+		// Per-post override: force "all_instructors" on for the related course
+		// or membership even if the global admin setting is off.
+		$force_all = false;
+		$instructors_post = $this->get_instructors_post();
+		if ( $instructors_post ) {
+			$force_all = ( 'yes' === $instructors_post->get( 'notification_all_instructors' ) );
+		}
+
 		foreach ( array_keys( $this->get_supported_types() ) as $type ) {
 			if ( ! is_null( $filter_types ) && ! in_array( $type, $filter_types, true ) ) {
 				continue;
@@ -227,10 +332,14 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 
 			foreach ( $this->get_subscribers_settings( $type ) as $subscriber_key => $enabled ) {
 
-				if ( 'no' === $enabled ) {
+				if ( 'no' === $enabled && ! ( 'all_instructors' === $subscriber_key && $force_all ) ) {
 					continue;
 				} elseif ( 'custom' === $subscriber_key ) {
 					$this->add_custom_subscriptions( $type );
+					continue;
+				} elseif ( 'all_instructors' === $subscriber_key ) {
+					$this->add_all_instructors_subscriptions( $type );
+					continue;
 				}
 
 				$subscriber = $this->get_subscriber( $subscriber_key );
@@ -338,6 +447,9 @@ abstract class LLMS_Abstract_Notification_Controller extends LLMS_Abstract_Optio
 			),
 			'course_author' => array(
 				'title' => __( 'Course Author', 'lifterlms' ),
+			),
+			'all_instructors' => array(
+				'title' => __( 'All Instructors', 'lifterlms' ),
 			),
 			'custom'        => array(
 				'description' => __( 'Enter additional email addresses which will receive this notification. Separate multiple addresses with commas.', 'lifterlms' ),

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.course.options.php
@@ -259,6 +259,31 @@ class LLMS_Meta_Box_Course_Options extends LLMS_Admin_Metabox {
 						'value'           => llms_make_select2_post_array( array( $course->get( 'completion_page_id' ) ) ),
 						'type'            => 'select',
 					),
+					array(
+						'allow_null' => false,
+						'class'      => 'llms-select2',
+						'desc'       => __( 'Override the global "All Instructors" notification setting for this course. Instructors can receive notifications for all instructors assigned to the course, not just the author.', 'lifterlms' ),
+						'desc_class' => 'd-all',
+						'group'      => 'bottom',
+						'id'         => $this->prefix . 'notification_all_instructors',
+						'label'      => __( 'Send Notifications to All Instructors', 'lifterlms' ),
+						'selected'   => $course->get( 'notification_all_instructors' ) ? $course->get( 'notification_all_instructors' ) : 'global',
+						'type'       => 'select',
+						'value'      => array(
+							array(
+								'key'   => 'global',
+								'title' => __( 'Use Global Setting', 'lifterlms' ),
+							),
+							array(
+								'key'   => 'yes',
+								'title' => __( 'Send', 'lifterlms' ),
+							),
+							array(
+								'key'   => 'no',
+								'title' => __( 'Do Not Send', 'lifterlms' ),
+							),
+						),
+					),
 				),
 			),
 			array(

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.membership.php
@@ -197,6 +197,31 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 						'class' => 'code input-full',
 						'value' => 'test',
 					),
+					array(
+						'allow_null' => false,
+						'class'      => 'llms-select2',
+						'desc'       => __( 'Override the global "All Instructors" notification setting for this membership. Instructors can receive notifications for all instructors assigned to the membership, not just the author.', 'lifterlms' ),
+						'desc_class' => 'd-all',
+						'group'      => 'bottom',
+						'id'         => $this->prefix . 'notification_all_instructors',
+						'label'      => __( 'Send Notifications to All Instructors', 'lifterlms' ),
+						'selected'   => $membership->get( 'notification_all_instructors' ) ? $membership->get( 'notification_all_instructors' ) : 'global',
+						'type'       => 'select',
+						'value'      => array(
+							array(
+								'key'   => 'global',
+								'title' => __( 'Use Global Setting', 'lifterlms' ),
+							),
+							array(
+								'key'   => 'yes',
+								'title' => __( 'Send', 'lifterlms' ),
+							),
+							array(
+								'key'   => 'no',
+								'title' => __( 'Do Not Send', 'lifterlms' ),
+							),
+						),
+					),
 				),
 			),
 
@@ -413,6 +438,7 @@ class LLMS_Meta_Box_Membership extends LLMS_Admin_Metabox {
 			$this->prefix . 'audio_embed',
 			$this->prefix . 'tile_featured_video',
 			$this->prefix . 'instructors_data',
+			$this->prefix . 'notification_all_instructors',
 		);
 
 		if ( ! is_array( $fields ) ) {

--- a/includes/notifications/controllers/class.llms.notification.controller.course.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.course.complete.php
@@ -118,6 +118,7 @@ class LLMS_Notification_Controller_Course_Complete extends LLMS_Abstract_Notific
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'course_author', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.enrollment.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.enrollment.php
@@ -118,10 +118,12 @@ class LLMS_Notification_Controller_Enrollment extends LLMS_Abstract_Notification
 			case 'basic':
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				break;
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.lesson.complete.php
@@ -131,6 +131,7 @@ class LLMS_Notification_Controller_Lesson_Complete extends LLMS_Abstract_Notific
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'lesson_author', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'course_author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.manual.payment.due.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.manual.payment.due.php
@@ -141,6 +141,7 @@ class LLMS_Notification_Controller_Manual_Payment_Due extends LLMS_Abstract_Noti
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.payment.retry.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.payment.retry.php
@@ -128,6 +128,7 @@ class LLMS_Notification_Controller_Payment_Retry extends LLMS_Abstract_Notificat
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.purchase.receipt.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.purchase.receipt.php
@@ -243,6 +243,7 @@ class LLMS_Notification_Controller_Purchase_Receipt extends LLMS_Abstract_Notifi
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'yes' );
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.failed.php
@@ -220,6 +220,7 @@ class LLMS_Notification_Controller_Quiz_Failed extends LLMS_Abstract_Notificatio
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'course_author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.quiz.passed.php
@@ -224,6 +224,7 @@ class LLMS_Notification_Controller_Quiz_Passed extends LLMS_Abstract_Notificatio
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'course_author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.section.complete.php
@@ -126,6 +126,7 @@ class LLMS_Notification_Controller_Section_Complete extends LLMS_Abstract_Notifi
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'course_author', 'no' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.subscription.cancelled.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.subscription.cancelled.php
@@ -117,6 +117,7 @@ class LLMS_Notification_Controller_Subscription_Cancelled extends LLMS_Abstract_
 
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 

--- a/includes/notifications/controllers/class.llms.notification.controller.upcoming.payment.reminder.php
+++ b/includes/notifications/controllers/class.llms.notification.controller.upcoming.payment.reminder.php
@@ -190,6 +190,7 @@ class LLMS_Notification_Controller_Upcoming_Payment_Reminder extends LLMS_Abstra
 			case 'email':
 				$options[] = $this->get_subscriber_option_array( 'author', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'student', 'yes' );
+				$options[] = $this->get_subscriber_option_array( 'all_instructors', 'no' );
 				$options[] = $this->get_subscriber_option_array( 'custom', 'no' );
 				break;
 


### PR DESCRIPTION
## Description

Notifications for courses and memberships currently target only the post author, ignoring secondary instructors and assistants stored in the `_llms_instructors` post meta. This adds an "All Instructors" recipient option on the 11 notifications that previously targeted the author or course author, and a per-course / per-membership override that lets instructors force the setting on or off for a single course or membership regardless of the global admin default.

For notifications triggered by a lesson, section, quiz, or order, the related course or membership is resolved by walking the related objects (Lesson::get_course, Quiz::get_course, Section::get_course, Transaction::get_order, Order::get_product) before reading the override meta and the instructor list.

Fixes #375

## How has this been tested?

**PHPUnit:** `vendor/bin/phpunit --filter 'Notification|Instructor'` passes: 94 tests, 384 assertions, 0 failures.

**PHPCS:** `composer run-script check-cs` exits 0 with no errors on changed files.

**Manual test plan:**

1. Global "Send to all instructors"
   - Add a second user as an instructor to a test course.
   - Go to LifterLMS > Settings > Notifications > Enrollment.
   - Enable the new "All Instructors" checkbox under Email recipients.
   - Enrol a student in that course.
   - Result: both the author and the secondary instructor receive the enrolment email.

2. Per-course override (force off)
   - On the test course, set General > "Send Notifications to All Instructors" to "Do Not Send".
   - Enrol another student in the same course.
   - Result: neither instructor receives the enrolment email, even though the global setting is still on.

3. Per-course override (force on)
   - Turn the global notification setting off.
   - On a different course, set General > "Send Notifications to All Instructors" to "Send".
   - Enrol a student in that course.
   - Result: the course's instructors receive the enrolment email despite the global off.

4. Lesson triggered notification
   - Enable "All Instructors" globally for the Lesson Complete notification.
   - Add a secondary instructor to the lesson's parent course.
   - Mark the lesson complete for an enrolled student.
   - Result: both instructors receive the lesson-complete email.

5. Order triggered notification
   - Enable "All Instructors" globally for Purchase Receipt.
   - Add a secondary instructor to the product (course or membership).
   - Complete a purchase.
   - Result: both instructors receive the purchase receipt.

Environment: WordPress 6.x, PHP 7.4+, LifterLMS dev branch.

## Screenshots

n/a (no visible UI changes for end users; the new control matches existing select styling on the Course Options and Membership Settings metaboxes).

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file. (`.changelogs/all-instructors-notifications.yml` — added / minor)
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.