### PR TITLE
Add the user to the order status change note

### DIFF
--- a/.changelogs/issue_3039.yml
+++ b/.changelogs/issue_3039.yml
@@ -1,0 +1,8 @@
+significance: patch
+type: changed
+comment: Add the user to the status change note.
+links:
+  - "#3039"
+attributions:
+  - "@robindevitt"
+entry: Add the user to the status change note.

--- a/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.notes.php
+++ b/includes/admin/post-types/meta-boxes/class.llms.meta.box.order.notes.php
@@ -74,12 +74,27 @@ class LLMS_Meta_Box_Order_Notes extends LLMS_Admin_Metabox {
 		if ( $notes ) {
 			echo '<ul class="llms-order-notes">';
 			foreach ( $notes  as $note ) {
+
+				$note_author = sprintf(
+					/* translators: %s: Order note author name. */
+					esc_html_x( 'by %s', 'order note author', 'lifterlms' ),
+					esc_html( get_comment_author( $note->comment_ID ) )
+				);
+
+				$note_text = get_comment_text( $note->comment_ID );
+
+				if ( 0 !== (int) $note->user_id ) {
+					$profile_url  = get_edit_user_link( $note->user_id );
+					$profile_link = sprintf( ' (<a href="%s">#%d</a>)', esc_url( $profile_url ), absint( $note->user_id ) );
+
+					$note_text .= ' ' . $note_author . $profile_link;
+				}
 				?>
 
 				<li class="llms-order-note" id="llms-order-note-<?php echo esc_attr( $note->comment_ID ); ?>">
-					<div class="llms-order-note-content"><?php echo wp_kses_post( wpautop( get_comment_text( $note->comment_ID ) ) ); ?></div>
+					<div class="llms-order-note-content"><?php echo wp_kses_post( wpautop( $note_text ) ); ?></div>
 					<div class="llms-order-note-meta">
-						<?php printf( esc_html_x( 'by %s', 'order note author', 'lifterlms' ), esc_html( get_comment_author( $note->comment_ID ) ) ); ?>
+						<?php echo esc_html( $note_author ); ?>
 						<?php printf( esc_html_x( 'on %s', 'order note date', 'lifterlms' ), esc_html( get_comment_date( 'M j, Y h:i a', $note->comment_ID ) ) ); ?>
 					</div>
 

--- a/includes/controllers/class.llms.controller.orders.php
+++ b/includes/controllers/class.llms.controller.orders.php
@@ -654,7 +654,7 @@ class LLMS_Controller_Orders {
 		// Record order status changes as notes.
 		if ( 'order' === $post_type ) {
 			/* translators: %1$s: Old Status, %2$s: New status. */
-			$obj->add_note( sprintf( __( 'Order status changed from %1$s to %2$s', 'lifterlms' ), llms_get_order_status_name( $old_status ), llms_get_order_status_name( $new_status ) ) );
+			$obj->add_note( sprintf( __( 'Order status changed from %1$s to %2$s', 'lifterlms' ), llms_get_order_status_name( $old_status ), llms_get_order_status_name( $new_status ) ), true );
 		}
 
 		// Remove prefixes from all the things.


### PR DESCRIPTION
## Description
Add the user to the order status change note.

Fixes #3039 

## How has this been tested?
Manually and reviewed via the order edit screen.

## Screenshots
<img width="432" height="335" alt="Screenshot 2026-08-26 at 10 13 07" src="https://github.com/user-attachments/assets/71d4024e-ee20-468b-93a4-037a27370f8e" />


## Types of changes
The function `add_note` has a second parameter `added_by_user` which by default is `false`. So this change is setting the `added_by_user` parameter to true so the user details are shown in the notes.

By default it renders the users `display_name`. Referenced the screenshot for these below notes.
**Note 1**: Currently the note author was set to show as `LifterLMS`
**Note 2**: Showing the status update made by me with my display name being shown.
**Note 3**: I changed my display name and then changed the order status, to confirm it shows my updated display name.


## Checklist:
- [x] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [x] My code has been tested.
- [x] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [x] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

