### PR TITLE
Fix bug around existing lesson saving

### DIFF
--- a/.changelogs/adding-existing-lesson-saving.yml
+++ b/.changelogs/adding-existing-lesson-saving.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed saving when attaching an existing lesson after editing its title or permalink in the Course Builder.

--- a/assets/js/builder/Controllers/Sync.js
+++ b/assets/js/builder/Controllers/Sync.js
@@ -317,23 +317,74 @@ define( [], function() {
 		};
 
 		/**
+		 * Recursively restart change tracking on a model and its relationship children.
+		 *
+		 * Used after a full sync (temp-id create or `_forceSync` attach) so residual
+		 * dirty state from relationship initialization cannot keep the save button active.
+		 *
+		 * @since [version]
+		 *
+		 * @param {Object} model Backbone.Model instance.
+		 * @return {void}
+		 */
+		function restart_tracking_tree( model ) {
+
+			if ( ! model || ! model.restartTracking ) {
+				return;
+			}
+
+			model.unset( '_forceSync' );
+			model.restartTracking();
+
+			if ( ! model.get_relationships ) {
+				return;
+			}
+
+			_.each( model.get_child_props(), function( prop ) {
+
+				var child = model.get( prop );
+
+				if ( child instanceof Backbone.Model ) {
+					restart_tracking_tree( child );
+				} else if ( child instanceof Backbone.Collection ) {
+					child.each( restart_tracking_tree );
+				}
+
+			} );
+
+		}
+
+		/**
 		 * Compares changes synced to the server against current model and restarts
 		 * tracking on elements that haven't changed since the last sync
 		 *
 		 * @param    obj   model  instance of a Backbone.Model
 		 * @param    obj   data   data set that was processed by the server
-		 * @return   void
+		 * @return   {Boolean} True when this was a full sync (caller should restart the tree).
 		 * @since    3.16.11
-		 * @version  3.19.4
+		 * @since    3.19.4 Unknown.
+		 * @since    [version] Return whether this was a full sync; fix child-prop omit;
+		 *                     defer tree restart to the caller until after child updates apply.
+		 * @version  [version]
 		 */
 		function maybe_restart_tracking( model, data ) {
 
 			Backbone.pubSub.trigger( model.get( 'type' ) + '-maybe-restart-tracking', model, data );
 
+			var full_sync = true === model.get( '_forceSync' ) ||
+				( data.orig_id && ! _.isNumber( data.orig_id ) && 0 === String( data.orig_id ).indexOf( 'temp_' ) );
+
+			model.unset( '_forceSync' );
+
+			// Full syncs: caller runs restart_tracking_tree() after child updates are applied.
+			if ( full_sync ) {
+				return true;
+			}
+
 			var omit = [ 'id', 'orig_id' ];
 
 			if ( model.get_relationships ) {
-				omit.concat( model.get_child_props() );
+				omit = omit.concat( model.get_child_props() );
 			}
 
 			_.each( _.omit( data, omit ), function( val, prop ) {
@@ -345,8 +396,7 @@ define( [], function() {
 
 			} );
 
-			// if syncing was forced, allow tracking to move forward as normal moving forward
-			model.unset( '_forceSync' );
+			return false;
 
 		};
 
@@ -447,7 +497,21 @@ define( [], function() {
 						model.set( 'content_added_in_builder', info.content_added_in_builder );
 					}
 
-					maybe_restart_tracking( model, info );
+					// Keep client parent/order in sync with server-authoritative values before tracking reset.
+					if ( info.parent_course ) {
+						model.set( 'parent_course', info.parent_course );
+					}
+					if ( info.parent_section ) {
+						model.set( 'parent_section', info.parent_section );
+					}
+					if ( info.order ) {
+						model.set( 'order', info.order );
+					}
+					if ( info.lesson_id ) {
+						model.set( 'lesson_id', info.lesson_id );
+					}
+
+					var full_sync = maybe_restart_tracking( model, info );
 
 					// check children
 					if ( model.get_relationships ) {
@@ -456,6 +520,10 @@ define( [], function() {
 							_.extend( data[ type ], process_object_updates( data[ type ], child_key, model, main_data ) );
 						} );
 
+					}
+
+					if ( full_sync ) {
+						restart_tracking_tree( model );
 					}
 
 				}
@@ -490,8 +558,20 @@ define( [], function() {
 							model.set( 'content_added_in_builder', info.content_added_in_builder );
 						}
 
+						if ( info.parent_course ) {
+							model.set( 'parent_course', info.parent_course );
+						}
+						if ( info.parent_section ) {
+							model.set( 'parent_section', info.parent_section );
+						}
+						if ( info.order ) {
+							model.set( 'order', info.order );
+						}
+						if ( info.lesson_id ) {
+							model.set( 'lesson_id', info.lesson_id );
+						}
 
-						maybe_restart_tracking( model, info );
+						var full_sync = maybe_restart_tracking( model, info );
 
 						// check children
 						if ( model.get_relationships ) {
@@ -500,6 +580,10 @@ define( [], function() {
 								_.extend( data[ type ], process_object_updates( data[ type ][ index ], child_key, model, main_data ) );
 							} );
 
+						}
+
+						if ( full_sync ) {
+							restart_tracking_tree( model );
 						}
 
 					}

--- a/assets/js/builder/Controllers/Sync.js
+++ b/assets/js/builder/Controllers/Sync.js
@@ -2,7 +2,8 @@
  * Sync builder data to the server
  *
  * @since 3.16.0
- * @version 4.17.0
+ * @since [version] Always sync temp-id and `_forceSync` models even while focused.
+ * @version [version]
  */
 define( [], function() {
 
@@ -194,15 +195,19 @@ define( [], function() {
 		 * @param    obj   model  instance of a Backbone.Model
 		 * @return   obj
 		 * @since    3.16.0
-		 * @version  3.16.6
+		 * @since    [version] Always sync temp-id and `_forceSync` models even while focused.
+		 *                     Skipping them dropped attached/cloned lessons from the save payload
+		 *                     when the settings panel auto-focused the title after a permalink edit.
+		 * @version  [version]
 		 */
 		function get_changed_attributes( model ) {
 
 			var atts = {},
 				sync_type;
 
-			// don't save mid editing
-			if ( model.get( '_has_focus' ) ) {
+			// New or force-synced models must always sync (e.g. attaching an existing lesson).
+			// Only skip partial edits while the field still has focus.
+			if ( model.get( '_has_focus' ) && ! has_temp_id( model ) && true !== model.get( '_forceSync' ) ) {
 				return atts;
 			}
 

--- a/assets/js/builder/Views/LessonEditor.js
+++ b/assets/js/builder/Views/LessonEditor.js
@@ -5,7 +5,8 @@
  *
  * @since 3.17.0
  * @since 3.35.2 Added filter `llms_lesson_rerender_change_events` to view re-render change events.
- * @version 3.35.2
+ * @since [version] Only autofocus the title on the initial render.
+ * @version [version]
  */
 define( [
 		'Views/_Detachable',
@@ -100,34 +101,46 @@ define( [
 
 			},
 
-			/**
-			 * Render the view
-			 *
-			 * @return   obj
-			 * @since    3.17.0
-			 * @version  3.24.0
-			 */
-			render: function() {
+		/**
+		 * Render the view
+		 *
+		 * @since 3.17.0
+		 * @since 3.24.0 Unknown.
+		 * @since [version] Only autofocus the title on the initial render.
+		 *                     Refocusing after permalink/`name` changes left `_has_focus` set and
+		 *                     caused attached lessons to be skipped on save.
+		 *
+		 * @return {Object}
+		 */
+		render: function() {
 
-				this.$el.html( this.template( this.model ) );
+			var is_initial = ! this._has_rendered;
 
-				this.remove_subview( 'settings' );
+			this.$el.html( this.template( this.model ) );
 
-				this.render_subview( 'settings', {
-					el: '#llms-lesson-settings-fields',
-					model: this.model,
-				} );
+			this.remove_subview( 'settings' );
 
-				this.init_datepickers();
-				this.init_selects();
+			this.render_subview( 'settings', {
+				el: '#llms-lesson-settings-fields',
+				model: this.model,
+			} );
 
-				this.render_points_percentage();
+			this.init_datepickers();
+			this.init_selects();
 
+			this.render_points_percentage();
+
+			this._has_rendered = true;
+
+			// Only steal focus when the editor is first opened, not on subsequent re-renders
+			// (e.g. after editing the permalink, which triggers change:name → render).
+			if ( is_initial ) {
 				this.$('.llms-editable-title').focus();
+			}
 
-				return this;
+			return this;
 
-			},
+		},
 
 			/**
 			 * Render the portion of the template which displays the points percentage

--- a/includes/admin/class.llms.admin.builder.php
+++ b/includes/admin/class.llms.admin.builder.php
@@ -343,7 +343,12 @@ class LLMS_Admin_Builder {
 					return array();
 				}
 				$parent_course = self::get_object_parent_course_id( $id );
-				if ( ! $parent_course || absint( $parent_course ) !== absint( $request['course_id'] ) ) {
+				// Allow orphans the current user can edit (e.g. just-attached lessons before save).
+				if ( $parent_course ) {
+					if ( absint( $parent_course ) !== absint( $request['course_id'] ) ) {
+						return array();
+					}
+				} elseif ( ! current_user_can( 'edit_post', $id ) ) {
 					return array();
 				}
 				$title = isset( $request['title'] ) ? sanitize_title( $request['title'] ) : null;
@@ -1207,6 +1212,18 @@ class LLMS_Admin_Builder {
 				}
 				$res['parent_section'] = $lesson->get( 'parent_section' );
 				$res['parent_course']  = $lesson->get( 'parent_course' );
+
+				// Course Builder lesson lists query by `_llms_order`. Ensure attached/created
+				// lessons always have one so they appear after reload even if the client
+				// omitted `order` from a partial sync payload.
+				if ( empty( $lesson->get( 'order' ) ) ) {
+					$order = isset( $lesson_data['order'] ) ? absint( $lesson_data['order'] ) : 0;
+					if ( ! $order ) {
+						$order = count( $section->get_lessons( 'ids' ) ) + 1;
+					}
+					$lesson->set( 'order', $order );
+				}
+				$res['order'] = $lesson->get( 'order' );
 
 				// Update all custom fields.
 				self::update_custom_schemas( 'lesson', $lesson, $lesson_data );

--- a/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
+++ b/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
@@ -1,0 +1,125 @@
+/**
+ * Course Builder — attach existing lesson, edit title/permalink, save.
+ *
+ * @since [version]
+ */
+
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Set text on a contenteditable element and blur to commit via builder Editable handlers.
+ *
+ * @param {import('@playwright/test').Locator} locator Contenteditable locator.
+ * @param {string}                             text    New text.
+ */
+async function setContentEditable( locator, text ) {
+	await locator.click();
+	await locator.evaluate( ( el, value ) => {
+		el.focus();
+		el.textContent = value;
+		el.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		el.blur();
+	}, text );
+}
+
+test.describe( 'Course Builder / Attach Existing Lesson', () => {
+
+	test( 'attaching an orphan lesson, editing title and permalink, then saving persists the lesson', async ( {
+		page,
+		requestUtils,
+	} ) => {
+
+		const stamp = Date.now();
+		const orphanTitle = `Orphan ${ stamp }`;
+		const newTitle = `Attached Lesson ${ stamp }`;
+		const newSlug = `attached-lesson-${ stamp }`;
+
+		const course = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/courses',
+			data: {
+				title: `Builder Attach Course ${ stamp }`,
+				content: 'x',
+				status: 'publish',
+			},
+		} );
+
+		const section = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/sections',
+			data: {
+				title: 'Section 1',
+				parent_id: course.id,
+				order: 1,
+			},
+		} );
+
+		// Orphan lesson (no parent) so the builder uses the attach action.
+		const orphan = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/lessons',
+			data: {
+				title: orphanTitle,
+				content: 'orphan content',
+				status: 'publish',
+				parent_id: 0,
+			},
+		} );
+
+		await page.goto( `/wp-admin/admin.php?page=llms-course-builder&course_id=${ course.id }` );
+		await page.locator( '.wrap.lifterlms.llms-builder' ).waitFor( { state: 'visible' } );
+		await page.locator( `#llms-section-${ section.id }` ).waitFor( { state: 'visible' } );
+
+		// Open "Add Existing Lesson" and select the orphan.
+		await page.locator( '#llms-existing-lesson' ).click();
+		await page.locator( '.webui-popover .select2-container' ).click();
+		await page.locator( '.select2-search__field' ).fill( orphanTitle );
+		await page.locator( `.select2-results__option:has-text("${ orphanTitle }")` ).first().click();
+
+		// Lesson should appear in the section and open the editor.
+		const lessonItem = page.locator( `#llms-lesson-${ orphan.id }` );
+		await expect( lessonItem ).toBeVisible( { timeout: 10000 } );
+
+		const editor = page.locator( '#llms-editor-lesson' );
+		await expect( editor ).toBeVisible();
+
+		// Edit title (header contenteditable).
+		await setContentEditable( editor.locator( '.llms-editable-title' ).first(), newTitle );
+
+		// Edit permalink slug.
+		await editor.locator( 'a[href="#llms-edit-slug"]' ).click();
+		const slugInput = editor.locator( 'input.permalink' );
+		await expect( slugInput ).toBeVisible();
+		await slugInput.fill( newSlug );
+		await slugInput.press( 'Enter' );
+		// Give the async get_permalink call a moment; blur is enough to commit `name`.
+		await page.waitForTimeout( 500 );
+
+		// Wait for save button to reflect unsaved state, then save.
+		const saveBtn = page.locator( '#llms-save-button' );
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'unsaved', { timeout: 5000 } );
+		await saveBtn.click();
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved', { timeout: 15000 } );
+
+		// Must stay saved (not flip back to unsaved from a stuck _forceSync / focus state).
+		await page.waitForTimeout( 2000 );
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved' );
+
+		// Reload the builder — the attached lesson must still be present with the new title.
+		await page.reload();
+		await page.locator( '.wrap.lifterlms.llms-builder' ).waitFor( { state: 'visible' } );
+		await expect( page.locator( `#llms-lesson-${ orphan.id }` ) ).toBeVisible( { timeout: 10000 } );
+		await expect( page.locator( `#llms-lesson-${ orphan.id }` ) ).toContainText( newTitle );
+
+		// Confirm parent association was persisted server-side.
+		const saved = await requestUtils.rest( {
+			method: 'GET',
+			path: `/llms/v1/lessons/${ orphan.id }`,
+			params: { context: 'edit' },
+		} );
+		expect( saved.parent_id ).toBe( section.id );
+		const title = typeof saved.title === 'object' ? saved.title.raw : saved.title;
+		expect( title ).toBe( newTitle );
+	} );
+
+} );

--- a/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
+++ b/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
@@ -101,8 +101,14 @@ test.describe( 'Course Builder / Attach Existing Lesson', () => {
 		await saveBtn.click();
 		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved', { timeout: 15000 } );
 
-		// Must stay saved (not flip back to unsaved from a stuck _forceSync / focus state).
-		await page.waitForTimeout( 2000 );
+		// Must stay saved — residual tracking dirt from quiz/relationship init used to
+		// flip this back to "Save changes" after a successful attach/clone sync.
+		await page.waitForTimeout( 3000 );
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved' );
+		await expect( saveBtn ).toBeDisabled();
+
+		// Still clean after another changes-check interval.
+		await page.waitForTimeout( 1500 );
 		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved' );
 
 		// Reload the builder — the attached lesson must still be present with the new title.

--- a/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
+++ b/tests/phpunit/unit-tests/admin/class-llms-test-admin-builder.php
@@ -999,6 +999,72 @@ class LLMS_Test_Admin_Builder extends LLMS_Unit_Test_Case {
 	}
 
 	/**
+	 * Test attaching an orphan lesson via update_lessons while also updating title and slug.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_lessons_can_attach_orphan_with_title_and_name() {
+
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
+		$course  = $this->factory->course->create_and_get( array(
+			'sections' => 1,
+			'lessons'  => 0,
+			'quizzes'  => 0,
+		) );
+		$section = $course->get_sections()[0];
+
+		// Orphan lesson (no parent course/section) with a quiz, matching the attach path.
+		$orphan_id = $this->factory->post->create( array(
+			'post_type'  => 'lesson',
+			'post_title' => 'Orphan Lesson',
+			'post_name'  => 'orphan-lesson',
+		) );
+		$orphan    = llms_get_post( $orphan_id );
+		$this->assertTrue( $orphan->is_orphan() );
+
+		$quiz = new LLMS_Quiz( 'new', array( 'post_title' => 'Orphan Quiz' ) );
+		$orphan->set( 'quiz', $quiz->get( 'id' ) );
+		$orphan->set( 'quiz_enabled', 'yes' );
+		$quiz->set( 'lesson_id', $orphan->get( 'id' ) );
+
+		$lessons_data = array(
+			array(
+				'id'             => $orphan->get( 'id' ),
+				'title'          => 'Attached Lesson Title',
+				'name'           => 'attached-lesson-slug',
+				'parent_course'  => $course->get( 'id' ),
+				'parent_section' => $section->get( 'id' ),
+				// Intentionally omit `order` — partial syncs after attach can leave it out,
+				// and the builder's section lesson query requires `_llms_order`.
+			),
+		);
+
+		$res = LLMS_Unit_Test_Util::call_method(
+			$this->main,
+			'update_lessons',
+			array( $lessons_data, $section, $course->get( 'id' ) )
+		);
+
+		$this->assertArrayNotHasKey( 'error', $res[0] );
+
+		$orphan = llms_get_post( $orphan->get( 'id' ) );
+		$this->assertEquals( $course->get( 'id' ), $orphan->get( 'parent_course' ) );
+		$this->assertEquals( $section->get( 'id' ), $orphan->get( 'parent_section' ) );
+		$this->assertEquals( 'Attached Lesson Title', $orphan->get( 'title', true ) );
+		$this->assertEquals( 'attached-lesson-slug', $orphan->get( 'name' ) );
+		$this->assertNotEmpty( $orphan->get( 'order' ) );
+		$this->assertFalse( $orphan->is_orphan() );
+
+		// Fresh section instance — builder reload queries lessons by `_llms_parent_section` + `_llms_order`.
+		$section         = llms_get_post( $section->get( 'id' ) );
+		$section_lessons = $section->get_lessons( 'ids' );
+		$this->assertContains( $orphan->get( 'id' ), $section_lessons );
+	}
+
+	/**
 	 * Catch wp_die() called by ajax methods & store the output buffer contents for use later.
 	 *
 	 * The same method is used in LLMS_Test_AJAX_Handler.


### PR DESCRIPTION

## Description
Fixes #3308

## How has this been tested?
Manual, E2E, phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

