### PR TITLE
Quiz question text rendering

### DIFF
--- a/.changelogs/quiz-question-heading-render.yml
+++ b/.changelogs/quiz-question-heading-render.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed multi-line quiz question spacing on the front end. Change quiz question header from h3 to div for accessibility.

--- a/.changelogs/quiz-question-heading-render.yml
+++ b/.changelogs/quiz-question-heading-render.yml
@@ -2,4 +2,4 @@ significance: patch
 type: fixed
 links:
   - "#3286"
-entry: Fixed multi-line quiz question spacing on the front end.
+entry: Fixed multi-line quiz question spacing and accessibility on the front end.

--- a/.changelogs/quiz-question-heading-render.yml
+++ b/.changelogs/quiz-question-heading-render.yml
@@ -1,3 +1,5 @@
 significance: patch
 type: fixed
-entry: Fixed multi-line quiz question spacing on the front end. Change quiz question header from h3 to div for accessibility.
+links:
+  - "#3286"
+entry: Fixed multi-line quiz question spacing on the front end.

--- a/assets/scss/frontend/_llms-quizzes.scss
+++ b/assets/scss/frontend/_llms-quizzes.scss
@@ -175,6 +175,14 @@
 		font-size: 30px;
 		font-weight: 400;
 		margin-bottom: 15px;
+
+		p {
+			margin: 0 0 0.75em;
+
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
 	}
 
 	.llms-question-choices {

--- a/includes/models/model.llms.question.php
+++ b/includes/models/model.llms.question.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Models/Classes
  *
  * @since 1.0.0
- * @version 7.8.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -367,7 +367,54 @@ class LLMS_Question extends LLMS_Post_Model {
 		 * @param LLMS_Question     $question Question object.
 		 * @param LLMS_Quiz_Attempt $attempt  Attempt object.
 		 */
-		return apply_filters( "llms_{$this->get( 'question_type' )}_question_get_question", $this->get( 'title' ), $format, $this, $attempt );
+		$title = apply_filters( "llms_{$this->get( 'question_type' )}_question_get_question", $this->get( 'title' ), $format, $this, $attempt );
+
+		if ( 'html' === $format ) {
+			$title = $this->format_question_html( $title );
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Convert br-separated question title lines into paragraph tags for front-end display.
+	 *
+	 * The course builder stores multi-line question titles with `<br>` tags after stripping
+	 * Quill's wrapping `<p>` elements. Converting those breaks back to paragraphs restores
+	 * normal block spacing that cannot be achieved by styling `<br>` alone.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $html Question title HTML.
+	 * @return string
+	 */
+	protected function format_question_html( $html ) {
+
+		if ( ! is_string( $html ) || '' === $html ) {
+			return $html;
+		}
+
+		// Already has block-level structure; leave alone.
+		if ( preg_match( '/<(p|div|ul|ol|h[1-6])\b/i', $html ) ) {
+			return $html;
+		}
+
+		if ( ! preg_match( '/<br\s*\/?>/i', $html ) ) {
+			return $html;
+		}
+
+		$parts  = preg_split( '/<br\s*\/?>/i', $html );
+		$output = '';
+
+		foreach ( $parts as $part ) {
+			if ( '' === trim( $part ) ) {
+				$output .= '<p><br></p>';
+			} else {
+				$output .= '<p>' . $part . '</p>';
+			}
+		}
+
+		return $output;
 	}
 
 	/**

--- a/templates/content-single-question.php
+++ b/templates/content-single-question.php
@@ -5,7 +5,8 @@
  * @since 1.0.0
  * @since 3.16.0 Unknown.
  * @since 7.8.0 Pass the `$attempt` object when retrieving the question content via `$question->get_question();`
- * @version 7.8.0
+ * @since [version] Use a div wrapper so multi-line question text can render as paragraphs.
+ * @version [version]
  *
  * @arg  $attempt  (obj)  LLMS_Quiz_Attempt instance
  * @arg  $question (obj)  LLMS_Question instance
@@ -20,12 +21,12 @@ defined( 'ABSPATH' ) || exit;
  */
 do_action( 'lifterlms_single_question_before_summary', $args ); ?>
 
-	<h3 class="llms-question-text">
+	<div class="llms-question-text">
 	<?php
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in the question templates.
 			echo $question->get_question( 'html', $attempt );
 	?>
-	</h3>
+	</div>
 
 	<?php
 		/**

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-question.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-question.php
@@ -383,4 +383,117 @@ class LLMS_Test_LLMS_Question extends LLMS_PostModelUnitTestCase {
 
 	}
 
+	/**
+	 * Test get_question() converts br-separated lines to paragraphs for html format.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_question_converts_br_to_paragraphs() {
+
+		$this->create( 'title' );
+		$this->set_question_title_html( 'Line one<br>Line two<br />Line three' );
+
+		$this->assertSame(
+			'<p>Line one</p><p>Line two</p><p>Line three</p>',
+			$this->obj->get_question( 'html' )
+		);
+	}
+
+	/**
+	 * Test get_question() preserves empty br segments as spacing paragraphs.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_question_converts_empty_br_segments() {
+
+		$this->create( 'title' );
+		$this->set_question_title_html( 'Line one<br><br>Line two' );
+
+		$this->assertSame(
+			'<p>Line one</p><p><br></p><p>Line two</p>',
+			$this->obj->get_question( 'html' )
+		);
+	}
+
+	/**
+	 * Test get_question() leaves titles without br tags unchanged.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_question_without_br_unchanged() {
+
+		$this->create( 'title' );
+		$this->set_question_title_html( 'Single line <strong>question</strong>' );
+
+		$this->assertSame(
+			'Single line <strong>question</strong>',
+			$this->obj->get_question( 'html' )
+		);
+	}
+
+	/**
+	 * Test get_question() does not re-wrap titles that already contain paragraphs.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_question_existing_paragraphs_unchanged() {
+
+		$this->create( 'title' );
+		$this->set_question_title_html( '<p>Line one</p><p>Line two<br>still in para</p>' );
+
+		$this->assertSame(
+			'<p>Line one</p><p>Line two<br>still in para</p>',
+			$this->obj->get_question( 'html' )
+		);
+	}
+
+	/**
+	 * Test get_question() plain format is not converted to paragraphs.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_question_plain_format_skips_conversion() {
+
+		$this->create( 'title' );
+		$this->set_question_title_html( 'Line one<br>Line two' );
+
+		$this->assertSame(
+			'Line one<br>Line two',
+			$this->obj->get_question( 'plain' )
+		);
+	}
+
+	/**
+	 * Persist HTML in post_title without title_save_pre stripping tags.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $title Question title HTML.
+	 * @return void
+	 */
+	private function set_question_title_html( $title ) {
+
+		global $wpdb;
+
+		$wpdb->update(
+			$wpdb->posts,
+			array( 'post_title' => $title ),
+			array( 'ID' => $this->obj->get( 'id' ) ),
+			array( '%s' ),
+			array( '%d' )
+		);
+		clean_post_cache( $this->obj->get( 'id' ) );
+		$this->obj = llms_get_post( $this->obj->get( 'id' ) );
+	}
+
 }


### PR DESCRIPTION

## Description

Switch h3 to div, and turn the `<br>`s into paragraph tags.

Fixes #3286

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2352" height="852" alt="Slack 2026-07-30 09 13 08" src="https://github.com/user-attachments/assets/ba9405d9-29c3-47cc-833a-dc87dd632a7a" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

