### PR TITLE
fix(reporting): align wrapped widgets

### DIFF
--- a/.changelogs/3118-reporting-widgets-layout.yml
+++ b/.changelogs/3118-reporting-widgets-layout.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Fixed misaligned reporting widgets on admin reporting screens when extra widgets are added by add-ons."

--- a/assets/scss/admin/_reporting.scss
+++ b/assets/scss/admin/_reporting.scss
@@ -341,6 +341,19 @@
 	@include clearfix;
 }
 
+@media (min-width: 1030px) {
+
+	.llms-reporting-widgets {
+		display: flex;
+		flex-wrap: wrap;
+
+		> header,
+		> .llms-table-wrap {
+			width: 100%;
+		}
+	}
+}
+
 .llms-reporting-widget {
 
 	border-top: 4px solid $color-brand-blue;


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description

On the student course reporting screen (LifterLMS → Reporting → Students → [student] → Courses → [course]), five core reporting widgets fill one row exactly at 20% width each. When an add-on such as LifterLMS PDFs injects an extra widget via the `llms_reporting_single_student_course_after_widgets` action, the sixth widget wraps to a second row. Because the container used `float: left`, the wrapped widget seats against the tallest item of the previous row and leaves a visible vertical gap above it.

This change switches the `.llms-reporting-widgets` container to `display: flex; flex-wrap: wrap` at the existing 1030px desktop breakpoint. Wrapped widgets now start a clean new row with no gap. The rule is scoped to the breakpoint where the `d-*` float columns exist, so mobile and tablet stacking is unchanged. Direct children that are not widgets (`<header>`, `.llms-table-wrap`) are forced to `width: 100%` so they stay on their own rows.

Fixes #3118

## How has this been tested?

- `composer check-cs` passes.
- `composer tests-run` — `LLMS_Test_Admin_Reporting` widget snapshot tests pass (markup unchanged). Three unrelated failures verified to fail on `upstream/dev` before this change.
- `npm run build:styles` compiles; the new flex block is present in compiled `assets/css/admin.css` and `assets/css/admin-rtl.css` at `@media (min-width: 1030px)`.
- Manual verification with LifterLMS PDFs active: five core widgets line up in one row, PDFs widget wraps to a clean second row with no gap. Spot-checked all other reporting screens using the same container — no regressions.

## Screenshots

Before: extra space above the wrapped widget (CSS float staircase artifact). After: wrapped widget starts a clean second row with no gap.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
