### PR TITLE
Fixing blocks like tab that need things running in wp_head prior to content

### DIFF
--- a/.changelogs/fix-focus-mode-tabs-block.yml
+++ b/.changelogs/fix-focus-mode-tabs-block.yml
@@ -1,0 +1,3 @@
+significance: patch
+type: fixed
+entry: "Fixed interactive blocks not working in focus mode."

--- a/.changelogs/fix-focus-mode-tabs-block.yml
+++ b/.changelogs/fix-focus-mode-tabs-block.yml
@@ -1,3 +1,5 @@
 significance: patch
 type: fixed
+links:
+  - "#3350"
 entry: "Fixed interactive blocks not working in focus mode."

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
+	"core": "https://wordpress.org/wordpress-7.1.zip",
 	"plugins": [ "." ],
 	"mappings": {
 		"wp-content/mu-plugins": "./tests/e2e/mu-plugins"

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
-	"core": "https://wordpress.org/wordpress-7.1.zip",
 	"plugins": [ "." ],
 	"mappings": {
 		"wp-content/mu-plugins": "./tests/e2e/mu-plugins"

--- a/templates/single-lesson-focus.php
+++ b/templates/single-lesson-focus.php
@@ -5,7 +5,8 @@
  * @package LifterLMS/Templates
  *
  * @since 10.0.0
- * @version 10.0.0
+ * @since [version] Render post content before `wp_head()` so block script modules populate the import map.
+ * @version [version]
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -33,6 +34,20 @@ $next_id = ( $lesson && is_callable( array( $lesson, 'get_next_lesson' ) ) ) ? $
 
 $prev_restricted = $prev_id ? llms_page_restricted( $prev_id, get_current_user_id() ) : array( 'is_restricted' => false );
 $next_restricted = $next_id ? llms_page_restricted( $next_id, get_current_user_id() ) : array( 'is_restricted' => false );
+
+/*
+ * Render block content before <head> so script modules (e.g. core/tabs) populate
+ * the import map. Matches wp-includes/template-canvas.php. On block themes the
+ * map prints in wp_head(); processing after that leaves @wordpress/interactivity
+ * unresolved and interactive blocks dead.
+ */
+$llms_focus_mode_content = '';
+if ( have_posts() ) {
+	the_post();
+	ob_start();
+	do_action( 'llms_focus_mode_the_content' );
+	$llms_focus_mode_content = ob_get_clean();
+}
 ?>
 <!DOCTYPE html>
 <html <?php language_attributes(); ?>>
@@ -112,27 +127,13 @@ $next_restricted = $next_id ? llms_page_restricted( $next_id, get_current_user_i
 			?>
 			<main class="<?php echo esc_attr( implode( ' ', array_filter( $content_classes ) ) ); ?>">
 				<?php
-				while ( have_posts() ) :
-					the_post();
-					$lesson_content_classes = array( 'llms-lesson-content', 'entry-content', 'is-layout-constrained' );
-					$lesson_content_classes = apply_filters( 'llms_focus_mode_lesson_content_classes', $lesson_content_classes );
-					?>
-					<h1 class="llms-focus-mode-title"><?php the_title(); ?></h1>
-					<div class="<?php echo esc_attr( implode( ' ', array_filter( $lesson_content_classes ) ) ); ?>">
-						<?php
-						/**
-						 * Renders the post content in focus mode.
-						 *
-						 * @since 10.0.0
-						 *
-						 * @see llms_focus_mode_render_content() Default handler.
-						 */
-						do_action( 'llms_focus_mode_the_content' );
-						?>
-					</div>
-					<?php
-				endwhile;
+				$lesson_content_classes = array( 'llms-lesson-content', 'entry-content', 'is-layout-constrained' );
+				$lesson_content_classes = apply_filters( 'llms_focus_mode_lesson_content_classes', $lesson_content_classes );
 				?>
+				<h1 class="llms-focus-mode-title"><?php the_title(); ?></h1>
+				<div class="<?php echo esc_attr( implode( ' ', array_filter( $lesson_content_classes ) ) ); ?>">
+					<?php echo $llms_focus_mode_content; ?>
+				</div>
 			</main>
 
 			<?php if ( 'lesson' === $post_type && $lesson ) : ?>

--- a/tests/e2e/bin/create-focus-mode-tabs-course.php
+++ b/tests/e2e/bin/create-focus-mode-tabs-course.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Create a focus-mode course whose lesson contains a core/tabs block.
+ *
+ * Idempotent. Run from tests/e2e/bin/setup-env.sh via `wp eval-file`.
+ *
+ * @package LifterLMS/Tests/E2E
+ *
+ * @since [version]
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+$tabs_content = <<<'HTML'
+<!-- wp:tabs -->
+<div class="wp-block-tabs"><!-- wp:tab-list -->
+<div class="wp-block-tab-list" role="tablist"><button type="button" role="tab">Overview</button><button type="button" role="tab">Details</button></div>
+<!-- /wp:tab-list -->
+
+<!-- wp:tab-panels -->
+<div class="wp-block-tab-panels"><!-- wp:tab-panel {"anchor":"overview","label":"Overview"} -->
+<section class="wp-block-tab-panel" id="overview" role="tabpanel" tabindex="0"><!-- wp:paragraph -->
+<p>Overview tab content.</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:tab-panel -->
+
+<!-- wp:tab-panel {"anchor":"details","label":"Details"} -->
+<section class="wp-block-tab-panel" id="details" role="tabpanel" tabindex="0"><!-- wp:paragraph -->
+<p>Details tab content.</p>
+<!-- /wp:paragraph --></section>
+<!-- /wp:tab-panel --></div>
+<!-- /wp:tab-panels --></div>
+<!-- /wp:tabs -->
+HTML;
+
+$course_query = new WP_Query(
+	array(
+		'name'           => 'focus-mode-tabs-course',
+		'post_type'      => 'course',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+$course_id    = $course_query->posts ? (int) $course_query->posts[0] : 0;
+if ( ! $course_id ) {
+	$course_id = wp_insert_post(
+		array(
+			'post_type'    => 'course',
+			'post_title'   => 'Focus Mode Tabs Course',
+			'post_name'    => 'focus-mode-tabs-course',
+			'post_status'  => 'publish',
+			'post_content' => 'Focus mode course used to test the core Tabs block.',
+		)
+	);
+}
+
+update_post_meta( $course_id, '_llms_focus_mode', 'enable' );
+
+$section_query = new WP_Query(
+	array(
+		'name'           => 'focus-mode-tabs-section',
+		'post_type'      => 'section',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+$section_id    = $section_query->posts ? (int) $section_query->posts[0] : 0;
+if ( ! $section_id ) {
+	$section_id = wp_insert_post(
+		array(
+			'post_type'   => 'section',
+			'post_title'  => 'Focus Mode Tabs Section',
+			'post_name'   => 'focus-mode-tabs-section',
+			'post_status' => 'publish',
+		)
+	);
+}
+update_post_meta( $section_id, '_llms_parent_course', $course_id );
+update_post_meta( $section_id, '_llms_order', 1 );
+
+$lesson_query = new WP_Query(
+	array(
+		'name'           => 'focus-mode-tabs-lesson',
+		'post_type'      => 'lesson',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+$lesson_id    = $lesson_query->posts ? (int) $lesson_query->posts[0] : 0;
+if ( ! $lesson_id ) {
+	$lesson_id = wp_insert_post(
+		array(
+			'post_type'    => 'lesson',
+			'post_title'   => 'Focus Mode Tabs Lesson',
+			'post_name'    => 'focus-mode-tabs-lesson',
+			'post_status'  => 'publish',
+			'post_content' => $tabs_content,
+		)
+	);
+} else {
+	wp_update_post(
+		array(
+			'ID'           => $lesson_id,
+			'post_content' => $tabs_content,
+		)
+	);
+}
+update_post_meta( $lesson_id, '_llms_parent_course', $course_id );
+update_post_meta( $lesson_id, '_llms_parent_section', $section_id );
+update_post_meta( $lesson_id, '_llms_order', 1 );
+
+$plan_query = new WP_Query(
+	array(
+		'name'           => 'focus-mode-tabs-plan',
+		'post_type'      => 'llms_access_plan',
+		'post_status'    => 'publish',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => true,
+	)
+);
+$plan_id    = $plan_query->posts ? (int) $plan_query->posts[0] : 0;
+if ( ! $plan_id ) {
+	$plan_id = wp_insert_post(
+		array(
+			'post_type'   => 'llms_access_plan',
+			'post_title'  => 'Free Access',
+			'post_name'   => 'focus-mode-tabs-plan',
+			'post_status' => 'publish',
+		)
+	);
+}
+update_post_meta( $plan_id, '_llms_product_id', $course_id );
+update_post_meta( $plan_id, '_llms_is_free', 'yes' );
+update_post_meta( $plan_id, '_llms_price', 0 );
+update_post_meta( $plan_id, '_llms_frequency', 0 );
+update_post_meta( $plan_id, '_llms_availability', 'open' );
+update_post_meta( $plan_id, '_llms_access_expiration', 'lifetime' );
+update_post_meta( $plan_id, '_llms_enroll_text', 'Enroll' );
+
+$student = get_user_by( 'login', 'validcreds' );
+if ( $student ) {
+	llms_enroll_student( $student->ID, $course_id, 'e2e_setup' );
+}

--- a/tests/e2e/bin/setup-env.sh
+++ b/tests/e2e/bin/setup-env.sh
@@ -101,4 +101,8 @@ if [ -z "$FREE_COURSE_ID" ]; then
   fi
 fi
 
+# 8. Create a focus-mode course whose lesson contains a core/tabs block (WP 7.1+).
+#    Path is relative to the WordPress root inside the tests-cli container.
+$CLI wp eval-file wp-content/plugins/lifterlms/tests/e2e/bin/create-focus-mode-tabs-course.php
+
 echo "E2E environment bootstrapped successfully."

--- a/tests/e2e/specs/student/focus-mode-tabs.spec.js
+++ b/tests/e2e/specs/student/focus-mode-tabs.spec.js
@@ -1,0 +1,44 @@
+/**
+ * Test the core Tabs block on a focus-mode lesson.
+ *
+ * Requires WordPress 7.1+ (when core/tabs shipped). Without processing
+ * lesson blocks before wp_head(), the Interactivity import map is empty on
+ * block themes and tab clicks do nothing.
+ */
+
+import { test, expect } from '@wordpress/e2e-test-utils-playwright';
+import { loginStudent, logoutUser } from '../../utils/index.js';
+
+test.describe( 'FocusModeTabs', () => {
+	test( 'switches tab panels when a tab is clicked', async ( { page } ) => {
+		const interactivityErrors = [];
+		page.on( 'pageerror', ( error ) => {
+			if ( error.message.includes( '@wordpress/interactivity' ) ) {
+				interactivityErrors.push( error.message );
+			}
+		} );
+
+		await logoutUser( page );
+		await loginStudent( page, 'validcreds@email.tld', 'password' );
+
+		await page.goto( '/lesson/focus-mode-tabs-lesson/' );
+
+		await expect( page.locator( 'body' ) ).toHaveClass( /llms-focus-mode/ );
+		await expect( page.getByRole( 'tab', { name: 'Overview' } ) ).toBeVisible();
+		await expect( page.getByRole( 'tab', { name: 'Details' } ) ).toBeVisible();
+
+		await expect( page.getByText( 'Overview tab content.' ) ).toBeVisible();
+		await expect( page.getByText( 'Details tab content.' ) ).toBeHidden();
+
+		await page.getByRole( 'tab', { name: 'Details' } ).click();
+
+		await expect( page.getByText( 'Details tab content.' ) ).toBeVisible();
+		await expect( page.getByText( 'Overview tab content.' ) ).toBeHidden();
+		await expect( page.getByRole( 'tab', { name: 'Details' } ) ).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+
+		expect( interactivityErrors, 'Interactivity API failed to resolve' ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION

## Description

Fixes #3350

## How has this been tested?
Manually + E2E

## Screenshots <!-- if applicable -->
<img width="4066" height="2114" alt="CleanShot 2026-09-03 at 08 39 29@2x" src="https://github.com/user-attachments/assets/0365d46e-4bdf-4480-81ce-3ef55108e5c6" />

## Checklist:
- [ ] This PR requires and contains at least one changelog file. <!-- To create a changelog yml file: `npm run dev changelog add -- -i` and follow the prompt. See also: https://github.com/gocodebox/lifterlms/blob/trunk/packages/dev/README.md#changelog-add -->
- [ ] My code has been tested.
- [ ] My code passes all existing automated tests. <!-- Check code: `composer run-script tests-run`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/tests/README.md -->
- [ ] My code follows the LifterLMS Coding & Documentation Standards. <!-- Check code: `composer run-script check-cs-errors`, Guidelines: https://github.com/gocodebox/lifterlms/blob/trunk/docs/coding-standards.md and https://github.com/gocodebox/lifterlms/blob/trunk/docs/documentation-standards.md -->

