### PR TITLE
Improved staging site detection

### DIFF
--- a/.changelogs/fix-staging-clone-recurring-charges.yml
+++ b/.changelogs/fix-staging-clone-recurring-charges.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Improved prevention of recurring charges when the site URL no longer matches the stored lock.

--- a/includes/class.llms.site.php
+++ b/includes/class.llms.site.php
@@ -66,7 +66,6 @@ class LLMS_Site {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -119,7 +118,6 @@ class LLMS_Site {
 		 * @param string $url The cleaned LLMS_Site URL.
 		 */
 		return apply_filters( 'llms_site_get_url', $url );
-
 	}
 
 	/**
@@ -128,6 +126,9 @@ class LLMS_Site {
 	 * Checks for a feature constant first and, if none is defined,
 	 * uses the stored site setting (with a fallback to the default value), and
 	 * a final fallback to `false` if the feature cannot be found.
+	 *
+	 * Recurring payments are treated as disabled when the site is a clone,
+	 * so Action Scheduler charges skip without waiting for an admin to visit wp-admin.
 	 *
 	 * @since 3.0.0
 	 * @since 4.12.0 Allow feature configuration via constants.
@@ -140,9 +141,12 @@ class LLMS_Site {
 		$status = self::get_feature_constant( $feature );
 		if ( is_null( $status ) ) {
 
-			$features = self::get_features();
-			$status   = isset( $features[ $feature ] ) ? $features[ $feature ] : false;
-
+			if ( 'recurring_payments' === $feature && self::is_clone() ) {
+				$status = false;
+			} else {
+				$features = self::get_features();
+				$status   = isset( $features[ $feature ] ) ? $features[ $feature ] : false;
+			}
 		}
 
 		/**
@@ -154,7 +158,6 @@ class LLMS_Site {
 		 * @param string  $feature The feature ID/key.
 		 */
 		return apply_filters( 'llms_site_get_feature', $status, $feature );
-
 	}
 
 	/**
@@ -176,7 +179,6 @@ class LLMS_Site {
 		}
 
 		return null;
-
 	}
 
 	/**
@@ -206,7 +208,6 @@ class LLMS_Site {
 		);
 
 		return get_option( 'llms_site_get_features', $defaults );
-
 	}
 
 	/**
@@ -223,7 +224,6 @@ class LLMS_Site {
 		$features             = self::get_features();
 		$features[ $feature ] = $val;
 		update_option( 'llms_site_get_features', $features );
-
 	}
 
 	/**
@@ -249,7 +249,6 @@ class LLMS_Site {
 		 * @param boolean $is_clone When `true` the site is considered a "clone", otherwise it is not.
 		 */
 		return apply_filters( 'llms_site_is_clone', $is_clone );
-
 	}
 
 	/**
@@ -273,7 +272,5 @@ class LLMS_Site {
 		 * @param boolean $is_clone_ignored If `true`, the clone is ignored, otherwise it is not.
 		 */
 		return apply_filters( 'llms_site_is_clone_ignored', llms_parse_bool( get_option( 'llms_site_url_ignore', 'no' ) ) );
-
 	}
-
 }

--- a/tests/phpunit/unit-tests/class-llms-test-site.php
+++ b/tests/phpunit/unit-tests/class-llms-test-site.php
@@ -149,7 +149,8 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 	 */
 	public function test_get_feature_clone_disables_recurring_payments() {
 
-		$original = get_site_url();
+		$original_siteurl = get_option( 'siteurl' );
+		$original_lock    = get_option( 'llms_site_url' );
 
 		try {
 			LLMS_Site::update_feature( 'recurring_payments', true );
@@ -159,10 +160,11 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 			$this->assertTrue( LLMS_Site::is_clone() );
 			$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
 
-			update_option( 'siteurl', $original );
+			update_option( 'siteurl', $original_siteurl );
 			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
 		} finally {
-			update_option( 'siteurl', $original );
+			update_option( 'siteurl', $original_siteurl );
+			update_option( 'llms_site_url', $original_lock );
 		}
 
 	}
