### PR TITLE
Ensures that no extra comma shows in address display 

### DIFF
--- a/.changelogs/issue_3020.yml
+++ b/.changelogs/issue_3020.yml
@@ -1,0 +1,9 @@
+significance: patch
+type: fixed
+comment: Ensures that  no extra comma shows in address display if there's no
+  state/region/province
+links:
+  - "#3020"
+attributions:
+  - "@robindevitt"
+entry: Show address fields that are populated.

--- a/includes/admin/views/metaboxes/view-order-details.php
+++ b/includes/admin/views/metaboxes/view-order-details.php
@@ -285,9 +285,20 @@ $supports_modify_recurring_payments = $order->supports_modify_recurring_payments
 				<?php if ( isset( $order->billing_address_2 ) ) : ?>
 					<?php echo esc_html( $order->get( 'billing_address_2' ) ); ?><br>
 				<?php endif; ?>
-				<?php echo esc_html( $order->get( 'billing_city' ) ); ?>,
-				<?php echo esc_html( $order->get( 'billing_state' ) ); ?>,
-				<?php echo esc_html( $order->get( 'billing_zip' ) ); ?><br>
+				<?php
+				// Collect city, state, zip and filter out empty values.
+				$order_address_array = array_filter(
+					array(
+						$order->get( 'billing_city' ),
+						$order->get( 'billing_state' ),
+						$order->get( 'billing_zip' ),
+					)
+				);
+				// Output joined with commas only if there is at least one non-empty value.
+				if ( ! empty( $order_address_array ) ) {
+					echo esc_html( implode( ', ', $order_address_array ) ) . '<br>';
+				}
+				?>
 				<?php echo esc_html( llms_get_country_name( $order->get( 'billing_country' ) ) ); ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
## Description
Ensures that no extra comma shows in address display if there's no state/region/province

Fixes #3020 

## How has this been tested?
Manually. Purchased a plan for a course or membership, using a country that does not require a state/region/province/etc (ie. Ivory Coast)

## Screenshots 
<img width="230" height="239" alt="Screenshot 2026-08-26 at 09 16 12" src="https://github.com/user-attachments/assets/1cc6ba50-7496-4772-a360-acc264946440" />


## Types of changes
Rather than rendering out the empty value causing there to be extra commas. The address fields are set into an array and then using implode to comma seperate them.

## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

