### PR TITLE
Avoid "blip" when refreshing and minimum time not met.

### DIFF
--- a/.changelogs/fix-mark-complete-progression-gates.yml
+++ b/.changelogs/fix-mark-complete-progression-gates.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: Disabled the Mark Complete button in markup while a lesson's minimum time is still running, and left it disabled when other progression requirements remain.

--- a/.changelogs/fix-mark-complete-progression-gates.yml
+++ b/.changelogs/fix-mark-complete-progression-gates.yml
@@ -1,3 +1,5 @@
 significance: patch
 type: fixed
+links:
+  - "#3352"
 entry: Disabled the Mark Complete button in markup while a lesson's minimum time is still running, and left it disabled when other progression requirements remain.

--- a/includes/functions/llms-functions-progression.php
+++ b/includes/functions/llms-functions-progression.php
@@ -5,7 +5,7 @@
  * @package LifterLMS/Functions
  *
  * @since 3.29.0
- * @version 3.29.0
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -70,6 +70,34 @@ function llms_can_user_complete_lesson( $user_id, $lesson ) {
 	 * @param LLMS_Lesson|bool $lesson  LLMS_Lesson instance, or `false` for an invalid lesson.
 	 */
 	return apply_filters( 'llms_can_user_complete_lesson', $allowed, $user_id, $lesson );
+}
+
+/**
+ * Determine whether a student has met a lesson's minimum time requirement.
+ *
+ * Returns true when the lesson has no minimum time, or when the student's
+ * accumulated time is at least the required number of seconds.
+ *
+ * @since [version]
+ *
+ * @param int             $user_id WP User ID of the student.
+ * @param LLMS_Lesson|int $lesson  LLMS_Lesson instance or WP Post ID of a lesson.
+ * @return bool
+ */
+function llms_has_met_lesson_minimum_time( $user_id, $lesson ) {
+
+	if ( ! $lesson instanceof LLMS_Lesson ) {
+		$lesson = llms_get_post( $lesson );
+	}
+
+	if ( ! $lesson || ! is_a( $lesson, 'LLMS_Lesson' ) || ! $lesson->has_minimum_time() ) {
+		return true;
+	}
+
+	$total    = LLMS_Lesson_Time_Tracking::instance()->get_total_seconds( $user_id, $lesson->get( 'id' ) );
+	$required = absint( $lesson->get( 'minimum_time' ) );
+
+	return $total >= $required;
 }
 
 /**

--- a/src/js/lesson-timer.js
+++ b/src/js/lesson-timer.js
@@ -39,6 +39,27 @@ import '../scss/lesson-timer.scss';
 	function eachActionButton( callback ) {
 		document.querySelectorAll( '.llms-complete-lesson-form [type="submit"]' ).forEach( callback );
 		document.querySelectorAll( '#llms_start_quiz, [id="llms_start_quiz"]' ).forEach( callback );
+		document.querySelectorAll( '#llms-start-assignment, [id="llms-start-assignment"]' ).forEach( callback );
+	}
+
+	/**
+	 * Whether another add-on still has a progression lock on the element.
+	 *
+	 * Locks are `data-llms-lock-{id}` attributes (e.g. `data-llms-lock-video` from
+	 * Advanced Videos). The button must stay disabled until every lock is gone.
+	 */
+	function hasProgressionLock( el ) {
+		var i, name;
+		if ( ! el || ! el.attributes ) {
+			return false;
+		}
+		for ( i = 0; i < el.attributes.length; i++ ) {
+			name = el.attributes[ i ].name;
+			if ( 0 === name.indexOf( 'data-llms-lock-' ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**
@@ -92,6 +113,8 @@ import '../scss/lesson-timer.scss';
 	/**
 	 * Enable the action buttons. Only called once the server has confirmed the
 	 * minimum time is met, so the completion request can't be rejected server-side.
+	 * Other add-on locks (data-llms-lock-*) are left in place so those requirements
+	 * can still keep the button disabled.
 	 */
 	function enableButtons() {
 		if ( buttonsEnabled ) {
@@ -99,8 +122,11 @@ import '../scss/lesson-timer.scss';
 		}
 		buttonsEnabled = true;
 		eachActionButton( function( btn ) {
-			btn.disabled = false;
+			btn.removeAttribute( 'data-llms-lock-time' );
 			btn.classList.remove( 'llms-lesson-time-disabled' );
+			if ( ! hasProgressionLock( btn ) ) {
+				btn.disabled = false;
+			}
 		} );
 		document.dispatchEvent( new CustomEvent( 'llms-lesson-time-met' ) );
 	}
@@ -249,6 +275,7 @@ import '../scss/lesson-timer.scss';
 			eachActionButton( function( btn ) {
 				btn.disabled = true;
 				btn.classList.add( 'llms-lesson-time-disabled' );
+				btn.setAttribute( 'data-llms-lock-time', '1' );
 			} );
 		} else if ( hasMinimum ) {
 			// Already met at load: prior sessions are persisted server-side, so the button is safe to leave enabled.

--- a/src/scss/lesson-timer.scss
+++ b/src/scss/lesson-timer.scss
@@ -16,7 +16,8 @@
 	}
 }
 
-.llms-lesson-time-disabled {
+.llms-lesson-time-disabled,
+.llms-complete-lesson-form [type="submit"]:disabled {
 	opacity: 0.5;
 	cursor: not-allowed !important;
 	pointer-events: none;

--- a/templates/course/complete-lesson-link.php
+++ b/templates/course/complete-lesson-link.php
@@ -8,7 +8,8 @@
  * @since 3.33.0 Only render on lesson post types.
  * @since 10.0.7 Use `llms_can_user_complete_lesson()` to gate rendering.
  * @since 10.1.0 Added `wp-element-button` class to the Take Quiz button so it inherits theme button styling.
- * @version 10.1.0
+ * @since [version] Disable Mark Complete / Take Quiz in markup when minimum time is not yet met.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,6 +26,11 @@ if ( ! llms_can_user_complete_lesson( get_current_user_id(), $lesson ) ) {
 }
 
 $student = llms_get_student( get_current_user_id() );
+
+$time_gated = $student
+	&& $lesson->has_minimum_time()
+	&& ! $student->is_complete( $lesson->get( 'id' ), 'lesson' )
+	&& ! llms_has_met_lesson_minimum_time( get_current_user_id(), $lesson );
 ?>
 
 <div class="clear"></div>
@@ -85,10 +91,18 @@ $student = llms_get_student( get_current_user_id() );
 				<?php wp_nonce_field( 'mark_complete' ); ?>
 
 				<?php
+				$complete_classes = 'llms-button-primary auto button';
+				$complete_atts    = array();
+				if ( $time_gated ) {
+					$complete_classes                    .= ' llms-lesson-time-disabled';
+					$complete_atts['data-llms-lock-time'] = '1';
+				}
 				llms_form_field(
 					array(
 						'columns'     => 12,
-						'classes'     => 'llms-button-primary auto button',
+						'classes'     => $complete_classes,
+						'attributes'  => $complete_atts,
+						'disabled'    => $time_gated,
 						'id'          => 'llms_mark_complete',
 						'value'       => apply_filters( 'lifterlms_mark_lesson_complete_button_text', __( 'Mark Complete', 'lifterlms' ), $lesson ),
 						'last_column' => true,
@@ -111,7 +125,45 @@ $student = llms_get_student( get_current_user_id() );
 
 		<?php do_action( 'llms_before_start_quiz_button' ); ?>
 
-		<a class="llms-button-action auto button wp-element-button" id="llms_start_quiz" href="<?php echo esc_url( get_permalink( $lesson->get( 'quiz' ) ) ); ?>">
+		<?php
+		$quiz_classes = array( 'llms-button-action', 'auto', 'button', 'wp-element-button' );
+		$quiz_atts    = array();
+		if ( $time_gated ) {
+			$quiz_classes[]                   = 'llms-lesson-time-disabled';
+			$quiz_atts['data-llms-lock-time'] = '1';
+		}
+
+		/**
+		 * Filters HTML attributes for the Take Quiz button.
+		 *
+		 * Add-ons may add `data-llms-lock-{id}` attributes so the button stays
+		 * disabled until every progression requirement is met.
+		 *
+		 * @since [version]
+		 *
+		 * @param array       $quiz_atts Attribute key/value pairs.
+		 * @param LLMS_Lesson $lesson    Lesson object.
+		 */
+		$quiz_atts = apply_filters( 'llms_start_quiz_button_attributes', $quiz_atts, $lesson );
+
+		/**
+		 * Filters CSS classes for the Take Quiz button.
+		 *
+		 * @since [version]
+		 *
+		 * @param string[]    $quiz_classes CSS class names.
+		 * @param LLMS_Lesson $lesson       Lesson object.
+		 */
+		$quiz_classes = apply_filters( 'llms_start_quiz_button_classes', $quiz_classes, $lesson );
+
+		?>
+		<a class="<?php echo esc_attr( implode( ' ', $quiz_classes ) ); ?>" id="llms_start_quiz" href="<?php echo esc_url( get_permalink( $lesson->get( 'quiz' ) ) ); ?>"
+			<?php
+			foreach ( $quiz_atts as $quiz_attr => $quiz_attr_val ) {
+				printf( '%s="%s" ', esc_attr( $quiz_attr ), esc_attr( $quiz_attr_val ) );
+			}
+			?>
+		>
 			<?php echo wp_kses_post( apply_filters( 'lifterlms_start_quiz_button_text', esc_html__( 'Take Quiz', 'lifterlms' ), $lesson->get( 'quiz' ), $lesson ) ); ?>
 		</a>
 

--- a/tests/phpunit/unit-tests/class-llms-test-lesson-time-session.php
+++ b/tests/phpunit/unit-tests/class-llms-test-lesson-time-session.php
@@ -423,4 +423,31 @@ class LLMS_Test_Lesson_Time_Session extends LLMS_UnitTestCase {
 		$total = LLMS_Lesson_Time_Tracking::instance()->get_total_seconds( $this->student_id, $this->lesson_id );
 		$this->assertGreaterThanOrEqual( 120, $total );
 	}
+
+	/**
+	 * Test llms_has_met_lesson_minimum_time().
+	 *
+	 * @since [version]
+	 *
+	 * @return void
+	 */
+	public function test_llms_has_met_lesson_minimum_time() {
+
+		$lesson = llms_get_post( $this->lesson_id );
+
+		$this->assertFalse( llms_has_met_lesson_minimum_time( $this->student_id, $lesson ) );
+		$this->assertFalse( llms_has_met_lesson_minimum_time( $this->student_id, $this->lesson_id ) );
+
+		$session = LLMS_Lesson_Time_Tracking::instance()->start_session( $this->student_id, $this->lesson_id );
+		$session->set( 'accumulated_seconds', 600 );
+		$session->set( 'session_end', current_time( 'mysql' ) );
+		$session->save();
+		LLMS_Lesson_Time_Tracking::instance()->update_cached_time( $this->student_id, $this->lesson_id );
+
+		$this->assertTrue( llms_has_met_lesson_minimum_time( $this->student_id, $lesson ) );
+
+		update_post_meta( $this->lesson_id, '_llms_has_minimum_time', 'no' );
+		$lesson = llms_get_post( $this->lesson_id );
+		$this->assertTrue( llms_has_met_lesson_minimum_time( $this->student_id, $lesson ) );
+	}
 }


### PR DESCRIPTION

## Description
Disable the Mark Completed button in the markup first vs. just JS.

Also adds general "progression lock" where addons can add a `data-llms-lock-*` data param to indicate that progression cannot yet continue.

Fixes #3352

## How has this been tested?
Manually + phpunit test

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

