### PR TITLE
Quiz results indicator of answer and notes

### DIFF
--- a/.changelogs/quiz-results-indicator-of-answer-and-notes.yml
+++ b/.changelogs/quiz-results-indicator-of-answer-and-notes.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added an accessible expand control on quiz attempt results so students can discover answer details and clarifications.

--- a/assets/js/app/llms-quiz-attempt.js
+++ b/assets/js/app/llms-quiz-attempt.js
@@ -4,7 +4,8 @@
  * @package LifterLMS/Scripts
  *
  * @since 7.3.0
- * @version 7.3.0
+ * @since [version] Toggle aria-expanded and screen-reader labels on answer details.
+ * @version [version]
  */
 
 LLMS.Quiz_Attempt = {
@@ -15,18 +16,28 @@ LLMS.Quiz_Attempt = {
 	 */
 	init: function() {
 
-		$( '.llms-quiz-attempt-question-header a.toggle-answer' ).on( 'click', function( e ) {
+		$( '.llms-quiz-attempt-question-header .toggle-answer' ).on( 'click', function( e ) {
 
 			e.preventDefault();
 
-			var $curr = $( this ).closest( 'header' ).next( '.llms-quiz-attempt-question-main' );
+			var $btn      = $( this ),
+				$curr     = $btn.closest( 'header' ).next( '.llms-quiz-attempt-question-main' ),
+				$siblings = $btn.closest( 'li' ).siblings(),
+				expand    = $btn.attr( 'data-label-expand' ) || '',
+				collapse  = $btn.attr( 'data-label-collapse' ) || '';
 
-			$( this ).closest( 'li' ).siblings().find( '.llms-quiz-attempt-question-main' ).slideUp( 200 );
+			$siblings.find( '.llms-quiz-attempt-question-main' ).slideUp( 200 );
+			$siblings.find( '.toggle-answer' ).attr( 'aria-expanded', 'false' )
+				.find( '.llms-toggle-answer-text' ).text( expand );
 
 			if ( $curr.is( ':visible' ) ) {
 				$curr.slideUp( 200 );
-			}  else {
+				$btn.attr( 'aria-expanded', 'false' );
+				$btn.find( '.llms-toggle-answer-text' ).text( expand );
+			} else {
 				$curr.slideDown( 200 );
+				$btn.attr( 'aria-expanded', 'true' );
+				$btn.find( '.llms-toggle-answer-text' ).text( collapse );
 			}
 
 		} );

--- a/assets/scss/_includes/_quiz-result-question-list.scss
+++ b/assets/scss/_includes/_quiz-result-question-list.scss
@@ -47,6 +47,14 @@
 			font-size: 22px;
 			margin: 0;
 			line-height: 1.4;
+
+			p {
+				margin: 0 0 0.5em;
+
+				&:last-child {
+					margin-bottom: 0;
+				}
+			}
 		}
 
 		.llms-points {

--- a/assets/scss/_includes/_quiz-result-question-list.scss
+++ b/assets/scss/_includes/_quiz-result-question-list.scss
@@ -12,12 +12,41 @@
 		position: relative;
 		list-style-type: none;
 		.toggle-answer {
+			align-items: center;
+			background: none;
+			border: none;
+			box-sizing: border-box;
 			color: inherit;
+			cursor: pointer;
 			display: flex;
+			font: inherit;
 			gap: 10px;
 			justify-content: space-between;
 			padding: 15px 35px 15px 15px;
+			text-align: left;
 			text-decoration: none;
+			width: 100%;
+
+			&:focus-visible {
+				outline: 2px solid currentColor;
+				outline-offset: -2px;
+			}
+		}
+
+		.llms-toggle-answer-icon {
+			border-bottom: 2px solid currentColor;
+			border-right: 2px solid currentColor;
+			display: inline-block;
+			flex: 0 0 auto;
+			height: 0.55em;
+			margin-left: 0.25em;
+			transform: rotate(45deg);
+			transition: transform 0.2s ease;
+			width: 0.55em;
+		}
+
+		.toggle-answer[aria-expanded="true"] .llms-toggle-answer-icon {
+			transform: rotate(-135deg);
 		}
 
 		&.status--waiting.correct,
@@ -44,6 +73,7 @@
 			overflow: auto;
 		}
 		.llms-question-title {
+			flex: 1 1 auto;
 			font-size: 22px;
 			margin: 0;
 			line-height: 1.4;

--- a/assets/scss/_includes/_quiz-result-question-list.scss
+++ b/assets/scss/_includes/_quiz-result-question-list.scss
@@ -22,7 +22,7 @@
 			font: inherit;
 			gap: 10px;
 			justify-content: space-between;
-			padding: 15px 35px 15px 15px;
+			padding: 15px;
 			text-align: left;
 			text-decoration: none;
 			width: 100%;
@@ -30,6 +30,12 @@
 			&:focus-visible {
 				outline: 2px solid currentColor;
 				outline-offset: -2px;
+			}
+
+			// Keep the status badge in normal flow so it doesn't overlap the chevron.
+			.llms-status-icon-tip {
+				position: static;
+				flex: 0 0 auto;
 			}
 		}
 
@@ -39,13 +45,15 @@
 			display: inline-block;
 			flex: 0 0 auto;
 			height: 0.55em;
-			margin-left: 0.25em;
+			margin-left: 8px;
+			opacity: 0.7;
 			transform: rotate(45deg);
-			transition: transform 0.2s ease;
+			transition: transform 0.2s ease, opacity 0.2s ease;
 			width: 0.55em;
 		}
 
 		.toggle-answer[aria-expanded="true"] .llms-toggle-answer-icon {
+			opacity: 1;
 			transform: rotate(-135deg);
 		}
 

--- a/includes/models/model.llms.quiz.attempt.question.php
+++ b/includes/models/model.llms.quiz.attempt.question.php
@@ -41,7 +41,6 @@ class LLMS_Quiz_Attempt_Question {
 				'correct' => null,
 			)
 		);
-
 	}
 
 	/**
@@ -68,7 +67,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -115,7 +113,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return apply_filters( 'llms_quiz_attempt_question_get_answer', $ret, $answers, $question, $this );
-
 	}
 
 	/**
@@ -150,7 +147,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return apply_filters( 'llms_quiz_attempt_question_get_answer_array', $ret, $answers, $question, $this );
-
 	}
 
 	/**
@@ -177,7 +173,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return apply_filters( 'llms_quiz_attempt_question_get_correct_answer', $ret, $answers, $this->get_question(), $this );
-
 	}
 
 	/**
@@ -206,7 +201,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return apply_filters( 'llms_quiz_attempt_question_get_correct_answer_array', $ret, $question, $this );
-
 	}
 
 	/**
@@ -250,11 +244,10 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		if ( $icon ) {
-			return sprintf( '<span class="llms-status-icon-tip tip--top-left" data-tip="%1$s"><i class="llms-status-icon fa fa-%2$s"></i><span>', $tip, $icon );
+			return sprintf( '<span class="llms-status-icon-tip tip--top-left" data-tip="%1$s"><i class="llms-status-icon fa fa-%2$s" aria-hidden="true"></i></span>', $tip, $icon );
 		}
 
 		return '';
-
 	}
 
 	/**
@@ -305,7 +298,6 @@ class LLMS_Quiz_Attempt_Question {
 	public function has_remarks() {
 
 		return ( $this->get( 'remarks' ) );
-
 	}
 
 	/**
@@ -322,7 +314,6 @@ class LLMS_Quiz_Attempt_Question {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -337,5 +328,4 @@ class LLMS_Quiz_Attempt_Question {
 	public function set( $key, $val ) {
 		$this->data[ $key ] = $val;
 	}
-
 }

--- a/templates/quiz/results-attempt-questions-list.php
+++ b/templates/quiz/results-attempt-questions-list.php
@@ -10,6 +10,7 @@
  * @since 7.3.0 Script moved into the main llms.js.
  * @since 7.8.0 Hide answers if resumable attempt is incomplete.
  * @since [version] Use a div wrapper and HTML question text so multi-line titles render as paragraphs.
+ *                     Use an accessible expand/collapse control for answer details.
  * @version [version]
  */
 
@@ -44,6 +45,7 @@ defined( 'ABSPATH' ) || exit;
 			<?php
 			continue;
 		}
