### PR TITLE
Fix incorrect docblocks on get_course() and get_lesson()

### DIFF
--- a/.changelogs/2175-course-lesson-docblocks.yml
+++ b/.changelogs/2175-course-lesson-docblocks.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: dev
+links:
+  - "#2175"
+entry: Corrected the docblocks for `get_course()` and `get_lesson()` so the documented `$the_course`/`$the_lesson` and `$args` parameters match the `LLMS_Course` and `LLMS_Lesson` constructors they forward to.

--- a/includes/functions/llms.functions.course.php
+++ b/includes/functions/llms.functions.course.php
@@ -16,8 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * @since Unknown
  * @since 3.37.13 Use `LLMS_Course` in favor of the deprecated `LLMS_Course_Factory::get_course()` method.
  *
- * @param WP_Post|int|false $the_course Course post object or id. If `false` uses the global `$post` object.
- * @param array             $args       Arguments to pass to the LLMS_Course Constructor.
+ * @param string|int|LLMS_Post_Model|WP_Post|false $the_course 'new', WP post id, instance of an extending class, instance of WP_Post. If `false` uses the global `$post` object.
+ * @param array                                    $args       Args to create the post, only applies when `$the_course` is 'new'.
  * @return LLMS_Course
  */
 function get_course( $the_course = false, $args = array() ) {
@@ -37,8 +37,8 @@ function get_course( $the_course = false, $args = array() ) {
  * @since Unknown
  * @since 3.37.13 Use `LLMS_Lesson` in favor of the deprecated `LLMS_Course_Factory::get_lesson()` method.
  *
- * @param WP_Post|int|false $the_lesson Lesson post object or id. If `false` uses the global `$post` object.
- * @param array             $args        Arguments to pass to the LLMS_Lesson Constructor.
+ * @param string|int|LLMS_Post_Model|WP_Post|false $the_lesson 'new', WP post id, instance of an extending class, instance of WP_Post. If `false` uses the global `$post` object.
+ * @param array                                    $args       Args to create the post, only applies when `$the_lesson` is 'new'.
  * @return LLMS_Lesson
  */
 function get_lesson( $the_lesson = false, $args = array() ) {


### PR DESCRIPTION
## Description

Corrects the docblocks on `get_course()` and `get_lesson()` so they match the constructors these functions forward to. Comments only — no runtime behaviour changes.

Three problems in `includes/functions/llms.functions.course.php` (lines 13–53):

1. **The parameter type was incomplete.** Both were documented as `WP_Post|int|false`, but `LLMS_Post_Model::__construct()` also accepts the string `'new'` and an instance of an extending class. Passing `'new'` through `get_course()` reaches `create( $args )` and creates a post, so that type is reachable in practice.

2. **`$args` was misdescribed.** "Arguments to pass to the LLMS_Course Constructor" reads as though it always applies. It is forwarded, but `LLMS_Post_Model::__construct()` only uses it when `$model` is `'new'` — with any other input it is silently ignored. This is the point @thomasplevy raised on the issue.

3. **`get_lesson()`'s `$args` description was indented one space too far**, so it did not line up with the parameter above it — the copy-paste artifact mentioned in the issue.

Wording for both is taken from the `LLMS_Course` / `LLMS_Lesson` constructor docblocks, so the wrapper and the thing it wraps now read the same.

### Deliberately left out

- **Deprecating `$args`**, as @thomasplevy suggested. That is a signature change rather than a documentation fix, and per *Preserving Public API Signatures* it deserves its own decision. Happy to open a follow-up if you want it.
- **Removing `@version` from the file header.** The documentation standards say `@version` belongs only in template files, but 38 of the 39 files in `includes/functions/` still carry one. Changing just this file would make it the odd one out — that looks like a separate repo-wide cleanup.
- **Two pre-existing `PSR2.Methods.FunctionClosingBrace` errors** on lines 32 and 53 (blank line before the closing brace). They are present on `dev` and unrelated to this issue, so I left them rather than widen the diff. Say the word and I'll fold the fix in.

Fixes #2175

## How has this been tested?

This is a comment-only change, so there is no runtime behaviour to exercise. What I verified instead:

- Read `LLMS_Post_Model::__construct()`, `LLMS_Course::__construct()`, and `LLMS_Lesson::__construct()` to confirm the documented types and the `'new'`-only handling of `$args` are accurate.
- Ran `composer run-script check-cs-errors` against this file on both `upstream/dev` and this branch. Both report the **same two pre-existing errors** (lines 32 and 53, noted above) and nothing else — this change introduces no new PHPCS violations.
- Confirmed all four `@param` descriptions now start at the same column.

I did not run PHPUnit locally (it needs a MySQL instance and the WP test suite). Since the change touches only comments it cannot affect test outcomes, and the PHPUnit workflow runs on this PR.

## Types of changes

Documentation fix — non-breaking, comments only.

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
