### PR TITLE
Object cache invalidation and hardening for persistent object cache hosts

### DIFF
--- a/.changelogs/fix-object-cache-invalidation-2-2.yml
+++ b/.changelogs/fix-object-cache-invalidation-2-2.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: Improved cache miss detection and added expiration times to object cache entries for more reliable behavior on persistent object cache backends.

--- a/.changelogs/fix-object-cache-invalidation-2.yml
+++ b/.changelogs/fix-object-cache-invalidation-2.yml
@@ -1,0 +1,5 @@
+significance: patch
+type: fixed
+links:
+  - "#3116"
+entry: Fixed stale object cache values for core forms, membership-associated posts, student grades, product active-subscription counts, and theme template override directories on sites using a persistent object cache (Redis, Memcached).

--- a/class-lifterlms.php
+++ b/class-lifterlms.php
@@ -85,6 +85,9 @@ final class LifterLMS {
 
 		add_action( 'init', array( $this, 'localize' ), 0 );
 		add_action( 'init', array( $this, 'init' ), 0 );
+		add_action( 'init', array( 'LLMS_Membership', 'init_associated_posts_cache_hooks' ), 0 );
+		add_action( 'init', array( 'LLMS_Product', 'init_active_subscriptions_cache_hooks' ), 0 );
+		add_action( 'init', array( 'LLMS_Grades', 'init_grade_cache_hooks' ), 0 );
 		add_action( 'init', array( $this, 'integrations' ), 1 );
 		add_action( 'init', array( $this, 'processors' ), 5 );
 		add_action( 'init', array( $this, 'events' ), 5 );

--- a/includes/admin/tools/class-llms-admin-tool-batch-eraser.php
+++ b/includes/admin/tools/class-llms-admin-tool-batch-eraser.php
@@ -51,7 +51,6 @@ class LLMS_Admin_Tool_Batch_Eraser extends LLMS_Abstract_Admin_Tool {
 		);
 
 		return $desc;
-
 	}
 
 	/**
@@ -98,7 +97,6 @@ class LLMS_Admin_Tool_Batch_Eraser extends LLMS_Abstract_Admin_Tool {
 		}
 
 		return $count;
-
 	}
 
 	/**
@@ -118,7 +116,6 @@ class LLMS_Admin_Tool_Batch_Eraser extends LLMS_Abstract_Admin_Tool {
 		$res = $wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%llms_%_batch_%';" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 		wp_cache_delete( $this->id, 'llms_tool_data' );
 		return $res > 0;
-
 	}
 
 	/**
@@ -133,9 +130,7 @@ class LLMS_Admin_Tool_Batch_Eraser extends LLMS_Abstract_Admin_Tool {
 	protected function should_load() {
 
 		return $this->get_pending_batches() > 0;
-
 	}
-
 }
 
 return new LLMS_Admin_Tool_Batch_Eraser();

--- a/includes/admin/tools/class-llms-admin-tool-batch-eraser.php
+++ b/includes/admin/tools/class-llms-admin-tool-batch-eraser.php
@@ -93,7 +93,7 @@ class LLMS_Admin_Tool_Batch_Eraser extends LLMS_Abstract_Admin_Tool {
 			global $wpdb;
 			$count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->options} WHERE option_name LIKE '%llms_%_batch_%';" ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 
-			wp_cache_set( $this->id, $count, 'llms_tool_data' );
+			wp_cache_set( $this->id, $count, 'llms_tool_data', HOUR_IN_SECONDS );
 
 		}
 

--- a/includes/admin/tools/class-llms-admin-tool-course-data-lock-eraser.php
+++ b/includes/admin/tools/class-llms-admin-tool-course-data-lock-eraser.php
@@ -91,7 +91,7 @@ class LLMS_Admin_Tool_Course_Data_Lock_Eraser extends LLMS_Abstract_Admin_Tool {
 			global $wpdb;
 			$count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->postmeta} WHERE meta_key = '_llms_temp_calc_data_lock';" ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 
-			wp_cache_set( $this->id, $count, 'llms_tool_data' );
+			wp_cache_set( $this->id, $count, 'llms_tool_data', HOUR_IN_SECONDS );
 
 		}
 

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -70,7 +70,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		}
 
 		return array_filter( $csv );
-
 	}
 
 	/**
@@ -106,7 +105,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		fclose( $fh ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose
 
 		return ob_get_clean();
-
 	}
 
 	/**
@@ -141,7 +139,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		);
 
 		return $desc;
-
 	}
 
 	/**
@@ -192,7 +189,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		}
 
 		return array();
-
 	}
 
 	/**
@@ -215,7 +211,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		);
 
 		return $txns['total'];
-
 	}
 
 	/**
@@ -245,7 +240,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		}
 
 		return $csv;
-
 	}
 
 	/**
@@ -270,7 +264,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		}
 
 		llms_exit( $file );
-
 	}
 
 	/**
@@ -285,7 +278,6 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	protected function should_load() {
 		return count( $this->get_csv() ) > 0;
 	}
-
 }
 
 return new LLMS_Admin_Tool_Limited_Billing_Order_Locator();

--- a/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
+++ b/includes/admin/tools/class-llms-admin-tool-limited-billing-order-locator.php
@@ -241,7 +241,7 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 		$csv = wp_cache_get( $this->id, 'llms_tool_data' );
 		if ( ! $csv ) {
 			$csv = $this->generate_csv();
-			wp_cache_set( $this->id, $csv, 'llms_tool_data' );
+			wp_cache_set( $this->id, $csv, 'llms_tool_data', HOUR_IN_SECONDS );
 		}
 
 		return $csv;
@@ -258,6 +258,9 @@ class LLMS_Admin_Tool_Limited_Billing_Order_Locator extends LLMS_Abstract_Admin_
 	protected function handle() {
 
 		$file = $this->get_csv_file();
+
+		// Ensure the next tool run re-queries instead of serving a stale report from a persistent object cache.
+		wp_cache_delete( $this->id, 'llms_tool_data' );
 
 		if ( ! headers_sent() ) { // This makes the method testable via phpunit.
 			header( 'Content-Type: text/csv' );

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -92,7 +92,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		$orders = wp_cache_get( $this->id, 'llms_tool_data' );
 		if ( ! $orders ) {
 			$orders = wp_list_pluck( $this->query_orders(), 'ID' );
-			wp_cache_set( $this->id, $orders, 'llms_tool_data' );
+			wp_cache_set( $this->id, $orders, 'llms_tool_data', HOUR_IN_SECONDS );
 		}
 
 		return $orders;
@@ -163,7 +163,7 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 			    AND m.meta_value IS NULL";
 
 		$total = $wpdb->get_var( "SELECT COUNT(*) {$from_joins_where}" ); // no-cache ok.
-		wp_cache_set( sprintf( '%s-total-results', $this->id ), $total, 'llms_tool_data' );
+		wp_cache_set( sprintf( '%s-total-results', $this->id ), $total, 'llms_tool_data', HOUR_IN_SECONDS );
 
 		$orders = $wpdb->get_results(
 			"SELECT p.ID

--- a/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
+++ b/includes/admin/tools/class-llms-admin-tool-recurring-payment-rescheduler.php
@@ -53,7 +53,6 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		);
 
 		return $desc;
-
 	}
 
 	/**
@@ -96,7 +95,6 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		}
 
 		return $orders;
-
 	}
 
 	/**
@@ -132,7 +130,6 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		wp_cache_delete( sprintf( '%s-total-results', $this->id ), 'llms_tool_data' );
 
 		return $orders;
-
 	}
 
 	/**
@@ -174,7 +171,6 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 		); // no-cache ok -- Caching implemented in `get_orders()`.
 
 		return $orders;
-
 	}
 
 	/**
@@ -189,7 +185,6 @@ class LLMS_Admin_Tool_Recurring_Payment_Rescheduler extends LLMS_Abstract_Admin_
 	protected function should_load() {
 		return count( $this->get_orders() ) > 0;
 	}
-
 }
 
 return new LLMS_Admin_Tool_Recurring_Payment_Rescheduler();

--- a/includes/class-llms-grades.php
+++ b/includes/class-llms-grades.php
@@ -41,6 +41,72 @@ class LLMS_Grades {
 	}
 
 	/**
+	 * Register hooks that invalidate the per-student grade cache when data affecting a grade changes.
+	 *
+	 * Registered during plugin bootstrap by {@see LifterLMS::__construct()} rather than in this
+	 * class' constructor: the singleton constructor only runs the first time the instance is
+	 * requested, so hooks added there would not re-register after the WordPress test suite's
+	 * `restore_hooks()` wipes them between tests.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function init_grade_cache_hooks() {
+		add_action( 'llms_mark_complete', array( __CLASS__, 'clear_student_cache_static' ), 10, 1 );
+		add_action( 'llms_mark_incomplete', array( __CLASS__, 'clear_student_cache_static' ), 10, 1 );
+		add_action( 'lifterlms_quiz_completed', array( __CLASS__, 'clear_student_cache_static' ), 10, 1 );
+		add_action( 'llms_user_enrollment_deleted', array( __CLASS__, 'clear_student_cache_static' ), 10, 1 );
+	}
+
+	/**
+	 * Static wrapper for {@see LLMS_Grades::clear_student_cache()} usable as a hook callback.
+	 *
+	 * All of the actions registered by {@see LLMS_Grades::init_grade_cache_hooks()} pass the
+	 * student's user ID as their first parameter.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $student_id WP_User ID of the student.
+	 * @return void
+	 */
+	public static function clear_student_cache_static( $student_id ) {
+		self::instance()->clear_student_cache( $student_id );
+	}
+
+	/**
+	 * Retrieves the cache group name used for a student's cached grades.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $student_id WP_User ID of the student.
+	 * @return string
+	 */
+	public static function get_cache_group( $student_id ) {
+		return sprintf( 'student_%d', absint( $student_id ) );
+	}
+
+	/**
+	 * Invalidates every cached grade for a student.
+	 *
+	 * Uses the {@see LLMS_Cache_Helper} prefix-bump pattern so a single call orphans all
+	 * cached grades for the student without relying on `wp_cache_flush_group()`, which
+	 * is not supported by some persistent object cache backends.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $student_id WP_User ID of the student.
+	 * @return void
+	 */
+	public function clear_student_cache( $student_id ) {
+
+		$student_id = absint( $student_id );
+		if ( $student_id ) {
+			LLMS_Cache_Helper::invalidate_group( self::get_cache_group( $student_id ) );
+		}
+	}
+
+	/**
 	 * Calculates the grades for elements that have a list of children which are averaged / weighted to come up with the total grade
 	 *
 	 * @param    array        $children list of child objects
@@ -224,11 +290,9 @@ class LLMS_Grades {
 			$grade = $this->calculate_grade( $post, $student );
 
 			// Store in the cache.
-			wp_cache_set(
-				sprintf( '%d_grade', $post->get( 'id' ) ),
-				$grade,
-				sprintf( 'student_%d', $student->get( 'id' ) )
-			);
+			$cache_group = self::get_cache_group( $student->get( 'id' ) );
+			$cache_key   = LLMS_Cache_Helper::get_prefix( $cache_group ) . sprintf( '%d_grade', $post->get( 'id' ) );
+			wp_cache_set( $cache_key, $grade, $cache_group, HOUR_IN_SECONDS );
 
 		}
 
@@ -249,10 +313,17 @@ class LLMS_Grades {
 	 */
 	private function get_grade_from_cache( $post, $student ) {
 
-		return wp_cache_get(
-			sprintf( '%d_grade', $post->get( 'id' ) ),
-			sprintf( 'student_%d', $student->get( 'id' ) )
-		);
+		$cache_group = self::get_cache_group( $student->get( 'id' ) );
+		$cache_key   = LLMS_Cache_Helper::get_prefix( $cache_group ) . sprintf( '%d_grade', $post->get( 'id' ) );
+
+		$cached = wp_cache_get( $cache_key, $cache_group );
+
+		// Persistent object caches (Redis, Memcached) can deserialize a cached null as an empty string.
+		if ( '' === $cached ) {
+			return false;
+		}
+
+		return $cached;
 
 	}
 