@@ -179,7 +181,8 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 	 */
 	public function test_get_feature_constant_overrides_clone() {
 
-		$original = get_site_url();
+		$original_siteurl = get_option( 'siteurl' );
+		$original_lock    = get_option( 'llms_site_url' );
 
 		try {
 			LLMS_Site::update_feature( 'recurring_payments', true );
@@ -189,7 +192,8 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 			llms_maybe_define_constant( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', true );
 			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
 		} finally {
-			update_option( 'siteurl', $original );
+			update_option( 'siteurl', $original_siteurl );
+			update_option( 'llms_site_url', $original_lock );
 		}
 
 	}

--- a/tests/phpunit/unit-tests/class-llms-test-site.php
+++ b/tests/phpunit/unit-tests/class-llms-test-site.php
@@ -140,6 +140,60 @@ class LLMS_Test_Site extends LLMS_UnitTestCase {
 
 	}
 
+	/**
+	 * Recurring payments read as disabled on a clone even when the stored feature is still enabled.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_get_feature_clone_disables_recurring_payments() {
+
+		$original = get_site_url();
+
+		try {
+			LLMS_Site::update_feature( 'recurring_payments', true );
+			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
+
+			update_option( 'siteurl', 'http://fakeurl.tld' );
+			$this->assertTrue( LLMS_Site::is_clone() );
+			$this->assertFalse( LLMS_Site::get_feature( 'recurring_payments' ) );
+
+			update_option( 'siteurl', $original );
+			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
+		} finally {
+			update_option( 'siteurl', $original );
+		}
+
+	}
+
+	/**
+	 * A feature constant still wins when the site is a clone.
+	 *
+	 * @since [version]
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_get_feature_constant_overrides_clone() {
+
+		$original = get_site_url();
+
+		try {
+			LLMS_Site::update_feature( 'recurring_payments', true );
+			update_option( 'siteurl', 'http://fakeurl.tld' );
+			$this->assertTrue( LLMS_Site::is_clone() );
+
+			llms_maybe_define_constant( 'LLMS_SITE_FEATURE_RECURRING_PAYMENTS', true );
+			$this->assertTrue( LLMS_Site::get_feature( 'recurring_payments' ) );
+		} finally {
+			update_option( 'siteurl', $original );
+		}
+
+	}
+
 
 	/**
 	 * Test is_clone() function

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -643,11 +643,10 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 	 */
 	public function test_recurring_charge_skipped_on_clone_before_admin_visit() {
 
-		$original = get_site_url();
+		add_filter( 'llms_site_is_clone', '__return_true' );
 
 		try {
 			LLMS_Site::update_feature( 'recurring_payments', true );
-			update_option( 'siteurl', 'http://fakeurl.tld' );
 
 			$plan  = $this->get_mock_plan( '200.00', 1 );
 			$order = $this->get_mock_order( $plan );
@@ -660,7 +659,7 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 			$this->assertSame( $note_actions + 1, did_action( 'llms_new_order_note_added' ) );
 			$this->assertSame( $skip_actions + 1, did_action( 'llms_order_recurring_charge_skipped' ) );
 		} finally {
-			update_option( 'siteurl', $original );
+			remove_filter( 'llms_site_is_clone', '__return_true' );
 		}
 
 	}

--- a/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
+++ b/tests/phpunit/unit-tests/controllers/class-llms-test-controller-orders.php
@@ -635,6 +635,37 @@ class LLMS_Test_Controller_Orders extends LLMS_UnitTestCase {
 	}
 
 	/**
+	 * Recurring charges skip on a clone even when the stored feature is still enabled.
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_recurring_charge_skipped_on_clone_before_admin_visit() {
+
+		$original = get_site_url();
+
+		try {
+			LLMS_Site::update_feature( 'recurring_payments', true );
+			update_option( 'siteurl', 'http://fakeurl.tld' );
+
+			$plan  = $this->get_mock_plan( '200.00', 1 );
+			$order = $this->get_mock_order( $plan );
+
+			$skip_actions = did_action( 'llms_order_recurring_charge_skipped' );
+			$note_actions = did_action( 'llms_new_order_note_added' );
+
+			do_action( 'llms_charge_recurring_payment', $order->get( 'id' ) );
+
+			$this->assertSame( $note_actions + 1, did_action( 'llms_new_order_note_added' ) );
+			$this->assertSame( $skip_actions + 1, did_action( 'llms_order_recurring_charge_skipped' ) );
+		} finally {
+			update_option( 'siteurl', $original );
+		}
+
+	}
+
+	/**
 	 * Test gateway-related errors encountered during a recurring_charge attempt.
 	 *
 	 * @since 3.32.0


### PR DESCRIPTION

## Description
Adds an additional check without needing to login as an administrator prior to a staging site being detected.

## How has this been tested?
phpunit

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

