### PR TITLE
Filter output of access plan button

### DIFF
--- a/.changelogs/fix-access-plan-button-text.yml
+++ b/.changelogs/fix-access-plan-button-text.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: security
+entry: Additional checks on access plan button output.

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -214,7 +214,7 @@ class LLMS_Shortcodes {
 	 * @since 3.4.1 Unknown.
 	 *
 	 * @param array  $atts    Associative array of shortcode attributes.
-	 * @param string $content Optional. Shortcode content, enables custom text/html in the button. Default empty string.
+	 * @param string $content Optional. Shortcode content, used as the button label. Default empty string.
 	 * @return string
 	 */
 	public static function access_plan_button( $atts, $content = '' ) {
@@ -241,7 +241,7 @@ class LLMS_Shortcodes {
 
 			$text = empty( $content ) ? $plan->get_enroll_text() : $content;
 
-			$ret = '<a class="' . esc_attr( $classes ) . '" href="' . esc_url( $plan->get_checkout_url() ) . '" title="' . esc_attr( $plan->get( 'title' ) ) . '" aria-label="' . esc_attr( $plan->get_enroll_text( true ) ) . '">' . $text . '</a>';
+			$ret = '<a class="' . esc_attr( $classes ) . '" href="' . esc_url( $plan->get_checkout_url() ) . '" title="' . esc_attr( $plan->get( 'title' ) ) . '" aria-label="' . esc_attr( $plan->get_enroll_text( true ) ) . '">' . esc_html( $text ) . '</a>';
 		}
 
 		/**
@@ -251,7 +251,7 @@ class LLMS_Shortcodes {
 		 *
 		 * @param string $ret     The shortcode output.
 		 * @param array  $atts    Associative array of shortcode attributes.
-		 * @param string $content Shortcode content, enables custom text/html in the button. Default empty string.
+		 * @param string $content Shortcode content, used as the button label. Default empty string.
 		 */
 		return apply_filters( 'llms_shortcode_access_plan_button', $ret, $atts, $content );
 	}

--- a/includes/shortcodes/class.llms.shortcodes.php
+++ b/includes/shortcodes/class.llms.shortcodes.php
@@ -214,7 +214,7 @@ class LLMS_Shortcodes {
 	 * @since 3.4.1 Unknown.
 	 *
 	 * @param array  $atts    Associative array of shortcode attributes.
-	 * @param string $content Optional. Shortcode content, used as the button label. Default empty string.
+	 * @param string $content Optional. Shortcode content, enables custom text/html in the button. Default empty string.
 	 * @return string
 	 */
 	public static function access_plan_button( $atts, $content = '' ) {
@@ -241,7 +241,7 @@ class LLMS_Shortcodes {
 
 			$text = empty( $content ) ? $plan->get_enroll_text() : $content;
 
-			$ret = '<a class="' . esc_attr( $classes ) . '" href="' . esc_url( $plan->get_checkout_url() ) . '" title="' . esc_attr( $plan->get( 'title' ) ) . '" aria-label="' . esc_attr( $plan->get_enroll_text( true ) ) . '">' . esc_html( $text ) . '</a>';
+			$ret = '<a class="' . esc_attr( $classes ) . '" href="' . esc_url( $plan->get_checkout_url() ) . '" title="' . esc_attr( $plan->get( 'title' ) ) . '" aria-label="' . esc_attr( $plan->get_enroll_text( true ) ) . '">' . wp_kses_post( $text ) . '</a>';
 		}
 
 		/**
@@ -251,7 +251,7 @@ class LLMS_Shortcodes {
 		 *
 		 * @param string $ret     The shortcode output.
 		 * @param array  $atts    Associative array of shortcode attributes.
-		 * @param string $content Shortcode content, used as the button label. Default empty string.
+		 * @param string $content Shortcode content, enables custom text/html in the button. Default empty string.
 		 */
 		return apply_filters( 'llms_shortcode_access_plan_button', $ret, $atts, $content );
 	}

--- a/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
+++ b/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
@@ -138,13 +138,13 @@ class LLMS_Test_Shortcodes extends LLMS_UnitTestCase {
 	}
 
 	/**
-	 * Test access plan button output escapes custom label text.
+	 * Test access plan button output allows safe HTML in custom label text.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_access_plan_button_escapes_custom_text() {
+	public function test_access_plan_button_allows_safe_html() {
 
 		$plan = $this->get_mock_plan();
 		$html = LLMS_Shortcodes::access_plan_button(
@@ -152,24 +152,44 @@ class LLMS_Test_Shortcodes extends LLMS_UnitTestCase {
 			'Custom <b>Label</b>'
 		);
 
-		$this->assertStringContains( esc_html( 'Custom <b>Label</b>' ), $html );
-		$this->assertStringNotContains( '<b>Label</b>', $html );
+		$this->assertStringContains( '<b>Label</b>', $html );
 
 	}
 
 	/**
-	 * Test access plan button output escapes the plan enroll text fallback.
+	 * Test access plan button output strips disallowed markup from custom label text.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_access_plan_button_escapes_enroll_text() {
+	public function test_access_plan_button_strips_unsafe_html() {
+
+		$plan = $this->get_mock_plan();
+		$html = LLMS_Shortcodes::access_plan_button(
+			array( 'id' => $plan->get( 'id' ) ),
+			'Buy <script>bad</script><img src="x" onerror="bad">'
+		);
+
+		$this->assertStringNotContains( '<script>', $html );
+		$this->assertStringNotContains( 'onerror', $html );
+		$this->assertStringContains( '<img', $html );
+
+	}
+
+	/**
+	 * Test access plan button output sanitizes the plan enroll text fallback.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_access_plan_button_sanitizes_enroll_text() {
 
 		$plan = $this->get_mock_plan();
 
 		$handler = function ( $text ) {
-			return 'Enroll <b>Now</b>';
+			return 'Enroll <b>Now</b><script>bad</script>';
 		};
 		add_filter( 'llms_plan_get_enroll_text', $handler );
 
@@ -177,34 +197,34 @@ class LLMS_Test_Shortcodes extends LLMS_UnitTestCase {
 
 		remove_filter( 'llms_plan_get_enroll_text', $handler );
 
-		$this->assertStringContains( esc_html( 'Enroll <b>Now</b>' ), $html );
-		$this->assertStringNotContains( '<b>Now</b>', $html );
+		$this->assertStringContains( '<b>Now</b>', $html );
+		$this->assertStringNotContains( '<script>', $html );
 
 	}
 
 	/**
-	 * Test the access plan button block escapes its text attribute.
+	 * Test the access plan button block sanitizes its text attribute.
 	 *
 	 * @since [version]
 	 *
 	 * @return void
 	 */
-	public function test_access_plan_button_block_escapes_text_attribute() {
+	public function test_access_plan_button_block_sanitizes_text_attribute() {
 
-		$plan    = $this->get_mock_plan();
-		$markup  = sprintf(
+		$plan   = $this->get_mock_plan();
+		$markup = sprintf(
 			'<!-- wp:llms/access-plan-button %s /-->',
 			wp_json_encode(
 				array(
 					'id'   => (string) $plan->get( 'id' ),
-					'text' => 'Buy <b>Now</b>',
+					'text' => 'Buy <b>Now</b><script>bad</script>',
 				)
 			)
 		);
 		$html = do_blocks( $markup );
 
-		$this->assertStringContains( esc_html( 'Buy <b>Now</b>' ), $html );
-		$this->assertStringNotContains( '<b>Now</b>', $html );
+		$this->assertStringContains( '<b>Now</b>', $html );
+		$this->assertStringNotContains( '<script>', $html );
 
 	}
 

--- a/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
+++ b/tests/phpunit/unit-tests/class-llms-test-shortcodes.php
@@ -138,6 +138,77 @@ class LLMS_Test_Shortcodes extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test access plan button output escapes custom label text.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_access_plan_button_escapes_custom_text() {
+
+		$plan = $this->get_mock_plan();
+		$html = LLMS_Shortcodes::access_plan_button(
+			array( 'id' => $plan->get( 'id' ) ),
+			'Custom <b>Label</b>'
+		);
+
+		$this->assertStringContains( esc_html( 'Custom <b>Label</b>' ), $html );
+		$this->assertStringNotContains( '<b>Label</b>', $html );
+
+	}
+
+	/**
+	 * Test access plan button output escapes the plan enroll text fallback.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_access_plan_button_escapes_enroll_text() {
+
+		$plan = $this->get_mock_plan();
+
+		$handler = function ( $text ) {
+			return 'Enroll <b>Now</b>';
+		};
+		add_filter( 'llms_plan_get_enroll_text', $handler );
+
+		$html = LLMS_Shortcodes::access_plan_button( array( 'id' => $plan->get( 'id' ) ) );
+
+		remove_filter( 'llms_plan_get_enroll_text', $handler );
+
+		$this->assertStringContains( esc_html( 'Enroll <b>Now</b>' ), $html );
+		$this->assertStringNotContains( '<b>Now</b>', $html );
+
+	}
+
+	/**
+	 * Test the access plan button block escapes its text attribute.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_access_plan_button_block_escapes_text_attribute() {
+
+		$plan    = $this->get_mock_plan();
+		$markup  = sprintf(
+			'<!-- wp:llms/access-plan-button %s /-->',
+			wp_json_encode(
+				array(
+					'id'   => (string) $plan->get( 'id' ),
+					'text' => 'Buy <b>Now</b>',
+				)
+			)
+		);
+		$html = do_blocks( $markup );
+
+		$this->assertStringContains( esc_html( 'Buy <b>Now</b>' ), $html );
+		$this->assertStringNotContains( '<b>Now</b>', $html );
+
+	}
+
+	/**
 	 * Tests that the shortcodes are initialized before the WordPress 'init' action hook calls any other LifterLMS callbacks.
 	 *
 	 * @since 6.4.0


### PR DESCRIPTION

## Description

Allow custom html as per the docblock, but not non-post tags.

## How has this been tested?
Manually + phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