+		$panel_id = 'llms-quiz-attempt-question-main-' . $quiz_question->get( 'id' );
 		?>
 
 	<li class="llms-quiz-attempt-question type--<?php echo esc_attr( $quiz_question->get( 'question_type' ) ); ?> status--<?php echo esc_attr( $attempt_question->get_status() ); ?> <?php echo $attempt_question->is_correct() ? 'correct' : 'incorrect'; ?>"
@@ -52,7 +54,14 @@ defined( 'ABSPATH' ) || exit;
 		data-points="<?php echo esc_attr( $attempt_question->get( 'points' ) ); ?>"
 		data-points-curr="<?php echo esc_attr( $attempt_question->get( 'earned' ) ); ?>">
 		<header class="llms-quiz-attempt-question-header">
-			<a class="toggle-answer" href="#">
+			<button
+				type="button"
+				class="toggle-answer"
+				aria-expanded="false"
+				aria-controls="<?php echo esc_attr( $panel_id ); ?>"
+				data-label-expand="<?php esc_attr_e( 'Show answer details', 'lifterlms' ); ?>"
+				data-label-collapse="<?php esc_attr_e( 'Hide answer details', 'lifterlms' ); ?>"
+			>
 
 				<div class="llms-question-title"><?php echo wp_kses_post( $quiz_question->get_question( 'html' ) ); ?></div>
 