--- a/includes/class-llms-grades.php
+++ b/includes/class-llms-grades.php
@@ -37,7 +37,6 @@ class LLMS_Grades {
 	private function __construct() {
 
 		$this->rounding_precision = apply_filters( 'llms_grade_rounding_precision', $this->rounding_precision );
-
 	}
 
 	/**
@@ -166,7 +165,6 @@ class LLMS_Grades {
 		}
 
 		return $grade;
-
 	}
 
 	/**
@@ -186,7 +184,6 @@ class LLMS_Grades {
 			$course,
 			$student
 		);
-
 	}
 
 	/**
@@ -238,7 +235,6 @@ class LLMS_Grades {
 		}
 
 		return apply_filters( 'llms_calculate_grade', $grade, $post, $student );
-
 	}
 
 	/**
@@ -261,7 +257,6 @@ class LLMS_Grades {
 		}
 
 		return apply_filters( 'llms_calculate_lesson_grade', $grade, $lesson, $student );
-
 	}
 
 	/**
@@ -297,7 +292,6 @@ class LLMS_Grades {
 		}
 
 		return apply_filters( 'llms_get_grade', $grade, $post, $student );
-
 	}
 
 	/**
@@ -324,7 +318,6 @@ class LLMS_Grades {
 		}
 
 		return $cached;
-
 	}
 
 	/**
@@ -338,7 +331,5 @@ class LLMS_Grades {
 	public function round( $grade ) {
 
 		return round( $grade, $this->rounding_precision );
-
 	}
-
 }

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -29,7 +29,6 @@ class LLMS_Cache_Helper {
 
 		add_action( 'wp', array( $this, 'maybe_no_cache' ) );
 		add_action( 'switch_theme', array( __CLASS__, 'clear_template_override_directories_cache' ) );
-
 	}
 
 	/**
@@ -103,7 +102,6 @@ class LLMS_Cache_Helper {
 		}
 
 		return sprintf( 'llms_cache_%s_', $prefix );
-
 	}
 
 	/**
@@ -175,7 +173,6 @@ class LLMS_Cache_Helper {
 			remove_filter( 'nocache_headers', array( __CLASS__, 'additional_nocache_headers' ), 99 );
 
 		}
-
 	}
 
 	/**
@@ -214,9 +211,7 @@ class LLMS_Cache_Helper {
 		$headers['Cache-Control'] = implode( ', ', $nocache_headers_cache_control );
 
 		return $headers;
-
 	}
-
 }
 
 return new LLMS_Cache_Helper();

--- a/includes/class.llms.cache.helper.php
+++ b/includes/class.llms.cache.helper.php
@@ -28,7 +28,22 @@ class LLMS_Cache_Helper {
 	public function __construct() {
 
 		add_action( 'wp', array( $this, 'maybe_no_cache' ) );
+		add_action( 'switch_theme', array( __CLASS__, 'clear_template_override_directories_cache' ) );
 
+	}
+
+	/**
+	 * Clears the cached list of theme override directories used by `llms_get_template_override_directories()`.
+	 *
+	 * The cached value contains absolute paths derived from the active theme; on hosts with a
+	 * persistent object cache the stale paths would otherwise survive a theme switch.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function clear_template_override_directories_cache() {
+		wp_cache_delete( 'theme-override-directories', 'llms_template_functions' );
 	}
 
 	/**

--- a/includes/forms/class-llms-forms.php
+++ b/includes/forms/class-llms-forms.php
@@ -45,6 +45,85 @@ class LLMS_Forms {
 
 		add_filter( 'render_block', array( $this, 'render_field_block' ), 10, 2 );
 		add_filter( 'llms_get_form_post', array( $this, 'maybe_load_preview' ) );
+
+		add_action( 'save_post_' . $this->get_post_type(), array( $this, 'flush_core_forms_cache' ) );
+		add_action( 'deleted_post', array( $this, 'maybe_flush_core_forms_cache_on_delete' ), 10, 2 );
+		add_action( 'trashed_post', array( $this, 'maybe_flush_core_forms_cache_on_status_change' ) );
+		add_action( 'untrashed_post', array( $this, 'maybe_flush_core_forms_cache_on_status_change' ) );
+
+		// The cached set is derived from `_llms_form_is_core` and `_llms_form_location` postmeta,
+		// so programmatic meta updates must also bust the cache.
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $action ) {
+			add_action( $action, array( $this, 'maybe_flush_core_forms_cache_on_meta_change' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Invalidates the cache used by {@see LLMS_Forms::get_core_forms()}.
+	 *
+	 * The cached set is derived from `_llms_form_location` and `_llms_form_is_core` postmeta
+	 * on form posts. Whenever a form is saved, trashed, untrashed, or deleted the cached set
+	 * may diverge from the live data; flush it so the next read re-queries.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function flush_core_forms_cache() {
+		wp_cache_delete( 'llms_core_forms' );
+		wp_cache_delete( 'llms_core_form_ids' );
+	}
+
+	/**
+	 * Flushes the core forms cache when a form post is deleted.
+	 *
+	 * @since [version]
+	 *
+	 * @param int     $post_id WP_Post ID.
+	 * @param WP_Post $post    Post object.
+	 * @return void
+	 */
+	public function maybe_flush_core_forms_cache_on_delete( $post_id, $post ) {
+		if ( $post instanceof WP_Post && $this->get_post_type() === $post->post_type ) {
+			$this->flush_core_forms_cache();
+		}
+	}
+
+	/**
+	 * Flushes the core forms cache when one of the meta keys the cache is derived from changes.
+	 *
+	 * @since [version]
+	 *
+	 * @param int    $meta_id   Meta row ID (unused).
+	 * @param int    $object_id WP_Post ID whose meta changed.
+	 * @param string $meta_key  Meta key that changed.
+	 * @return void
+	 */
+	public function maybe_flush_core_forms_cache_on_meta_change( $meta_id, $object_id, $meta_key ) {
+
+		if ( ! in_array( $meta_key, array( '_llms_form_is_core', '_llms_form_location' ), true ) ) {
+			return;
+		}
+
+		if ( $this->get_post_type() !== get_post_type( $object_id ) ) {
+			return;
+		}
+
+		$this->flush_core_forms_cache();
+	}
+
+	/**
+	 * Flushes the core forms cache when a form post is trashed or untrashed.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $post_id WP_Post ID.
+	 * @return void
+	 */
+	public function maybe_flush_core_forms_cache_on_status_change( $post_id ) {
+		if ( $this->get_post_type() === get_post_type( $post_id ) ) {
+			$this->flush_core_forms_cache();
+		}
 	}
 
 	/**
@@ -680,7 +759,7 @@ GROUP BY locations.meta_value";
 		$form_ids = array_map( 'absint', $form_ids );
 		$forms    = 'post' === $return ? array_map( 'get_post', $form_ids ) : $form_ids;
 
-		wp_cache_set( $forms_cache_key, $forms );
+		wp_cache_set( $forms_cache_key, $forms, '', HOUR_IN_SECONDS );
 
 		return $forms;
 	}

--- a/includes/functions/llms.functions.template.php
+++ b/includes/functions/llms.functions.template.php
@@ -237,7 +237,9 @@ function llms_get_template_override_directories() {
 			),
 			'is_dir'
 		);
-		wp_cache_set( 'theme-override-directories', $dirs, 'llms_template_functions' );
+		// Expire so newly created or removed theme `lifterlms` directories are picked up
+		// on persistent object caches; the cache is also deleted on `switch_theme`.
+		wp_cache_set( 'theme-override-directories', $dirs, 'llms_template_functions', DAY_IN_SECONDS );
 	}
 
 	/**

--- a/includes/models/model.llms.membership.php
+++ b/includes/models/model.llms.membership.php
@@ -352,9 +352,10 @@ class LLMS_Membership extends LLMS_Post_Model implements LLMS_Interface_Post_Ins
 		global $wpdb;
 
 		// See if we have a cached result first.
-		$cache = sprintf( 'membership_%1$d_associated_%2$s', $this->get( 'id' ), $post_type );
-		$found = null;
-		$ids   = wp_cache_get( $cache, '', false, $found );
+		$cache_group = self::get_associated_posts_cache_group( $this->get( 'id' ) );
+		$cache_key   = LLMS_Cache_Helper::get_prefix( $cache_group ) . $post_type;
+		$found       = null;
+		$ids         = wp_cache_get( $cache_key, $cache_group, false, $found );
 
 		// We don't, perform a query.
 		if ( ! $found ) {
@@ -384,11 +385,148 @@ class LLMS_Membership extends LLMS_Post_Model implements LLMS_Interface_Post_Ins
 			$ids = array_map( 'absint', $ids );
 
 			// Cache the result.
-			wp_cache_set( $cache, $ids );
+			wp_cache_set( $cache_key, $ids, $cache_group, HOUR_IN_SECONDS );
 
 		}
 
 		return $ids;
+	}
+
+	/**
+	 * Retrieves the cache group name used by {@see LLMS_Membership::query_associated_posts()}.
+	 *
+	 * The group is per-membership so {@see LLMS_Cache_Helper::invalidate_group()} can orphan
+	 * every cached associated post type for the membership in a single call.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $membership_id WP_Post ID of the membership.
+	 * @return string
+	 */
+	public static function get_associated_posts_cache_group( $membership_id ) {
+		return sprintf( 'llms_membership_%d_associated', absint( $membership_id ) );
+	}
+
+	/**
+	 * Invalidates the associated-posts cache for one or more memberships.
+	 *
+	 * @since [version]
+	 *
+	 * @param int|int[] $membership_ids One or more membership post IDs.
+	 * @return void
+	 */
+	public static function flush_associated_posts_cache( $membership_ids ) {
+		foreach ( (array) $membership_ids as $membership_id ) {
+			$membership_id = absint( $membership_id );
+			if ( $membership_id ) {
+				LLMS_Cache_Helper::invalidate_group( self::get_associated_posts_cache_group( $membership_id ) );
+			}
+		}
+	}
+
+	/**
+	 * Registers hooks that invalidate the associated-posts cache when restriction or
+	 * access-plan-availability metadata changes on an associated post.
+	 *
+	 * Registered during plugin bootstrap by {@see LifterLMS::__construct()}.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function init_associated_posts_cache_hooks() {
+
+		// Capture the prior membership list before meta is updated so removals also bust the cache.
+		add_filter( 'update_post_metadata', array( __CLASS__, 'capture_associated_posts_pre_update_meta' ), 10, 4 );
+
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $action ) {
+			add_action( $action, array( __CLASS__, 'flush_associated_posts_cache_on_meta_change' ), 10, 4 );
+		}
+
+		// Post deletion / trash status changes can remove an association without touching meta.
+		add_action( 'before_delete_post', array( __CLASS__, 'flush_associated_posts_cache_on_post_change' ) );
+		add_action( 'trashed_post', array( __CLASS__, 'flush_associated_posts_cache_on_post_change' ) );
+		add_action( 'untrashed_post', array( __CLASS__, 'flush_associated_posts_cache_on_post_change' ) );
+	}
+
+	/**
+	 * Retrieves the meta keys that drive the associated-posts cache.
+	 *
+	 * @since [version]
+	 *
+	 * @return string[]
+	 */
+	protected static function get_associated_posts_meta_keys() {
+		return array(
+			'_llms_restricted_levels',
+			'_llms_availability_restrictions',
+		);
+	}
+
+	/**
+	 * Captures the existing membership list before a restriction meta value is overwritten.
+	 *
+	 * `updated_post_meta` only exposes the new value, so memberships removed from the list
+	 * would otherwise never have their cache invalidated.
+	 *
+	 * @since [version]
+	 *
+	 * @param null|bool $check      Whether to allow the metadata update; returned untouched.
+	 * @param int       $object_id  WP_Post ID whose meta is being updated.
+	 * @param string    $meta_key   Meta key being updated.
+	 * @param mixed     $meta_value New meta value (unused).
+	 * @return null|bool The original `$check` value, never modified.
+	 */
+	public static function capture_associated_posts_pre_update_meta( $check, $object_id, $meta_key, $meta_value ) {
+
+		if ( in_array( $meta_key, self::get_associated_posts_meta_keys(), true ) ) {
+			$old = get_post_meta( $object_id, $meta_key, true );
+			if ( ! empty( $old ) ) {
+				self::flush_associated_posts_cache( (array) $old );
+			}
+		}
+
+		return $check;
+	}
+
+	/**
+	 * Invalidates the cache for memberships referenced by a changed meta value.
+	 *
+	 * @since [version]
+	 *
+	 * @param int    $meta_id    Meta row ID (unused).
+	 * @param int    $object_id  WP_Post ID whose meta changed.
+	 * @param string $meta_key   Meta key that changed.
+	 * @param mixed  $meta_value The new (or now-deleted) meta value.
+	 * @return void
+	 */
+	public static function flush_associated_posts_cache_on_meta_change( $meta_id, $object_id, $meta_key, $meta_value ) {
+
+		if ( ! in_array( $meta_key, self::get_associated_posts_meta_keys(), true ) ) {
+			return;
+		}
+
+		if ( ! empty( $meta_value ) ) {
+			self::flush_associated_posts_cache( (array) $meta_value );
+		}
+	}
+
+	/**
+	 * Invalidates the cache when a post that may be associated to a membership is deleted, trashed, or untrashed.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $post_id WP_Post ID being deleted, trashed, or untrashed.
+	 * @return void
+	 */
+	public static function flush_associated_posts_cache_on_post_change( $post_id ) {
+
+		foreach ( self::get_associated_posts_meta_keys() as $meta_key ) {
+			$value = get_post_meta( $post_id, $meta_key, true );
+			if ( ! empty( $value ) ) {
+				self::flush_associated_posts_cache( (array) $value );
+			}
+		}
 	}
 
 	/**

--- a/includes/models/model.llms.product.php
+++ b/includes/models/model.llms.product.php
@@ -417,11 +417,83 @@ class LLMS_Product extends LLMS_Post_Model {
 			wp_cache_set(
 				$this->get( 'id' ),
 				$subscriptions_count,
-				'llms_product_subscriptions_count'
+				'llms_product_subscriptions_count',
+				HOUR_IN_SECONDS
 			);
 
 		}
 
 		return (bool) $subscriptions_count;
+	}
+
+	/**
+	 * Invalidates the cache used by {@see LLMS_Product::has_active_subscriptions()}.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $product_id WP_Post ID of the product.
+	 * @return void
+	 */
+	public static function flush_active_subscriptions_cache( $product_id ) {
+
+		$product_id = absint( $product_id );
+		if ( $product_id ) {
+			wp_cache_delete( $product_id, 'llms_product_subscriptions_count' );
+		}
+	}
+
+	/**
+	 * Registers hooks that invalidate the active-subscriptions cache when an order's
+	 * status changes or an order is deleted.
+	 *
+	 * Registered during plugin bootstrap by {@see LifterLMS::__construct()}.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function init_active_subscriptions_cache_hooks() {
+		add_action( 'transition_post_status', array( __CLASS__, 'flush_active_subscriptions_cache_on_status_change' ), 10, 3 );
+		add_action( 'before_delete_post', array( __CLASS__, 'flush_active_subscriptions_cache_on_post_delete' ) );
+	}
+
+	/**
+	 * Invalidates the active-subscriptions cache when an `llms_order` post changes status.
+	 *
+	 * The cached count covers orders in the `llms-active`, `llms-pending-cancel`, and
+	 * `llms-on-hold` statuses. Any transition into or out of one of those statuses can
+	 * change the count, so the cache is invalidated on every order status change.
+	 *
+	 * @since [version]
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 * @return void
+	 */
+	public static function flush_active_subscriptions_cache_on_status_change( $new_status, $old_status, $post ) {
+
+		if ( ! $post instanceof WP_Post || 'llms_order' !== $post->post_type || $new_status === $old_status ) {
+			return;
+		}
+
+		self::flush_active_subscriptions_cache( (int) get_post_meta( $post->ID, '_llms_product_id', true ) );
+	}
+
+	/**
+	 * Invalidates the active-subscriptions cache when an `llms_order` post is deleted.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $post_id WP_Post ID being deleted.
+	 * @return void
+	 */
+	public static function flush_active_subscriptions_cache_on_post_delete( $post_id ) {
+
+		if ( 'llms_order' !== get_post_type( $post_id ) ) {
+			return;
+		}
+
+		self::flush_active_subscriptions_cache( (int) get_post_meta( $post_id, '_llms_product_id', true ) );
 	}
 }

