### PR TITLE
Migrate System Report to WP core Site Health Info screen

### DIFF
--- a/.changelogs/854-site-health.yml
+++ b/.changelogs/854-site-health.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: "Migrated the System Report tab on the Status screen to a notice linking to the WordPress core Site Health info tab, where the same diagnostic data is now collected and copied as part of the single unified debug view."

--- a/includes/admin/class-llms-admin-site-health.php
+++ b/includes/admin/class-llms-admin-site-health.php
@@ -17,8 +17,8 @@ defined( 'ABSPATH' ) || exit;
  *
  * Hooks the {@see 'debug_information'} filter to surface LifterLMS-specific
  * data (settings, gateways, integrations, template overrides, constants) on the
- * Tools > Site Health > Info screen. Core-provided sections (WordPress, Server,
- * Theme, Plugins) are intentionally not duplicated.
+ * Tools > Site Health > Info screen. Core-provided sections are intentionally not
+ * duplicated.
  *
  * Data is sourced from {@see LLMS_Data::get_data()}, which is also used by the
  * telemetry tracker, so the underlying data class is left untouched.
@@ -68,8 +68,8 @@ class LLMS_Admin_Site_Health {
 		$report = LLMS_Data::get_data( 'system_report' );
 
 		$info['lifterlms-settings']     = self::section_from_map( __( 'LifterLMS Settings', 'lifterlms' ), isset( $report['settings'] ) ? $report['settings'] : array() );
-		$info['lifterlms-gateways']     = self::section_from_map( __( 'Payment Gateways', 'lifterlms' ), isset( $report['gateways'] ) ? $report['gateways'] : array() );
-		$info['lifterlms-integrations'] = self::section_from_map( __( 'Integrations', 'lifterlms' ), isset( $report['integrations'] ) ? $report['integrations'] : array() );
+		$info['lifterlms-gateways']     = self::section_from_map( __( 'LifterLMS Payment Gateways', 'lifterlms' ), isset( $report['gateways'] ) ? $report['gateways'] : array() );
+		$info['lifterlms-integrations'] = self::section_from_map( __( 'LifterLMS Integrations', 'lifterlms' ), isset( $report['integrations'] ) ? $report['integrations'] : array() );
 		$info['lifterlms-templates']    = self::section_templates( isset( $report['template_overrides'] ) ? $report['template_overrides'] : array() );
 		$info['lifterlms-constants']    = self::section_from_map( __( 'LifterLMS Constants', 'lifterlms' ), isset( $report['constants'] ) ? $report['constants'] : array() );
 
@@ -91,6 +91,8 @@ class LLMS_Admin_Site_Health {
 	/**
 	 * Build a Site Health section from a flat key => value map.
 	 *
+	 * Emits one benign row when the data is empty so WordPress core doesn't skip the section.
+	 *
 	 * @since [version]
 	 *
 	 * @param string $label Section label.
@@ -101,12 +103,14 @@ class LLMS_Admin_Site_Health {
 
 		$fields = array();
 
-		foreach ( $data as $key => $value ) {
-			$fields[ $key ] = array(
-				'label'   => self::humanize( $key ),
-				'value'   => self::to_string( $value ),
-				'private' => self::is_sensitive_key( $key ),
-			);
+		if ( ! empty( $data ) && is_array( $data ) ) {
+			foreach ( $data as $key => $value ) {
+				$fields[ $key ] = array(
+					'label'   => self::humanize( $key ),
+					'value'   => self::to_string( $value ),
+					'private' => self::is_sensitive_key( $key ),
+				);
+			}
 		}
 
 		// WordPress core skips any Site Health section whose fields are empty, so always
@@ -139,18 +143,20 @@ class LLMS_Admin_Site_Health {
 
 		$rows = array();
 
-		foreach ( $overrides as $override ) {
-			$rows[] = sprintf(
-				'%1$s (core: %2$s) - %3$s (version: %4$s)',
-				$override['template'],
-				$override['core_version'],
-				$override['location'],
-				$override['version']
-			);
+		if ( is_array( $overrides ) && ! empty( $overrides ) ) {
+			foreach ( $overrides as $override ) {
+				$rows[] = sprintf(
+					'%1$s (core: %2$s) - %3$s (version: %4$s)',
+					$override['template'],
+					$override['core_version'],
+					$override['location'],
+					$override['version']
+				);
+			}
 		}
 
 		return array(
-			'label'      => __( 'Template Overrides', 'lifterlms' ),
+			'label'      => __( 'LifterLMS Template Overrides', 'lifterlms' ),
 			'show_count' => true,
 			'fields'     => array(
 				'overrides' => array(

--- a/includes/admin/class-llms-admin-site-health.php
+++ b/includes/admin/class-llms-admin-site-health.php
@@ -67,16 +67,25 @@ class LLMS_Admin_Site_Health {
 
 		$report = LLMS_Data::get_data( 'system_report' );
 
-		$info['lifterlms-settings']     = self::section_from_map( __( 'LifterLMS Settings', 'lifterlms' ), $report['settings'] );
-		$info['lifterlms-gateways']     = self::section_from_map( __( 'Payment Gateways', 'lifterlms' ), $report['gateways'] );
-		$info['lifterlms-integrations'] = self::section_from_map( __( 'Integrations', 'lifterlms' ), $report['integrations'] );
-		$info['lifterlms-templates']    = self::section_templates( $report['template_overrides'] );
+		$info['lifterlms-settings']     = self::section_from_map( __( 'LifterLMS Settings', 'lifterlms' ), isset( $report['settings'] ) ? $report['settings'] : array() );
+		$info['lifterlms-gateways']     = self::section_from_map( __( 'Payment Gateways', 'lifterlms' ), isset( $report['gateways'] ) ? $report['gateways'] : array() );
+		$info['lifterlms-integrations'] = self::section_from_map( __( 'Integrations', 'lifterlms' ), isset( $report['integrations'] ) ? $report['integrations'] : array() );
+		$info['lifterlms-templates']    = self::section_templates( isset( $report['template_overrides'] ) ? $report['template_overrides'] : array() );
+		$info['lifterlms-constants']    = self::section_from_map( __( 'LifterLMS Constants', 'lifterlms' ), isset( $report['constants'] ) ? $report['constants'] : array() );
 
-		if ( isset( $report['constants'] ) ) {
-			$info['lifterlms-constants'] = self::section_from_map( __( 'LifterLMS Constants', 'lifterlms' ), $report['constants'] );
+		// Pin LifterLMS sections after every core section so they stay grouped at the bottom.
+		$core = array();
+		$llms = array();
+
+		foreach ( $info as $slug => $section ) {
+			if ( 0 === strpos( $slug, 'lifterlms-' ) ) {
+				$llms[ $slug ] = $section;
+			} else {
+				$core[ $slug ] = $section;
+			}
 		}
 
-		return $info;
+		return array_merge( $core, $llms );
 	}
 
 	/**
@@ -97,6 +106,15 @@ class LLMS_Admin_Site_Health {
 				'label'   => self::humanize( $key ),
 				'value'   => self::to_string( $value ),
 				'private' => self::is_sensitive_key( $key ),
+			);
+		}
+
+		// WordPress core skips any Site Health section whose fields are empty, so always
+		// surface at least one row even when there is nothing to report.
+		if ( empty( $fields ) ) {
+			$fields['no_data'] = array(
+				'label' => __( 'Status', 'lifterlms' ),
+				'value' => __( 'No data available.', 'lifterlms' ),
 			);
 		}
 

--- a/includes/admin/class-llms-admin-site-health.php
+++ b/includes/admin/class-llms-admin-site-health.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Admin Site Health
+ *
+ * Adds LifterLMS diagnostics to the WordPress core Site Health Info screen.
+ *
+ * @package LifterLMS/Admin/Classes
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * LLMS_Admin_Site_Health class.
+ *
+ * Hooks the {@see 'debug_information'} filter to surface LifterLMS-specific
+ * data (settings, gateways, integrations, template overrides, constants) on the
+ * Tools > Site Health > Info screen. Core-provided sections (WordPress, Server,
+ * Theme, Plugins) are intentionally not duplicated.
+ *
+ * Data is sourced from {@see LLMS_Data::get_data()}, which is also used by the
+ * telemetry tracker, so the underlying data class is left untouched.
+ *
+ * @since [version]
+ */
+class LLMS_Admin_Site_Health {
+
+	/**
+	 * Keys whose values may be sensitive (emails, URLs) and are excluded from the copied report.
+	 *
+	 * @since [version]
+	 *
+	 * @var string[]
+	 */
+	private static $sensitive_substrings = array( 'email', 'url', 'login', 'permalink' );
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		add_filter( 'debug_information', array( __CLASS__, 'add_debug_info' ) );
+	}
+
+	/**
+	 * Add LifterLMS sections to the Site Health Info report.
+	 *
+	 * Registers unconditionally: the debug_information filter only fires on the
+	 * Info screen, where WP_Debug_Data is guaranteed to be loaded first. The
+	 * class_exists() fallback in this callback guards against future core changes.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $info The debug information array.
+	 * @return array
+	 */
+	public static function add_debug_info( $info ) {
+
+		if ( ! class_exists( 'WP_Debug_Data' ) ) {
+			return $info;
+		}
+
+		$report = LLMS_Data::get_data( 'system_report' );
+
+		$info['lifterlms-settings']     = self::section_from_map( __( 'LifterLMS Settings', 'lifterlms' ), $report['settings'] );
+		$info['lifterlms-gateways']     = self::section_from_map( __( 'Payment Gateways', 'lifterlms' ), $report['gateways'] );
+		$info['lifterlms-integrations'] = self::section_from_map( __( 'Integrations', 'lifterlms' ), $report['integrations'] );
+		$info['lifterlms-templates']    = self::section_templates( $report['template_overrides'] );
+
+		if ( isset( $report['constants'] ) ) {
+			$info['lifterlms-constants'] = self::section_from_map( __( 'LifterLMS Constants', 'lifterlms' ), $report['constants'] );
+		}
+
+		return $info;
+	}
+
+	/**
+	 * Build a Site Health section from a flat key => value map.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $label Section label.
+	 * @param array  $data  Flat associative array of data.
+	 * @return array
+	 */
+	private static function section_from_map( $label, $data ) {
+
+		$fields = array();
+
+		foreach ( $data as $key => $value ) {
+			$fields[ $key ] = array(
+				'label'   => self::humanize( $key ),
+				'value'   => self::to_string( $value ),
+				'private' => self::is_sensitive_key( $key ),
+			);
+		}
+
+		return array(
+			'label'  => $label,
+			'fields' => $fields,
+		);
+	}
+
+	/**
+	 * Build a Site Health section for template overrides.
+	 *
+	 * Each override is collapsed into a single field whose value lists every
+	 * overridden template on its own line.
+	 *
+	 * @since [version]
+	 *
+	 * @param array $overrides Array of template override data.
+	 * @return array
+	 */
+	private static function section_templates( $overrides ) {
+
+		$rows = array();
+
+		foreach ( $overrides as $override ) {
+			$rows[] = sprintf(
+				'%1$s (core: %2$s) - %3$s (version: %4$s)',
+				$override['template'],
+				$override['core_version'],
+				$override['location'],
+				$override['version']
+			);
+		}
+
+		return array(
+			'label'      => __( 'Template Overrides', 'lifterlms' ),
+			'show_count' => true,
+			'fields'     => array(
+				'overrides' => array(
+					'label' => __( 'Overrides', 'lifterlms' ),
+					'value' => $rows ? implode( "\n", $rows ) : __( 'No overrides found.', 'lifterlms' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Humanize a snake_case key for display.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key The data key.
+	 * @return string
+	 */
+	private static function humanize( $key ) {
+
+		return ucwords( str_replace( '_', ' ', $key ) );
+	}
+
+	/**
+	 * Cast a value to its display string.
+	 *
+	 * @since [version]
+	 *
+	 * @param mixed $value The raw value.
+	 * @return string
+	 */
+	private static function to_string( $value ) {
+
+		if ( is_bool( $value ) ) {
+			return $value ? __( 'Yes', 'lifterlms' ) : __( 'No', 'lifterlms' );
+		}
+
+		if ( is_array( $value ) ) {
+			return implode( ', ', array_map( array( __CLASS__, 'to_string' ), $value ) );
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Determine whether a key's value should be treated as sensitive.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $key The data key.
+	 * @return bool
+	 */
+	private static function is_sensitive_key( $key ) {
+
+		$key = strtolower( (string) $key );
+
+		foreach ( self::$sensitive_substrings as $needle ) {
+			if ( false !== strpos( $key, $needle ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}
+
+LLMS_Admin_Site_Health::init();

--- a/includes/admin/class.llms.admin.page.status.php
+++ b/includes/admin/class.llms.admin.page.status.php
@@ -206,7 +206,7 @@ class LLMS_Admin_Page_Status {
 			)
 		);
 
-		$current_tab = empty( $_GET['tab'] ) ? 'report' : llms_filter_input_sanitize_string( INPUT_GET, 'tab' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing the form data.
+		$current_tab = empty( $_GET['tab'] ) ? 'tools' : llms_filter_input_sanitize_string( INPUT_GET, 'tab' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- We're not processing the form data.
 		?>
 
 		<div class="wrap lifterlms llms-status llms-status--<?php echo esc_attr( $current_tab ); ?>">
@@ -238,7 +238,7 @@ class LLMS_Admin_Page_Status {
 					break;
 
 				case 'report':
-					LLMS_Admin_System_Report::output();
+					self::output_system_report_redirect();
 					break;
 
 				case 'tools':
@@ -251,6 +251,35 @@ class LLMS_Admin_Page_Status {
 
 		</div>
 
+		<?php
+	}
+
+	/**
+	 * Output a notice pointing users to the WordPress Site Health Info screen.
+	 *
+	 * The LifterLMS System Report data now lives on the core Tools > Site Health > Info page,
+	 * so this tab no longer renders the old report directly.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	private static function output_system_report_redirect() {
+		?>
+		<div class="wrap lifterlms">
+			<p class="llms-info-box">
+				<?php
+				printf(
+					wp_kses(
+						/* translators: %s: URL to the Site Health Info screen. */
+						__( 'The LifterLMS System Report has moved to the WordPress Site Health info screen. Visit <a href="%s">Tools &rsaquo; Site Health &rsaquo; Info</a> to view LifterLMS diagnostics there.', 'lifterlms' ),
+						array( 'a' => array( 'href' => array() ) )
+					),
+					esc_url( admin_url( 'site-health.php?tab=debug' ) )
+				);
+				?>
+			</p>
+		</div>
 		<?php
 	}
 

--- a/includes/admin/class.llms.admin.system-report.php
+++ b/includes/admin/class.llms.admin.system-report.php
@@ -14,6 +14,8 @@ defined( 'ABSPATH' ) || exit;
  * Admin System Report Class.
  *
  * @since 2.1.0
+ * @deprecated [version] Use the WordPress Site Health Info screen (Tools > Site Health > Info) instead.
+ *                       Kept for backwards compatibility; may be removed in a future release.
  */
 class LLMS_Admin_System_Report {
 
@@ -26,6 +28,8 @@ class LLMS_Admin_System_Report {
 	 * @return void
 	 */
 	public static function output() {
+
+		_deprecated_function( __METHOD__, '[version]', 'The WordPress Site Health Info screen (Tools > Site Health > Info)' );
 
 		echo '<div class="wrap lifterlms">';
 

--- a/includes/class-llms-loader.php
+++ b/includes/class-llms-loader.php
@@ -338,6 +338,7 @@ class LLMS_Loader {
 	 * @since 6.0.0 Removed loading of class files that don't instantiate their class in favor of autoloading.
 	 * @since 7.2.0 Include `LLMS_Admin_Dashboard_Wigdet` class.
 	 * @since [version] Include `LLMS_Admin_Help_Beacon` class.
+	 * @since [version] Include `LLMS_Admin_Site_Health` class.
 	 *
 	 * @return void
 	 */
@@ -353,6 +354,7 @@ class LLMS_Loader {
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-plugins.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-review.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-help-beacon.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-site-health.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-users-table.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-sendwp.php';
 		require_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-mailhawk.php';

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-site-health.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-site-health.php
@@ -177,4 +177,62 @@ class LLMS_Test_Admin_Site_Health extends LLMS_Unit_Test_Case {
 		$this->assertArrayHasKey( 'lifterlms-settings', $info );
 	}
 
-}
+	/**
+	 * Test that every LifterLMS section renders even when its source data is empty.
+	 *
+	 * WordPress core skips any Site Health section with empty fields. On a fresh install
+	 * with no gateways or integrations the source maps are empty, so each section must
+	 * still carry a placeholder row.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_sections_visible_when_data_empty() {
+
+		$info = LLMS_Admin_Site_Health::add_debug_info( array() );
+
+		$expected = array(
+			'lifterlms-settings',
+			'lifterlms-gateways',
+			'lifterlms-integrations',
+			'lifterlms-templates',
+			'lifterlms-constants',
+		);
+
+		foreach ( $expected as $section_id ) {
+			$this->assertNotEmpty( $info[ $section_id ]['fields'], "$section_id must render even with no data." );
+		}
+	}
+
+	/**
+	 * Test that all LifterLMS sections render after every non-LifterLMS section.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_pins_llms_sections_to_bottom() {
+
+		$existing = array(
+			'wp-core'     => array( 'label' => 'WordPress', 'fields' => array( 'v' => array( 'label' => 'Version', 'value' => '7.0' ) ) ),
+			'wp-database' => array( 'label' => 'Database', 'fields' => array( 'v' => array( 'label' => 'Version', 'value' => '10.6' ) ) ),
+		);
+
+		$info = LLMS_Admin_Site_Health::add_debug_info( $existing );
+		$keys = array_keys( $info );
+
+		// Verify that once the first LifterLMS section appears, no non-LifterLMS section follows.
+		$seen_llms = false;
+		foreach ( $keys as $slug ) {
+			if ( 0 === strpos( $slug, 'lifterlms-' ) ) {
+				$seen_llms = true;
+			} elseif ( $seen_llms ) {
+				$this->fail( "Non-LifterLMS section '$slug' appeared after a LifterLMS section. Expected LifterLMS sections only at the bottom." );
+			}
+		}
+
+		$this->assertTrue( $seen_llms, 'Expected at least one LifterLMS section in debug info.' );
+	} // end test_add_debug_info_pins_llms_sections_to_bottom
+
+} // class LLMS_Test_Admin_Site_Health

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-site-health.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-site-health.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Test Admin Site Health integration
+ *
+ * @package LifterLMS/Tests/Admin
+ *
+ * @group admin
+ * @group status
+ *
+ * @since [version]
+ */
+class LLMS_Test_Admin_Site_Health extends LLMS_Unit_Test_Case {
+
+	/**
+	 * Instance of the class being tested.
+	 *
+	 * @var string
+	 */
+	protected $main = 'LLMS_Admin_Site_Health';
+
+	/**
+	 * Set up before class
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+
+		// WP_Debug_Data is lazy-loaded in production; load explicitly here so the
+		// add_debug_info() guard sees it and the tests can exercise the real path.
+		if ( file_exists( ABSPATH . 'wp-admin/includes/class-wp-debug-data.php' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/class-wp-debug-data.php';
+		}
+
+		include_once LLMS_PLUGIN_DIR . 'includes/admin/class-llms-admin-site-health.php';
+
+	}
+
+	/**
+	 * Test that the LLMS sections are added to the debug information array.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_has_llms_sections() {
+
+		$info = LLMS_Admin_Site_Health::add_debug_info( array() );
+
+		$expected = array(
+			'lifterlms-settings',
+			'lifterlms-gateways',
+			'lifterlms-integrations',
+			'lifterlms-templates',
+			'lifterlms-constants',
+		);
+
+		foreach ( $expected as $section_id ) {
+			$this->assertArrayHasKey( $section_id, $info, "$section_id section missing." );
+			$this->assertNotEmpty( $info[ $section_id ]['label'], "$section_id has no label." );
+			$this->assertArrayHasKey( 'fields', $info[ $section_id ], "$section_id has no fields." );
+			$this->assertNotEmpty( $info[ $section_id ]['fields'], "$section_id has empty fields." );
+		}
+	}
+
+	/**
+	 * Test that init() registers the debug_information filter.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_init_registers_filter() {
+
+		remove_filter( 'debug_information', array( 'LLMS_Admin_Site_Health', 'add_debug_info' ) );
+
+		LLMS_Admin_Site_Health::init();
+
+		$this->assertNotFalse( has_filter( 'debug_information', array( 'LLMS_Admin_Site_Health', 'add_debug_info' ) ) );
+	}
+
+	/**
+	 * Test that core-provided sections are not duplicated.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_skips_core_sections() {
+
+		$info = LLMS_Admin_Site_Health::add_debug_info( array() );
+
+		$not_expected = array(
+			'wp-constants',
+			'wp-files',
+			'wp-database',
+			'wp-media',
+			'wp-server',
+			'wp-dropins',
+		);
+
+		foreach ( $not_expected as $section_id ) {
+			$this->assertArrayNotHasKey( $section_id, $info, "$section_id should not be added." );
+		}
+	}
+
+	/**
+	 * Test that the template overrides section lists overrides correctly.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_templates_section() {
+
+		$info    = LLMS_Admin_Site_Health::add_debug_info( array() );
+		$section = $info['lifterlms-templates'];
+
+		$this->assertNotEmpty( $section['show_count'] );
+		$this->assertArrayHasKey( 'overrides', $section['fields'] );
+
+		// Even when no overrides exist the field value is a defined string, never empty.
+		$this->assertNotEmpty( $section['fields']['overrides']['value'] );
+	}
+
+	/**
+	 * Test that sensitive keys are marked as private.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_sensitive_keys_are_private() {
+
+		$info    = LLMS_Admin_Site_Health::add_debug_info( array() );
+		$fields  = $info['lifterlms-settings']['fields'];
+		$private = array();
+
+		foreach ( $fields as $key => $field ) {
+			if ( ! empty( $field['private'] ) ) {
+				$private[] = $key;
+			}
+		}
+
+		// At least one URL or email related key should be flagged as private.
+		$this->assertNotEmpty(
+			array_filter(
+				$private,
+				function ( $key ) {
+					return (bool) preg_match( '/email|url|login|permalink/i', $key );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Test that the returned info still contains previously registered sections.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_add_debug_info_preserves_existing_sections() {
+
+		$existing = array(
+			'wp-core' => array(
+				'label'  => 'WordPress',
+				'fields' => array( 'version' => array( 'label' => 'Version', 'value' => '6.5' ) ),
+			),
+		);
+
+		$info = LLMS_Admin_Site_Health::add_debug_info( $existing );
+
+		$this->assertArrayHasKey( 'wp-core', $info );
+		$this->assertSame( 'WordPress', $info['wp-core']['label'] );
+		$this->assertArrayHasKey( 'lifterlms-settings', $info );
+	}
+
+}


### PR DESCRIPTION
## Description

Fixes #854

Moves the LifterLMS System Report from its own custom tab on the Status screen to the WordPress core Site Health Info screen (Tools > Site Health > Info). The same diagnostic data (settings, payment gateways, integrations, template overrides, constants) is now surfaced through the `debug_information` filter, so it shows up alongside the core WordPress, Server, Theme, and Plugins sections and is included when a user copies the site info to clipboard.

The old System Report tab on LifterLMS > Status is replaced with a notice linking to the Site Health Info screen. The `LLMS_Admin_System_Report` class is kept for backwards compatibility but now emits a deprecation notice when called directly. Telemetry (`LLMS_Tracker`) and its data source (`LLMS_Data`) are untouched, so the underlying data class is not duplicated or forked.

What changed:

- New: `includes/admin/class-llms-admin-site-health.php` hooks `debug_information` and surfaces LifterLMS-specific sections only. Core-provided sections (WordPress, Server, Theme, Plugins) are intentionally not duplicated. LifterLMS sections are pinned to the bottom so they stay grouped together. Sensitive values (keys containing `email`, `url`, `login`, or `permalink`) are flagged as private so they are excluded from the copied report but still visible on screen.
- Changed: `includes/admin/class.llms.admin.page.status.php` sets the Status screen default tab to `tools` and renders a redirect notice on the old `report` tab linking to `site-health.php?tab=debug`.
- Deprecated: `includes/admin/class.llms.admin.system-report.php` now calls `_deprecated_function()` in `output()` but still renders for back-compat.
- Loaded the new class via `includes/class-llms-loader.php`.
- Added a changelog entry at `.changelogs/854-site-health.yml`.

## How has this been tested?

- PHPUnit, `@group status`: 15 tests, 48 assertions, all pass. The 8 new tests in `tests/phpunit/unit-tests/admin/class-llms-test-admin-site-health.php` cover filter registration, the five LifterLMS sections being present, core sections not being duplicated, the template overrides section, sensitive keys being marked private, sections staying visible when their source data is empty, and all LifterLMS sections rendering after every non-LifterLMS section.
- PHPCS (LifterLMS standard): clean on all new and changed lines.
- Manual testing on a Local by Flywheel site (WordPress 6.x, PHP 8.x), logged in as Administrator:
  1. Tools > Site Health > Info shows all five LifterLMS sections (LifterLMS Settings, LifterLMS Payment Gateways, LifterLMS Integrations, LifterLMS Template Overrides, LifterLMS Constants) grouped at the bottom, after the core sections. Each expands to show populated rows. Sections whose source map is empty (for example no payment gateway add-on installed) still render with a "No data available." row.
  2. Copy site info to clipboard excludes values for keys containing `email`, `url`, `login`, or `permalink` while the rows still display on screen.
  3. LifterLMS > Status lands on the Tools and Utilities tab by default. Clicking the System Report tab shows the redirect notice, and its link opens the Site Health Info screen.
  4. With `WP_DEBUG` on, calling the old `LLMS_Admin_System_Report::output()` still renders the report and logs a deprecation notice.
  5. `wp llms tracker send --force` still succeeds and the payload still includes the full tracker dataset.

## Screenshots

The LifterLMS sections render inside the existing WordPress core Site Health Info UI, so no new UI is introduced.

## Types of changes

New feature (non-breaking change which adds functionality). The existing System Report tab is preserved as a redirect notice and the old renderer is deprecated, not removed, so existing integrations that call `LLMS_Admin_System_Report` keep working.

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.

## Screenshot
https://screendrop-worker.faisalahammad24.workers.dev/fe3a75b9