### PR TITLE
Abilities API tweaks

### DIFF
--- a/.changelogs/fix-abilities-api-feedback.yml
+++ b/.changelogs/fix-abilities-api-feedback.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Awarded certificates and achievements now fall back to the template's post title when the deprecated title meta value is empty.

--- a/includes/abstracts/llms-abstract-user-engagement.php
+++ b/includes/abstracts/llms-abstract-user-engagement.php
@@ -239,7 +239,12 @@ abstract class LLMS_Abstract_User_Engagement extends LLMS_Post_Model {
 			return false;
 		}
 
-		$this->set( 'title', get_post_meta( $template_id, "_llms_{$this->model_post_type}_title", true ) );
+		// Templates built since 6.0 store the title on the post itself; the meta value is deprecated and often empty.
+		$title = get_post_meta( $template_id, "_llms_{$this->model_post_type}_title", true );
+		if ( ! $title ) {
+			$title = $template->get( 'title' );
+		}
+		$this->set( 'title', $title );
 		if ( get_post_thumbnail_id( $template_id ) !== get_post_thumbnail_id( $this->get( 'post' ) ) &&
 			! set_post_thumbnail( $this->get( 'post' ), get_post_thumbnail_id( $template_id ) )
 		) {

--- a/includes/class-llms-engagement-handler.php
+++ b/includes/class-llms-engagement-handler.php
@@ -207,8 +207,13 @@ class LLMS_Engagement_Handler {
 	 */
 	private static function create( $type, $user_id, $template_id, $related_id = '', $engagement_id = null ) {
 
-		$title    = get_post_meta( $template_id, "_llms_{$type}_title", true );
 		$template = get_post( $template_id );
+
+		// Templates built since 6.0 store the title on the post itself; the meta value is deprecated and often empty.
+		$title = get_post_meta( $template_id, "_llms_{$type}_title", true );
+		if ( ! $title && $template ) {
+			$title = $template->post_title;
+		}
 
 		// Setup args, ultimately passed to `wp_insert_post()`.
 		$post_args = array(

--- a/libraries/lifterlms-rest/includes/server/class-llms-rest-lessons-controller.php
+++ b/libraries/lifterlms-rest/includes/server/class-llms-rest-lessons-controller.php
@@ -319,6 +319,55 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 	}
 
 	/**
+	 * Insert a lesson at its explicit order among its section siblings and resequence them.
+	 *
+	 * The explicit `order` is treated as a 1-based position: the position is clamped to the
+	 * number of lessons in the section, siblings at that position and after are shifted,
+	 * and all sibling orders are rewritten sequentially (1..n) so they remain unique.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Lesson $lesson Lesson instance whose stored order is the requested position.
+	 * @return void
+	 */
+	protected function resequence_siblings( $lesson ) {
+
+		$parent_id = absint( $lesson->get( 'parent_section' ) );
+		if ( ! $parent_id ) {
+			return;
+		}
+
+		$siblings = get_posts(
+			array(
+				'post_type'              => 'lesson',
+				'post_status'            => array( 'publish', 'draft', 'pending', 'private', 'future' ),
+				'posts_per_page'         => -1,
+				'orderby'                => 'meta_value_num',
+				'meta_key'               => '_llms_order',
+				'order'                  => 'ASC',
+				'fields'                 => 'ids',
+				'post__not_in'           => array( $lesson->get( 'id' ) ),
+				'update_post_term_cache' => false,
+				'meta_query'             => array(
+					array(
+						'key'   => '_llms_parent_section',
+						'value' => $parent_id,
+					),
+				),
+			)
+		);
+
+		$position = min( max( 1, absint( $lesson->get( 'order' ) ) ), count( $siblings ) + 1 );
+		array_splice( $siblings, $position - 1, 0, array( absint( $lesson->get( 'id' ) ) ) );
+
+		foreach ( $siblings as $index => $sibling_id ) {
+			if ( absint( get_post_meta( $sibling_id, '_llms_order', true ) ) !== $index + 1 ) {
+				update_post_meta( $sibling_id, '_llms_order', $index + 1 );
+			}
+		}
+	}
+
+	/**
 	 * Updates a single llms lesson.
 	 *
 	 * @since 1.0.0-beta.7
@@ -426,6 +475,11 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 			return $error;
 		}
 
+		// An explicit order is a position request: resequence siblings so orders stay unique.
+		if ( ! empty( $schema['properties']['order'] ) && ! empty( $request['order'] ) ) {
+			$this->resequence_siblings( $lesson );
+		}
+
 		return ! empty( $to_set );
 	}
 
@@ -459,7 +513,7 @@ class LLMS_REST_Lessons_Controller extends LLMS_REST_Posts_Controller {
 				'readonly'    => true,
 			),
 			'order'        => array(
-				'description' => __( 'Order of the lesson within its immediate parent.', 'lifterlms' ),
+				'description' => __( 'Order of the lesson within its immediate parent. Treated as a 1-based position on create/update: sibling lessons at that position and after are shifted so orders remain unique. Omit to append the lesson after its siblings.', 'lifterlms' ),
 				'type'        => 'integer',
 				'context'     => array( 'view', 'edit' ),
 				'arg_options' => array(

--- a/libraries/lifterlms-rest/includes/server/class-llms-rest-quizzes-controller.php
+++ b/libraries/lifterlms-rest/includes/server/class-llms-rest-quizzes-controller.php
@@ -288,6 +288,9 @@ class LLMS_REST_Quizzes_Controller extends LLMS_REST_Posts_Controller {
 
 		$schema = parent::get_item_schema_base();
 
+		// The quiz description (content) is optional.
+		$schema['properties']['content']['required'] = false;
+
 		$quiz_properties = array(
 			'lesson_id'           => array(
 				'description' => __( 'WordPress post ID of the quiz\'s parent lesson. 0 indicates an "orphaned" quiz not attached to any lesson.', 'lifterlms' ),

--- a/libraries/lifterlms-rest/includes/server/class-llms-rest-sections-controller.php
+++ b/libraries/lifterlms-rest/includes/server/class-llms-rest-sections-controller.php
@@ -271,6 +271,78 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 	}
 
 	/**
+	 * Resequence section orders after a create/update with an explicit order.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Section    $section       LLMS_Section instance.
+	 * @param WP_REST_Request $request       Full details about the request.
+	 * @param array           $schema        The item schema.
+	 * @param array           $prepared_item Prepared item array.
+	 * @param bool            $creating      Optional. Whether we're in creation or update phase. Default true (create).
+	 * @return bool|WP_Error True on success or false if nothing to update, WP_Error object if something went wrong during the update.
+	 */
+	protected function update_additional_object_fields( $section, $request, $schema, $prepared_item, $creating = true ) {
+
+		// An explicit order is a position request: resequence siblings so orders stay unique.
+		if ( ! empty( $schema['properties']['order'] ) && ! empty( $request['order'] ) ) {
+			$this->resequence_siblings( $section );
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Insert a section at its explicit order among its course siblings and resequence them.
+	 *
+	 * The explicit `order` is treated as a 1-based position: the position is clamped to the
+	 * number of sections in the course, siblings at that position and after are shifted,
+	 * and all sibling orders are rewritten sequentially (1..n) so they remain unique.
+	 *
+	 * @since [version]
+	 *
+	 * @param LLMS_Section $section Section instance whose stored order is the requested position.
+	 * @return void
+	 */
+	protected function resequence_siblings( $section ) {
+
+		$parent_id = absint( $section->get( 'parent_course' ) );
+		if ( ! $parent_id ) {
+			return;
+		}
+
+		$siblings = get_posts(
+			array(
+				'post_type'              => 'section',
+				'post_status'            => array( 'publish', 'draft', 'pending', 'private', 'future' ),
+				'posts_per_page'         => -1,
+				'orderby'                => 'meta_value_num',
+				'meta_key'               => '_llms_order',
+				'order'                  => 'ASC',
+				'fields'                 => 'ids',
+				'post__not_in'           => array( $section->get( 'id' ) ),
+				'update_post_term_cache' => false,
+				'meta_query'             => array(
+					array(
+						'key'   => '_llms_parent_course',
+						'value' => $parent_id,
+					),
+				),
+			)
+		);
+
+		$position = min( max( 1, absint( $section->get( 'order' ) ) ), count( $siblings ) + 1 );
+		array_splice( $siblings, $position - 1, 0, array( absint( $section->get( 'id' ) ) ) );
+
+		foreach ( $siblings as $index => $sibling_id ) {
+			if ( absint( get_post_meta( $sibling_id, '_llms_order', true ) ) !== $index + 1 ) {
+				update_post_meta( $sibling_id, '_llms_order', $index + 1 );
+			}
+		}
+	}
+
+	/**
 	 * Get the Section's schema base, conforming to JSON Schema.
 	 *
 	 * @since 1.0.0-beta.27
@@ -297,7 +369,7 @@ class LLMS_REST_Sections_Controller extends LLMS_REST_Posts_Controller {
 
 		// Section order.
 		$schema['properties']['order'] = array(
-			'description' => __( 'Order of the section within the course.', 'lifterlms' ),
+			'description' => __( 'Order of the section within the course. Treated as a 1-based position on create/update: sibling sections at that position and after are shifted so orders remain unique. Omit to append the section after its siblings.', 'lifterlms' ),
 			'type'        => 'integer',
 			'context'     => array( 'view', 'edit' ),
 			'arg_options' => array(

--- a/tests/phpunit/unit-tests/class-llms-test-engagement-handler.php
+++ b/tests/phpunit/unit-tests/class-llms-test-engagement-handler.php
@@ -229,6 +229,37 @@ class LLMS_Test_Engagement_Handler extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Test create() falls back to the template's post title when the deprecated title meta is empty.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_title_falls_back_to_post_title() {
+
+		$user_id     = $this->factory->user->create();
+		$template_id = $this->factory->post->create(
+			array(
+				'post_type'    => 'llms_certificate',
+				'post_title'   => 'Certificate Of Completion',
+				'post_content' => '{site_title}',
+			)
+		);
+
+		$earned = LLMS_Unit_Test_Util::call_method( 'LLMS_Engagement_Handler', 'create', array( 'certificate', $user_id, $template_id ) );
+
+		$this->assertInstanceOf( 'LLMS_User_Certificate', $earned );
+		$this->assertEquals( 'Certificate Of Completion', $earned->get( 'title' ) );
+
+		// The deprecated meta value still wins when present.
+		update_post_meta( $template_id, '_llms_certificate_title', 'Meta Title' );
+
+		$earned = LLMS_Unit_Test_Util::call_method( 'LLMS_Engagement_Handler', 'create', array( 'certificate', $user_id, $template_id ) );
+
+		$this->assertEquals( 'Meta Title', $earned->get( 'title' ) );
+	}
+
+	/**
 	 * Test do_deprecated_creation_filters()
 	 *
 	 * @since 6.0.0

--- a/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-lessons.php
+++ b/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-lessons.php
@@ -554,6 +554,80 @@ class LLMS_REST_Test_Lessons extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test creating a lesson with an explicit order shifts the existing siblings.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_lesson_explicit_order_shifts_siblings() {
+
+		wp_set_current_user( $this->user_allowed );
+
+		$course = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 3,
+				'quiz'     => 0,
+			)
+		);
+
+		$section  = llms_get_post( $course->get_sections( 'ids' )[0] );
+		$existing = $section->get_lessons( 'ids' );
+
+		$sample_lesson = array_merge(
+			$this->sample_lesson,
+			array(
+				'parent_id' => $section->get( 'id' ),
+				'order'     => 2,
+			)
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route, $sample_lesson );
+
+		$this->assertResponseStatusEquals( 201, $response );
+		$this->assertEquals( 2, $response->get_data()['order'] );
+
+		// Former lessons at positions 2 and 3 are shifted; orders remain unique and sequential.
+		$this->assertEquals( 1, llms_get_post( $existing[0] )->get( 'order' ) );
+		$this->assertEquals( 3, llms_get_post( $existing[1] )->get( 'order' ) );
+		$this->assertEquals( 4, llms_get_post( $existing[2] )->get( 'order' ) );
+	}
+
+	/**
+	 * Test that an explicit order beyond the number of siblings is clamped to the end.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_lesson_explicit_order_clamped() {
+
+		wp_set_current_user( $this->user_allowed );
+
+		$course = $this->factory->course->create_and_get(
+			array(
+				'sections' => 1,
+				'lessons'  => 2,
+				'quiz'     => 0,
+			)
+		);
+
+		$sample_lesson = array_merge(
+			$this->sample_lesson,
+			array(
+				'parent_id' => $course->get_sections( 'ids' )[0],
+				'order'     => 50,
+			)
+		);
+
+		$response = $this->perform_mock_request( 'POST', $this->route, $sample_lesson );
+
+		$this->assertResponseStatusEquals( 201, $response );
+		$this->assertEquals( 3, $response->get_data()['order'] );
+	}
+
+	/**
 	 * Test creating lesson auth errors.
 	 *
 	 * @since 1.0.0-beta.7

--- a/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-quizzes-controller.php
+++ b/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-quizzes-controller.php
@@ -35,6 +35,32 @@ class LLMS_REST_Test_Quizzes_Controller extends LLMS_REST_Unit_Test_Case_Server 
 	}
 
 	/**
+	 * Test creating a quiz with only a title: the content (description) is optional.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_item_title_only() {
+
+		wp_set_current_user( $this->user_allowed );
+
+		$response = $this->perform_mock_request(
+			'POST',
+			$this->route,
+			array(
+				'title' => 'Title Only Quiz',
+			)
+		);
+
+		$this->assertResponseStatusEquals( 201, $response );
+
+		$data = $response->get_data();
+		$this->assertEquals( 'Title Only Quiz', $data['title']['raw'] );
+		$this->assertEquals( '', $data['content']['raw'] );
+	}
+
+	/**
 	 * Test creating a quiz with boolean settings converts them to "yesno" values.
 	 *
 	 * @since [version]

--- a/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-sections.php
+++ b/tests/phpunit/unit-tests/libraries/lifterlms-rest/server/class-llms-rest-test-sections.php
@@ -274,6 +274,36 @@ class LLMS_REST_Test_Sections extends LLMS_REST_Unit_Test_Case_Posts {
 	}
 
 	/**
+	 * Test creating a section with an explicit order shifts the existing siblings.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_create_section_explicit_order_shifts_siblings() {
+
+		wp_set_current_user( $this->user_allowed );
+
+		$course   = $this->factory->course->create_and_get( array( 'sections' => 2, 'lessons' => 0 ) );
+		$existing = $course->get_sections( 'ids' );
+
+		$section_args              = $this->sample_section_args;
+		$section_args['parent_id'] = $course->get( 'id' );
+		$section_args['order']     = 2;
+
+		$request = new WP_REST_Request( 'POST', $this->route );
+		$request->set_body_params( $section_args );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 201, $response->get_status() );
+		$this->assertEquals( 2, $response->get_data()['order'] );
+
+		// The former section at position 2 is shifted; orders remain unique and sequential.
+		$this->assertEquals( 1, llms_get_post( $existing[0] )->get( 'order' ) );
+		$this->assertEquals( 3, llms_get_post( $existing[1] )->get( 'order' ) );
+	}
+
+	/**
 	 * Test that an instructor cannot create a section inside a course they cannot edit.
 	 *
 	 * @since 1.0.6


### PR DESCRIPTION

## Description
- Quiz/assignment content (2): content.required = false in the quizzes controller schema (core) and assignments controller schema (add-on), same pattern the questions controller already used. Title-only creates now return 201.
- Certificate title fallback to meta (pre-6.0)
- Lesson order now resequences on create

## How has this been tested?
phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