--- a/includes/models/model.llms.quiz.attempt.php
+++ b/includes/models/model.llms.quiz.attempt.php
@@ -986,6 +986,13 @@ class LLMS_Quiz_Attempt extends LLMS_Abstract_Database_Store {
 			return false;
 		}
 
+		/*
+		 * Deleting an attempt can change the computed quiz/lesson/course grade even when the
+		 * lesson remains complete (no `llms_mark_incomplete` fires), so the per-student grade
+		 * cache must be invalidated directly.
+		 */
+		llms()->grades()->clear_student_cache( $this->get( 'student_id' ) );
+
 		$lesson = llms_get_post( $this->get( 'lesson_id' ) );
 
 		// No lesson, or lesson incomplete, nothing special to do here.

--- a/includes/models/model.llms.student.php
+++ b/includes/models/model.llms.student.php
@@ -527,7 +527,8 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 		$cache_key = sprintf( 'date_%1$s_%2$s', $date, $product_id );
 		$res       = $this->cache_get( $cache_key );
 
-		if ( false === $res ) {
+		// Persistent object caches (Redis, Memcached) can deserialize a cached null as an empty string; treat it as a miss.
+		if ( false === $res || '' === $res ) {
 
 			$key = ( 'enrolled' === $date ) ? '_start_date' : '_status';
 
@@ -589,10 +590,11 @@ class LLMS_Student extends LLMS_Abstract_User_Data {
 		/**
 		 * After checking the cache, $status will be:
 		 *     + `false` if there was nothing in the cache or the function was instructed to not use the cache: Query the database to get the status.
+		 *     + `''` if a persistent object cache deserialized a cached `null` as an empty string: Query the database to get the status.
 		 *     + a string if there was a status: No need to query the database.
 		 *     + `null` if there's no status: No need to query the database.
 		 */
-		if ( false === $status ) {
+		if ( false === $status || '' === $status ) {
 
 			global $wpdb;
 

--- a/tests/phpunit/unit-tests/class-llms-test-grades.php
+++ b/tests/phpunit/unit-tests/class-llms-test-grades.php
@@ -140,7 +140,8 @@ class LLMS_Test_Grades extends LLMS_UnitTestCase {
 
 			$grade = $possible_grades[ rand( 0, count( $possible_grades ) - 1 ) ];
 			$this->take_quiz( $quiz_id, $student->get( 'id' ), $grade );
-			$this->assertNull( $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ) ) ); // cached
+			// Cache is busted by `lifterlms_quiz_completed`, so the cached read sees the new grade.
+			$this->assertEquals( $grade, $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ) ) ); // cached
 			$this->assertEquals( $grade, $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ), false ) ); // no cache
 			$this->assertEquals( $grade, $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ) ) ); // cached
 			$lesson_grades[] = $grade;

