### PR TITLE
Limit number of memberships shown in student dashboard

### DIFF
--- a/.changelogs/2442-limit-memberships-loop.yml
+++ b/.changelogs/2442-limit-memberships-loop.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Added a filterable limit to the number of memberships displayed in the student dashboard My Memberships loop."

--- a/includes/functions/llms.functions.templates.dashboard.php
+++ b/includes/functions/llms.functions.templates.dashboard.php
@@ -384,6 +384,20 @@ if ( ! function_exists( 'lifterlms_template_my_memberships_loop' ) ) {
 
 		$memberships = $student->get_membership_levels();
 
+		/**
+		 * Filter the maximum number of memberships displayed in the "My Memberships" loop.
+		 *
+		 * @since [version]
+		 *
+		 * @param int          $limit   Maximum number of memberships to display. Default `500`.
+		 * @param LLMS_Student $student Student object.
+		 */
+		$limit = apply_filters( 'llms_my_memberships_loop_limit', 500, $student );
+
+		if ( $limit > 0 && count( $memberships ) > $limit ) {
+			$memberships = array_slice( $memberships, 0, $limit );
+		}
+
 		if ( ! $memberships ) {
 
 			printf(

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-dasbhoard.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-dasbhoard.php
@@ -154,4 +154,96 @@ class LLMS_Test_Functions_Templates_Dashboard extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Enroll a student into a set number of memberships and return the membership post IDs.
+	 *
+	 * @param int $user_id Student user ID.
+	 * @param int $count   Number of memberships to create and enroll into.
+	 * @return int[]
+	 */
+	private function enroll_in_memberships( $user_id, $count ) {
+
+		$membership_ids = $this->factory->post->create_many( $count, array( 'post_type' => 'llms_membership' ) );
+
+		foreach ( $membership_ids as $membership_id ) {
+			llms_enroll_student( $user_id, $membership_id );
+		}
+
+		return $membership_ids;
+
+	}
+
+	/**
+	 * Test lifterlms_template_my_memberships_loop() when the student's membership count is under the default limit.
+	 *
+	 * @return void
+	 */
+	public function test_lifterlms_template_my_memberships_loop_under_limit() {
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$membership_ids = $this->enroll_in_memberships( $user_id, 3 );
+
+		$output = $this->get_output( 'lifterlms_template_my_memberships_loop' );
+
+		foreach ( $membership_ids as $membership_id ) {
+			$this->assertStringContainsString( get_the_title( $membership_id ), $output );
+		}
+
+	}
+
+	/**
+	 * Test lifterlms_template_my_memberships_loop() treats a falsy `llms_my_memberships_loop_limit` filter value as "no limit".
+	 *
+	 * @return void
+	 */
+	public function test_lifterlms_template_my_memberships_loop_filter_zero_disables_limit() {
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$membership_ids = $this->enroll_in_memberships( $user_id, 3 );
+
+		add_filter( 'llms_my_memberships_loop_limit', '__return_zero' );
+		$output = $this->get_output( 'lifterlms_template_my_memberships_loop' );
+		remove_filter( 'llms_my_memberships_loop_limit', '__return_zero' );
+
+		foreach ( $membership_ids as $membership_id ) {
+			$this->assertStringContainsString( get_the_title( $membership_id ), $output );
+		}
+
+	}
+
+	/**
+	 * Test lifterlms_template_my_memberships_loop() respects the `llms_my_memberships_loop_limit` filter.
+	 *
+	 * @return void
+	 */
+	public function test_lifterlms_template_my_memberships_loop_filtered_limit() {
+
+		$user_id = $this->factory->user->create();
+		wp_set_current_user( $user_id );
+
+		$membership_ids = $this->enroll_in_memberships( $user_id, 3 );
+
+		$limit = function() {
+			return 1;
+		};
+
+		add_filter( 'llms_my_memberships_loop_limit', $limit );
+		$output = $this->get_output( 'lifterlms_template_my_memberships_loop' );
+		remove_filter( 'llms_my_memberships_loop_limit', $limit );
+
+		$rendered = array_filter(
+			$membership_ids,
+			function( $membership_id ) use ( $output ) {
+				return false !== strpos( $output, get_the_title( $membership_id ) );
+			}
+		);
+
+		$this->assertCount( 1, $rendered );
+
+	}
+
 }


### PR DESCRIPTION
## Description

The My Memberships tab (`/my-account/my-memberships/`) lists every membership a student belongs to with no cap and no pagination. `lifterlms_template_my_memberships_loop()` now caps the list at 500 by default. The limit can be changed with a new filter:

```php
add_filter( 'llms_my_memberships_loop_limit', function( $limit, $student ) {
	return 10; // or 0 for no limit
}, 10, 2 );
```

This mirrors the existing pattern in `lifterlms_template_my_courses_loop()`, which already caps its list at 500 the same way.

Fixes #2442

## How has this been tested?

Added PHPUnit coverage in `tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-dasbhoard.php`:
- Membership count under the limit renders unchanged.
- A `0` filter value disables the cap entirely.
- A filter that lowers the limit actually trims the rendered list.

Ran `composer tests -- --filter LLMS_Test_Functions_Templates_Dashboard` (11/11 passing) and `composer check-cs` (clean).

Manually tested on a local install: enrolled a test student in several memberships, confirmed the dashboard tab renders all of them normally, then lowered the filter to 1 and confirmed only 1 membership rendered, then set it to 0 and confirmed all memberships rendered again.

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.