### PR TITLE
Improved data escaping and display in the course builder

### DIFF
--- a/.changelogs/fix-course-title-sanitization.yml
+++ b/.changelogs/fix-course-title-sanitization.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed course, section, lesson, and quiz titles containing quotes or HTML characters displaying incorrectly in the course builder.

--- a/assets/js/builder/Views/_Editable.js
+++ b/assets/js/builder/Views/_Editable.js
@@ -487,7 +487,8 @@ define( [], function() {
 			if ( 'INPUT' === $el[0].tagName ) {
 				$el.val( val );
 			} else if ( $el.attr( 'data-formatting' ) || $el.hasClass( 'ql-editor' ) ) {
-				$el.html( val );
+				// Restore formatted content through the same tag whitelist applied when saving.
+				$el.html( _.stripFormatting( val, this.get_allowed_tags( $el ) ) );
 			} else {
 				$el.text( val );
 			}

--- a/assets/js/builder/Views/_Editable.js
+++ b/assets/js/builder/Views/_Editable.js
@@ -10,7 +10,8 @@
  * @since 3.25.4 Unknown
  * @since 3.37.11 Replace reference to `wp.editor` with `_.getEditor()` helper.
  * @since 10.0.0 Add paste event handler for plain contenteditable elements to strip formatting. Fixes #3057.
- * @version 10.0.0
+ * @since [version] Revert edits as plain text unless the element allows formatting.
+ * @version [version]
  */
 define( [], function() {
 
@@ -476,12 +477,21 @@ define( [], function() {
 		 * @param    obj   event  js event object
 		 * @return   void
 		 * @since    3.16.0
-		 * @version  3.16.0
+		 * @version  [version]
 		 */
 		revert_edits: function( event ) {
+
 			var $el = $( event.target ),
 				val = $el.attr( 'data-original-content' );
-			$el.html( val );
+
+			if ( 'INPUT' === $el[0].tagName ) {
+				$el.val( val );
+			} else if ( $el.attr( 'data-formatting' ) || $el.hasClass( 'ql-editor' ) ) {
+				$el.html( val );
+			} else {
+				$el.text( val );
+			}
+
 		},
 
 		/**

--- a/includes/admin/views/builder/course.php
+++ b/includes/admin/views/builder/course.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-builder-header llms-course-header">
 
 		<h1 class="llms-headline">
-			<span data-original-content="{{ data.get( 'title' ) }}" data-required="required" type="text">{{ data.get( 'title' ) }}</span>
+			<span data-original-content="{{ _.unescape( data.get( 'title' ) ) }}" data-required="required" type="text">{{ _.unescape( data.get( 'title' ) ) }}</span>
 		</h1>
 
 		<div class="llms-action-icons static">

--- a/includes/admin/views/builder/course.php
+++ b/includes/admin/views/builder/course.php
@@ -3,7 +3,8 @@
  * Builder main course view
  *
  * @since   3.16.0
- * @version 3.17.8
+ * @since   [version] Escaped course title output.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -12,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-builder-header llms-course-header">
 
 		<h1 class="llms-headline">
-			<span data-original-content="{{{ data.get( 'title' ) }}}" data-required="required" type="text">{{{ data.get( 'title' ) }}}</span>
+			<span data-original-content="{{ data.get( 'title' ) }}" data-required="required" type="text">{{ data.get( 'title' ) }}</span>
 		</h1>
 
 		<div class="llms-action-icons static">

--- a/includes/admin/views/builder/lesson-settings.php
+++ b/includes/admin/views/builder/lesson-settings.php
@@ -3,7 +3,8 @@
  * Builder lesson settings template
  *
  * @since   3.17.0
- * @version 3.17.2
+ * @since   [version] Escaped lesson title output.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -12,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-model-header" id="llms-lesson-header">
 
 		<h3 class="llms-headline llms-model-title">
-			<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
+			<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ data.get( 'title' ) }}" data-required="required">{{ data.get( 'title' ) }}</span>
 		</h3>
 
 		<label class="llms-switch llms-model-status">

--- a/includes/admin/views/builder/lesson-settings.php
+++ b/includes/admin/views/builder/lesson-settings.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-model-header" id="llms-lesson-header">
 
 		<h3 class="llms-headline llms-model-title">
-			<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ data.get( 'title' ) }}" data-required="required">{{ data.get( 'title' ) }}</span>
+			<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ _.unescape( data.get( 'title' ) ) }}" data-required="required">{{ _.unescape( data.get( 'title' ) ) }}</span>
 		</h3>
 
 		<label class="llms-switch llms-model-status">

--- a/includes/admin/views/builder/lesson.php
+++ b/includes/admin/views/builder/lesson.php
@@ -6,7 +6,8 @@
  * @since 3.30.3 Fixed spelling errors.
  * @since 7.2.0 Added lesson id.
  * @since 10.1.0 Added quiz id display in lesson listing.
- * @version 10.1.0
+ * @since [version] Escaped lesson, quiz, and assignment title output.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -16,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<header class="llms-builder-header">
 		<h3 class="llms-headline">
-			<span>{{{ data.get( 'title' ) }}}</span>
+			<span>{{ data.get( 'title' ) }}</span>
 		</h3>
 
 		<div class="llms-action-icons">
@@ -97,7 +98,7 @@ defined( 'ABSPATH' ) || exit;
 				'action'           => 'edit-assignment',
 				'active_condition' => "'yes' === data.get( 'assignment_enabled' )",
 				'tip'              => esc_attr__( 'Add an assignment', 'lifterlms' ),
-				'tip_active'       => sprintf( esc_attr__( 'Edit assignment: %s', 'lifterlms' ), "{{{ _.isEmpty( data.get( 'assignment' ) ) ? '' : data.get( 'assignment' ).get( 'title' ) }}}" ),
+				'tip_active'       => sprintf( esc_attr__( 'Edit assignment: %s', 'lifterlms' ), "{{ _.isEmpty( data.get( 'assignment' ) ) ? '' : data.get( 'assignment' ).get( 'title' ) }}" ),
 				'icon'             => '<i class="fa fa-check-square-o"></i> ' . esc_html__( 'Add assignment', 'lifterlms' ),
 				'icon_active'      => '<i class="fa fa-check-square-o"></i>' . esc_html__( 'Edit assignment', 'lifterlms' ),
 			),
@@ -106,7 +107,7 @@ defined( 'ABSPATH' ) || exit;
 				'action'           => 'edit-quiz',
 				'active_condition' => "'yes' === data.get( 'quiz_enabled' )",
 				'tip'              => esc_attr__( 'Add a quiz', 'lifterlms' ),
-				'tip_active'       => sprintf( esc_attr__( 'Edit quiz: %s', 'lifterlms' ), "{{{ ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'title' ) : '' }}}" ),
+				'tip_active'       => sprintf( esc_attr__( 'Edit quiz: %s', 'lifterlms' ), "{{ ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'title' ) : '' }}" ),
 				'icon'             => '<i class="fa fa-question-circle"></i> ' . esc_html__( 'Add quiz', 'lifterlms' ),
 				'icon_active'      => '<i class="fa fa-question-circle"></i>' . esc_html__( 'Edit quiz', 'lifterlms' ) . ' <span class="llms-item-id">' . esc_html__( 'ID:', 'lifterlms' ) . " {{{ ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'id' ) : '' }}}</span>",
 			),

--- a/includes/admin/views/builder/lesson.php
+++ b/includes/admin/views/builder/lesson.php
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<header class="llms-builder-header">
 		<h3 class="llms-headline">
-			<span>{{ data.get( 'title' ) }}</span>
+			<span>{{ _.unescape( data.get( 'title' ) ) }}</span>
 		</h3>
 
 		<div class="llms-action-icons">
@@ -98,7 +98,7 @@ defined( 'ABSPATH' ) || exit;
 				'action'           => 'edit-assignment',
 				'active_condition' => "'yes' === data.get( 'assignment_enabled' )",
 				'tip'              => esc_attr__( 'Add an assignment', 'lifterlms' ),
-				'tip_active'       => sprintf( esc_attr__( 'Edit assignment: %s', 'lifterlms' ), "{{ _.isEmpty( data.get( 'assignment' ) ) ? '' : data.get( 'assignment' ).get( 'title' ) }}" ),
+				'tip_active'       => sprintf( esc_attr__( 'Edit assignment: %s', 'lifterlms' ), "{{ _.unescape( _.isEmpty( data.get( 'assignment' ) ) ? '' : data.get( 'assignment' ).get( 'title' ) ) }}" ),
 				'icon'             => '<i class="fa fa-check-square-o"></i> ' . esc_html__( 'Add assignment', 'lifterlms' ),
 				'icon_active'      => '<i class="fa fa-check-square-o"></i>' . esc_html__( 'Edit assignment', 'lifterlms' ),
 			),
@@ -107,7 +107,7 @@ defined( 'ABSPATH' ) || exit;
 				'action'           => 'edit-quiz',
 				'active_condition' => "'yes' === data.get( 'quiz_enabled' )",
 				'tip'              => esc_attr__( 'Add a quiz', 'lifterlms' ),
-				'tip_active'       => sprintf( esc_attr__( 'Edit quiz: %s', 'lifterlms' ), "{{ ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'title' ) : '' }}" ),
+				'tip_active'       => sprintf( esc_attr__( 'Edit quiz: %s', 'lifterlms' ), "{{ _.unescape( ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'title' ) : '' ) }}" ),
 				'icon'             => '<i class="fa fa-question-circle"></i> ' . esc_html__( 'Add quiz', 'lifterlms' ),
 				'icon_active'      => '<i class="fa fa-question-circle"></i>' . esc_html__( 'Edit quiz', 'lifterlms' ) . ' <span class="llms-item-id">' . esc_html__( 'ID:', 'lifterlms' ) . " {{{ ( 'yes' === data.get( 'quiz_enabled' ) ) ? data.get( 'quiz' ).get( 'id' ) : '' }}}</span>",
 			),

--- a/includes/admin/views/builder/question-choice.php
+++ b/includes/admin/views/builder/question-choice.php
@@ -3,7 +3,8 @@
  * Builder question view
  *
  * @since   3.16.0
- * @version 3.17.8
+ * @since   [version] Escaped choice content in the original-content attribute.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -21,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<# if ( 'text' === data.get( 'choice_type' ) ) { #>
 		<div class="llms-input-wrapper">
-			<span class="llms-input llms-editable-title" contenteditable="true" data-attribute="choice" data-formatting="b,i,u,em,strong" data-original-content="{{{ data.get( 'choice' ) }}}" data-placeholder="<?php esc_attr_e( 'Enter a choice...', 'lifterlms' ); ?>">{{{ data.get( 'choice' ) }}}</span>
+			<span class="llms-input llms-editable-title" contenteditable="true" data-attribute="choice" data-formatting="b,i,u,em,strong" data-original-content="{{ data.get( 'choice' ) }}" data-placeholder="<?php esc_attr_e( 'Enter a choice...', 'lifterlms' ); ?>">{{{ data.get( 'choice' ) }}}</span>
 		</div>
 	<# } else if ( 'image' === data.get( 'choice_type' ) ) { #>
 		<div class="llms-editable-image">

--- a/includes/admin/views/builder/quiz.php
+++ b/includes/admin/views/builder/quiz.php
@@ -3,7 +3,8 @@
  * Builder quiz model view
  *
  * @since   3.16.0
- * @version 3.17.6
+ * @since   [version] Escaped quiz title output.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -34,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 		<header class="llms-model-header" id="llms-lesson-header">
 
 			<h3 class="llms-headline llms-model-title">
-				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{{ data.get( 'title' ) }}}" data-required="required">{{{ data.get( 'title' ) }}}</span>
+				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ data.get( 'title' ) }}" data-required="required">{{ data.get( 'title' ) }}</span>
 			</h3>
 
 			<div class="llms-headline llms-quiz-points">

--- a/includes/admin/views/builder/quiz.php
+++ b/includes/admin/views/builder/quiz.php
@@ -35,7 +35,7 @@ defined( 'ABSPATH' ) || exit;
 		<header class="llms-model-header" id="llms-lesson-header">
 
 			<h3 class="llms-headline llms-model-title">
-				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ data.get( 'title' ) }}" data-required="required">{{ data.get( 'title' ) }}</span>
+				<?php esc_html_e( 'Title', 'lifterlms' ); ?>: <span class="llms-input llms-editable-title" contenteditable="true" data-attribute="title" data-original-content="{{ _.unescape( data.get( 'title' ) ) }}" data-required="required">{{ _.unescape( data.get( 'title' ) ) }}</span>
 			</h3>
 
 			<div class="llms-headline llms-quiz-points">

--- a/includes/admin/views/builder/section.php
+++ b/includes/admin/views/builder/section.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-builder-header">
 
 		<h2 class="llms-headline">
-			<span class="llms-input" contenteditable="true" data-attribute="title" data-original-content="{{ data.title }}" data-required="required">{{ data.title }}</span>
+			<span class="llms-input" contenteditable="true" data-attribute="title" data-original-content="{{ _.unescape( data.title ) }}" data-required="required">{{ _.unescape( data.title ) }}</span>
 		</h2>
 
 		<div class="llms-action-icons">

--- a/includes/admin/views/builder/section.php
+++ b/includes/admin/views/builder/section.php
@@ -3,7 +3,8 @@
  * Builder section model
  *
  * @since   3.16.0
- * @version 3.17.2
+ * @since   [version] Escaped section title output.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -14,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 	<header class="llms-builder-header">
 
 		<h2 class="llms-headline">
-			<span class="llms-input" contenteditable="true" data-attribute="title" data-original-content="{{{ data.title }}}" data-required="required">{{{ data.title }}}</span>
+			<span class="llms-input" contenteditable="true" data-attribute="title" data-original-content="{{ data.title }}" data-required="required">{{ data.title }}</span>
 		</h2>
 
 		<div class="llms-action-icons">


### PR DESCRIPTION

## Description

Fixes #3280

## How has this been tested?
Manually

## Testing Guide

Use a test title like `Mastering "Advanced" Excel: <Final>` throughout. Type it manually — the block editor strips `<Final>` on copy/paste. Note that the block editor saves `<` as `&lt;` in the database while titles typed directly into the builder are stored raw; both forms should now display identically.

### 1. Course title (original report)

1. Edit a course, set the title to `Mastering "Advanced" Excel: <Final>`, save.
2. Click **Launch Course Builder**.
3. **Before:** heading shows `" data-required="required" type="text">Mastering "Advanced" Excel: <Final>`.
   **After:** heading shows the title exactly as typed (no `&lt;Final>` either).

### 2. Section title

1. In the builder, click a section title, type `Section "One": <Draft>`, press Enter.
2. **Before:** garbage text after the title re-renders (same shape as the course bug).
   **After:** displays as typed, and persists after a page reload.

### 3. Lesson title in the outline

1. Give a lesson the same style of title (from the WordPress editor or the builder's lesson settings panel).
2. View the lesson row in the builder outline.
3. **Before:** `<Final>` silently disappears; a `"` could break the row markup.
   **After:** full title visible as typed.

### 4. Lesson settings panel

1. Click the gear (Settings) icon on that lesson to open the settings sidebar.
2. Check the **Title:** field at the top — same before/after as above (separate template).

### 5. Quiz title

1. On a lesson, add/edit a quiz and set its title to `Quiz "Hard" <v2>`, save, reload the builder, reopen the quiz.
2. **Before:** broken attribute spill / missing `<v2>`.
   **After:** displays as typed.

### 6. Quiz and assignment tooltips on the lesson row

1. With the quiz from step 5 enabled, hover the quiz icon on the lesson row in the outline (tooltip reads "Edit quiz: {title}").
2. **Before:** a `"` in the quiz title truncates the tooltip and dumps attribute junk into the row.
   **After:** full title in the tooltip. (Same check for the assignment icon if the Assignments add-on is active.)

### 7. Question choice

1. In a quiz, add a multiple choice question and set a choice to `Say "hello" > goodbye`.
2. Blur the field, click back in, then blur again **without changing anything**.
3. **Before:** the broken `data-original-content` attribute makes change detection misfire (spurious saves); `<` / `>` could break the row markup.
   **After:** no spurious change detection, renders correctly. Bold/italic/underline formatting in choices must still render as formatting, not literal `<b>` tags.

### 8. Escape-key revert

1. Click into any editable title (section, quiz, lesson settings) whose saved value contains `<Final>`.
2. Type some extra characters, then press **Escape**.
3. **Before:** `<Final>` was parsed as an HTML tag and vanished — blurring afterward saved the truncated title.
   **After:** the original title, including `<Final>`, is restored intact.

### Regression sweep

- Normal titles (no special characters) still render and save unchanged everywhere above.
- A title with `&` (e.g. `Cats & Dogs`) round-trips through an edit + save without turning into `&amp;` — confirms no double-encoding, whether saved from the block editor or the builder.
- Question titles with bold/italic formatting still display formatted in the builder.
- Editing a Gutenberg-saved title in the builder and saving stores the decoded form (raw `<`), matching the builder's existing save behavior — confirm it still displays correctly in both the builder and the block editor afterward.

## Screenshots <!-- if applicable -->
<img width="2846" height="1350" alt="CleanShot 2026-07-28 at 10 02 51@2x" src="https://github.com/user-attachments/assets/2336321e-8541-4db7-a54f-28b235e05ba7" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