--- a/tests/phpunit/unit-tests/class-llms-test-grades.php
+++ b/tests/phpunit/unit-tests/class-llms-test-grades.php
@@ -164,6 +164,117 @@ class LLMS_Test_Grades extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test get_grade() treats an empty string in the cache as a miss.
+	 *
+	 * Simulates a persistent object cache (Redis, Memcached) deserializing a cached null as ''.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_grade_empty_string_cache_treated_as_miss() {
+
+		$grader  = llms()->grades();
+		$student = $this->get_mock_student();
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 1, 1 )[0] );
+
+		$student->enroll( $course->get( 'id' ) );
+
+		$course_id  = $course->get( 'id' );
+		$student_id = $student->get( 'id' );
+		$group      = LLMS_Grades::get_cache_group( $student_id );
+		$cache_key  = LLMS_Cache_Helper::get_prefix( $group ) . sprintf( '%d_grade', $course_id );
+
+		// Simulate a persistent cache returning '' for a cached null grade.
+		wp_cache_set( $cache_key, '', $group );
+
+		// Should treat '' as a cache miss and recalculate, returning null since no quizzes were taken.
+		$this->assertNull( $grader->get_grade( $course_id, $student_id ) );
+
+	}
+
+	/**
+	 * Test get_grade() returns a numeric grade from the cache without recalculating.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_grade_numeric_cache_returned() {
+
+		$grader  = llms()->grades();
+		$student = $this->get_mock_student();
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 1, 1 )[0] );
+
+		$student->enroll( $course->get( 'id' ) );
+
+		$course_id  = $course->get( 'id' );
+		$student_id = $student->get( 'id' );
+		$group      = LLMS_Grades::get_cache_group( $student_id );
+		$cache_key  = LLMS_Cache_Helper::get_prefix( $group ) . sprintf( '%d_grade', $course_id );
+
+		wp_cache_set( $cache_key, 85.5, $group );
+
+		$this->assertEquals( 85.5, $grader->get_grade( $course_id, $student_id ) );
+
+	}
+
+	/**
+	 * Test get_grade() treats null in the cache as a valid "no grade" hit.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_grade_null_cache_is_valid_hit() {
+
+		$grader  = llms()->grades();
+		$student = $this->get_mock_student();
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 1, 1 )[0] );
+
+		$student->enroll( $course->get( 'id' ) );
+
+		$course_id  = $course->get( 'id' );
+		$student_id = $student->get( 'id' );
+		$group      = LLMS_Grades::get_cache_group( $student_id );
+		$cache_key  = LLMS_Cache_Helper::get_prefix( $group ) . sprintf( '%d_grade', $course_id );
+
+		wp_cache_set( $cache_key, null, $group );
+
+		$this->assertNull( $grader->get_grade( $course_id, $student_id ) );
+
+	}
+
+	/**
+	 * Test that deleting a quiz attempt invalidates the student's cached grades.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_grade_cache_invalidated_on_attempt_deletion() {
+
+		$grader  = llms()->grades();
+		$student = $this->get_mock_student();
+		$course  = llms_get_post( $this->generate_mock_courses( 1, 1, 1, 1, 1 )[0] );
+
+		$student->enroll( $course->get( 'id' ) );
+
+		$lesson  = llms_get_post( $course->get_lessons( 'ids' )[0] );
+		$quiz_id = $lesson->get( 'quiz' );
+
+		$this->take_quiz( $quiz_id, $student->get( 'id' ), 100 );
+		$this->assertEquals( 100, $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ) ) );
+
+		// Delete the only attempt; the cached grade must not survive.
+		$attempt = $student->quizzes()->get_best_attempt( $quiz_id );
+		$attempt->delete();
+
+		$this->assertNull( $grader->get_grade( $lesson->get( 'id' ), $student->get( 'id' ) ) );
+
+	}
+
+	/**
 	 * test round() method
 	 * @return   void
 	 * @since    3.24.0

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-product.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-product.php
@@ -501,6 +501,8 @@ class LLMS_Test_LLMS_Product extends LLMS_PostModelUnitTestCase {
 	 * Test `has_active_subscriptions()` using cache mechanism.
 	 *
 	 * @since 5.4.0
+	 * @since [version] The cache is now invalidated on order status transitions, so the
+	 *                  cached and fresh reads always agree after a status change.
 	 *
 	 * @return void
 	 */
