### PR TITLE
Add existing lesson button in each section of the Course Builder

### DIFF
--- a/.changelogs/feature-builder-add-existing-lesson.yml
+++ b/.changelogs/feature-builder-add-existing-lesson.yml
@@ -1,0 +1,3 @@
+significance: minor
+type: added
+entry: Added an "Add Existing Lesson" button next to "Add New Lesson" in each Course Builder section.

--- a/assets/js/builder/Views/Elements.js
+++ b/assets/js/builder/Views/Elements.js
@@ -2,9 +2,9 @@
  * Sidebar Elements View
  *
  * @since    3.16.0
- * @version  3.16.12
+ * @version  [version]
  */
-define( [ 'Models/Section', 'Views/Section', 'Models/Lesson', 'Views/Lesson', 'Views/Popover', 'Views/PostSearch' ], function( Section, SectionView, Lesson, LessonView, Popover, LessonSearch ) {
+define( [ 'Models/Section', 'Views/Section', 'Models/Lesson', 'Views/Lesson', 'Views/ExistingLessonPopover' ], function( Section, SectionView, Lesson, LessonView, show_existing_lesson_popover ) {
 
 	return Backbone.View.extend( {
 
@@ -124,44 +124,12 @@ define( [ 'Models/Section', 'Views/Section', 'Models/Lesson', 'Views/Lesson', 'V
 		 * @param    object   event  JS Event Object
 		 * @return   void
 		 * @since    3.16.12
-		 * @version  3.16.12
+		 * @version  [version]
 		 */
 		add_existing_lesson: function( event ) {
 
 			event.preventDefault();
-
-			var pop, onLessonSelect;
-
-			pop = new Popover( {
-				el: '#llms-existing-lesson',
-				args: {
-					backdrop: true,
-					closeable: true,
-					container: '.wrap.lifterlms.llms-builder',
-					dismissible: true,
-					placement: 'left',
-					width: 480,
-					title: LLMS.l10n.translate( 'Add Existing Lesson' ),
-					content: new LessonSearch( {
-						post_type: 'lesson',
-						searching_message: LLMS.l10n.translate( 'Search for existing lessons...' ),
-					} ).render().$el,
-					onHide: function() {
-						Backbone.pubSub.off( 'lesson-search-select', onLessonSelect );
-					},
-				}
-			} );
-
-			onLessonSelect = function() {
-				pop.hide();
-
-				// Ref #3097 — pop.hide() doesn't always remove the DOM elements.
-				$( '.webui-popover' ).remove();
-				$( '.webui-popover-backdrop' ).remove();
-			};
-
-			pop.show();
-			Backbone.pubSub.once( 'lesson-search-select', onLessonSelect );
+			show_existing_lesson_popover( '#llms-existing-lesson', 'left' );
 
 		},
 

--- a/assets/js/builder/Views/ExistingLessonPopover.js
+++ b/assets/js/builder/Views/ExistingLessonPopover.js
@@ -1,0 +1,55 @@
+/**
+ * Existing Lesson search popover.
+ *
+ * @since [version]
+ * @version [version]
+ */
+define( [ 'Views/Popover', 'Views/PostSearch' ], function( Popover, LessonSearch ) {
+
+	/**
+	 * Show the popover used to attach or clone an existing lesson.
+	 *
+	 * @since [version]
+	 *
+	 * @param {String|Element} el        Popover trigger selector or element.
+	 * @param {String}         placement webuiPopover placement.
+	 * @return {Void}
+	 */
+	return function( el, placement ) {
+
+		var pop, onLessonSelect;
+
+		pop = new Popover( {
+			el: el,
+			args: {
+				backdrop: true,
+				closeable: true,
+				container: '.wrap.lifterlms.llms-builder',
+				dismissible: true,
+				placement: placement || 'left',
+				width: 480,
+				title: LLMS.l10n.translate( 'Add Existing Lesson' ),
+				content: new LessonSearch( {
+					post_type: 'lesson',
+					searching_message: LLMS.l10n.translate( 'Search for existing lessons...' ),
+				} ).render().$el,
+				onHide: function() {
+					Backbone.pubSub.off( 'lesson-search-select', onLessonSelect );
+				},
+			}
+		} );
+
+		onLessonSelect = function() {
+			pop.hide();
+
+			// Ref #3097 — pop.hide() doesn't always remove the DOM elements.
+			$( '.webui-popover' ).remove();
+			$( '.webui-popover-backdrop' ).remove();
+		};
+
+		pop.show();
+		Backbone.pubSub.once( 'lesson-search-select', onLessonSelect );
+
+	};
+
+} );

--- a/assets/js/builder/Views/ExistingLessonPopover.js
+++ b/assets/js/builder/Views/ExistingLessonPopover.js
@@ -9,6 +9,11 @@ define( [ 'Views/Popover', 'Views/PostSearch' ], function( Popover, LessonSearch
 	/**
 	 * Show the popover used to attach or clone an existing lesson.
 	 *
+	 * webuiPopover keeps its instance on the trigger and ignores later inits, so
+	 * destroy any previous instance first. Leave cache on so the select is moved
+	 * (not cloned) into the popover — Select2 is initialized on that node via
+	 * setTimeout after it is in the DOM.
+	 *
 	 * @since [version]
 	 *
 	 * @param {String|Element} el        Popover trigger selector or element.
@@ -17,7 +22,11 @@ define( [ 'Views/Popover', 'Views/PostSearch' ], function( Popover, LessonSearch
 	 */
 	return function( el, placement ) {
 
-		var pop, onLessonSelect;
+		var $el = $( el ), pop, onLessonSelect;
+
+		if ( $el.data( 'plugin_webuiPopover' ) ) {
+			$el.webuiPopover( 'destroy' );
+		}
 
 		pop = new Popover( {
 			el: el,
@@ -40,9 +49,11 @@ define( [ 'Views/Popover', 'Views/PostSearch' ], function( Popover, LessonSearch
 		} );
 
 		onLessonSelect = function() {
-			pop.hide();
+			if ( $el.data( 'plugin_webuiPopover' ) ) {
+				$el.webuiPopover( 'destroy' );
+			}
 
-			// Ref #3097 — pop.hide() doesn't always remove the DOM elements.
+			// Ref #3097 — hide/destroy leaves the popover and backdrop in the DOM.
 			$( '.webui-popover' ).remove();
 			$( '.webui-popover-backdrop' ).remove();
 		};

--- a/assets/js/builder/Views/Section.js
+++ b/assets/js/builder/Views/Section.js
@@ -1,18 +1,21 @@
 /**
  * Single Section View
+ *
  * @since    3.13.0
- * @version  3.16.12
+ * @version  [version]
  */
 define( [
 		'Views/LessonList',
 		'Views/_Editable',
 		'Views/_Shiftable',
-		'Views/_Trashable'
+		'Views/_Trashable',
+		'Views/ExistingLessonPopover'
 	], function(
 		LessonListView,
 		Editable,
 		Shiftable,
-		Trashable
+		Trashable,
+		show_existing_lesson_popover
 	) {
 
 	return Backbone.View.extend( _.defaults( {
@@ -39,7 +42,7 @@ define( [
 		 * Events
 		 * @type     {Object}
 		 * @since    3.16.0
-		 * @version  3.16.12
+		 * @version  [version]
 		 */
 		events: _.defaults( {
 
@@ -48,6 +51,7 @@ define( [
 			'click .shift-up--section': 'shift_up',
 			'click .shift-down--section': 'shift_down',
 			'click .new-lesson': 'add_new_lesson',
+			'click .existing-lesson': 'add_existing_lesson',
 			'click .llms-builder-header': 'toggle',
 			'mouseenter .llms-lessons': 'on_mouseenter',
 
@@ -131,6 +135,23 @@ define( [
 
 			Backbone.pubSub.trigger( 'section-select', this.model );
 			Backbone.pubSub.trigger( 'add-new-lesson' );
+
+		},
+
+		/**
+		 * Open the existing-lesson search popover for this section.
+		 *
+		 * @since [version]
+		 *
+		 * @param {Object} event JS event object.
+		 * @return {Void}
+		 */
+		add_existing_lesson: function( event ) {
+
+			event.preventDefault();
+
+			Backbone.pubSub.trigger( 'section-select', this.model );
+			show_existing_lesson_popover( event.currentTarget, 'top' );
 
 		},
 

--- a/assets/scss/admin/_course-builder.scss
+++ b/assets/scss/admin/_course-builder.scss
@@ -202,7 +202,29 @@ body.admin_page_llms-course-builder {
 
 				> .llms-builder-footer {
 					border-top: 1px solid #efefef;
+					display: flex;
+					flex-wrap: wrap;
+					gap: 8px;
 					padding: 20px 20px 20px 30px;
+
+					.existing-lesson {
+						background: #fff;
+						border: 1px solid #d4d4d4;
+						color: $color-cinder;
+
+						&:hover,
+						&:active {
+							background: #f6f6f6;
+							border-color: #c4c4c4;
+							color: #414141;
+						}
+
+						&:focus {
+							background: #fff;
+							border-color: $color-brand-blue;
+							color: $color-cinder;
+						}
+					}
 				}
 			}
 

--- a/includes/admin/views/builder/section.php
+++ b/includes/admin/views/builder/section.php
@@ -4,7 +4,8 @@
  *
  * @since   3.16.0
  * @since   10.1.0 Escaped section title output.
- * @version 10.1.0
+ * @since   [version] Added an "Add Existing Lesson" button to the section footer.
+ * @version [version]
  */
 defined( 'ABSPATH' ) || exit;
 ?>
@@ -65,6 +66,9 @@ defined( 'ABSPATH' ) || exit;
 		<div class="llms-builder-footer">
 			<button class="llms-button-secondary small new-lesson">
 				<span class="fa fa-file"></span> <?php esc_html_e( 'Add New Lesson', 'lifterlms' ); ?>
+			</button>
+			<button class="llms-button-secondary small existing-lesson">
+				<span class="fa fa-file-text"></span> <?php esc_html_e( 'Add Existing Lesson', 'lifterlms' ); ?>
 			</button>
 		</div>
 	<# } #>

--- a/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
+++ b/tests/e2e/specs/admin/course-builder-attach-lesson.spec.js
@@ -22,6 +22,39 @@ async function setContentEditable( locator, text ) {
 	}, text );
 }
 
+/**
+ * Attach an existing lesson via the section footer's "Add Existing Lesson" button.
+ *
+ * @param {import('@playwright/test').Page}    page      Playwright page.
+ * @param {import('@playwright/test').Locator} sectionEl Section locator.
+ * @param {string}                             title     Lesson title to search for.
+ * @return {Promise<void>}
+ */
+async function attachExistingLessonFromSection( page, sectionEl, title ) {
+
+	const btn = sectionEl.locator( '.llms-builder-footer .existing-lesson' );
+	await expect( btn ).toBeVisible();
+	await btn.click();
+
+	const popover = page.locator( '.webui-popover' ).filter( { hasText: 'Add Existing Lesson' } );
+	await expect( popover ).toBeVisible();
+
+	const select2 = popover.locator( '.select2-container' );
+	await expect( select2 ).toBeVisible();
+	await expect.poll( async () => {
+		const box = await select2.boundingBox();
+		return box?.width ?? 0;
+	} ).toBeGreaterThan( 200 );
+
+	await select2.click();
+	await page.locator( '.select2-search__field' ).fill( title );
+	await page.locator( `.select2-results__option:has-text("${ title }")` ).first().click();
+
+	await expect( popover ).toHaveCount( 0, { timeout: 5000 } );
+	await expect( page.locator( '.webui-popover-backdrop' ) ).toHaveCount( 0 );
+
+}
+
 test.describe( 'Course Builder / Attach Existing Lesson', () => {
 
 	test( 'attaching an orphan lesson, editing title and permalink, then saving persists the lesson', async ( {
@@ -126,6 +159,96 @@ test.describe( 'Course Builder / Attach Existing Lesson', () => {
 		expect( saved.parent_id ).toBe( section.id );
 		const title = typeof saved.title === 'object' ? saved.title.raw : saved.title;
 		expect( title ).toBe( newTitle );
+	} );
+
+	test( 'section footer can attach two existing lessons to the same section', async ( {
+		page,
+		requestUtils,
+	} ) => {
+
+		const stamp = Date.now();
+		const firstTitle = `Orphan A ${ stamp }`;
+		const secondTitle = `Orphan B ${ stamp }`;
+
+		const course = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/courses',
+			data: {
+				title: `Builder Attach Two ${ stamp }`,
+				content: 'x',
+				status: 'publish',
+			},
+		} );
+
+		const section = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/sections',
+			data: {
+				title: 'Section 1',
+				parent_id: course.id,
+				order: 1,
+			},
+		} );
+
+		const first = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/lessons',
+			data: {
+				title: firstTitle,
+				content: 'orphan a',
+				status: 'publish',
+				parent_id: 0,
+			},
+		} );
+
+		const second = await requestUtils.rest( {
+			method: 'POST',
+			path: '/llms/v1/lessons',
+			data: {
+				title: secondTitle,
+				content: 'orphan b',
+				status: 'publish',
+				parent_id: 0,
+			},
+		} );
+
+		await page.goto( `/wp-admin/admin.php?page=llms-course-builder&course_id=${ course.id }` );
+		await page.locator( '.wrap.lifterlms.llms-builder' ).waitFor( { state: 'visible' } );
+
+		const sectionEl = page.locator( `#llms-section-${ section.id }` );
+		await sectionEl.waitFor( { state: 'visible' } );
+
+		await attachExistingLessonFromSection( page, sectionEl, firstTitle );
+		await expect( sectionEl.locator( `#llms-lesson-${ first.id }` ) ).toBeVisible( { timeout: 10000 } );
+
+		await attachExistingLessonFromSection( page, sectionEl, secondTitle );
+		await expect( sectionEl.locator( `#llms-lesson-${ second.id }` ) ).toBeVisible( { timeout: 10000 } );
+
+		await expect( sectionEl.locator( `#llms-lesson-${ first.id }` ) ).toBeVisible();
+		await expect( sectionEl.locator( `#llms-lesson-${ second.id }` ) ).toBeVisible();
+
+		const saveBtn = page.locator( '#llms-save-button' );
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'unsaved', { timeout: 5000 } );
+		await saveBtn.click();
+		await expect( saveBtn ).toHaveAttribute( 'data-status', 'saved', { timeout: 15000 } );
+
+		await page.reload();
+		await page.locator( '.wrap.lifterlms.llms-builder' ).waitFor( { state: 'visible' } );
+		await expect( page.locator( `#llms-lesson-${ first.id }` ) ).toBeVisible( { timeout: 10000 } );
+		await expect( page.locator( `#llms-lesson-${ second.id }` ) ).toBeVisible();
+
+		const savedFirst = await requestUtils.rest( {
+			method: 'GET',
+			path: `/llms/v1/lessons/${ first.id }`,
+			params: { context: 'edit' },
+		} );
+		const savedSecond = await requestUtils.rest( {
+			method: 'GET',
+			path: `/llms/v1/lessons/${ second.id }`,
+			params: { context: 'edit' },
+		} );
+		expect( savedFirst.parent_id ).toBe( section.id );
+		expect( savedSecond.parent_id ).toBe( section.id );
 	} );
 
 } );


### PR DESCRIPTION

## Description
Makes it easier to add an existing lesson without needing to close the Lesson panel each time.

## How has this been tested?
Manually + E2E test

## Screenshots <!-- if applicable -->
<img width="3622" height="1122" alt="CleanShot 2026-09-02 at 11 04 42@2x" src="https://github.com/user-attachments/assets/a0f9c8a7-f03a-412d-80ac-b30e1ec1eeb5" />
<img width="3622" height="1120" alt="CleanShot 2026-09-02 at 11 04 50@2x" src="https://github.com/user-attachments/assets/f0916b54-e7da-4f48-a7ce-2b610bd12c0b" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

