### PR TITLE
Performance improvements for course students export and lesson time calculations

### DIFF
--- a/.changelogs/course-students-export-performance-2.yml
+++ b/.changelogs/course-students-export-performance-2.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: changed
+entry: The course students reporting table now sorts by student ID by default instead of by name, avoiding expensive name joins and filesorts on large sites. Columns remain click-sortable.

--- a/.changelogs/course-students-export-performance-3.yml
+++ b/.changelogs/course-students-export-performance-3.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Course and membership student exports now honor the boosted export page size, reducing the number of requests required to generate an export file by up to 10x.

--- a/.changelogs/course-students-export-performance-4.yml
+++ b/.changelogs/course-students-export-performance-4.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: performance
+entry: Course and membership student exports now count the total result set once instead of re-running the count query on every page of the export.

--- a/.changelogs/course-students-export-performance-5.yml
+++ b/.changelogs/course-students-export-performance-5.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Zero-value lesson time totals are no longer cached in user meta, and an automatic database update removes previously created zero-value rows.

--- a/.changelogs/course-students-export-performance-5.yml
+++ b/.changelogs/course-students-export-performance-5.yml
@@ -1,3 +1,3 @@
-significance: minor
+significance: patch
 type: fixed
-entry: Zero-value lesson time totals are no longer cached in user meta, and an automatic database update removes previously created zero-value rows.
+entry: Course reports and exports no longer bulk-create per-lesson time cache rows in user meta, and an automatic database update removes the zero-value rows previously created this way.

--- a/.changelogs/course-students-export-performance-5.yml
+++ b/.changelogs/course-students-export-performance-5.yml
@@ -1,3 +1,3 @@
-significance: patch
+significance: minor
 type: fixed
 entry: Zero-value lesson time totals are no longer cached in user meta, and an automatic database update removes previously created zero-value rows.

--- a/.changelogs/course-students-export-performance.yml
+++ b/.changelogs/course-students-export-performance.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: performance
+entry: Improved the performance of the Time in Course column on the course students reporting screen and export by computing course totals with a single query, adding a lesson index to the time sessions table, and skipping all per-student queries when a course has no tracked time.