@@ -514,20 +516,18 @@ class LLMS_Test_LLMS_Product extends LLMS_PostModelUnitTestCase {
 		$order_recurring->set( 'product_id', $product->get('id') );
 		$order_recurring->set( 'status', 'llms-active' );
 
+		// Warm the cache with the active subscription present.
 		$this->assertTrue( $product->has_active_subscriptions( false ), $order_recurring->get( 'status' ) );
-
-		// Cancel subscription.
-		$order_recurring->set( 'status', 'llms-cancelled' );
-		// Use cache, I expect an active subscription.
 		$this->assertTrue( $product->has_active_subscriptions( true ), $order_recurring->get( 'status' ) );
-		// Do not use cache, I expect no active subscriptions.
+
+		// Cancel subscription. The `transition_post_status` hook busts the cache.
+		$order_recurring->set( 'status', 'llms-cancelled' );
+		$this->assertFalse( $product->has_active_subscriptions( true ), $order_recurring->get( 'status' ) );
 		$this->assertFalse( $product->has_active_subscriptions( false ), $order_recurring->get( 'status' ) );
 
-		// Activate it again.
+		// Activate it again. Same hook re-busts.
 		$order_recurring->set( 'status', 'llms-active' );
-		// Use cache, I expect no active subscriptions.
-		$this->assertFalse( $product->has_active_subscriptions( true ), $order_recurring->get( 'status' ) );
-		// Do not use cache, I expect an active subscription.
+		$this->assertTrue( $product->has_active_subscriptions( true ), $order_recurring->get( 'status' ) );
 		$this->assertTrue( $product->has_active_subscriptions( false ), $order_recurring->get( 'status' ) );
 
 	}

