### PR TITLE
Revert "fix(template): add wp-element-button to access plan button"

### DIFF
--- a/.changelogs/3234-wp-element-button.yml
+++ b/.changelogs/3234-wp-element-button.yml
@@ -1,3 +1,0 @@
-significance: patch
-type: changed
-entry: "Added the `wp-element-button` class to the access plan button and free enrollment form so they inherit theme button styling from `theme.json`."

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -235,7 +235,7 @@ class LLMS_Shortcodes {
 		if ( ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
 			$plan = new LLMS_Access_Plan( $atts['id'] );
 
-			$classes  = 'llms-button-' . $atts['type'] . ' wp-element-button';
+			$classes  = 'llms-button-' . $atts['type'];
 			$classes .= ! empty( $atts['size'] ) ? ' ' . $atts['size'] : '';
 			$classes .= ! empty( $atts['classes'] ) ? ' ' . $atts['classes'] : '';
 

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -8,8 +8,7 @@
  *
  * @since 3.23.0
  * @since 4.2.0 Added `llms_display_free_enroll_form` filter hook.
- * @since [version] Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
- * @version [version]
+ * @version 4.2.0
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -26,5 +25,5 @@ if ( apply_filters( 'llms_display_free_enroll_form', get_current_user_id() && $p
 	?>
 	<?php llms_get_template( 'product/free-enroll-form.php', compact( 'plan' ) ); ?>
 <?php else : ?>
-	<a class="llms-button-action button wp-element-button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
+	<a class="llms-button-action button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
 <?php endif; ?>

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -9,8 +9,7 @@
  * @since 3.4.0
  * @since 3.30.0 Added redirect field.
  * @since 5.0.0 Use `LLMS_Forms::get_free_enroll_form_html()` in favor of deprecated `LLMS_Person_Handler::get_available_fields()`.
- * @since [version] Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
- * @version [version]
+ * @version 5.0.0
  *
  * @property LLMS_Access_Plan $plan Instance of the plan object.
  */
@@ -38,6 +37,6 @@ if ( ! $uid || empty( $plan ) || ! $plan->has_free_checkout() ) {
 
 	<?php do_action( 'lifterlms_after_free_enroll_fields' ); ?>
 
-	<button class="llms-button-action button wp-element-button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
+	<button class="llms-button-action button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
 
 </form>

--- a/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
+++ b/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
@@ -93,7 +93,7 @@ class LLMS_Test_Functions_Templates_Pricing_Tables extends LLMS_UnitTestCase {
 		$ob = $this->get_ob( 'llms_template_access_plan_button', array( 0 ) );
 
 		// purchase button link
-		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button wp-element-button"' ) );
+		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button"' ) );
 		$this->assertTrue( false !== strpos( $ob['html'], sprintf( 'href="%s"', esc_url( $ob['plan']->get_checkout_url() ) ) ) );
 
 		// check free enroll form


### PR DESCRIPTION
Reverts gocodebox/lifterlms#3237

By adding wp-button-element and keeping the existing classes, there are themes where the button text is not legible at all. We need to rework things in general.