### PR TITLE
Remove legacy user information options from system report data

### DIFF
--- a/.changelogs/1675-remove-legacy-user-info-options.yml
+++ b/.changelogs/1675-remove-legacy-user-info-options.yml
@@ -1,0 +1,5 @@
+significance: minor
+type: removed
+links:
+  - "#1675"
+entry: Removed the legacy `lifterlms_user_info_field_*_visibility` and `lifterlms_voucher_field_registration_visibility` option values from the system report and tracker data. These options were superseded by LifterLMS Forms in 5.0.0 and no longer describe how any form is rendered.

--- a/includes/class.llms.data.php
+++ b/includes/class.llms.data.php
@@ -293,22 +293,7 @@ class LLMS_Data {
 		$data['terms_required'] = get_option( 'lifterlms_registration_require_agree_to_terms', 'no' );
 		$data['terms_page']     = self::get_page_data( 'lifterlms_terms_page_id' );
 
-		$data['checkout_names']              = get_option( 'lifterlms_user_info_field_names_checkout_visibility' );
-		$data['checkout_address']            = get_option( 'lifterlms_user_info_field_address_checkout_visibility' );
-		$data['checkout_phone']              = get_option( 'lifterlms_user_info_field_phone_checkout_visibility' );
-		$data['checkout_email_confirmation'] = get_option( 'lifterlms_user_info_field_email_confirmation_checkout_visibility', 'no' );
-
-		$data['open_registration']               = get_option( 'lifterlms_enable_myaccount_registration', 'no' );
-		$data['registration_names']              = get_option( 'lifterlms_user_info_field_names_registration_visibility' );
-		$data['registration_address']            = get_option( 'lifterlms_user_info_field_address_registration_visibility' );
-		$data['registration_phone']              = get_option( 'lifterlms_user_info_field_phone_registration_visibility' );
-		$data['registration_voucher']            = get_option( 'lifterlms_voucher_field_registration_visibility' );
-		$data['registration_email_confirmation'] = get_option( 'lifterlms_user_info_field_email_confirmation_registration_visibility', 'no' );
-
-		$data['account_names']              = get_option( 'lifterlms_user_info_field_names_account_visibility' );
-		$data['account_address']            = get_option( 'lifterlms_user_info_field_address_account_visibility' );
-		$data['account_phone']              = get_option( 'lifterlms_user_info_field_phone_account_visibility' );
-		$data['account_email_confirmation'] = get_option( 'lifterlms_user_info_field_email_confirmation_account_visibility', 'no' );
+		$data['open_registration'] = get_option( 'lifterlms_enable_myaccount_registration', 'no' );
 
 		$data['confirmation_endpoint'] = get_option( 'lifterlms_myaccount_confirm_payment_endpoint' );
 		$data['force_ssl_checkout']    = get_option( 'lifterlms_checkout_force_ssl' );


### PR DESCRIPTION
## Description

`LLMS_Data::get_llms_settings()` read fourteen legacy options into the system report and tracker payload:

- `lifterlms_user_info_field_{names,address,phone,email_confirmation}_{checkout,registration,account}_visibility`
- `lifterlms_voucher_field_registration_visibility`

These were superseded by LifterLMS Forms in 5.0.0. On any install since then they no longer describe how a form is actually rendered, so the values reported are at best stale and at worst misleading when someone is reading a system report to debug a form.

This removes those reads. `$data['open_registration']` sat inside the same block but reads `lifterlms_enable_myaccount_registration`, which is still a live setting, so it is kept and moved above the removed lines.

### What is deliberately left alone

The other readers of these options are still doing real work:

| File | Why it stays |
|---|---|
| `includes/forms/class-llms-form-templates.php` | Reads them to build form templates when migrating a pre-5.0.0 install. This is the "functional" usage noted in the issue. |
| `includes/admin/tools/class-llms-admin-tool-wipe-legacy-account-options.php` | Exists specifically to delete these options. |
| `includes/functions/updates/llms-functions-updates-300.php` | Historical 3.0.0 migration. |

The `class.llms.notification.view.student.welcome.php` line referenced in the issue already went through `LLMS_Forms::instance()->are_usernames_enabled()`, which reads `llms_forms_username_locations` — so that one appears to have been resolved since the issue was filed.

### One thing worth a maintainer's eye

`get_llms_settings()` feeds both the admin System Report **and** `LLMS_Tracker`. So this changes the shape of the tracker payload — fourteen keys disappear. That seems like the intent of the issue, but if anything downstream consumes those keys I'd rather you tell me now than find out after a release. Happy to restrict the change to the system report and leave the tracker untouched if you prefer.

Fixes #1675

## How has this been tested?

- Grepped for every reader of `lifterlms_user_info_field_*` and `lifterlms_voucher_field_*` to confirm the three remaining call sites above are the only ones, and that each is still load-bearing.
- Confirmed nothing consumes the removed `$data` keys (`checkout_names`, `registration_address`, and so on). `LLMS_Admin_System_Report::output()` iterates the array generically rather than referencing keys by name, so the only visible effect is that those rows stop being rendered.
- Confirmed no test asserts on the removed keys. The test hits for these option names are in the wipe-tool and form-template suites, which exercise the options themselves rather than the report.
- Ran `composer run-script check-cs-errors` against this file on both `upstream/dev` and this branch. Both report the same 16 pre-existing errors (`PSR2.Methods.FunctionClosingBrace.SpacingBeforeClose` ×15, `PSR2.Classes.ClassDeclaration.CloseBraceAfterBody` ×1) and nothing else — this change adds no new PHPCS violations.

I did not run PHPUnit locally (it needs a MySQL instance and the WP test suite); the workflow runs on this PR.

## Types of changes

Removal of superseded reporting data — no change to how forms behave.

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