--- a/tests/phpunit/unit-tests/user/class-llms-test-student.php
+++ b/tests/phpunit/unit-tests/user/class-llms-test-student.php
@@ -409,9 +409,10 @@ class LLMS_Test_Student extends LLMS_UnitTestCase {
 
 			$grade = $possible_grades[ rand( 0, count( $possible_grades ) - 1 ) ];
 			$this->take_quiz( $quiz_id, $student->get( 'id' ), $grade );
-			$this->assertEquals( 'N/A', $student->get_grade( $lesson->get( 'id' ) ) ); // with cache
+			// Cache is busted by `lifterlms_quiz_completed`, so the cached read sees the new grade.
+			$this->assertEquals( $grade, $student->get_grade( $lesson->get( 'id' ) ) ); // with cache
 			$this->assertEquals( $grade, $student->get_grade( $lesson->get( 'id' ), false ) ); // no cache
-			$this->assertEquals( $grade, $student->get_grade( $lesson->get( 'id' ) ) ); // with  cache
+			$this->assertEquals( $grade, $student->get_grade( $lesson->get( 'id' ) ) ); // with cache
 			$lesson_grades[] = $grade;
 
 		}


### PR DESCRIPTION
## Description

On hosts with a persistent object cache (Redis, Memcached, APCu), several `wp_cache_get`/`wp_cache_set` pairs had no matching invalidation on their write paths, so cached values could remain stale indefinitely. This PR adds explicit invalidation (via `wp_cache_delete()` or the existing `LLMS_Cache_Helper` prefix-bump pattern — no reliance on `wp_cache_flush_group()`, which several persistent backends do not support), hardens cache-miss detection, and adds expiration times so worst-case staleness is bounded.

