### PR TITLE
Add llms_can_user_bypass_restrictions filter for custom role bypass

### DIFF
--- a/.changelogs/2180-bypass-filter.yml
+++ b/.changelogs/2180-bypass-filter.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: "Added the `llms_can_user_bypass_restrictions` filter to allow custom and third-party roles to bypass enrollment, drip, and prerequisite restrictions."

--- a/includes/functions/llms.functions.person.php
+++ b/includes/functions/llms.functions.person.php
@@ -33,6 +33,24 @@ function llms_can_user_bypass_restrictions( $user = null, $post_id = null ) {
 		return false;
 	}
 
+	/**
+	 * Short-circuit whether a user can bypass enrollment, drip, and prerequisite restrictions.
+	 *
+	 * Return a boolean to bypass the default role and capability checks. Return null
+	 * (the default) to run the standard logic.
+	 *
+	 * @since [version]
+	 *
+	 * @param bool|null         $can_bypass Whether the user can bypass restrictions. Default null.
+	 * @param LLMS_Student      $user       LLMS_Student object for the user being checked.
+	 * @param int|null          $post_id    The WP_Post ID being checked, or null.
+	 */
+	$can_bypass = apply_filters( 'llms_can_user_bypass_restrictions', null, $user, $post_id );
+
+	if ( null !== $can_bypass ) {
+		return (bool) $can_bypass;
+	}
+
 	$roles = get_option( 'llms_grant_site_access', '' );
 	if ( ! $roles ) {
 		$roles = array();

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-person.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-person.php
@@ -75,6 +75,72 @@ class LLMS_Test_Functions_Person extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test the llms_can_user_bypass_restrictions filter.
+	 *
+	 * @return void
+	 */
+	public function test_llms_can_user_bypass_restrictions_filter() {
+
+		$student_id = $this->factory->user->create( array( 'role' => 'student' ) );
+		$admin_id   = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		$course_id  = $this->factory->course->create( array( 'sections' => 1, 'lessons' => 1 ) );
+
+		// Student in allowed list but lacks edit_post on the course.
+		update_option( 'llms_grant_site_access', array( 'student' ) );
+
+		// Default: edit_post gate blocks student.
+		$this->assertFalse( llms_can_user_bypass_restrictions( $student_id, $course_id ) );
+
+		// Filter forces bypass.
+		$callback = function () {
+			return true;
+		};
+		add_filter( 'llms_can_user_bypass_restrictions', $callback );
+		$this->assertTrue( llms_can_user_bypass_restrictions( $student_id, $course_id ) );
+		remove_filter( 'llms_can_user_bypass_restrictions', $callback );
+
+		// Default restored.
+		$this->assertFalse( llms_can_user_bypass_restrictions( $student_id, $course_id ) );
+
+		// Filter can deny access that default would allow.
+		update_option( 'llms_grant_site_access', array( 'administrator' ) );
+		$this->assertTrue( llms_can_user_bypass_restrictions( $admin_id, $course_id ) );
+
+		$deny = function () {
+			return false;
+		};
+		add_filter( 'llms_can_user_bypass_restrictions', $deny );
+		$this->assertFalse( llms_can_user_bypass_restrictions( $admin_id, $course_id ) );
+		remove_filter( 'llms_can_user_bypass_restrictions', $deny );
+
+	}
+
+	/**
+	 * Test the llms_can_user_bypass_restrictions filter receives the post_id.
+	 *
+	 * @return void
+	 */
+	public function test_llms_can_user_bypass_restrictions_filter_args() {
+
+		$student_id = $this->factory->user->create( array( 'role' => 'student' ) );
+		$course_id  = $this->factory->course->create( array( 'sections' => 1, 'lessons' => 1, 'quizzes' => 1 ) );
+
+		$received_post_id = null;
+		$callback = function ( $can_bypass, $user, $post_id ) use ( &$received_post_id ) {
+			$received_post_id = $post_id;
+			return $can_bypass;
+		};
+		add_filter( 'llms_can_user_bypass_restrictions', $callback, 10, 3 );
+
+		llms_can_user_bypass_restrictions( $student_id, $course_id );
+
+		remove_filter( 'llms_can_user_bypass_restrictions', $callback, 10 );
+
+		$this->assertSame( $course_id, $received_post_id );
+
+	}
+
+	/**
 	 * Test llms_get_minimum_password_strength_name().
 	 *
 	 * @since Unknown.


### PR DESCRIPTION
## Description

Add the `llms_can_user_bypass_restrictions` filter to `llms_can_user_bypass_restrictions()` so custom and third-party roles (e.g. Memberium, User Role Editor) added to Unrestricted Preview Access can bypass enrollment, drip, and prerequisite restrictions.

The `edit_post` capability gate added in #1987 blocks roles that lack that capability. The filter gives developers an opt-in escape hatch. Default `null` preserves the existing behavior, including the #1974 security fix.

```php
$can_bypass = apply_filters( 'llms_can_user_bypass_restrictions', null, $user, $post_id );
if ( null !== $can_bypass ) {
    return (bool) $can_bypass;
}
```

Fixes #2180

## How has this been tested?

- `composer tests -- --filter=test_llms_can_user_bypass_restrictions` passes (29 assertions across 3 methods including 2 new filter tests).
- `composer check-cs` clean.
- Manual test plan in `TESTING_INSTRUCTIONS.md`.

Environment: LifterLMS dev environment, WordPress 6.x, PHP 7.4+.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.