### PR TITLE
Avoid cancellation of automatic payment retry

### DIFF
--- a/.changelogs/fix-recurring-retry-cancelled.yml
+++ b/.changelogs/fix-recurring-retry-cancelled.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed automatic recurring payment retries never running when a failed payment placed an active order on hold.

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -1746,8 +1746,13 @@ class LLMS_Order extends LLMS_Post_Model {
 
 		$timestamp = current_time( 'timestamp' ) + $current_rule['delay'];
 
-		$this->set_date( 'next_payment', date_i18n( 'Y-m-d H:i:s', $timestamp ) );
+		/**
+		 * The status must be set before scheduling the retry: transitioning an active order to on-hold
+		 * fires `LLMS_Controller_Orders::error_order()`, which unschedules pending recurring payments
+		 * and would cancel a retry scheduled prior to the status change.
+		 */
 		$this->set_status( $current_rule['status'] );
+		$this->set_date( 'next_payment', date_i18n( 'Y-m-d H:i:s', $timestamp ) );
 		$this->set( 'last_retry_rule', $current_rule_index );
 
 		$this->add_note(

--- a/includes/models/model.llms.order.php
+++ b/includes/models/model.llms.order.php
@@ -1759,7 +1759,7 @@ class LLMS_Order extends LLMS_Post_Model {
 			sprintf(
 				// Translators: %s = next attempt date.
 				esc_html__( 'Automatic retry attempt scheduled for %s', 'lifterlms' ),
-				date( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp )
+				date_i18n( get_option( 'date_format' ) . ' ' . get_option( 'time_format' ), $timestamp )
 			)
 		);
 

--- a/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
+++ b/tests/phpunit/unit-tests/models/class-llms-test-model-llms-order.php
@@ -1642,6 +1642,41 @@ class LLMS_Test_LLMS_Order extends LLMS_PostModelUnitTestCase {
 	}
 
 	/**
+	 * Test that the first retry stays scheduled when a failed payment moves an active order to on-hold.
+	 *
+	 * The `lifterlms_order_status_on-hold` transition triggers `LLMS_Controller_Orders::error_order()`,
+	 * which unschedules pending recurring payments. The retry must survive that transition.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_maybe_schedule_retry_on_active_order() {
+
+		$this->mock_gateway_support( 'recurring_retry' );
+
+		$order = $this->get_order();
+		$order->set_status( 'active' );
+
+		$txn = $order->record_transaction( array(
+			'amount'       => 25.99,
+			'status'       => 'llms-txn-pending',
+			'payment_type' => 'recurring',
+		) );
+		$txn->set( 'status', 'llms-txn-failed' );
+
+		$order = llms_get_post( $order->get( 'id' ) );
+
+		$this->assertEquals( 'llms-on-hold', $order->get( 'status' ) );
+		$this->assertEquals( 1, did_action( 'llms_automatic_payment_retry_scheduled' ) );
+
+		$action_time = as_next_scheduled_action( 'llms_charge_recurring_payment', array( 'order_id' => $order->get( 'id' ) ) );
+		$this->assertNotFalse( $action_time, 'The scheduled retry was unscheduled by the on-hold status transition.' );
+		$this->assertEqualsWithDelta( $order->get_next_payment_due_date( 'U' ), $action_time, $this->date_delta );
+
+	}
+
+	/**
 	 * Test record_transaction() method
 	 *
 	 * @since Unknown


### PR DESCRIPTION

## Description
If the order status is set to on hold after the next payment retry is scheduled, the automatic payment retry can be cancelled. Flip the order to avoid this.

## How has this been tested?
Phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

