### PR TITLE
Clarify Unrestricted Preview Access setting description (#2133)

### DIFF
--- a/.changelogs/2133.yml
+++ b/.changelogs/2133.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: "Clarified the Unrestricted Preview Access setting description to note that bypassing restrictions also requires the user to be able to edit the content."

--- a/includes/admin/settings/class.llms.settings.general.php
+++ b/includes/admin/settings/class.llms.settings.general.php
@@ -93,7 +93,7 @@ class LLMS_Settings_General extends LLMS_Settings_Page {
 				'data-placeholder' => __( 'Select user roles', 'lifterlms' ),
 			),
 			'default'           => array( 'administrator', 'lms_manager', 'instructor', 'instructors_assistant' ),
-			'desc'              => __( 'Users with the selected roles will bypass enrollment, drip, and prerequisite restrictions for courses and memberships.', 'lifterlms' ),
+			'desc'              => __( 'Users with the selected roles will bypass enrollment, drip, and prerequisite restrictions for courses and memberships. To bypass a restriction, the user must also be able to edit the content, for example by being assigned as an instructor of the course.', 'lifterlms' ),
 			'id'                => 'llms_grant_site_access',
 			'options'           => array_filter(
 				LLMS_Roles::get_all_role_names(),


### PR DESCRIPTION
## Summary

Updates the description of the Unrestricted Preview Access setting to state that bypassing restrictions also requires the user to be able to edit the content. The current description promises a blanket bypass but never mentions the edit-capability check that `llms_can_user_bypass_restrictions()` has enforced since v5.9 (a deliberate security fix from #1974 / #1987 to stop instructors of one course bypassing restrictions on another). This is a documentation-only change. No logic, signature, or filter changed.

Fixes #2133

## Changes

### `includes/admin/settings/class.llms.settings.general.php`

**Before:**
```php
'desc' => __( 'Users with the selected roles will bypass enrollment, drip, and prerequisite restrictions for courses and memberships.', 'lifterlms' ),
```

**After:**
```php
'desc' => __( 'Users with the selected roles will bypass enrollment, drip, and prerequisite restrictions for courses and memberships. To bypass a restriction, the user must also be able to edit the content, for example by being assigned as an instructor of the course.', 'lifterlms' ),
```

**Why:** The setting id `llms_grant_site_access` feeds the allowlist, but the bypass only applies when the user also holds edit capability for the specific post. The description now matches the actual behavior, so admins are not surprised that an instructor assistant enrolled as a student in a course cannot bypass its drip locks.

## Testing

**Test 1: setting description renders correctly**
1. Go to WP Admin, then LifterLMS, then Settings, then General.
2. Find the Unrestricted Preview Access row.
3. Read the description.

Result: the description includes the second sentence noting the edit-capability requirement.

**Test 2: role multi-select still saves**
1. On the same page, add or remove a role in the multi-select.
2. Save.
3. Reload the page.

Result: the selection persists and no PHP warnings show.

## Screenshot
<img width="1740" height="462" alt="image" src="https://github.com/user-attachments/assets/e5a6f47e-bfc9-49fd-a2e4-6051fec11b6e" />