### PR TITLE
Fix protected media hook name saving

### DIFF
--- a/.changelogs/protected-media-file-hook-saving-new.yml
+++ b/.changelogs/protected-media-file-hook-saving-new.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Preserve the authorization hook name passed to media upload.

--- a/includes/class-llms-media-protector.php
+++ b/includes/class-llms-media-protector.php
@@ -399,7 +399,7 @@ class LLMS_Media_Protector {
 		add_filter( 'upload_dir', array( $this, 'upload_dir' ), 10, 1 );
 		$media_id = media_handle_upload( $file_id, $post_id, $post_data, $overrides );
 		remove_filter( 'upload_dir', array( $this, 'upload_dir' ), 10 );
-		$this->add_authorization_meta_to_media_post( $media_id );
+		$this->add_authorization_meta_to_media_post( $media_id, $hook_name );
 
 		return $media_id;
 	}

--- a/tests/phpunit/unit-tests/class-llms-test-media-protector.php
+++ b/tests/phpunit/unit-tests/class-llms-test-media-protector.php
@@ -174,4 +174,46 @@ class LLMS_Test_Media_Protector extends LLMS_UnitTestCase {
 		$this->assertNotSame( 'null', $cached, 'Cached value should be overwritten once protection is set.' );
 		$this->assertTrue( (bool) $cached );
 	}
+
+	/**
+	 * Test that handle_upload() stores the supplied authorization hook name.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_handle_upload_persists_custom_hook_name() {
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/media.php';
+		require_once ABSPATH . 'wp-admin/includes/image.php';
+
+		$tmp = wp_tempnam( 'llms-media-protector-test.txt' );
+		file_put_contents( $tmp, 'test' );
+
+		$_FILES['file'] = array(
+			'name'     => 'llms-media-protector-test.txt',
+			'tmp_name' => $tmp,
+			'type'     => 'text/plain',
+			'error'    => 0,
+			'size'     => filesize( $tmp ),
+		);
+
+		$protector = new LLMS_Media_Protector();
+		$media_id  = $protector->handle_upload(
+			'file',
+			0,
+			'llms_test_authorize_media_view',
+			array(),
+			array(
+				'test_form' => false,
+				'action'    => 'testing',
+			)
+		);
+
+		unset( $_FILES['file'] );
+
+		$this->assertFalse( is_wp_error( $media_id ), is_wp_error( $media_id ) ? $media_id->get_error_message() : '' );
+		$this->assertSame( 'llms_test_authorize_media_view', $protector->get_authorization_filter_name( $media_id ) );
+	}
 }


### PR DESCRIPTION

## Description
Persist the auth hook name, if any is passed in.

## How has this been tested?
Manually plus phpunit.

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

