### PR TITLE
Theme Styling Enhancements

### DIFF
--- a/.changelogs/theme-styling-enhancements-2.yml
+++ b/.changelogs/theme-styling-enhancements-2.yml
@@ -1,3 +1,0 @@
-significance: patch
-type: changed
-entry: Added the `wp-element-button` class to front-end buttons (pricing tables, checkout, registration, quizzes, dashboard, certificates) so they inherit theme button styling.

--- a/.changelogs/theme-styling-enhancements-2.yml
+++ b/.changelogs/theme-styling-enhancements-2.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Added the `wp-element-button` class to front-end buttons (pricing tables, checkout, registration, quizzes, dashboard, certificates) so they inherit theme button styling.

--- a/.changelogs/theme-styling-enhancements.yml
+++ b/.changelogs/theme-styling-enhancements.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed potentially low-contrast button text when a theme styles buttons carrying the `wp-element-button` class; LifterLMS button colors no longer apply to theme-styled buttons.

--- a/.changelogs/theme-styling-enhancements.yml
+++ b/.changelogs/theme-styling-enhancements.yml
@@ -1,3 +1,5 @@
-significance: patch
-type: fixed
-entry: Fixed potentially low-contrast button text when a theme styles buttons carrying the `wp-element-button` class; LifterLMS button colors no longer apply to theme-styled buttons.
+significance: minor
+type: changed
+entry: Added the `wp-element-button` class to front-end buttons (pricing tables,
+  checkout, registration, quizzes, dashboard, certificates) so they inherit
+  theme button styling.

--- a/assets/js/llms-quiz.js
+++ b/assets/js/llms-quiz.js
@@ -599,7 +599,7 @@
 
 						// Adding Exit Button in Layout if quiz is resumable.
 						if ( self.resumable ) {
-							$( '#llms-quiz-nav' ).append( '<button class="button llms-button-secondary" id="llms-exit-quiz" name="llms_exit_quiz">' + LLMS.l10n.translate( 'Save & Exit Quiz' ) + '</button>' );
+							$( '#llms-quiz-nav' ).append( '<button class="button llms-button-secondary wp-element-button" id="llms-exit-quiz" name="llms_exit_quiz">' + LLMS.l10n.translate( 'Save & Exit Quiz' ) + '</button>' );
 						}
 
 						self.load_question( r.data.html );
@@ -787,9 +787,9 @@
 				$header = $( '<header class="llms-quiz-header" id="llms-quiz-header" />' )
 				$footer = $( '<footer class="llms-quiz-nav" id="llms-quiz-nav" />' );
 
-			$footer.append( '<button class="button large llms-button-action" id="llms-next-question" name="llms_next_question" type="submit">' + LLMS.l10n.translate( 'Next Question' ) + '</button>' );
-			$footer.append( '<button class="button large llms-button-action llms-button-quiz-complete" id="llms-complete-quiz" name="llms_complete_quiz" type="submit" style="display:none;">' + LLMS.l10n.translate( 'Complete Quiz' ) + '</button>' );
-			$footer.append( '<button class="button llms-button-secondary" id="llms-prev-question" name="llms_prev_question" type="submit" style="display:none;">' + LLMS.l10n.translate( 'Previous Question' ) + '</button>' );
+			$footer.append( '<button class="button large llms-button-action wp-element-button" id="llms-next-question" name="llms_next_question" type="submit">' + LLMS.l10n.translate( 'Next Question' ) + '</button>' );
+			$footer.append( '<button class="button large llms-button-action llms-button-quiz-complete wp-element-button" id="llms-complete-quiz" name="llms_complete_quiz" type="submit" style="display:none;">' + LLMS.l10n.translate( 'Complete Quiz' ) + '</button>' );
+			$footer.append( '<button class="button llms-button-secondary wp-element-button" id="llms-prev-question" name="llms_prev_question" type="submit" style="display:none;">' + LLMS.l10n.translate( 'Previous Question' ) + '</button>' );
 
 			$header.append( '<div class="llms-progress"><div class="progress-bar-complete"></div></div>' );
 			$footer.append( '<div class="llms-quiz-counter" id="llms-quiz-counter"><span class="llms-current"></span><span class="llms-sep">/</span><span class="llms-total"></span></div>' )