@@ -64,10 +73,13 @@ defined( 'ABSPATH' ) || exit;
 
 				<?php echo wp_kses_post( $attempt_question->get_status_icon() ); ?>
 
-			</a>
+				<span class="llms-toggle-answer-icon" aria-hidden="true"></span>
+				<span class="sr-only llms-toggle-answer-text"><?php esc_html_e( 'Show answer details', 'lifterlms' ); ?></span>
+
+			</button>
 		</header>
 
-		<section class="llms-quiz-attempt-question-main">
+		<section class="llms-quiz-attempt-question-main" id="<?php echo esc_attr( $panel_id ); ?>">
 
 			<?php if ( apply_filters( 'llms_quiz_show_question_description', true, $attempt, $attempt_question, $quiz_question ) && $quiz_question->has_description() ) : ?>
 				<div class="llms-quiz-attempt-answer-section llms-question-description">

--- a/templates/quiz/results-attempt-questions-list.php
+++ b/templates/quiz/results-attempt-questions-list.php
@@ -71,10 +71,10 @@ defined( 'ABSPATH' ) || exit;
 					</span>
 				<?php endif; ?>
 
-				<?php echo wp_kses_post( $attempt_question->get_status_icon() ); ?>
-
 				<span class="llms-toggle-answer-icon" aria-hidden="true"></span>
 				<span class="sr-only llms-toggle-answer-text"><?php esc_html_e( 'Show answer details', 'lifterlms' ); ?></span>
+
+				<?php echo wp_kses_post( $attempt_question->get_status_icon() ); ?>
 
 			</button>
 		</header>

--- a/templates/quiz/results-attempt-questions-list.php
+++ b/templates/quiz/results-attempt-questions-list.php
@@ -4,13 +4,13 @@
  *
  * @param LLMS_Quiz_Attempt $attempt LLMS_Quiz_Attempt instance.
  *
+ * @since 3.16.0
  * @since 3.17.8 Unknown.
  * @since 5.3.0 Display removed questions too.
  * @since 7.3.0 Script moved into the main llms.js.
  * @since 7.8.0 Hide answers if resumable attempt is incomplete.
- * @version 7.3.0
- *
- * @since 3.16.0
+ * @since [version] Use a div wrapper and HTML question text so multi-line titles render as paragraphs.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -31,7 +31,7 @@ defined( 'ABSPATH' ) || exit;
 			data-points-curr="<?php echo esc_attr( $attempt_question->get( 'earned' ) ); ?>">
 			<header class="llms-quiz-attempt-question-header">
 				<span class="toggle-answer">
-					<h3 class="llms-question-title"><?php esc_html_e( 'This question has been deleted', 'lifterlms' ); ?></h3>
+					<div class="llms-question-title"><?php esc_html_e( 'This question has been deleted', 'lifterlms' ); ?></div>
 					<span class="llms-points">
 						<?php if ( $attempt_question->get( 'points' ) ) : ?>
 							<?php echo esc_html( sprintf( __( '%1$d / %2$d points', 'lifterlms' ), $attempt_question->get( 'earned' ), $attempt_question->get( 'points' ) ) ); ?>
@@ -54,7 +54,7 @@ defined( 'ABSPATH' ) || exit;
 		<header class="llms-quiz-attempt-question-header">
 			<a class="toggle-answer" href="#">
 
-				<h3 class="llms-question-title"><?php echo wp_kses_post( $quiz_question->get_question( 'plain' ) ); ?></h3>
+				<div class="llms-question-title"><?php echo wp_kses_post( $quiz_question->get_question( 'html' ) ); ?></div>
 
 				<?php if ( $quiz_question->get( 'points' ) ) : ?>
 					<span class="llms-points">


### PR DESCRIPTION

## Description
Cheveron to indicate that the quiz questions can be clicked to see the selected answer, and possibly any clarifying text.

Relates to https://github.com/gocodebox/sky-pilot/issues/105 but best to live in core.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="2564" height="1968" alt="image" src="https://github.com/user-attachments/assets/49b9c99b-b9fb-4a4f-aee3-edb18b0be3ea" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