Replaces #3146 and #3117

## Invalidation fixes

1. **`LLMS_Forms::get_core_forms()`** — the `llms_core_forms` / `llms_core_form_ids` keys are now flushed when a form is saved, trashed, untrashed, or deleted, and when the `_llms_form_is_core` / `_llms_form_location` postmeta changes.
2. **`LLMS_Membership::query_associated_posts()`** — moved to a named per-membership cache group using the `LLMS_Cache_Helper` prefix-bump pattern; invalidated when `_llms_restricted_levels` / `_llms_availability_restrictions` postmeta changes on an associated post (including memberships *removed* from the list, captured pre-update) and when an associated post is trashed, untrashed, or deleted. Moving off the default (empty) cache group also keeps LifterLMS keys out of WordPress's shared default group.
3. **`LLMS_Grades::get_grade()`** — per-student grade cache now uses the prefix-bump pattern with a new public `LLMS_Grades::clear_student_cache( $student_id )` method, invalidated on `llms_mark_complete`, `llms_mark_incomplete`, `lifterlms_quiz_completed`, `llms_user_enrollment_deleted`, and quiz attempt deletion (`LLMS_Quiz_Attempt::delete()` can change a computed grade even when the lesson stays complete). Hooks are registered from `LifterLMS::__construct()` rather than the singleton constructor so they survive the test suite's `restore_hooks()`.
4. **`LLMS_Product::has_active_subscriptions()`** — the `llms_product_subscriptions_count` entry is invalidated when an `llms_order` transitions status or is deleted.
5. **`llms_get_template_override_directories()`** — the cached theme override directory paths are now deleted on `switch_theme` (and expire daily), so switching themes no longer leaves stale absolute paths cached.
6. **`LLMS_Admin_Tool_Limited_Billing_Order_Locator`** — the generated CSV cache now expires and is deleted after the report is served, matching the other admin tools.