--- a/assets/scss/_includes/_buttons.scss
+++ b/assets/scss/_includes/_buttons.scss
@@ -1,32 +1,52 @@
-.llms-button-action,
-.llms-button-danger,
-.llms-button-primary,
-.llms-button-secondary {
-	border:none;
+/*
+ * Opinionated LifterLMS button styling (colors, shape, typography).
+ *
+ * Buttons carrying the `wp-element-button` class opt out of these rules and
+ * instead inherit the theme's button styling — `theme.json` element styles in
+ * block themes, or the `classic-themes.css` defaults (and any theme overrides)
+ * in classic themes — so the text and background colors always come from the
+ * same source and remain a legible pair.
+ *
+ * This block must precede the structural rules below: the `:not()` guard puts
+ * these selectors at the same specificity as the size modifiers (`.small`,
+ * `.large`), so source order decides the winner.
+ */
+.llms-button-action:not(.wp-element-button),
+.llms-button-danger:not(.wp-element-button),
+.llms-button-primary:not(.wp-element-button),
+.llms-button-secondary:not(.wp-element-button) {
+	border: none;
 	border-radius: 8px;
 	color: $color-white;
-	cursor: pointer;
-	display: inline-block;
 	font-size: 18px;
 	font-weight: 700;
-	text-decoration: none;
-	text-shadow: none;
 	line-height: 1;
-	margin: 0;
-	max-width: 100%;
 	padding: 12px 24px;
-	position: relative;
+	text-shadow: none;
 	transition: all .5s ease;
-	white-space: nowrap;
 
-	&:disabled {
-		opacity: 0.5;
-	}
 	&:hover, &:active {
 		color: $color-white;
 	}
 	&:focus {
 		color: $color-white;
+	}
+}
+
+.llms-button-action,
+.llms-button-danger,
+.llms-button-primary,
+.llms-button-secondary {
+	cursor: pointer;
+	display: inline-block;
+	margin: 0;
+	max-width: 100%;
+	position: relative;
+	text-decoration: none;
+	white-space: nowrap;
+
+	&:disabled {
+		opacity: 0.5;
 	}
 
 	&.auto {
@@ -63,13 +83,13 @@
 }
 
 /* Fix for cases where link color overrides the button color */
-a.llms-button-action,
-a.llms-button-danger,
-a.llms-button-primary {
+a.llms-button-action:not(.wp-element-button),
+a.llms-button-danger:not(.wp-element-button),
+a.llms-button-primary:not(.wp-element-button) {
 	color: $color-white;
 }
 
-.llms-button-primary {
+.llms-button-primary:not(.wp-element-button) {
 	background: $color-brand-blue;
 	&:hover,
 	&.clicked {
@@ -81,7 +101,7 @@ a.llms-button-primary {
 	}
 }
 
-.llms-button-secondary {
+.llms-button-secondary:not(.wp-element-button) {
 	background: #e1e1e1;
 	color: $color-cinder;
 	&:hover {
@@ -95,11 +115,31 @@ a.llms-button-primary {
 	}
 }
 /* Fix for cases where link color overrides the button color */
-a.llms-button-secondary {
+a.llms-button-secondary:not(.wp-element-button) {
 	color: $color-cinder;
 }
 
-.llms-button-action {
+/*
+ * Theme-styled secondary buttons keep LifterLMS's neutral colors so they stay
+ * visually distinct from primary/action buttons, but the complete pair
+ * (background and text color) is asserted together to guarantee contrast.
+ * Shape and typography still come from the theme's button styling.
+ */
+.llms-button-secondary.wp-element-button {
+	background: #e1e1e1;
+	color: $color-cinder;
+	&:hover {
+		color: #414141;
+		background: #cdcdcd;
+	}
+	&:focus,
+	&:active {
+		color: #414141;
+		background: #ebebeb;
+	}
+}
+
+.llms-button-action:not(.wp-element-button) {
 	background: $color-orange;
 	&:hover,
 	&.clicked {
@@ -111,7 +151,7 @@ a.llms-button-secondary {
 	}
 }
 
-.llms-button-danger {
+.llms-button-danger:not(.wp-element-button) {
 	background: $color-danger;
 	&:hover {
 		background: #981c17;

--- a/includes/forms/class-llms-form-field.php
+++ b/includes/forms/class-llms-form-field.php
@@ -311,8 +311,9 @@ class LLMS_Form_Field {
 			case 'button':
 			case 'reset':
 			case 'submit':
-				$tag                 = 'button';
-				$classes             = array( 'llms-field-button' );
+				$tag = 'button';
+				// The `wp-element-button` class lets the theme's button styling (via `theme.json` or classic theme defaults) apply.
+				$classes             = array( 'llms-field-button', 'wp-element-button' );
 				$inner_html          = $this->settings['value'];
 				$extra_attrs['type'] = $this->settings['type'];
 				break;

--- a/includes/llms.template.functions.php
+++ b/includes/llms.template.functions.php
@@ -688,7 +688,7 @@ if ( ! function_exists( 'lifterlms_course_progress_bar' ) ) {
 		$html = llms_get_progress_bar_html( $progress );
 
 		if ( $button ) {
-			$html .= '<' . $tag . ' class="llms-button-primary llms-purchase-button"' . $href . '>' . __( 'Continue', 'lifterlms' ) . '(' . $progress . '%)</' . $tag . '>';
+			$html .= '<' . $tag . ' class="llms-button-primary llms-purchase-button wp-element-button"' . $href . '>' . __( 'Continue', 'lifterlms' ) . '(' . $progress . '%)</' . $tag . '>';
 		}
 
 		if ( $echo ) {
@@ -769,7 +769,7 @@ if ( ! function_exists( 'lifterlms_course_continue_button' ) ) {
 			$lesson = apply_filters( 'llms_course_continue_button_next_lesson', $student->get_next_lesson( $course->get( 'id' ) ), $course, $student );
 			if ( $lesson ) { ?>
 
-				<a class="llms-button-primary llms-course-continue-button" href="<?php echo esc_url( get_permalink( $lesson ) ); ?>">
+				<a class="llms-button-primary llms-course-continue-button wp-element-button" href="<?php echo esc_url( get_permalink( $lesson ) ); ?>">
 
 					<?php if ( 0 == $progress ) : ?>
 

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -235,7 +235,7 @@ class LLMS_Shortcodes {
 		if ( ! empty( $atts['id'] ) && is_numeric( $atts['id'] ) ) {
 			$plan = new LLMS_Access_Plan( $atts['id'] );
 
-			$classes  = 'llms-button-' . $atts['type'];
+			$classes  = 'llms-button-' . $atts['type'] . ' wp-element-button';
 			$classes .= ! empty( $atts['size'] ) ? ' ' . $atts['size'] : '';
 			$classes .= ! empty( $atts['classes'] ) ? ' ' . $atts['classes'] : '';
 

--- a/src/js/lesson-timer.js
+++ b/src/js/lesson-timer.js
@@ -124,7 +124,7 @@ import '../scss/lesson-timer.scss';
 		modal.appendChild( msg );
 
 		var btn = document.createElement( 'button' );
-		btn.className = 'llms-button-primary';
+		btn.className = 'llms-button-primary wp-element-button';
 		btn.textContent = buttonText;
 		btn.addEventListener( 'click', buttonAction );
 		modal.appendChild( btn );

--- a/templates/certificates/actions.php
+++ b/templates/certificates/actions.php
@@ -5,7 +5,8 @@
  * @package LifterLMS/Templates/Certificates
  *
  * @since 6.0.0
- * @version 6.0.0
+ * @since [version] Added `wp-element-button` class to the action buttons so they inherit theme button styling.
+ * @version [version]
  *
  * @param LLMS_User_Certificate $certificate       Certificate object.
  * @param string                $back_link         URL for the back link.
@@ -22,27 +23,27 @@ defined( 'ABSPATH' ) || exit;
 		<a class="llms-cert-return-link" href="<?php echo esc_url( $back_link ); ?>">&larr; <?php echo esc_html( $back_text ); ?></a>
 	<?php endif; ?>
 
-	<button class="llms-button-secondary" onClick="window.print()" type="button">
+	<button class="llms-button-secondary wp-element-button" onClick="window.print()" type="button">
 		<?php esc_html_e( 'Print', 'lifterlms' ); ?>
 		<i class="fa fa-print" aria-hidden="true"></i>
 	</button>
 
 	<form action="" method="POST">
 
-		<button class="llms-button-secondary" type="submit" name="llms_generate_cert">
+		<button class="llms-button-secondary wp-element-button" type="submit" name="llms_generate_cert">
 			<?php esc_html_e( 'Download', 'lifterlms' ); ?>
 			<i class="fa fa-cloud-download" aria-hidden="true"></i>
 		</button>
 
 		<?php if ( ! $is_template ) : ?>
-			<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing" value="<?php echo esc_attr( ! $is_sharing_enabled ); ?>">
+			<button class="llms-button-secondary wp-element-button" type="submit" name="llms_enable_cert_sharing" value="<?php echo esc_attr( ! $is_sharing_enabled ); ?>">
 			<?php echo ( $is_sharing_enabled ? esc_html__( 'Disable sharing', 'lifterlms' ) : esc_html__( 'Enable sharing', 'lifterlms' ) ); ?>
 				<i class="fa fa-share-alt" aria-hidden="true"></i>
 			</button>
 		<?php endif; ?>
-    
-    <?php if ( $is_sharing_enabled ) : ?>
-			<button id="llms-copy-to-clipboard" class="llms-button-secondary" type="button" aria-disabled="false">
+	
+	<?php if ( $is_sharing_enabled ) : ?>
+			<button id="llms-copy-to-clipboard" class="llms-button-secondary wp-element-button" type="button" aria-disabled="false">
 				<?php echo esc_html__( 'Copy Shareable Link', 'lifterlms' ); ?>
 				<i class="fa fa-clipboard" aria-hidden="true"></i>
 			</button> <span id="llms-copy-to-clipboard-success" class="fa fa-check" role="alert" aria-live="polite" style="display: none;"><span class="sr-only"><?php echo esc_html__( 'Copied', 'lifterlms' ); ?></span></span>

--- a/templates/course/complete-lesson-link.php
+++ b/templates/course/complete-lesson-link.php
@@ -7,7 +7,8 @@
  * @since 1.0.0
  * @since 3.33.0 Only render on lesson post types.
  * @since 10.0.7 Use `llms_can_user_complete_lesson()` to gate rendering.
- * @version 10.0.7
+ * @since [version] Added `wp-element-button` class to the Take Quiz button so it inherits theme button styling.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -110,7 +111,7 @@ $student = llms_get_student( get_current_user_id() );
 
 		<?php do_action( 'llms_before_start_quiz_button' ); ?>
 
-		<a class="llms-button-action auto button" id="llms_start_quiz" href="<?php echo esc_url( get_permalink( $lesson->get( 'quiz' ) ) ); ?>">
+		<a class="llms-button-action auto button wp-element-button" id="llms_start_quiz" href="<?php echo esc_url( get_permalink( $lesson->get( 'quiz' ) ) ); ?>">
 			<?php echo wp_kses_post( apply_filters( 'lifterlms_start_quiz_button_text', esc_html__( 'Take Quiz', 'lifterlms' ), $lesson->get( 'quiz' ), $lesson ) ); ?>
 		</a>
 

--- a/templates/myaccount/dashboard-section.php
+++ b/templates/myaccount/dashboard-section.php
@@ -4,7 +4,8 @@
  *
  * @since 3.14.0
  * @since 3.30.1 Added dynamic filter on the `$more` var to allow customization of the URL and text on the "More" button.
- * @version  3.30.1
+ * @since [version] Added `wp-element-button` class to the More button so it inherits theme button styling.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,7 +27,7 @@ $more = apply_filters( 'llms_' . $action . '_more', $more );
 
 	<?php if ( $more ) : ?>
 		<footer class="llms-sd-section-footer">
-			<a class="llms-button-secondary" href="<?php echo esc_url( $more['url'] ); ?>"><?php echo esc_html( $more['text'] ); ?></a>
+			<a class="llms-button-secondary wp-element-button" href="<?php echo esc_url( $more['url'] ); ?>"><?php echo esc_html( $more['text'] ); ?></a>
 		</footer>
 	<?php endif; ?>
 

--- a/templates/myaccount/form-redeem-voucher.php
+++ b/templates/myaccount/form-redeem-voucher.php
@@ -6,7 +6,8 @@
  *
  * @since 2.0.0
  * @since 4.12.0 Updated the label `for` attribute and added an `id` to the input element.
- * @version 4.12.0
+ * @since [version] Added `wp-element-button` class to the submit button so it inherits theme button styling.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,7 +30,7 @@ defined( 'ABSPATH' ) || exit;
 
 	<footer class="llms-form-fields">
 		<div class="llms-form-field type-submit llms-cols-6 llms-cols-last"">
-			<button id="llms-redeem-voucher-submit" type="submit" class="llms-field-button llms-button-action"><?php echo esc_html_x( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
+			<button id="llms-redeem-voucher-submit" type="submit" class="llms-field-button llms-button-action wp-element-button"><?php echo esc_html_x( 'Submit', 'Voucher Code', 'lifterlms' ); ?></button>
 		</div>
 		<?php wp_nonce_field( 'lifterlms_voucher_check', 'lifterlms_voucher_nonce' ); ?>
 	</footer>

--- a/templates/myaccount/my-grades.php
+++ b/templates/myaccount/my-grades.php
@@ -3,7 +3,8 @@
  * My Grades Template
  *
  * @since    3.24.0
- * @version  3.24.0
+ * @since [version] Added `wp-element-button` class to the sort button so it inherits theme button styling.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 llms_print_notices();
@@ -70,7 +71,7 @@ llms_print_notices();
 							<option value="title_asc" <?php selected( 'title_asc', $sort ); ?>><?php esc_attr_e( 'Course Title (A-Z)', 'lifterlms' ); ?></option>
 							<option value="title_desc" <?php selected( 'title_desc', $sort ); ?>><?php esc_attr_e( 'Course Title (Z-A)', 'lifterlms' ); ?></option>
 						</select>
-						<button class="llms-button-secondary small" type="submit"><?php esc_html_e( 'Update', 'lifterlms' ); ?></button>
+						<button class="llms-button-secondary small wp-element-button" type="submit"><?php esc_html_e( 'Update', 'lifterlms' ); ?></button>
 					</form>
 				</td>
 		</tfoot>

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -5,7 +5,8 @@
  * @package LifterLMS/Templates
  *
  * @since    3.0.0
- * @version  7.6.0
+ * @since [version] Added `wp-element-button` class to the View button so it inherits theme button styling.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -50,7 +51,7 @@ defined( 'ABSPATH' ) || exit;
 						<?php endif; ?>
 					</td>
 					<td>
-						<a class="llms-button-primary small" href="<?php echo esc_url( $order->get_view_link() ); ?>"><?php esc_html_e( 'View', 'lifterlms' ); ?></a>
+						<a class="llms-button-primary small wp-element-button" href="<?php echo esc_url( $order->get_view_link() ); ?>"><?php esc_html_e( 'View', 'lifterlms' ); ?></a>
 					</td>
 				</tr>
 			<?php endforeach; ?>

--- a/templates/myaccount/view-order-transactions.php
+++ b/templates/myaccount/view-order-transactions.php
@@ -6,7 +6,8 @@
  *
  * @since 3.10.0
  * @since 6.0.0 Logic to return empty when no transactions present has been moved to the template function.
- * @version 6.0.0
+ * @since [version] Added `wp-element-button` class to the pagination buttons so they inherit theme button styling.
+ * @version [version]
  *
  * @var array $transactions Result array from {@see LLMS_Order::get_transactions()}.
  */
@@ -49,10 +50,10 @@ defined( 'ABSPATH' ) || exit;
 			<tr>
 				<td colspan="5">
 					<?php if ( $transactions['page'] > 1 ) : ?>
-						<a class="llms-button-secondary small" href="<?php echo esc_url( add_query_arg( 'txnpage', $transactions['page'] - 1 ) ); ?>#llms-txns"><?php esc_html_e( 'Back', 'lifterlms' ); ?></a>
+						<a class="llms-button-secondary small wp-element-button" href="<?php echo esc_url( add_query_arg( 'txnpage', $transactions['page'] - 1 ) ); ?>#llms-txns"><?php esc_html_e( 'Back', 'lifterlms' ); ?></a>
 					<?php endif; ?>
 					<?php if ( $transactions['page'] < $transactions['pages'] ) : ?>
-						<a class="llms-button-secondary small" href="<?php echo esc_url( add_query_arg( 'txnpage', $transactions['page'] + 1 ) ); ?>#llms-txns"><?php esc_html_e( 'Next', 'lifterlms' ); ?></a>
+						<a class="llms-button-secondary small wp-element-button" href="<?php echo esc_url( add_query_arg( 'txnpage', $transactions['page'] + 1 ) ); ?>#llms-txns"><?php esc_html_e( 'Next', 'lifterlms' ); ?></a>
 					<?php endif; ?>
 				</td>
 			</tr>

--- a/templates/product/access-plan-button.php
+++ b/templates/product/access-plan-button.php
@@ -8,7 +8,8 @@
  *
  * @since 3.23.0
  * @since 4.2.0 Added `llms_display_free_enroll_form` filter hook.
- * @version 4.2.0
+ * @since [version] Added `wp-element-button` class so the button inherits theme button styling from `theme.json`.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -25,5 +26,5 @@ if ( apply_filters( 'llms_display_free_enroll_form', get_current_user_id() && $p
 	?>
 	<?php llms_get_template( 'product/free-enroll-form.php', compact( 'plan' ) ); ?>
 <?php else : ?>
-	<a class="llms-button-action button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
+	<a class="llms-button-action button wp-element-button" href="<?php echo esc_url( $plan->get_checkout_url() ); ?>" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></a>
 <?php endif; ?>

--- a/templates/product/free-enroll-form.php
+++ b/templates/product/free-enroll-form.php
@@ -9,7 +9,8 @@
  * @since 3.4.0
  * @since 3.30.0 Added redirect field.
  * @since 5.0.0 Use `LLMS_Forms::get_free_enroll_form_html()` in favor of deprecated `LLMS_Person_Handler::get_available_fields()`.
- * @version 5.0.0
+ * @since [version] Added `wp-element-button` class so the submit button inherits theme button styling from `theme.json`.
+ * @version [version]
  *
  * @property LLMS_Access_Plan $plan Instance of the plan object.
  */
@@ -37,6 +38,6 @@ if ( ! $uid || empty( $plan ) || ! $plan->has_free_checkout() ) {
 
 	<?php do_action( 'lifterlms_after_free_enroll_fields' ); ?>
 
-	<button class="llms-button-action button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
+	<button class="llms-button-action button wp-element-button" type="submit" aria-label="<?php echo esc_attr( $plan->get_enroll_text( true ) ); ?>"><?php echo esc_html( $plan->get_enroll_text() ); ?></button>
 
 </form>

--- a/templates/quiz/start-button.php
+++ b/templates/quiz/start-button.php
@@ -6,7 +6,8 @@
  * @since 3.25.0 Unknown.
  * @since 4.17.0 Early bail on orphan quiz.
  * @since 7.8.0 Added support for quiz resume.
- * @version 7.8.0
+ * @since [version] Added `wp-element-button` class to the quiz buttons so they inherit theme button styling.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -46,7 +47,7 @@ if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 				<?php if ( $quiz->can_be_resumed_by_student() ) : ?>
 					<?php
 						$message  = esc_html__( 'You have a partially completed attempt for this quiz. You can continue where you left off by clicking the Resume Quiz button below.', 'lifterlms' );
-						$message .= '<div><button class="llms-start-quiz-button llms-button-secondary button" id="llms_start_quiz" name="llms_start_quiz" type="submit">';
+						$message .= '<div><button class="llms-start-quiz-button llms-button-secondary button wp-element-button" id="llms_start_quiz" name="llms_start_quiz" type="submit">';
 
 						/**
 						 * Filters the restart quiz button text
@@ -64,7 +65,7 @@ if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 					<?php llms_print_notice( $message, 'notice' ); ?>
 				<?php else : ?>
 
-					<button class="llms-start-quiz-button llms-button-action button" id="llms_start_quiz" name="llms_start_quiz" type="submit">
+					<button class="llms-start-quiz-button llms-button-action button wp-element-button" id="llms_start_quiz" name="llms_start_quiz" type="submit">
 						<?php
 							/**
 							 * Filters the quiz button text
@@ -94,7 +95,7 @@ if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 
 				<?php wp_nonce_field( 'llms_resume_quiz' ); ?>
 
-				<button class="llms-resume-quiz-button llms-button-action button" id="llms_resume_quiz" name="llms_resume_quiz" type="submit">
+				<button class="llms-resume-quiz-button llms-button-action button wp-element-button" id="llms_resume_quiz" name="llms_resume_quiz" type="submit">
 					<?php
 						/**
 						 * Filters the quiz resume button text.
@@ -113,7 +114,7 @@ if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) ) {
 		<?php endif; ?>
 
 		<?php if ( $lesson->get_next_lesson() && llms_is_complete( get_current_user_id(), $lesson->get( 'id' ), 'lesson' ) ) : ?>
-			<a href="<?php echo esc_url( get_permalink( $lesson->get_next_lesson() ) ); ?>" class="button llms-button-secondary llms-next-lesson"><?php esc_html_e( 'Next Lesson', 'lifterlms' ); ?></a>
+			<a href="<?php echo esc_url( get_permalink( $lesson->get_next_lesson() ) ); ?>" class="button llms-button-secondary llms-next-lesson wp-element-button"><?php esc_html_e( 'Next Lesson', 'lifterlms' ); ?></a>
 		<?php endif; ?>
 
 	<?php else : ?>

--- a/tests/phpunit/unit-tests/forms/class-llms-test-form-field.php
+++ b/tests/phpunit/unit-tests/forms/class-llms-test-form-field.php
@@ -490,7 +490,7 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 		), false );
 
 		$this->assertStringContains( '<div class="llms-form-field type-button', $html );
-		$this->assertStringContains( '<button class="llms-field-button"', $html );
+		$this->assertStringContains( '<button class="llms-field-button wp-element-button"', $html );
 		$this->assertStringContains( 'type="button"', $html );
 		$this->assertStringContains( '>Button Text</button>', $html );
 
@@ -511,7 +511,7 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 		), false );
 
 		$this->assertStringContains( '<div class="llms-form-field type-submit', $html );
-		$this->assertStringContains( '<button class="llms-field-button"', $html );
+		$this->assertStringContains( '<button class="llms-field-button wp-element-button"', $html );
 		$this->assertStringContains( 'type="submit"', $html );
 		$this->assertStringContains( '>Button Text</button>', $html );
 
@@ -532,7 +532,7 @@ class LLMS_Test_Form_Field extends LLMS_Unit_Test_Case {
 		), false );
 
 		$this->assertStringContains( '<div class="llms-form-field type-reset', $html );
-		$this->assertStringContains( '<button class="llms-field-button"', $html );
+		$this->assertStringContains( '<button class="llms-field-button wp-element-button"', $html );
 		$this->assertStringContains( 'type="reset"', $html );
 		$this->assertStringContains( '>Button Text</button>', $html );
 	}

--- a/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
+++ b/tests/phpunit/unit-tests/functions-templates/class-llms-test-functions-templates-pricing-table.php
@@ -93,7 +93,7 @@ class LLMS_Test_Functions_Templates_Pricing_Tables extends LLMS_UnitTestCase {
 		$ob = $this->get_ob( 'llms_template_access_plan_button', array( 0 ) );
 
 		// purchase button link
-		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button"' ) );
+		$this->assertTrue( false !== strpos( $ob['html'], '<a class="llms-button-action button wp-element-button"' ) );
 		$this->assertTrue( false !== strpos( $ob['html'], sprintf( 'href="%s"', esc_url( $ob['plan']->get_checkout_url() ) ) ) );
 
 		// check free enroll form

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-certificates.php
@@ -150,13 +150,13 @@ class LLMS_Test_Functions_Templates_Certificates extends LLMS_UnitTestCase {
 
 		// Print button.
 		$this->assertOutputContains(
-			'<button class="llms-button-secondary" type="submit" name="llms_generate_cert">',
+			'<button class="llms-button-secondary wp-element-button" type="submit" name="llms_generate_cert">',
 			'llms_certificate_actions', array( $cert )
 		);
 
 		// Sharing button.
 		$this->assertOutputContains(
-			'<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing"',
+			'<button class="llms-button-secondary wp-element-button" type="submit" name="llms_enable_cert_sharing"',
 			'llms_certificate_actions', array( $cert )
 		);
 
@@ -192,13 +192,13 @@ class LLMS_Test_Functions_Templates_Certificates extends LLMS_UnitTestCase {
 
 		// Print button.
 		$this->assertOutputContains(
-			'<button class="llms-button-secondary" type="submit" name="llms_generate_cert">',
+			'<button class="llms-button-secondary wp-element-button" type="submit" name="llms_generate_cert">',
 			'llms_certificate_actions', array( $cert )
 		);
 
 		// Sharing button.
 		$this->assertOutputNotContains(
-			'<button class="llms-button-secondary" type="submit" name="llms_enable_cert_sharing"',
+			'<button class="llms-button-secondary wp-element-button" type="submit" name="llms_enable_cert_sharing"',
 			'llms_certificate_actions', array( $cert )
 		);
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-dasbhoard.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-dasbhoard.php
@@ -59,7 +59,7 @@ class LLMS_Test_Functions_Templates_Dashboard extends LLMS_UnitTestCase {
 
 		$this->assertStringContainsString( '<section class="llms-sd-section llms-my-achievements">', $output );
 		$this->assertStringContainsString( '<h3 class="llms-sd-section-title">', $output );
-		$this->assertStringContainsString( '<a class="llms-button-secondary" href="?my-achievements">View All My Achievements</a>', $output );
+		$this->assertStringContainsString( '<a class="llms-button-secondary wp-element-button" href="?my-achievements">View All My Achievements</a>', $output );
 
 	}
 
@@ -79,7 +79,7 @@ class LLMS_Test_Functions_Templates_Dashboard extends LLMS_UnitTestCase {
 		$this->assertStringContainsString( '<section class="llms-sd-section llms-my-achievements">', $output );
 
 		$this->assertStringNotContainsString( '<h3 class="llms-sd-section-title">', $output );
-		$this->assertStringNotContainsString( '<a class="llms-button-secondary" href="?my-achievements">View All My Achievements</a>', $output );
+		$this->assertStringNotContainsString( '<a class="llms-button-secondary wp-element-button" href="?my-achievements">View All My Achievements</a>', $output );
 
 	}
 
@@ -130,7 +130,7 @@ class LLMS_Test_Functions_Templates_Dashboard extends LLMS_UnitTestCase {
 
 		$this->assertStringContainsString( '<section class="llms-sd-section llms-my-certificates">', $output );
 		$this->assertStringContainsString( '<h3 class="llms-sd-section-title">', $output );
-		$this->assertStringContainsString( '<a class="llms-button-secondary" href="?my-certificates">View All My Certificates</a>', $output );
+		$this->assertStringContainsString( '<a class="llms-button-secondary wp-element-button" href="?my-certificates">View All My Certificates</a>', $output );
 
 	}
 
@@ -150,7 +150,7 @@ class LLMS_Test_Functions_Templates_Dashboard extends LLMS_UnitTestCase {
 		$this->assertStringContainsString( '<section class="llms-sd-section llms-my-certificates">', $output );
 
 		$this->assertStringNotContainsString( '<h3 class="llms-sd-section-title">', $output );
-		$this->assertStringNotContainsString( '<a class="llms-button-secondary" href="?my-certificates">View All My Certificates</a>', $output );
+		$this->assertStringNotContainsString( '<a class="llms-button-secondary wp-element-button" href="?my-certificates">View All My Certificates</a>', $output );
 
 	}
 

--- a/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-vier-order.php
+++ b/tests/phpunit/unit-tests/functions/class-llms-test-functions-templates-vier-order.php
@@ -219,7 +219,7 @@ class LLMS_Test_Functions_Templates_View_Order extends LLMS_UnitTestCase {
 		$res = $this->get_output( 'llms_template_view_order_transactions', array( $order ) );
 
 		$this->assertStringContainsString( '<tfoot>', $res );
-		$this->assertStringContainsString( '<a class="llms-button-secondary small" href="?txnpage=2#llms-txns">Next</a>', $res );
+		$this->assertStringContainsString( '<a class="llms-button-secondary small wp-element-button" href="?txnpage=2#llms-txns">Next</a>', $res );
 
 		// Two transactions in the table.
 		$dom = llms_get_dom_document( $res );
@@ -230,7 +230,7 @@ class LLMS_Test_Functions_Templates_View_Order extends LLMS_UnitTestCase {
 		$res = $this->get_output( 'llms_template_view_order_transactions', array( $order ) );
 
 		$this->assertStringContainsString( '<tfoot>', $res );
-		$this->assertStringContainsString( '<a class="llms-button-secondary small" href="?txnpage=1#llms-txns">Back</a>', $res );
+		$this->assertStringContainsString( '<a class="llms-button-secondary small wp-element-button" href="?txnpage=1#llms-txns">Back</a>', $res );
 
 		// One transaction in the table.
 		$dom = llms_get_dom_document( $res );


### PR DESCRIPTION

## Description
Add wp-button-element classes so buttons inherit theme styling, and only apply styling to buttons when the class is not there.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="4618" height="1792" alt="image" src="https://github.com/user-attachments/assets/d6241ede-b1b2-4b62-87d4-86046a93ff3a" />
<img width="4614" height="1798" alt="image" src="https://github.com/user-attachments/assets/5f3296ef-2884-451f-b2d4-add35aab2b2d" />
<img width="2128" height="2080" alt="CleanShot 2026-07-28 at 14 55 04@2x" src="https://github.com/user-attachments/assets/fe757a79-218d-46de-867a-ea7554c38360" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

