### PR TITLE
Fix #3328: Link doesn't open quiz panel in the course builder

### DIFF
--- a/.changelogs/fix-quiz-reporting-deep-link.yml
+++ b/.changelogs/fix-quiz-reporting-deep-link.yml
@@ -1,0 +1,4 @@
+significance: patch
+type: fixed
+entry: Fixed the link to a quiz in the reporting screen not opening the quiz
+  settings panel in the course builder.

--- a/assets/js/builder/main.js
+++ b/assets/js/builder/main.js
@@ -353,9 +353,9 @@ require( [
 				LLMS.wait_for( function() {
 					return ( undefined !== _.getEditor() && undefined !== window.tinymce );
                     }, function() {
-					$lesson.closest( '.llms-builder-item.llms-section' ).find( 'a.llms-action-icon.expand' ).trigger( 'click' );
+					$lesson.closest( '.llms-builder-item.llms-section' ).find( '.llms-action-icon.expand' ).trigger( 'click' );
 					var subtab = parts[1] ? parts[1] : 'lesson';
-					$( '#llms-lesson-' + parts[0] ).find( 'a.llms-action-icon.edit-' + subtab ).trigger( 'click' );
+					$( '#llms-lesson-' + parts[0] ).find( '.llms-action-icon.edit-' + subtab ).trigger( 'click' );
 				} );
 
 			}

--- a/tests/e2e/specs/admin/course-builder-deep-link.spec.js
+++ b/tests/e2e/specs/admin/course-builder-deep-link.spec.js
@@ -1,0 +1,61 @@
+/**
+ * Course Builder — deep linking to a lesson opens the lesson editor panel.
+ *
+ * Guards against the reporting screen lesson/quiz links no longer opening
+ * the relevant editor panel after the builder action icons were changed from
+ * anchors to buttons.
+ *
+ * @since 10.1.2
+ */
+
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+
+test.describe( 'Course Builder / Deep Link', () => {
+
+	test( 'deep linking to a lesson opens the lesson editor panel', async ( {
+		page,
+		requestUtils,
+	} ) => {
+
+		const stamp = Date.now();
+
+		const course = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/courses',
+			data: {
+				title: `Deep Link Course ${ stamp }`,
+				content: 'x',
+				status: 'publish',
+			},
+		} );
+
+		const section = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/sections',
+			data: {
+				title: 'Section 1',
+				parent_id: course.id,
+				order: 1,
+			},
+		} );
+
+		const lesson = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/lessons',
+			data: {
+				title: `Deep Link Lesson ${ stamp }`,
+				content: 'lesson content',
+				status: 'publish',
+				parent_id: section.id,
+				order: 1,
+			},
+		} );
+
+		await page.goto( `/wp-admin/admin.php?page=llms-course-builder&course_id=${ course.id }#lesson:${ lesson.id }` );
+		await page.locator( '.wrap.lifterlms.llms-builder' ).waitFor( { state: 'visible' } );
+
+		await expect( page.locator( '#llms-editor-lesson' ) ).toBeVisible( { timeout: 10000 } );
+
+	} );
+
+} );


### PR DESCRIPTION
<!--
Contributors:
Prior to opening a pull request, please review our contributing guidelines at https://github.com/gocodebox/lifterlms/blob/trunk/.github/CONTRIBUTING.md
-->

## Description
<!-- Please describe what you have changed or added -->

Fixes #3328

The reporting screen's Quizzes table builds deep links ending in `#lesson:{lesson_id}:quiz`, which the course builder consumes to open the matching editor panel. The builder's deep-link selectors still targeted `<a class="llms-action-icon …">` elements, but those action icons were converted from anchors to `<button>` elements (see #2614). The selectors matched nothing, so the quiz/lesson panel silently failed to open.

This removes the `a` element restriction from the two deep-link selectors in `assets/js/builder/main.js` so they match the `<button>` action icons (and would still match anchors).

## How has this been tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

Verified the two selectors are the only `a.llms-action-icon.*` occurrences in the builder JS, and correlated them with the `<button class="llms-action-icon …">` icons now emitted by `includes/admin/views/builder/section.php` and `includes/admin/views/builder/lesson.php`. Added a Playwright regression spec (`tests/e2e/specs/admin/course-builder-deep-link.spec.js`) that deep-links to a lesson and asserts the editor panel opens.

The full e2e/unit/CS suites could not be run locally (no WordPress/Docker environment available in the contributor workspace); they need to run in CI.

## Screenshots <!-- if applicable -->

N/A

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->