--- a/includes/abstracts/llms.abstract.exportable.admin.table.php
+++ b/includes/abstracts/llms.abstract.exportable.admin.table.php
@@ -79,6 +79,11 @@ abstract class LLMS_Abstract_Exportable_Admin_Table {
 		 */
 		$args['per_page'] = apply_filters( 'llms_table_generate_export_file_per_page_boost', 250 );
 
+		// A fresh export must compute its own page count; ignore any client-supplied value.
+		if ( empty( $filename ) ) {
+			unset( $args['export_max_pages'] );
+		}
+
 		$filename    = $filename ? basename( $filename ) : $this->get_export_file_name() . '.' . $type;
 		$file_path   = LLMS_TMP_DIR . $filename;
 		$option_name = 'llms_gen_export_' . basename( $filename, '.' . $type );
@@ -107,6 +112,10 @@ abstract class LLMS_Abstract_Exportable_Admin_Table {
 		if ( ! $this->is_last_page() ) {
 
 			$args['page'] = $this->get_current_page() + 1;
+
+			// Persist the page count so subsequent requests can skip re-counting the full result set.
+			$args['export_max_pages'] = $this->get_max_pages();
+
 			update_option( $option_name, $args );
 			$progress = round( ( $this->get_current_page() / $this->get_max_pages() ) * 100, 2 );
 

--- a/includes/admin/reporting/tables/llms.table.course.students.php
+++ b/includes/admin/reporting/tables/llms.table.course.students.php
@@ -81,9 +81,12 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 	/**
 	 * Field results are sorted by
 	 *
+	 * Defaults to `id`: sorting by name requires expensive usermeta joins and a
+	 * filesort in the student query, which is punishing on large sites.
+	 *
 	 * @var  string
 	 */
-	protected $orderby = 'name';
+	protected $orderby = 'id';
 
 	/**
 	 * Post ID for the current table
@@ -102,6 +105,36 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 	 * @var bool|null Null until computed, then true/false.
 	 */
 	protected $is_partial_tracking = null;
+
+	/**
+	 * Whether any time tracking sessions exist for this course.
+	 *
+	 * Computed once per table render and reused for every row so that courses
+	 * without any tracked time skip all per-student time queries.
+	 *
+	 * @since [version]
+	 *
+	 * @var bool|null Null until computed, then true/false.
+	 */
+	protected $has_time_data = null;
+
+	/**
+	 * Determine if any time tracking sessions exist for this course.
+	 *
+	 * Result is computed once and cached on the instance.
+	 *
+	 * @since [version]
+	 *
+	 * @return bool
+	 */
+	protected function has_time_data() {
+
+		if ( null === $this->has_time_data ) {
+			$this->has_time_data = LLMS_Lesson_Time_Tracking::instance()->course_has_time_data( $this->course_id );
+		}
+
+		return $this->has_time_data;
+	}
 
 	/**
 	 * Check whether this course has partial time tracking.
@@ -224,7 +257,8 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 				break;
 
 			case 'time_in_course':
-				$total = LLMS_Lesson_Time_Tracking::instance()->get_course_time( $student->get_id(), $this->course_id );
+				// No tracked time anywhere in the course: skip the per-student lookups entirely.
+				$total = $this->has_time_data() ? LLMS_Lesson_Time_Tracking::instance()->get_course_time( $student->get_id(), $this->course_id ) : 0;
 				$value = LLMS_Lesson_Time_Tracking::instance()->format_time( $total );
 
 				if ( $this->is_partial_tracking() ) {
@@ -238,7 +272,6 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		}// End switch().
 
 		return $this->filter_get_data( $value, $key, $student );
-
 	}
 
 	/**
@@ -276,7 +309,8 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 				break;
 
 			case 'time_in_course':
-				$total = LLMS_Lesson_Time_Tracking::instance()->get_course_time( $student->get_id(), $this->course_id );
+				// No tracked time anywhere in the course: skip the per-student lookups entirely.
+				$total = $this->has_time_data() ? LLMS_Lesson_Time_Tracking::instance()->get_course_time( $student->get_id(), $this->course_id ) : 0;
 				$value = LLMS_Lesson_Time_Tracking::instance()->format_time( $total );
 
 				if ( $this->is_partial_tracking() ) {
@@ -290,7 +324,6 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		}// End switch().
 
 		return $this->filter_get_data( $value, $key, $student, 'export' );
-
 	}
 
 
@@ -351,6 +384,10 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		if ( ! $args ) {
 			$args = $this->get_args();
 		}
+
+		// Export requests boost `per_page` and pass a pre-computed page count; capture both before clean_args() strips them.
+		$per_page         = isset( $args['per_page'] ) ? absint( $args['per_page'] ) : 25;
+		$export_max_pages = isset( $args['export_max_pages'] ) ? absint( $args['export_max_pages'] ) : 0;
 
 		$args = $this->clean_args( $args );
 
@@ -419,9 +456,14 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		$query_args = array(
 			'page'     => $this->get_current_page(),
 			'post_id'  => $args['course_id'],
-			'per_page' => apply_filters( 'llms_' . $this->id . '_table_students_per_page', 25 ),
+			'per_page' => apply_filters( 'llms_' . $this->id . '_table_students_per_page', $per_page ),
 			'sort'     => $sort,
 		);
+
+		// The total was already computed on the export's first page; don't re-run the COUNT query on every subsequent page.
+		if ( $export_max_pages ) {
+			$query_args['no_found_rows'] = true;
+		}
 
 		if ( 'status' === $this->get_filterby() && 'any' !== $this->get_filter() ) {
 
@@ -438,11 +480,15 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 
 		$query = new LLMS_Student_Query( $query_args );
 
-		$this->max_pages    = $query->get_max_pages();
-		$this->is_last_page = $query->is_last_page();
+		if ( $export_max_pages ) {
+			$this->max_pages    = $export_max_pages;
+			$this->is_last_page = $this->get_current_page() >= $export_max_pages;
+		} else {
+			$this->max_pages    = $query->get_max_pages();
+			$this->is_last_page = $query->is_last_page();
+		}
 
 		$this->tbody_data = $query->get_students();
-
 	}
 
 
@@ -462,7 +508,6 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		return array(
 			'course_id' => $this->course_id,
 		);
-
 	}
 
 	/**
@@ -474,52 +519,52 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 	 */
 	public function set_columns() {
 		$cols = array(
-			'id'          => array(
+			'id'             => array(
 				'exportable' => true,
 				'sortable'   => true,
 				'title'      => __( 'ID', 'lifterlms' ),
 			),
-			'name'        => array(
+			'name'           => array(
 				'sortable' => true,
 				'title'    => __( 'Name', 'lifterlms' ),
 			),
-			'name_last'   => array(
+			'name_last'      => array(
 				'exportable'  => true,
 				'export_only' => true,
 				'title'       => __( 'Last Name', 'lifterlms' ),
 			),
-			'name_first'  => array(
+			'name_first'     => array(
 				'exportable'  => true,
 				'export_only' => true,
 				'title'       => __( 'First Name', 'lifterlms' ),
 			),
-			'email'       => array(
+			'email'          => array(
 				'exportable'  => true,
 				'export_only' => true,
 				'title'       => __( 'Email', 'lifterlms' ),
 			),
-			'status'      => array(
+			'status'         => array(
 				'exportable' => true,
 				'filterable' => llms_get_enrollment_statuses(),
 				'sortable'   => true,
 				'title'      => __( 'Status', 'lifterlms' ),
 			),
-			'enrolled'    => array(
+			'enrolled'       => array(
 				'exportable' => true,
 				'sortable'   => true,
 				'title'      => __( 'Enrollment Updated', 'lifterlms' ),
 			),
-			'completed'   => array(
+			'completed'      => array(
 				'exportable' => true,
 				'sortable'   => true,
 				'title'      => __( 'Completed', 'lifterlms' ),
 			),
-			'progress'    => array(
+			'progress'       => array(
 				'exportable' => true,
 				'sortable'   => false,
 				'title'      => __( 'Progress', 'lifterlms' ),
 			),
-			'grade'       => array(
+			'grade'          => array(
 				'exportable' => true,
 				'sortable'   => false,
 				'title'      => __( 'Grade', 'lifterlms' ),
@@ -536,7 +581,5 @@ class LLMS_Table_Course_Students extends LLMS_Admin_Table {
 		);
 
 		return $cols;
-
 	}
-
 }

--- a/includes/admin/reporting/tables/llms.table.membership.students.php
+++ b/includes/admin/reporting/tables/llms.table.membership.students.php
@@ -172,7 +172,6 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 		}// End switch().
 
 		return $this->filter_get_data( $value, $key, $student );
-
 	}
 
 	/**
@@ -211,7 +210,6 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 		}// End switch().
 
 		return $this->filter_get_data( $value, $key, $student, 'export' );
-
 	}
 
 
@@ -272,6 +270,10 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 			$args = $this->get_args();
 		}
 
+		// Export requests boost `per_page` and pass a pre-computed page count; capture both before clean_args() strips them.
+		$per_page         = isset( $args['per_page'] ) ? absint( $args['per_page'] ) : 25;
+		$export_max_pages = isset( $args['export_max_pages'] ) ? absint( $args['export_max_pages'] ) : 0;
+
 		$args = $this->clean_args( $args );
 
 		if ( ! current_user_can( 'view_others_lifterlms_reports' ) && ! current_user_can( 'edit_post', absint( $args['membership_id'] ) ) ) {
@@ -330,9 +332,14 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 		$query_args = array(
 			'page'     => $this->get_current_page(),
 			'post_id'  => $args['membership_id'],
-			'per_page' => apply_filters( 'llms_' . $this->id . '_table_students_per_page', 25 ),
+			'per_page' => apply_filters( 'llms_' . $this->id . '_table_students_per_page', $per_page ),
 			'sort'     => $sort,
 		);
+
+		// The total was already computed on the export's first page; don't re-run the COUNT query on every subsequent page.
+		if ( $export_max_pages ) {
+			$query_args['no_found_rows'] = true;
+		}
 
 		if ( 'status' === $this->get_filterby() && 'any' !== $this->get_filter() ) {
 
@@ -349,11 +356,15 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 
 		$query = new LLMS_Student_Query( $query_args );
 
-		$this->max_pages    = $query->get_max_pages();
-		$this->is_last_page = $query->is_last_page();
+		if ( $export_max_pages ) {
+			$this->max_pages    = $export_max_pages;
+			$this->is_last_page = $this->get_current_page() >= $export_max_pages;
+		} else {
+			$this->max_pages    = $query->get_max_pages();
+			$this->is_last_page = $query->is_last_page();
+		}
 
 		$this->tbody_data = $query->get_students();
-
 	}
 
 
@@ -373,7 +384,6 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 		return array(
 			'membership_id' => $this->membership_id,
 		);
-
 	}
 
 	/**
@@ -423,7 +433,5 @@ class LLMS_Table_Membership_Students extends LLMS_Admin_Table {
 		);
 
 		return $cols;
-
 	}
-
 }

--- a/includes/class-llms-lesson-time-tracking.php
+++ b/includes/class-llms-lesson-time-tracking.php
@@ -200,12 +200,9 @@ class LLMS_Lesson_Time_Tracking {
 			)
 		);
 
-		// Only persist non-zero totals: caching zeros mass-inserts usermeta rows for students who never tracked time.
-		if ( $total ) {
-			$student = llms_get_student( $user_id );
-			if ( $student ) {
-				$student->set( 'lesson_time_' . $lesson_id, $total );
-			}
+		$student = llms_get_student( $user_id );
+		if ( $student ) {
+			$student->set( 'lesson_time_' . $lesson_id, $total );
 		}
 
 		return $total;

--- a/includes/class-llms-lesson-time-tracking.php
+++ b/includes/class-llms-lesson-time-tracking.php
@@ -200,12 +200,44 @@ class LLMS_Lesson_Time_Tracking {
 			)
 		);
 
-		$student = llms_get_student( $user_id );
-		if ( $student ) {
-			$student->set( 'lesson_time_' . $lesson_id, $total );
+		// Only persist non-zero totals: caching zeros mass-inserts usermeta rows for students who never tracked time.
+		if ( $total ) {
+			$student = llms_get_student( $user_id );
+			if ( $student ) {
+				$student->set( 'lesson_time_' . $lesson_id, $total );
+			}
 		}
 
 		return $total;
+	}
+
+	/**
+	 * Determine if any time tracking sessions exist for a course's lessons.
+	 *
+	 * Used to short-circuit per-student time calculations on reporting screens
+	 * when a course has no tracked time at all.
+	 *
+	 * @since [version]
+	 *
+	 * @param int $course_id Course post ID.
+	 * @return bool
+	 */
+	public function course_has_time_data( $course_id ) {
+
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT 1
+				 FROM {$wpdb->postmeta} AS pm
+				 INNER JOIN {$wpdb->prefix}lifterlms_lesson_time_sessions AS s
+					ON s.lesson_id = pm.post_id
+				 WHERE pm.meta_key = '_llms_parent_course'
+				   AND pm.meta_value = %s
+				 LIMIT 1",
+				absint( $course_id )
+			)
+		);
 	}
 
 	/**
@@ -235,6 +267,9 @@ class LLMS_Lesson_Time_Tracking {
 	/**
 	 * Update cached course time for a user.
 	 *
+	 * Computes the course total with a single query across all the course's lessons
+	 * rather than querying (and caching) each lesson individually.
+	 *
 	 * @since 10.1.0
 	 *
 	 * @param int $user_id   WP User ID.
@@ -248,12 +283,21 @@ class LLMS_Lesson_Time_Tracking {
 			return 0;
 		}
 
-		$lessons = $course->get_lessons( 'ids' );
-		$total   = 0;
+		global $wpdb;
 
-		foreach ( $lessons as $lid ) {
-			$total += $this->get_total_seconds( $user_id, $lid );
-		}
+		$total = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COALESCE( SUM( s.accumulated_seconds ), 0 )
+				 FROM {$wpdb->prefix}lifterlms_lesson_time_sessions AS s
+				 INNER JOIN {$wpdb->postmeta} AS pm
+					ON pm.post_id = s.lesson_id
+				   AND pm.meta_key = '_llms_parent_course'
+				 WHERE s.user_id = %d
+				   AND pm.meta_value = %s",
+				$user_id,
+				absint( $course_id )
+			)
+		);
 
 		$student = llms_get_student( $user_id );
 		if ( $student ) {

--- a/includes/class.llms.install.php
+++ b/includes/class.llms.install.php
@@ -531,6 +531,7 @@ CREATE TABLE `{$wpdb->prefix}lifterlms_lesson_time_sessions` (
   `flagged_gaps` int(10) unsigned NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `idx_user_lesson` (`user_id`, `lesson_id`),
+  KEY `idx_lesson` (`lesson_id`),
   KEY `idx_token` (`session_token`),
   KEY `idx_user_open` (`user_id`, `session_end`)
 ) $collate;

--- a/includes/functions/updates/llms-functions-updates-1020.php
+++ b/includes/functions/updates/llms-functions-updates-1020.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Update functions for version 10.2.0
+ *
+ * @package LifterLMS/Functions/Updates
+ *
+ * @since [version]
+ * @version [version]
+ */
+
+namespace LLMS\Updates\Version_10_2_0;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Retrieves the DB version of the migration.
+ *
+ * @since [version]
+ *
+ * @access private
+ *
+ * @return string
+ */
+function _get_db_version() {
+	return '10.2.0';
+}
+
+/**
+ * Deletes zero-value lesson and course time tracking cache rows from the usermeta table.
+ *
+ * Versions 10.1.x cached a `llms_lesson_time_{$lesson_id}` usermeta row for every
+ * student and lesson touched by reporting screens and exports, even when the student
+ * had no tracked time, bloating the usermeta table with zero-value rows. Zero totals
+ * are no longer cached per lesson, and course totals are recomputed cheaply on demand,
+ * so all zero-value rows can be safely removed.
+ *
+ * @since [version]
+ *
+ * @return bool Returns `true` if more records need to be deleted and `false` upon completion.
+ */
+function delete_zero_time_tracking_caches() {
+
+	global $wpdb;
+
+	$per_page = \llms_update_util_get_items_per_page();
+
+	$deleted = $wpdb->query(
+		$wpdb->prepare(
+			"DELETE FROM {$wpdb->usermeta}
+			 WHERE ( meta_key LIKE %s OR meta_key LIKE %s )
+			   AND meta_value = '0'
+			 LIMIT %d",
+			$wpdb->esc_like( 'llms_lesson_time_' ) . '%',
+			$wpdb->esc_like( 'llms_course_time_' ) . '%',
+			$per_page
+		)
+	);
+
+	// If a full page was deleted assume there are more rows and run again.
+	return ( $deleted === $per_page );
+}
+
+/**
+ * Update db version to 10.2.0.
+ *
+ * @since [version]
+ *
+ * @return false
+ */
+function update_db_version() {
+	\LLMS_Install::update_db_version( _get_db_version() );
+	return false;
+}

--- a/includes/functions/updates/llms-functions-updates-1020.php
+++ b/includes/functions/updates/llms-functions-updates-1020.php
@@ -26,19 +26,23 @@ function _get_db_version() {
 }
 
 /**
- * Deletes zero-value lesson and course time tracking cache rows from the usermeta table.
+ * Deletes zero-value per-lesson time tracking cache rows from the usermeta table.
  *
  * Versions 10.1.x cached a `llms_lesson_time_{$lesson_id}` usermeta row for every
- * student and lesson touched by reporting screens and exports, even when the student
- * had no tracked time, bloating the usermeta table with zero-value rows. Zero totals
- * are no longer cached per lesson, and course totals are recomputed cheaply on demand,
- * so all zero-value rows can be safely removed.
+ * student and lesson touched by course reporting screens and exports, even when the
+ * student had no tracked time, bloating the usermeta table with zero-value rows.
+ * Those screens now compute time at the course level and no longer read or write
+ * per-lesson caches, so the bulk-created zero rows can be safely removed: they only
+ * get recreated individually when a specific student/lesson is viewed.
+ *
+ * Course-level (`llms_course_time_{$course_id}`) rows are intentionally kept, as
+ * reports still use them and would recreate them on the next render.
  *
  * @since [version]
  *
  * @return bool Returns `true` if more records need to be deleted and `false` upon completion.
  */
-function delete_zero_time_tracking_caches() {
+function delete_zero_lesson_time_caches() {
 
 	global $wpdb;
 
@@ -47,11 +51,10 @@ function delete_zero_time_tracking_caches() {
 	$deleted = $wpdb->query(
 		$wpdb->prepare(
 			"DELETE FROM {$wpdb->usermeta}
-			 WHERE ( meta_key LIKE %s OR meta_key LIKE %s )
+			 WHERE meta_key LIKE %s
 			   AND meta_value = '0'
 			 LIMIT %d",
 			$wpdb->esc_like( 'llms_lesson_time_' ) . '%',
-			$wpdb->esc_like( 'llms_course_time_' ) . '%',
 			$per_page
 		)
 	);

--- a/includes/schemas/llms-db-updates.php
+++ b/includes/schemas/llms-db-updates.php
@@ -212,4 +212,12 @@ return array(
 			'update_db_version',
 		),
 	),
+	'10.2.0' => array(
+		'type'      => 'auto',
+		'namespace' => true,
+		'updates'   => array(
+			'delete_zero_time_tracking_caches',
+			'update_db_version',
+		),
+	),
 );

--- a/includes/schemas/llms-db-updates.php
+++ b/includes/schemas/llms-db-updates.php
@@ -216,7 +216,7 @@ return array(
 		'type'      => 'auto',
 		'namespace' => true,
 		'updates'   => array(
-			'delete_zero_time_tracking_caches',
+			'delete_zero_lesson_time_caches',
 			'update_db_version',
 		),
 	),

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-1020.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-1020.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Test updates functions when updating to 10.2.0.
+ *
+ * @package LifterLMS/Tests/Functions/Updates
+ *
+ * @group functions
+ * @group updates
+ * @group updates_1020
+ *
+ * @since [version]
+ */
+class LLMS_Test_Functions_Updates_1020 extends LLMS_UnitTestCase {
+
+	/**
+	 * Setup before class.
+	 *
+	 * Include update functions file.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		require_once LLMS_PLUGIN_DIR . 'includes/functions/updates/llms-functions-updates-1020.php';
+		require_once LLMS_PLUGIN_DIR . 'includes/functions/llms.functions.updates.php';
+	}
+
+	/**
+	 * Test delete_zero_time_tracking_caches().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_delete_zero_time_tracking_caches() {
+
+		$user_id = $this->factory->user->create();
+
+		// Zero-value cache rows: should be deleted.
+		update_user_meta( $user_id, 'llms_lesson_time_123', '0' );
+		update_user_meta( $user_id, 'llms_lesson_time_456', 0 );
+		update_user_meta( $user_id, 'llms_course_time_789', '0' );
+
+		// Non-zero cache rows: should be kept.
+		update_user_meta( $user_id, 'llms_lesson_time_321', 120 );
+		update_user_meta( $user_id, 'llms_course_time_987', 360 );
+
+		// Admin override rows (array values) share the meta key prefix: should be kept.
+		update_user_meta( $user_id, 'llms_lesson_time_override_123', array( 'admin_id' => 1 ) );
+
+		// Unrelated meta: should be kept.
+		update_user_meta( $user_id, 'llms_unrelated_meta', '0' );
+
+		while ( \LLMS\Updates\Version_10_2_0\delete_zero_time_tracking_caches() ) {
+			continue;
+		}
+
+		$this->assertEquals( '', get_user_meta( $user_id, 'llms_lesson_time_123', true ) );
+		$this->assertEquals( '', get_user_meta( $user_id, 'llms_lesson_time_456', true ) );
+		$this->assertEquals( '', get_user_meta( $user_id, 'llms_course_time_789', true ) );
+
+		$this->assertEquals( 120, get_user_meta( $user_id, 'llms_lesson_time_321', true ) );
+		$this->assertEquals( 360, get_user_meta( $user_id, 'llms_course_time_987', true ) );
+		$this->assertEquals( array( 'admin_id' => 1 ), get_user_meta( $user_id, 'llms_lesson_time_override_123', true ) );
+		$this->assertEquals( '0', get_user_meta( $user_id, 'llms_unrelated_meta', true ) );
+	}
+
+	/**
+	 * Test update_db_version().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_update_db_version() {
+
+		$orig = get_option( 'lifterlms_db_version' );
+
+		delete_option( 'lifterlms_db_version' );
+
+		\LLMS\Updates\Version_10_2_0\update_db_version();
+
+		$this->assertEquals( \LLMS\Updates\Version_10_2_0\_get_db_version(), get_option( 'lifterlms_db_version' ) );
+
+		update_option( 'lifterlms_db_version', $orig );
+	}
+}

--- a/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-1020.php
+++ b/tests/phpunit/unit-tests/functions/updates/class-llms-test-functions-updates-1020.php
@@ -28,23 +28,25 @@ class LLMS_Test_Functions_Updates_1020 extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test delete_zero_time_tracking_caches().
+	 * Test delete_zero_lesson_time_caches().
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_delete_zero_time_tracking_caches() {
+	public function test_delete_zero_lesson_time_caches() {
 
 		$user_id = $this->factory->user->create();
 
-		// Zero-value cache rows: should be deleted.
+		// Zero-value per-lesson cache rows: should be deleted.
 		update_user_meta( $user_id, 'llms_lesson_time_123', '0' );
 		update_user_meta( $user_id, 'llms_lesson_time_456', 0 );
-		update_user_meta( $user_id, 'llms_course_time_789', '0' );
 
 		// Non-zero cache rows: should be kept.
 		update_user_meta( $user_id, 'llms_lesson_time_321', 120 );
+
+		// Course-level cache rows are still used by reports: should be kept, even zeros.
+		update_user_meta( $user_id, 'llms_course_time_789', '0' );
 		update_user_meta( $user_id, 'llms_course_time_987', 360 );
 
 		// Admin override rows (array values) share the meta key prefix: should be kept.
@@ -53,15 +55,15 @@ class LLMS_Test_Functions_Updates_1020 extends LLMS_UnitTestCase {
 		// Unrelated meta: should be kept.
 		update_user_meta( $user_id, 'llms_unrelated_meta', '0' );
 
-		while ( \LLMS\Updates\Version_10_2_0\delete_zero_time_tracking_caches() ) {
+		while ( \LLMS\Updates\Version_10_2_0\delete_zero_lesson_time_caches() ) {
 			continue;
 		}
 
 		$this->assertEquals( '', get_user_meta( $user_id, 'llms_lesson_time_123', true ) );
 		$this->assertEquals( '', get_user_meta( $user_id, 'llms_lesson_time_456', true ) );
-		$this->assertEquals( '', get_user_meta( $user_id, 'llms_course_time_789', true ) );
 
 		$this->assertEquals( 120, get_user_meta( $user_id, 'llms_lesson_time_321', true ) );
+		$this->assertEquals( '0', get_user_meta( $user_id, 'llms_course_time_789', true ) );
 		$this->assertEquals( 360, get_user_meta( $user_id, 'llms_course_time_987', true ) );
 		$this->assertEquals( array( 'admin_id' => 1 ), get_user_meta( $user_id, 'llms_lesson_time_override_123', true ) );
 		$this->assertEquals( '0', get_user_meta( $user_id, 'llms_unrelated_meta', true ) );

--- a/tests/phpunit/unit-tests/tables/class-llms-test-table-course-students.php
+++ b/tests/phpunit/unit-tests/tables/class-llms-test-table-course-students.php
@@ -109,6 +109,65 @@ class LLMS_Test_Table_Course_Students extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test that generate_export_file() honors the per-page boost.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_export_file_honors_per_page_boost() {
+
+		$course = $this->factory->course->create_and_get();
+		$args   = array( 'course_id' => $course->get( 'id' ) );
+
+		$this->factory->student->create_and_enroll_many( 30, $course->get( 'id' ) );
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// With the default 250/page boost, 30 students complete in a single request.
+		$file = $this->table->generate_export_file( $args );
+		$this->assertEquals( 100, $file['progress'] );
+	}
+
+	/**
+	 * Test that generate_export_file() persists the page count and skips re-counting on subsequent pages.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_generate_export_file_persists_max_pages() {
+
+		$course = $this->factory->course->create_and_get();
+		$args   = array( 'course_id' => $course->get( 'id' ) );
+
+		$this->factory->student->create_and_enroll_many( 50, $course->get( 'id' ) );
+
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		// Unboost to force multiple pages.
+		add_filter( 'llms_table_generate_export_file_per_page_boost', function () {
+			return 25;
+		} );
+
+		$file = $this->table->generate_export_file( $args );
+		$this->assertEquals( 50, $file['progress'] );
+
+		$option_name = 'llms_gen_export_' . basename( $file['filename'], '.csv' );
+		$stored      = get_option( $option_name );
+		$this->assertEquals( 2, $stored['page'] );
+		$this->assertEquals( 2, $stored['export_max_pages'] );
+
+		// Finishing the export uses the stored page count and cleans up the option.
+		$table = new LLMS_Table_Course_Students();
+		$file  = $table->generate_export_file( $args, $file['filename'] );
+		$this->assertEquals( 100, $file['progress'] );
+		$this->assertFalse( get_option( $option_name ) );
+	}
+
+	/**
 	 * Test generate_export_file(): prevent invalid filetypes.
 	 *
 	 * @since 5.10.0
@@ -279,6 +338,72 @@ class LLMS_Test_Table_Course_Students extends LLMS_UnitTestCase {
 		$expected        = $student_statuses;
 		arsort( $expected );
 		$this->assert_student_results_equal( $args, $expected );
+	}
+
+	/**
+	 * Test that the table defaults to sorting by ID.
+	 *
+	 * Sorting by name requires usermeta joins and a filesort in the student query.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_default_orderby_is_id() {
+
+		$this->assertEquals( 'id', $this->table->get_orderby() );
+	}
+
+	/**
+	 * Test the time_in_course column short-circuits and writes no zero-value cache rows when a course has no tracked time.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_time_in_course_no_time_data() {
+
+		global $wpdb;
+
+		$course                 = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 3 ) );
+		$this->table->course_id = $course->get( 'id' );
+
+		$student = $this->factory->student->create_and_get();
+		$student->enroll( $course->get( 'id' ) );
+		$student_id = $student->get( 'id' );
+
+		$this->assertStringStartsWith( '0:00:00', $this->table->get_export_data( 'time_in_course', $student ) );
+
+		// No zero-value lesson/course time cache rows were written.
+		$count = (int) $wpdb->get_var(
+			"SELECT COUNT(*) FROM {$wpdb->usermeta} WHERE user_id = {$student_id} AND ( meta_key LIKE 'llms\_lesson\_time\_%' OR meta_key LIKE 'llms\_course\_time\_%' )"
+		);
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * Test the time_in_course column computes totals when a course has tracked time.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_time_in_course_with_time_data() {
+
+		$course  = $this->factory->course->create_and_get( array( 'sections' => 1, 'lessons' => 3 ) );
+		$lessons = $course->get_lessons( 'ids' );
+
+		$student = $this->factory->student->create_and_get();
+		$student->enroll( $course->get( 'id' ) );
+
+		$session = LLMS_Lesson_Time_Tracking::instance()->start_session( $student->get( 'id' ), $lessons[0] );
+		$session->set( 'accumulated_seconds', 90 );
+		$session->save();
+
+		$table            = new LLMS_Table_Course_Students();
+		$table->course_id = $course->get( 'id' );
+
+		$this->assertStringStartsWith( '0:01:30', $table->get_export_data( 'time_in_course', $student ) );
 	}
 
 	/**


### PR DESCRIPTION
HS-278529

## Description
- New course_has_time_data() method checks once whether any tracking sessions exist for a course's lessons. The course students table caches the result per render and skips every per-student time lookup when the course has no tracked time — this alone eliminates the per-row work that was hammering the customer's reporting tab.
- update_cached_course_time() now computes the course total with one SUM query joined through the lesson's _llms_parent_course postmeta (the same relationship LLMS_Course::get_lessons() uses), instead of one query plus one usermeta write per lesson.
- get_total_seconds() no longer persists zero-value llms_lesson_time_* usermeta rows, which is what was mass-inserting junk rows during renders and exports.
- idx_lesson (lesson_id) index to the sessions table schema so the course-level check is an index seek rather than a table scan.

## How has this been tested?
Manually

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