## Hardening (from #3117)

- Empty-string cache values are treated as misses in `LLMS_Grades::get_grade_from_cache()`, `LLMS_Student::get_enrollment_date()`, and `LLMS_Student::get_enrollment_status()`. Persistent object caches can deserialize a cached `null` as `''`, which previously bypassed the miss checks and propagated to rendering code (see #3116).
- Expiration times added to previously unexpiring `wp_cache_set()` calls (grades, core forms, membership associated posts, product subscription counts, admin tool data: one hour; template override directories: one day).

## Tests

- Updated three tests that previously asserted the stale-cache behavior as the expected contract (`LLMS_Test_Grades::test_get_grade`, `LLMS_Test_Student::test_get_grade`, `LLMS_Test_Model_LLMS_Product::test_has_active_subscriptions_use_cache`).
- New tests covering empty-string/null/numeric cached grade handling and grade cache invalidation on quiz attempt deletion.
- Suites run locally: grades, product, membership, forms, quiz attempt, student, admin tools, template functions, cache helper — all passing (only pre-existing deprecation warnings / incomplete tests).

## How to test

1. Enable a persistent object cache (e.g. `wp redis enable`) and confirm `wp eval 'var_dump( wp_using_ext_object_cache() );'` returns `true`.
2. For each area: trigger the read path to warm the cache, mutate the underlying data, then re-trigger the read path and compare against a `use_cache=false` read — they should always agree.

## Checklist:

- [x] This PR requires and contains at least one changelog file.
- [x] My code has been tested.
- [x] My code passes all existing automated tests.
- [x] My code follows the LifterLMS Coding & Documentation Standards.
