### PR TITLE
Avoid duplicate engagement emails if multiple engagements match the same quiz

### DIFF
--- a/.changelogs/fix-duplicate-engagement-email-dupcheck.yml
+++ b/.changelogs/fix-duplicate-engagement-email-dupcheck.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed duplicate engagement emails sent to all recipients when multiple emails share the same triggering post, such as when a manually graded quiz is completed and later graded.

--- a/.changelogs/fix-duplicate-engagement-email-dupcheck.yml
+++ b/.changelogs/fix-duplicate-engagement-email-dupcheck.yml
@@ -1,3 +1,3 @@
 significance: patch
 type: fixed
-entry: Fixed duplicate engagement emails sent to all recipients when multiple emails share the same triggering post, such as when a manually graded quiz is completed and later graded.
+entry: Fixed duplicate engagement emails sent to all recipients when multiple emails share the same triggering post.

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -109,7 +109,6 @@ class LLMS_Engagement_Handler {
 		 * }
 		 */
 		return apply_filters( "llms_proccess_{$type}_engagement", count( $errors ) ? $errors : true, $user_id, $template_id, $related_id, $engagement_id );
-
 	}
 
 	/**
@@ -134,7 +133,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return apply_filters_deprecated( $hook[0], array( $args ), '6.0.0', $hook[1] );
-
 	}
 
 	/**
@@ -187,7 +185,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return $args;
-
 	}
 
 	/**
@@ -240,7 +237,6 @@ class LLMS_Engagement_Handler {
 
 		// Reinstantiate the class so the merged post_content will be retrieved if accessed immediately.
 		return new $model_class( $generated->get( 'id' ) );
-
 	}
 
 	/**
@@ -290,7 +286,6 @@ class LLMS_Engagement_Handler {
 			$related_id,
 			$engagement_id
 		);
-
 	}
 
 	/**
@@ -326,7 +321,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -352,7 +346,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return true;
-
 	}
 
 	/**
@@ -425,7 +418,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return is_wp_error( $is_duplicate ) ? $is_duplicate : true;
-
 	}
 
 	/**
@@ -460,7 +452,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return 0;
-
 	}
 
 	/**
@@ -492,7 +483,6 @@ class LLMS_Engagement_Handler {
 		}
 
 		return self::create( $type, ...$args );
-
 	}
 
 	/**
@@ -572,7 +562,9 @@ class LLMS_Engagement_Handler {
 
 		$msg = sprintf( __( 'Email #%1$d to user #%2$d triggered by %3$s', 'lifterlms' ), $email_id, $person_id, $related_id ? '#' . $related_id : 'N/A' );
 
-		if ( $related_id && absint( $email_id ) === absint( llms_get_user_postmeta( $person_id, $related_id, $meta_key ) ) ) {
+		$sent_email_ids = $related_id ? array_map( 'absint', llms_get_user_postmeta( $person_id, $related_id, $meta_key, false ) ) : array();
+
+		if ( $related_id && in_array( absint( $email_id ), $sent_email_ids, true ) ) {
 
 			// User has already received this email, don't send it again.
 			llms_log( $msg . ' ' . __( 'not sent because of dupcheck.', 'lifterlms' ), 'engagement-emails' );
@@ -585,7 +577,8 @@ class LLMS_Engagement_Handler {
 		if ( $email && $email->send() ) {
 
 			if ( $related_id ) {
-				llms_update_user_postmeta( $person_id, $related_id, $meta_key, $email_id );
+				// Add a new record so previously sent emails for the same related post remain tracked for the dupcheck above.
+				llms_update_user_postmeta( $person_id, $related_id, $meta_key, $email_id, false );
 			}
 
 			llms_log( $msg . ' ' . __( 'sent successfully.', 'lifterlms' ), 'engagement-emails' );
@@ -595,7 +588,5 @@ class LLMS_Engagement_Handler {
 		// Error sending email.
 		llms_log( $msg . ' ' . __( 'not sent due to email sending issues.', 'lifterlms' ), 'engagement-emails' );
 		return array( new WP_Error( 'llms_engagement_email_not_sent_error', $msg, $args ) );
-
 	}
-
 }

--- a/tests/phpunit/unit-tests/class-llms-test-engagements.php
+++ b/tests/phpunit/unit-tests/class-llms-test-engagements.php
@@ -314,7 +314,7 @@ class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 		$this->assertEquals( 'Engagement Email', $sent->subject );
 
 		// User meta recorded.
-		$this->assertEquals( $emails[0], llms_get_user_postmeta( $user->ID, $course, '_email_sent' ) );
+		$this->assertEqualSets( array( $emails[0] ), llms_get_user_postmeta( $user->ID, $course, '_email_sent', false ) );
 
 		// Reset the mailer.
 		reset_phpmailer_instance();
@@ -328,8 +328,24 @@ class LLMS_Test_Engagements extends LLMS_UnitTestCase {
 		$this->assertEquals( $user->user_email, $sent->to[0][0] );
 		$this->assertEquals( 'Engagement Email', $sent->subject );
 
-		// User meta recorded.
-		$this->assertEquals( $emails[1], llms_get_user_postmeta( $user->ID, $course, '_email_sent' ) );
+		// Both sent emails are recorded in user meta.
+		$this->assertEqualSets( $emails, llms_get_user_postmeta( $user->ID, $course, '_email_sent', false ) );
+
+		// Reset the mailer.
+		reset_phpmailer_instance();
+		$mailer = tests_retrieve_phpmailer_instance();
+
+		// Re-triggering the first email, e.g. when a manually graded quiz re-fires its completion trigger, shouldn't send it again.
+		$send = $this->main->handle_email( array( $user->ID, $emails[0], $course ) );
+		$this->assertIsWPError( $send );
+		$this->assertWPErrorCodeEquals( 'llms_engagement_email_not_sent_dupcheck', $send );
+		$this->assertFalse( $mailer->get_sent() );
+
+		// Re-triggering the second email shouldn't send it again either.
+		$send = $this->main->handle_email( array( $user->ID, $emails[1], $course ) );
+		$this->assertIsWPError( $send );
+		$this->assertWPErrorCodeEquals( 'llms_engagement_email_not_sent_dupcheck', $send );
+		$this->assertFalse( $mailer->get_sent() );
 
 	}
 


### PR DESCRIPTION


## Description

Fixes #3304 

## How has this been tested?
Manually + phpunit

## Screenshots <!-- if applicable -->
<img width="6134" height="948" alt="CleanShot 2026-08-06 at 11 58 50@2x" src="https://github.com/user-attachments/assets/bd3bae9e-aef9-4d08-af8e-18cfa3bb65c6" />


## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

