### PR TITLE
Only allow same domain on get supplied redirect param

### DIFF
--- a/.changelogs/fix-checkout-completion-safe-redirect.yml
+++ b/.changelogs/fix-checkout-completion-safe-redirect.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: "Additional checks on checkout completion redirects."

--- a/includes/abstracts/abstract.llms.payment.gateway.php
+++ b/includes/abstracts/abstract.llms.payment.gateway.php
@@ -188,7 +188,7 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		// Ensure notification processors get dispatched since shutdown wont be called.
 		do_action( 'llms_dispatch_notification_processors' );
 
-		// Execute a redirect.
+		// Execute a redirect. Off-site destinations are allowed for admin-configured thank-you URLs.
 		llms_redirect_and_exit(
 			$redirect,
 			array(
@@ -447,17 +447,25 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 	 */
 	protected function get_complete_transaction_redirect_url( $order ) {
 
-		// Get the redirect parameter from INPUT_GET.
-		$redirect = urldecode( llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) ?? '' );
+		$plan = $this->get_order_access_plan( $order );
 
-		// Get the redirect parameter from INPUT_POST if not INPUT_GET redirect pased.
+		// Product permalink, then account page.
+		$fallback = get_permalink( $order->get( 'product_id' ) );
+		$fallback = $fallback ? $fallback : get_permalink( llms_get_page_id( 'myaccount' ) );
+
+		// Plan-configured redirect (may be off-site); never trust client input for this.
+		$plan_redirect = ( $plan ) ? $plan->get_configured_redirection_url() : '';
+
+		// Client-supplied redirect — same-origin or exact match to the plan's configured URL only.
+		$redirect = llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) ?? '';
 		$redirect = $redirect ? $redirect : llms_filter_input( INPUT_POST, 'redirect', FILTER_VALIDATE_URL );
 
-		// Redirect to the product's permalink, if no redirect found yet.
-		$redirect = $redirect ? $redirect : get_permalink( $order->get( 'product_id' ) );
+		if ( $redirect && ! $this->is_allowed_transaction_redirect( $redirect, $plan ) ) {
+			$redirect = '';
+		}
 
-		// Fallback to the account page if we don't have a url for some reason.
-		$redirect = $redirect ? $redirect : get_permalink( llms_get_page_id( 'myaccount' ) );
+		$redirect = $redirect ? $redirect : $plan_redirect;
+		$redirect = $redirect ? $redirect : $fallback;
 
 		// Add order key to the url.
 		$redirect = add_query_arg(
@@ -472,7 +480,11 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		$free_checkout_redirect = llms_filter_input( INPUT_POST, 'free_checkout_redirect', FILTER_VALIDATE_URL );
 
 		if ( get_current_user_id() && ( 'free_enroll' === $quick_enroll_form ) && $free_checkout_redirect ) {
-			$redirect = $free_checkout_redirect;
+			if ( $this->is_allowed_transaction_redirect( $free_checkout_redirect, $plan ) ) {
+				$redirect = $free_checkout_redirect;
+			} else {
+				$redirect = $plan_redirect ? $plan_redirect : $fallback;
+			}
 		}
 
 		/**
@@ -484,6 +496,50 @@ abstract class LLMS_Payment_Gateway extends LLMS_Abstract_Options_Data {
 		 * @param LLMS_Order $order    The order object.
 		 */
 		return esc_url( apply_filters( 'lifterlms_completed_transaction_redirect', $redirect, $order ) );
+	}
+
+	/**
+	 * Retrieve the access plan for an order, if available.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Order $order Order object.
+	 * @return LLMS_Access_Plan|false
+	 */
+	protected function get_order_access_plan( $order ) {
+
+		$plan_id = $order->get( 'plan_id' );
+		if ( ! $plan_id ) {
+			return false;
+		}
+
+		$plan = llms_get_post( $plan_id );
+		return ( $plan instanceof LLMS_Access_Plan ) ? $plan : false;
+	}
+
+	/**
+	 * Whether a client-supplied checkout completion redirect URL is allowed.
+	 *
+	 * Same-origin URLs are allowed. Off-site URLs are only allowed when they match
+	 * the access plan's configured custom checkout redirect URL.
+	 *
+	 * @since [version]
+	 *
+	 * @param string                 $url  Candidate redirect URL.
+	 * @param LLMS_Access_Plan|false $plan Access plan for the order, if any.
+	 * @return bool
+	 */
+	protected function is_allowed_transaction_redirect( $url, $plan = false ) {
+
+		if ( ! $url ) {
+			return false;
+		}
+
+		if ( $plan instanceof LLMS_Access_Plan ) {
+			return $plan->is_allowed_checkout_redirect( $url );
+		}
+
+		return (bool) wp_validate_redirect( $url, false );
 	}
 
 	/**

--- a/includes/models/model.llms.access.plan.php
+++ b/includes/models/model.llms.access.plan.php
@@ -226,8 +226,11 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 		// What type of redirection is set up by user?
 		$redirect_type = $this->get( 'checkout_redirect_type' );
 
-		// Force redirect querystring parameter over all else.
+		// Querystring redirect wins only when it is same-origin or matches this plan's configured URL.
 		$redirection = llms_filter_input( INPUT_GET, 'redirect', FILTER_VALIDATE_URL ) ?? '';
+		if ( $redirection && ! $this->is_allowed_checkout_redirect( $redirection ) ) {
+			$redirection = '';
+		}
 
 		if ( ! $redirection && ! $querystring_only ) {
 			$redirection = $this->calculate_redirection_url( $redirect_type );
@@ -247,6 +250,50 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 		$redirection = apply_filters( 'llms_plan_get_checkout_redirection', $redirection, $redirect_type, $this, $querystring_only );
 
 		return $encode ? urlencode( $redirection ) : $redirection;
+	}
+
+	/**
+	 * Retrieve the redirect URL from this plan's settings only (ignores querystring).
+	 *
+	 * @since [version]
+	 *
+	 * @return string
+	 */
+	public function get_configured_redirection_url() {
+		return $this->calculate_redirection_url( $this->get( 'checkout_redirect_type' ) );
+	}
+
+	/**
+	 * Whether a URL is allowed as a checkout redirect for this plan.
+	 *
+	 * Same-origin URLs are allowed. Off-site URLs are only allowed when they match
+	 * this plan's configured custom checkout redirect URL.
+	 *
+	 * @since [version]
+	 *
+	 * @param string $url Candidate redirect URL.
+	 * @return bool
+	 */
+	public function is_allowed_checkout_redirect( $url ) {
+
+		if ( ! $url ) {
+			return false;
+		}
+
+		if ( wp_validate_redirect( $url, false ) ) {
+			return true;
+		}
+
+		if ( 'url' !== $this->get( 'checkout_redirect_type' ) ) {
+			return false;
+		}
+
+		$allowed = $this->get( 'checkout_redirect_url' );
+		if ( ! $allowed ) {
+			return false;
+		}
+
+		return untrailingslashit( esc_url_raw( $url ) ) === untrailingslashit( esc_url_raw( $allowed ) );
 	}
 
 	/**
@@ -274,9 +321,10 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 				$ret_params  = array(
 					'plan' => $this->get( 'id' ),
 				);
-				$redirection = $this->get_redirection_url( true, true );
-				if ( $redirection ) {
-					$ret_params['redirect'] = $redirection;
+				$redirection = $this->get_redirection_url( false, true );
+				// Only same-origin redirects belong in the checkout URL query string.
+				if ( $redirection && wp_validate_redirect( $redirection, false ) ) {
+					$ret_params['redirect'] = urlencode( $redirection );
 				}
 
 				$ret = llms_get_page_url( 'checkout', $ret_params );
@@ -290,12 +338,13 @@ class LLMS_Access_Plan extends LLMS_Post_Model {
 			// if there's only 1 plan associated with the membership return that url.
 			if ( 1 === count( $memberships ) ) {
 				$ret         = get_permalink( $memberships[0] );
-				$redirection = $this->get_redirection_url();
+				$redirection = $this->get_redirection_url( false );
 
-				if ( $redirection ) {
+				// Only put same-origin redirects in the URL; off-site thank-you URLs stay on the plan and are resolved at completion.
+				if ( $redirection && wp_validate_redirect( $redirection, false ) ) {
 					$ret = add_query_arg(
 						array(
-							'redirect' => $redirection,
+							'redirect' => urlencode( $redirection ),
 						),
 						$ret
 					);

--- a/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-payment-gateway.php
+++ b/tests/phpunit/unit-tests/abstracts/class-llms-test-abstract-payment-gateway.php
@@ -375,50 +375,82 @@ class LLMS_Test_Payment_Gateway extends LLMS_UnitTestCase {
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 
-		// Force INPUT_GET redirect.
+		// Untrusted off-site INPUT_GET redirect is rejected.
 		$this->mockGetRequest(
 			array(
 				'redirect' => 'https://example-redirect-get.com',
 			)
 		);
 		$this->assertEquals(
-			'https://example-redirect-get.com?order-complete=' . $order->get( 'order_key' ),
+			'?order-complete=' . $order->get( 'order_key' ),
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 
-		// Force INPUT_POST redirect, the INPUT_GET will win.
+		// Untrusted off-site INPUT_POST redirect is rejected.
 		$this->mockPostRequest(
 			array(
 				'redirect' => 'https://example-redirect-post.com',
 			)
 		);
 		$this->assertEquals(
-			'https://example-redirect-get.com?order-complete=' . $order->get( 'order_key' ),
+			'?order-complete=' . $order->get( 'order_key' ),
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 
-		// Reset INPUT_GET, INPUT_POST will win.
+		// Reset INPUT_GET; POST still untrusted.
 		$this->mockGetRequest( array() );
 		$this->assertEquals(
-			'https://example-redirect-post.com?order-complete=' . $order->get( 'order_key' ),
+			'?order-complete=' . $order->get( 'order_key' ),
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 
-		// Free enroll and no user logged in, INPUT_POST will win.
-		$this->mockPostRequest(
+		// Same-origin redirect is allowed and receives the order key.
+		$local_redirect = home_url( '/thanks/' );
+		$this->mockGetRequest(
 			array(
-				'redirect'               => 'https://example-redirect-post.com',
-				'form'                   => 'free_enroll',
-				'free_checkout_redirect' => 'https://free-checkout-redirect.com',
+				'redirect' => $local_redirect,
 			)
 		);
 		$this->assertEquals(
-			'https://example-redirect-post.com?order-complete=' . $order->get( 'order_key' ),
+			add_query_arg( 'order-complete', $order->get( 'order_key' ), $local_redirect ),
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 
-		// Free enroll user logged in, INPUT_POST will win.
+		// Plan-configured off-site thank-you URL is allowed when it matches the plan.
+		$this->mockGetRequest( array() );
+		$this->mockPostRequest( array() );
+		$course = $this->factory->course->create_and_get( array( 'sections' => 0 ) );
+		$plan   = new LLMS_Access_Plan( 'new', $course->get( 'id' ) );
+		$plan->set( 'product_id', $course->get( 'id' ) );
+		$plan->set( 'checkout_redirect_type', 'url' );
+		$plan->set( 'checkout_redirect_url', 'https://thank-you.example.com/done' );
+		$order->set( 'plan_id', $plan->get( 'id' ) );
+		$order->set( 'product_id', $course->get( 'id' ) );
+
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://thank-you.example.com/done',
+			)
+		);
+		$this->assertEquals(
+			'https://thank-you.example.com/done?order-complete=' . $order->get( 'order_key' ),
+			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
+		);
+
+		// Attacker URL still rejected; falls back to the plan's configured URL.
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://attacker.example/collect',
+			)
+		);
+		$this->assertEquals(
+			'https://thank-you.example.com/done?order-complete=' . $order->get( 'order_key' ),
+			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
+		);
+
+		// Free enroll with untrusted off-site free_checkout_redirect falls back to plan URL.
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'student' ) ) );
+		$this->mockGetRequest( array() );
 		$this->mockPostRequest(
 			array(
 				'redirect'               => 'https://example-redirect-post.com',
@@ -427,7 +459,21 @@ class LLMS_Test_Payment_Gateway extends LLMS_UnitTestCase {
 			)
 		);
 		$this->assertEquals(
-			'https://free-checkout-redirect.com',
+			'https://thank-you.example.com/done',
+			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
+		);
+
+		// Free enroll with same-origin free_checkout_redirect is allowed.
+		$local_free = home_url( '/enrolled/' );
+		$this->mockPostRequest(
+			array(
+				'redirect'               => home_url( '/ignored/' ),
+				'form'                   => 'free_enroll',
+				'free_checkout_redirect' => $local_free,
+			)
+		);
+		$this->assertEquals(
+			$local_free,
 			LLMS_Unit_Test_Util::call_method( $this->main, 'get_complete_transaction_redirect_url', array( $order ) )
 		);
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-access-plan.php
@@ -250,17 +250,26 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 		// No redirect query arg added to the checkout url, the redirect will be added to the checkout form as hidden input field.
 		$this->assertEquals( get_permalink( $membership_id ), $this->obj->get_checkout_url() );
 
-		// Force the redirect via INPUT_GET
+		// Force the redirect via INPUT_GET — untrusted off-site URLs are ignored.
 		$this->mockGetRequest(
 			array(
 				'redirect' => 'https://example-redirect-get.com',
 			)
 		);
-		// Expect the redirect URL via INPUT_GET to be added to the membership's permalink.
+		// Off-site GET redirect is not added to the membership permalink.
+		$this->assertEquals( get_permalink( $membership_id ), $this->obj->get_checkout_url() );
+
+		// Same-origin GET redirect is allowed on the membership permalink.
+		$local_redirect = home_url( '/local-thanks/' );
+		$this->mockGetRequest(
+			array(
+				'redirect' => $local_redirect,
+			)
+		);
 		$this->assertEquals(
 			add_query_arg(
 				'redirect',
-				urlencode( 'https://example-redirect-get.com' ),
+				urlencode( $local_redirect ),
 				get_permalink( $membership_id )
 			),
 			$this->obj->get_checkout_url()
@@ -268,28 +277,19 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 
 		// Enable the option that forces the access plan redirection settings to take over the membership redirections.
 		$this->obj->set( 'checkout_redirect_forced', 'yes' );
-		// The INPUT_GET will win.
-		// Expect the redirect URL to be added to the membership's permalink.
+		// Same-origin INPUT_GET still wins and is added to the membership permalink.
 		$this->assertEquals(
 			add_query_arg(
 				'redirect',
-				urlencode( 'https://example-redirect-get.com' ),
+				urlencode( $local_redirect ),
 				get_permalink( $membership_id )
 			),
 			$this->obj->get_checkout_url()
 		);
 
-		// Reset the INPUT_GET
+		// Reset the INPUT_GET — plan off-site thank-you URL is not put in the membership URL.
 		$this->mockGetRequest( array() );
-		// Expect the redirect URL to be added to the membership's permalink.
-		$this->assertEquals(
-			add_query_arg(
-				'redirect',
-				urlencode( $this->obj->get( 'checkout_redirect_url' ) ),
-				get_permalink( $membership_id )
-			),
-			$this->obj->get_checkout_url()
-		);
+		$this->assertEquals( get_permalink( $membership_id ), $this->obj->get_checkout_url() );
 
 		// Multiple returns the hash for popover display.
 		$this->obj->set( 'availability_restrictions', array( $membership_id, 1234 ) );
@@ -1340,34 +1340,50 @@ class LLMS_Test_LLMS_Access_Plan extends LLMS_PostModelUnitTestCase {
 		// Expect empty string.
 		$this->assertEmpty( $this->obj->get_redirection_url() );
 
+		// Untrusted off-site GET redirect is ignored.
 		$this->mockGetRequest(
 			array(
 				'redirect' => 'https://example-redirect-get.com',
 			)
 		);
-		// Expect the encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
-		// Require only querystring, expect the encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url( true, true ), urlencode( 'https://example-redirect-get.com' ) );
+		$this->assertEmpty( $this->obj->get_redirection_url() );
+		$this->assertEmpty( $this->obj->get_redirection_url( true, true ) );
+		$this->assertEmpty( $this->obj->get_redirection_url( false ) );
+		$this->assertEmpty( $this->obj->get_redirection_url( false, true ) );
 
-		// Expect the not-encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
-		// Require only querystring, expect the not-encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url( false, true ), 'https://example-redirect-get.com' );
+		// Same-origin GET redirect is honored.
+		$local_redirect = home_url( '/local-thanks/' );
+		$this->mockGetRequest(
+			array(
+				'redirect' => $local_redirect,
+			)
+		);
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( $local_redirect ) );
+		$this->assertEquals( $this->obj->get_redirection_url( true, true ), urlencode( $local_redirect ) );
+		$this->assertEquals( $this->obj->get_redirection_url( false ), $local_redirect );
+		$this->assertEquals( $this->obj->get_redirection_url( false, true ), $local_redirect );
 
-		// Set access plan redirect options, still the $_GET variable will win.
+		// Plan-configured off-site URL is allowed via GET when it matches the plan setting.
 		$this->obj->set( 'checkout_redirect_type', 'url' );
 		$this->obj->set( 'checkout_redirect_url', 'https://example.com' );
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://example.com',
+			)
+		);
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example.com' ) );
+		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example.com' );
 
-		// Expect the encoded url.
-		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example-redirect-get.com' ) );
-		// Require only querystring, expect the encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url( true, true ), urlencode( 'https://example-redirect-get.com' ) );
-
-		// Expect the not-encoded url.
-		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example-redirect-get.com' );
-		// Require only querystring, expect the not-encoded URL.
-		$this->assertEquals( $this->obj->get_redirection_url( false, true ), 'https://example-redirect-get.com' );
+		// Untrusted off-site GET still loses to the plan's configured URL when not querystring-only.
+		$this->mockGetRequest(
+			array(
+				'redirect' => 'https://example-redirect-get.com',
+			)
+		);
+		$this->assertEquals( $this->obj->get_redirection_url(), urlencode( 'https://example.com' ) );
+		$this->assertEmpty( $this->obj->get_redirection_url( true, true ) );
+		$this->assertEquals( $this->obj->get_redirection_url( false ), 'https://example.com' );
+		$this->assertEmpty( $this->obj->get_redirection_url( false, true ) );
 
 		$this->obj->set( 'checkout_redirect_type', 'self' ); // Default.
 		$this->obj->set( 'checkout_redirect_url', '' );

--- a/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
+++ b/tests/phpunit/unit-tests/shortcodes/class-llms-test-shortcode-checkout.php
@@ -135,7 +135,7 @@ class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="https://example.com" />';
 		$this->assertStringContainsString( $contained, $atts['form_fields'] );
 
-		// INPUT_GET wins over plan's setting.
+		// Untrusted off-site INPUT_GET is ignored; plan setting remains.
 		$this->mockGetRequest(
 			array(
 				'redirect' => 'https://example-redirect-get.com',
@@ -149,7 +149,25 @@ class LLMS_Test_Shortcode_Checkout extends LLMS_ShortcodeTestCase {
 				array(),
 			)
 		);
-		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="https://example-redirect-get.com" />';
+		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="https://example.com" />';
+		$this->assertStringContainsString( $contained, $atts['form_fields'] );
+
+		// Same-origin INPUT_GET wins over plan setting.
+		$local_redirect = home_url( '/local-thanks/' );
+		$this->mockGetRequest(
+			array(
+				'redirect' => $local_redirect,
+			)
+		);
+		$atts = LLMS_Unit_Test_Util::call_method(
+			'LLMS_Shortcode_Checkout',
+			'setup_plan_and_form_atts',
+			array(
+				$plan->get('id'),
+				array(),
+			)
+		);
+		$contained = '<input class="llms-field-input" id="llms-redirect" name="redirect" type="hidden" value="' . esc_attr( $local_redirect ) . '" />';
 		$this->assertStringContainsString( $contained, $atts['form_fields'] );
 	}
 


### PR DESCRIPTION

## Description
Only allow same domain for user supplied redirect urls.

## How has this been tested?
Manually + phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

