### PR TITLE
Fixed lesson progression button layout and text alignment in the block editor

### DIFF
--- a/.changelogs/fix-lesson-progression-editor-buttons.yml
+++ b/.changelogs/fix-lesson-progression-editor-buttons.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Fixed lesson progression button layout and text alignment in the block editor.

--- a/assets/scss/_includes/_buttons.scss
+++ b/assets/scss/_includes/_buttons.scss
@@ -55,12 +55,17 @@ $llms-buttons-theme-inherit: true !default;
 .llms-button-danger,
 .llms-button-primary,
 .llms-button-secondary {
+	align-items: center;
+	box-sizing: border-box;
 	cursor: pointer;
-	display: inline-block;
+	display: inline-flex;
+	justify-content: center;
+	line-height: 1;
 	margin: 0;
 	max-width: 100%;
 	position: relative;
 	text-decoration: none;
+	vertical-align: middle;
 	white-space: nowrap;
 
 	&:disabled {
@@ -72,7 +77,7 @@ $llms-buttons-theme-inherit: true !default;
 	}
 
 	&.full {
-		display: block;
+		display: flex;
 		text-align: center;
 		width: 100%;
 	}
@@ -226,7 +231,7 @@ a.llms-button-secondary {
 	}
 
 	&.full {
-		display: block;
+		display: flex;
 		text-align: center;
 		width: 100%;
 	}

--- a/assets/scss/frontend/_main.scss
+++ b/assets/scss/frontend/_main.scss
@@ -269,10 +269,14 @@ input[type="text"].cc_cvv,
 }
 
 .llms-lesson-button-wrapper {
-  width: 100%;
-  display: block;
+  align-items: center;
   clear: both;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
   text-align: center;
+  width: 100%;
 }
 .llms-template-wrapper {
   width: 100%;

--- a/libraries/lifterlms-blocks/src/js/blocks/lesson-progression/editor.scss
+++ b/libraries/lifterlms-blocks/src/js/blocks/lesson-progression/editor.scss
@@ -1,7 +1,17 @@
 .wp-block[data-type="llms/lesson-progression"] {
 	text-align: center;
 
+	.llms-lesson-button-wrapper {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		justify-content: center;
+	}
+
 	button {
-		margin: 0 2px;
+		box-sizing: border-box;
+		line-height: 1;
+		margin: 0;
 	}
 }

--- a/libraries/lifterlms-blocks/src/js/blocks/lesson-progression/index.js
+++ b/libraries/lifterlms-blocks/src/js/blocks/lesson-progression/index.js
@@ -5,14 +5,13 @@
  * @since 1.5.0 Add supported post type settings.
  * @since 1.8.0 Use imports in favor of "wp." variables.
  *              Convert "edit" function from using ServerSideRender.
- * @version 2.5.0
+ * @since [version] Use native buttons with `wp-element-button` and an `extraButtons` filter so add-ons can render inside the wrapper.
+ * @version [version]
  */
 
 // WP Deps.
-import { Button } from '@wordpress/components';
 import { select } from '@wordpress/data';
 import { applyFilters } from '@wordpress/hooks';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 // Internal dependencies.
@@ -56,7 +55,7 @@ export const settings = {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return {Fragment} Edit component fragment.
+	 * @return {JSX.Element} Edit component.
 	 */
 	edit() {
 		const currentPost = select( 'core/editor' ).getCurrentPost(),
@@ -76,23 +75,35 @@ export const settings = {
 			showMainBtn
 		);
 
+		/**
+		 * Additional buttons rendered inside the lesson progression wrapper in the editor.
+		 *
+		 * Return an array of React elements. Used by add-ons (e.g. Assignments) so their
+		 * buttons sit in the same row as Take Quiz / Mark Complete.
+		 *
+		 * @since [version]
+		 *
+		 * @param {Array} buttons Extra button elements.
+		 */
+		const extraButtons = applyFilters(
+			'llms.lessonProgressBlock.extraButtons',
+			[]
+		);
+
 		return (
-			<>
 			<div className="llms-lesson-button-wrapper">
-			<Fragment>
+				{ extraButtons }
 				{ !! quiz && (
-					<Button className="llms-prog-btn--quiz llms-button-action auto button">
-						{__('Take Quiz', 'lifterlms')}
-					</Button>
+					<button type="button" className="llms-prog-btn--quiz llms-button-action auto button wp-element-button">
+						{ __( 'Take Quiz', 'lifterlms' ) }
+					</button>
 				) }
 				{ showMainBtn && (
-					<Button className="llms-prog-btn--complete llms-field-button llms-button-primary auto button">
-						{__('Mark Complete', 'lifterlms')}
-					</Button>
+					<button type="button" className="llms-prog-btn--complete llms-field-button llms-button-primary auto button wp-element-button">
+						{ __( 'Mark Complete', 'lifterlms' ) }
+					</button>
 				) }
-			</Fragment>
 			</div>
-			</>
 		);
 	},
 


### PR DESCRIPTION

## Description
Back-end formatting of take quiz button now matches front-end.

## How has this been tested?
Manually

## Screenshots <!-- if applicable -->
<img width="3840" height="1498" alt="image" src="https://github.com/user-attachments/assets/bab2c42d-1fd5-449b-a225-bee11514bc46" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

