### PR TITLE
Switch add access plan meta box to full screen

### DIFF
--- a/.changelogs/access-plan-meta-box-whole-window.yml
+++ b/.changelogs/access-plan-meta-box-whole-window.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Switched the "Add New Plan" access plan dialog to full screen in the editor.

--- a/assets/js/llms-metabox-product.js
+++ b/assets/js/llms-metabox-product.js
@@ -6,7 +6,8 @@
  * @since 3.0.0
  * @since 3.30.3 Unknown.
  * @since 3.36.3 Fixed conflicts with the Classic Editor block.
- * @version 7.3.0
+ * @since [version] Move the access plan dialog to the document body so it displays above the block editor meta boxes pane.
+ * @version [version]
  */
 ( function( $ ) {
 
@@ -182,6 +183,10 @@
 
 			var dialogEl = document.getElementById( 'llms-access-plan-dialog' );
 			if ( dialogEl ) {
+				// The WP 7.0+ block editor renders meta boxes in a resizable pane that establishes the
+				// containing block for `position: fixed`, trapping the dialog inside the (often short)
+				// pane. Move it to the body so it overlays the whole viewport.
+				document.body.appendChild( dialogEl );
 				self.$plan_dialog = new A11yDialog( dialogEl );
 			}
 

--- a/assets/scss/admin/metaboxes/_metabox-product.scss
+++ b/assets/scss/admin/metaboxes/_metabox-product.scss
@@ -88,7 +88,9 @@
 }
 
 .llms-dialog-container {
-	z-index: 2;
+	// The dialog is moved to the document body (see llms-metabox-product.js), so it must
+	// stack above the admin bar (z-index 99999) and the block editor interface.
+	z-index: 100000;
 	display: flex;
 
 	.llms-dialog-overlay {
@@ -110,12 +112,9 @@
 		background-color: white;
 		overflow: auto;
 		box-sizing: border-box;
-		// In WP < 7.0 the metabox rendered full-screen so `position: fixed` on the
-		// container resolved against the viewport and `90vh` was always the limit. In WP 7.0+
-		// the block editor wraps the meta-boxes area in an element that establishes the
-		// containing block for fixed positioning, so the container only fills that (often
-		// short) region. `min()` keeps the viewport cap while also clamping to the container
-		// height so the content scrolls instead of overflowing the meta-boxes area.
+		// The dialog is reparented to the document body (see llms-metabox-product.js), so
+		// `min()` resolves against the viewport; the 100% clamp only matters as a fallback
+		// if the dialog is ever rendered inside a container that traps fixed positioning.
 		max-height: min(90vh, 100%);
 
 		.llms-dialog-close {


### PR DESCRIPTION

## Description

Moves the access plan modal back to full screen since WP 7.0.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3968" height="2218" alt="image" src="https://github.com/user-attachments/assets/975a216b-8540-428e-854b-c2bbd266c41d" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

